### PR TITLE
Beautify Monster JSONs and Disable Key Sorting

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -1,67 +1,79 @@
 {
-    "slug": "aardart",
-    "category": "anteater",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "lick_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 10,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 13,
-            "technique": "lantern"
-        },
-        {
-            "level_learned": 16,
-            "technique": "assault"
-        },
-	    {
-            "level_learned": 25,
-            "technique": "feint"
-        },
-	    {
-            "level_learned": 28,
-            "technique": "sand_spray"
-        },
-	    {
-            "level_learned": 31,
-            "technique": "mudslide"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "aardorn",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["ground", "food", "claws", "tongue"],
-    "shape": "varmint",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 43,
-    "height": 185,
-    "weight": 45,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "aardart",
+  "category": "anteater",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "lick_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 10,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 13,
+      "technique": "lantern"
+    },
+    {
+      "level_learned": 16,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 25,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 31,
+      "technique": "mudslide"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "aardorn",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "ground",
+    "food",
+    "claws",
+    "tongue"
+  ],
+  "shape": "varmint",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 43,
+  "height": 185,
+  "weight": 45,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -1,72 +1,83 @@
 {
-    "slug": "aardorn",
-    "category": "snout",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "lick_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 10,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 13,
-            "technique": "lantern"
-        },
-        {
-            "level_learned": 16,
-            "technique": "assault"
-        },
-	    {
-            "level_learned": 25,
-            "technique": "feint"
-        },
-	    {
-            "level_learned": 28,
-            "technique": "sand_spray"
-        },
-	    {
-            "level_learned": 31,
-            "technique": "mudslide"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "aardart"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "aardart",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["ground", "food", "tongue"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 42,
-    "height": 40,
-    "weight": 18,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "aardorn",
+  "category": "snout",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "lick_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 10,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 13,
+      "technique": "lantern"
+    },
+    {
+      "level_learned": 16,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 25,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 31,
+      "technique": "mudslide"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "aardart"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "aardart",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "ground",
+    "food",
+    "tongue"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 42,
+  "height": 40,
+  "weight": 18,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -1,70 +1,81 @@
 {
-    "slug": "abesnaki",
-    "category": "shield-mask",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 13,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 16,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 19,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 25,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 31,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 37,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "sunburst"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["desert", "grassland", "ruins", "swamp"],
-    "tags": ["summoner", "mental", "gaze"],
-    "shape": "serpent",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 99,
-    "height": 104,
-    "weight": 14,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "abesnaki",
+  "category": "shield-mask",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 13,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 16,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 19,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 25,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 31,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 37,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "sunburst"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "desert",
+    "grassland",
+    "ruins",
+    "swamp"
+  ],
+  "tags": [
+    "summoner",
+    "mental",
+    "gaze"
+  ],
+  "shape": "serpent",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 99,
+  "height": 104,
+  "weight": 14,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -1,80 +1,93 @@
 {
-    "slug": "agnidon",
-    "category": "false_dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 28,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 34,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 43,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 46,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 52,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "agnigon"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "agnite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "agnigon",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "desert", "mountains"],
-    "tags": ["flame", "bite", "claws", "ground", "darkness"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 14,
-    "height": 320,
-    "weight": 230,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "agnidon",
+  "category": "false_dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 28,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 34,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 43,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 46,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 52,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "agnigon"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "agnite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "agnigon",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert",
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "bite",
+    "claws",
+    "ground",
+    "darkness"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 14,
+  "height": 320,
+  "weight": 230,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -1,79 +1,93 @@
 {
-    "slug": "agnigon",
-    "category": "false_dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 28,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 34,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 43,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 46,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 52,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 61,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "agnite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "agnidon",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "desert", "mountains"],
-    "tags": ["flame", "bite", "claws", "ground", "bird", "darkness"],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 15,
-    "height": 600,
-    "weight": 2000,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "agnigon",
+  "category": "false_dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 28,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 34,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 43,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 46,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 52,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 61,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "agnite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "agnidon",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert",
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "bite",
+    "claws",
+    "ground",
+    "bird",
+    "darkness"
+  ],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 15,
+  "height": 600,
+  "weight": 2000,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -1,80 +1,92 @@
 {
-    "slug": "agnite",
-    "category": "false_dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 28,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 34,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 43,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 46,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 52,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "agnidon"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "agnidon",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "agnigon",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "desert", "mountains"],
-    "tags": ["flame", "bite", "claws", "ground"],
-    "shape": "dragon",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 13,
-    "height": 80,
-    "weight": 24,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "agnite",
+  "category": "false_dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 28,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 34,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 43,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 46,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 52,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "agnidon"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "agnidon",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "agnigon",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert",
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "bite",
+    "claws",
+    "ground"
+  ],
+  "shape": "dragon",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 13,
+  "height": 80,
+  "weight": 24,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/agnsher.json
+++ b/mods/tuxemon/db/monster/agnsher.json
@@ -1,71 +1,73 @@
 {
-    "slug": "agnsher",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 4,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 7,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 13,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 25,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 31,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 37,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 40,
-            "technique": "firestorm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 60,
-    "weight": 5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "agnsher",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 4,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 7,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 13,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 25,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 31,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 37,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 40,
+      "technique": "firestorm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 60,
+  "weight": 5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -1,84 +1,95 @@
 {
-    "slug": "allagon",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 40,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 43,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 46,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 61,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 64,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 70,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 54,
-            "monster_slug": "ferricran"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "wrougon",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "ferricran",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["ruins", "underground"],
-    "tags": ["steel", "soldier", "sharp", "tail"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 160,
-    "height": 162,
-    "weight": 145,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.8,
-    "upper_catch_resistance": 1.05
+  "slug": "allagon",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 40,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 43,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 46,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 61,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 64,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 70,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 54,
+      "monster_slug": "ferricran"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "wrougon",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "ferricran",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "underground"
+  ],
+  "tags": [
+    "steel",
+    "soldier",
+    "sharp",
+    "tail"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 160,
+  "height": 162,
+  "weight": 145,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.8,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -1,75 +1,86 @@
 {
-    "slug": "altie",
-    "category": "alien",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 16,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 25,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 28,
-            "technique": "neutralize"
-        },
-        {
-            "level_learned": 31,
-            "technique": "demiurge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 40,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraterrestrial", "ruins"],
-    "tags": ["summoner", "mental", "weather", "celestial", "darkness", "tail"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 201,
-    "height": 130,
-    "weight": 30,
-    "catch_rate": 5.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "altie",
+  "category": "alien",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 16,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 25,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 28,
+      "technique": "neutralize"
+    },
+    {
+      "level_learned": 31,
+      "technique": "demiurge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 40,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraterrestrial",
+    "ruins"
+  ],
+  "tags": [
+    "summoner",
+    "mental",
+    "weather",
+    "celestial",
+    "darkness",
+    "tail"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 201,
+  "height": 130,
+  "weight": 30,
+  "catch_rate": 5.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/ambuwl.json
+++ b/mods/tuxemon/db/monster/ambuwl.json
@@ -1,70 +1,81 @@
 {
-    "slug": "ambuwl",
-    "category": "restorative",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "egg_smash"
-        },
-        {
-            "level_learned": 13,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 16,
-            "technique": "lantern"
-        },
-        {
-            "level_learned": 19,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 28,
-            "technique": "neutralize"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 37,
-            "technique": "pouch"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["desert", "woodland"],
-    "tags": ["food", "healing", "light", "bird"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 249,
-    "height": 98,
-    "weight": 38,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "ambuwl",
+  "category": "restorative",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "egg_smash"
+    },
+    {
+      "level_learned": 13,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 16,
+      "technique": "lantern"
+    },
+    {
+      "level_learned": 19,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 28,
+      "technique": "neutralize"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 37,
+      "technique": "pouch"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "desert",
+    "woodland"
+  ],
+  "tags": [
+    "food",
+    "healing",
+    "light",
+    "bird"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 249,
+  "height": 98,
+  "weight": 38,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ampystoma.json
+++ b/mods/tuxemon/db/monster/ampystoma.json
@@ -1,79 +1,90 @@
 {
-    "slug": "ampystoma",
-    "category": "lightning_salamander",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 7,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 13,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 16,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 28,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 31,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 37,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 40,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "axolightl",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["freshwater", "swamp"],
-    "tags": ["light", "weather", "water", "electricity"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 280,
-    "height": 180,
-    "weight": 80,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "ampystoma",
+  "category": "lightning_salamander",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 7,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 13,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 16,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 28,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 31,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 37,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 40,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "axolightl",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "swamp"
+  ],
+  "tags": [
+    "light",
+    "weather",
+    "water",
+    "electricity"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 280,
+  "height": 180,
+  "weight": 80,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -1,76 +1,86 @@
 {
-    "slug": "angesnow",
-    "category": "driven_snow",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 4,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 7,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 13,
-            "technique": "neutralize"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 34,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 43,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 46,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 52,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "seraphice"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "waysprite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "seraphice",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["extraplanar"],
-    "tags": ["ice", "leadership", "weather", "light", "healing"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 263,
-    "height": 120,
-    "weight": 30,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "angesnow",
+  "category": "driven_snow",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "neutralize"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 34,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 43,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 46,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 52,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "seraphice"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "waysprite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "seraphice",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "ice",
+    "leadership",
+    "weather",
+    "light",
+    "healing"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 263,
+  "height": 120,
+  "weight": 30,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -1,60 +1,69 @@
 {
-    "slug": "angrito",
-    "category": "enraged_emotion",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 7,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chromeye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["extraplanar", "urban"],
-    "tags": ["mental", "machine", "fury"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "fire",
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 175,
-    "height": 90,
-    "weight": 55,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "angrito",
+  "category": "enraged_emotion",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chromeye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "extraplanar",
+    "urban"
+  ],
+  "tags": [
+    "mental",
+    "machine",
+    "fury"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "fire",
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 175,
+  "height": 90,
+  "weight": 55,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -1,80 +1,89 @@
 {
-    "slug": "anoleaf",
-    "category": "sprout",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 13,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 40,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "gectile"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "gectile",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "velocitile",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["plant"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 65,
-    "height": 33,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "anoleaf",
+  "category": "sprout",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 13,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 40,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "gectile"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "gectile",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "velocitile",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 65,
+  "height": 33,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -1,74 +1,84 @@
 {
-    "slug": "anu",
-    "category": "dream_fox",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 19,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 28,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 31,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 37,
-            "technique": "dreamwalk"
-        },
-        {
-            "level_learned": 40,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["desert", "extraplanar"],
-    "tags": ["mental", "summoner", "tail"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 61,
-    "height": 100,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "anu",
+  "category": "dream_fox",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 19,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 28,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 31,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 37,
+      "technique": "dreamwalk"
+    },
+    {
+      "level_learned": 40,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "desert",
+    "extraplanar"
+  ],
+  "tags": [
+    "mental",
+    "summoner",
+    "tail"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 61,
+  "height": 100,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -1,64 +1,74 @@
 {
-    "slug": "apeoro",
-    "category": "old_block",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 4,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 7,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 28,
-            "technique": "wall_of_steel"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tetrchimp",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "extraplanar", "ruins"],
-    "tags": ["mental", "gadgets", "tail"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 197,
-    "height": 197,
-    "weight": 145,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "apeoro",
+  "category": "old_block",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 4,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 7,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 28,
+      "technique": "wall_of_steel"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tetrchimp",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "extraplanar",
+    "ruins"
+  ],
+  "tags": [
+    "mental",
+    "gadgets",
+    "tail"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 197,
+  "height": 197,
+  "weight": 145,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -1,70 +1,81 @@
 {
-    "slug": "araignee",
-    "category": "weaver",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "web"
-        },
-        {
-            "level_learned": 1,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 25,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 37,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 40,
-            "technique": "needle"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["jungle", "ruins", "underground", "urban", "woodland"],
-    "tags": ["toxic"],
-    "shape": "grub",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 100,
-    "height": 68,
-    "weight": 7,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "araignee",
+  "category": "weaver",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "web"
+    },
+    {
+      "level_learned": 1,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 25,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 37,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 40,
+      "technique": "needle"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "jungle",
+    "ruins",
+    "underground",
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "toxic"
+  ],
+  "shape": "grub",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 100,
+  "height": 68,
+  "weight": 7,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -1,75 +1,83 @@
 {
-    "slug": "arthrobolt",
-    "category": "foreman",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 10,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 37,
-            "technique": "magnetic_body"
-        },
-        {
-            "level_learned": 43,
-            "technique": "laser_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "nut",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "bolt",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "bomber", "gadgets", "light", "electricity"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 6,
-    "height": 110,
-    "weight": 125,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "arthrobolt",
+  "category": "foreman",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 10,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 37,
+      "technique": "magnetic_body"
+    },
+    {
+      "level_learned": 43,
+      "technique": "laser_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "nut",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "bolt",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "bomber",
+    "gadgets",
+    "light",
+    "electricity"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 6,
+  "height": 110,
+  "weight": 125,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/askylpaws.json
+++ b/mods/tuxemon/db/monster/askylpaws.json
@@ -1,88 +1,101 @@
 {
-    "slug": "askylpaws",
-    "category": "erythrocyte",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "barking"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 7,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mystic_blending"
-        },
-        {
-            "level_learned": 19,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 28,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        },
-        {
-            "level_learned": 61,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "medipup",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "doctsky",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["healing", "bite", "darkness", "gadgets", "toxic", "celestial", "staff"],
-    "shape": "hunter",
-    "stage": "stage2",
-    "types": [
-        "metal", "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 360,
-    "height": 200,
-    "weight": 80,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "askylpaws",
+  "category": "erythrocyte",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "barking"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 7,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mystic_blending"
+    },
+    {
+      "level_learned": 19,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 28,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    },
+    {
+      "level_learned": 61,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "medipup",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "doctsky",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "healing",
+    "bite",
+    "darkness",
+    "gadgets",
+    "toxic",
+    "celestial",
+    "staff"
+  ],
+  "shape": "hunter",
+  "stage": "stage2",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 360,
+  "height": 200,
+  "weight": 80,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/asudopt.json
+++ b/mods/tuxemon/db/monster/asudopt.json
@@ -1,63 +1,109 @@
 {
-    "slug": "asudopt",
-    "category": "god_penguin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 10,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tornado"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 40,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["other"],
-    "tags": ["amphibian", "bird", "bite", "bomber", "bug", "calamity", "celestial", "claws", "darkness", "electricity", "fists", "flame", "food", "fury", "gadgets", "gaze", "gemstone", "ghost", "ground", "healing", "ice", "leadership", "light", "love", "machine", "megafauna", "mental", "plant", "pseudopod", "rock", "shapeshifter", "sharp", "shielded", "soldier", "speed", "steel", "summoner", "toxic", "universal", "weather", "water"],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 300,
-    "height": 150,
-    "weight": 30,
-    "catch_rate": 5.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "asudopt",
+  "category": "god_penguin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 10,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tornado"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 40,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "other"
+  ],
+  "tags": [
+    "amphibian",
+    "bird",
+    "bite",
+    "bomber",
+    "bug",
+    "calamity",
+    "celestial",
+    "claws",
+    "darkness",
+    "electricity",
+    "fists",
+    "flame",
+    "food",
+    "fury",
+    "gadgets",
+    "gaze",
+    "gemstone",
+    "ghost",
+    "ground",
+    "healing",
+    "ice",
+    "leadership",
+    "light",
+    "love",
+    "machine",
+    "megafauna",
+    "mental",
+    "plant",
+    "pseudopod",
+    "rock",
+    "shapeshifter",
+    "sharp",
+    "shielded",
+    "soldier",
+    "speed",
+    "steel",
+    "summoner",
+    "toxic",
+    "universal",
+    "weather",
+    "water"
+  ],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 300,
+  "height": 150,
+  "weight": 30,
+  "catch_rate": 5.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -1,63 +1,70 @@
 {
-    "slug": "av8r",
-    "category": "heliotrope",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 19,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "botbot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["machine", "bird"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 126,
-    "height": 45,
-    "weight": 6,
-    "sounds": {
-        "combat_call": "sound_av8r",
-        "faint_call": "sound_av8r_faint"
+  "slug": "av8r",
+  "category": "heliotrope",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
     },
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+    {
+      "level_learned": 1,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 19,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "botbot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "machine",
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 126,
+  "height": 45,
+  "weight": 6,
+  "sounds": {
+    "combat_call": "sound_av8r",
+    "faint_call": "sound_av8r_faint"
+  },
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/axolightl.json
+++ b/mods/tuxemon/db/monster/axolightl.json
@@ -1,80 +1,88 @@
 {
-    "slug": "axolightl",
-    "category": "inchoate",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 7,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 13,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 16,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 28,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 31,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 37,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 40,
-            "technique": "geyser"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "ampystoma"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "ampystoma",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["freshwater", "swamp"],
-    "tags": ["light"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 101,
-    "height": 80,
-    "weight": 15,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "axolightl",
+  "category": "inchoate",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 7,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 13,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 16,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 28,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 31,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 37,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 40,
+      "technique": "geyser"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "ampystoma"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "ampystoma",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "swamp"
+  ],
+  "tags": [
+    "light"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 101,
+  "height": 80,
+  "weight": 15,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -1,60 +1,66 @@
 {
-    "slug": "b_ver_1",
-    "category": "gnawer",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "botbot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["machine", "bite"],
-    "shape": "varmint",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 130,
-    "height": 100,
-    "weight": 50,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "b_ver_1",
+  "category": "gnawer",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "botbot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "machine",
+    "bite"
+  ],
+  "shape": "varmint",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 130,
+  "height": 100,
+  "weight": 50,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/babysnitch.json
+++ b/mods/tuxemon/db/monster/babysnitch.json
@@ -1,60 +1,72 @@
 {
-    "slug": "babysnitch",
-    "category": "fuminous",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 4,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 10,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 19,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "baddrscratch"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "baddrscratch",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow", "mountains", "underground"],
-    "tags": ["bite", "claws", "fury", "ground"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 350,
-    "height": 35,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "babysnitch",
+  "category": "fuminous",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 4,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 10,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 19,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "baddrscratch"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "baddrscratch",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "mountains",
+    "underground"
+  ],
+  "tags": [
+    "bite",
+    "claws",
+    "fury",
+    "ground"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 350,
+  "height": 35,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/baddrscratch.json
+++ b/mods/tuxemon/db/monster/baddrscratch.json
@@ -1,55 +1,68 @@
 {
-    "slug": "baddrscratch",
-    "category": "fuminous",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 4,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 10,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 19,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "babysnitch",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["boreal_snow", "mountains", "underground"],
-    "tags": ["bite", "claws", "fury", "ground", "darkness"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 351,
-    "height": 140,
-    "weight": 65,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "baddrscratch",
+  "category": "fuminous",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 4,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 10,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 19,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "babysnitch",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "mountains",
+    "underground"
+  ],
+  "tags": [
+    "bite",
+    "claws",
+    "fury",
+    "ground",
+    "darkness"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 351,
+  "height": 140,
+  "weight": 65,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -1,59 +1,72 @@
 {
-    "slug": "bamboon",
-    "category": "prehensile",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 19,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 25,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 28,
-            "technique": "woodsmash"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "budaye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle"],
-    "tags": ["plant", "leadership", "food", "soldier", "tail", "staff"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 28,
-    "height": 120,
-    "weight": 40,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "bamboon",
+  "category": "prehensile",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 19,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 25,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 28,
+      "technique": "woodsmash"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "budaye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "leadership",
+    "food",
+    "soldier",
+    "tail",
+    "staff"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 28,
+  "height": 120,
+  "weight": 40,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -1,89 +1,97 @@
 {
-    "slug": "banling",
-    "category": "sepulchre",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 16,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 19,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "cutting_leaves"
-        },
-        {
-            "level_learned": 31,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "bansaken"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "bansaken",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "banvengeance",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "ghost", "darkness"],
-    "shape": "brute",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 355,
-    "height": 120,
-    "weight": 180,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "banling",
+  "category": "sepulchre",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 16,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 19,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "cutting_leaves"
+    },
+    {
+      "level_learned": 31,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "bansaken"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "bansaken",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "banvengeance",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ghost",
+    "darkness"
+  ],
+  "shape": "brute",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 355,
+  "height": 120,
+  "weight": 180,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/bansaken.json
+++ b/mods/tuxemon/db/monster/bansaken.json
@@ -1,89 +1,97 @@
 {
-    "slug": "bansaken",
-    "category": "sepulchre",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 16,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 19,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "cutting_leaves"
-        },
-        {
-            "level_learned": 31,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "banvengeance"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "banling",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "banvengeance",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "ghost", "darkness"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 356,
-    "height": 430,
-    "weight": 267,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "bansaken",
+  "category": "sepulchre",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 16,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 19,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "cutting_leaves"
+    },
+    {
+      "level_learned": 31,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "banvengeance"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "banling",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "banvengeance",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ghost",
+    "darkness"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 356,
+  "height": 430,
+  "weight": 267,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/banvengeance.json
+++ b/mods/tuxemon/db/monster/banvengeance.json
@@ -1,84 +1,92 @@
 {
-    "slug": "banvengeance",
-    "category": "sepulchre",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 16,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 19,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "cutting_leaves"
-        },
-        {
-            "level_learned": 31,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "banling",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "bansaken",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "ghost", "darkness"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 357,
-    "height": 800,
-    "weight": 354,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "banvengeance",
+  "category": "sepulchre",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 16,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 19,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "cutting_leaves"
+    },
+    {
+      "level_learned": 31,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "banling",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "bansaken",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ghost",
+    "darkness"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 357,
+  "height": 800,
+  "weight": 354,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -1,68 +1,74 @@
 {
-    "slug": "baobaraffe",
-    "category": "tree_giraffe",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "stick"
-        },
-        {
-            "level_learned": 4,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 7,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 16,
-            "technique": "trample"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "cutting_leaves"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "baoby",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "water", "megafauna"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 193,
-    "height": 320,
-    "weight": 302,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "baobaraffe",
+  "category": "tree_giraffe",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "stick"
+    },
+    {
+      "level_learned": 4,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 7,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 16,
+      "technique": "trample"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "cutting_leaves"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "baoby",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "water",
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 193,
+  "height": 320,
+  "weight": 302,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -1,69 +1,75 @@
 {
-    "slug": "baoby",
-    "category": "thirsty_okapi",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "stick"
-        },
-        {
-            "level_learned": 4,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 7,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 16,
-            "technique": "trample"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "baobaraffe"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "baobaraffe",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "water", "tail"],
-    "shape": "landrace",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 192,
-    "height": 54,
-    "weight": 23,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "baoby",
+  "category": "thirsty_okapi",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "stick"
+    },
+    {
+      "level_learned": 4,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 7,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 16,
+      "technique": "trample"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "baobaraffe"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "baobaraffe",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "water",
+    "tail"
+  ],
+  "shape": "landrace",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 192,
+  "height": 54,
+  "weight": 23,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/bearloch.json
+++ b/mods/tuxemon/db/monster/bearloch.json
@@ -1,71 +1,73 @@
 {
-    "slug": "bearloch",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 13,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 16,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 19,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 25,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 28,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 31,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 37,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 40,
-            "technique": "arcane_eye"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 131,
-    "weight": 46,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "bearloch",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 13,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 16,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 19,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 25,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 28,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 31,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 37,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 40,
+      "technique": "arcane_eye"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 131,
+  "weight": 46,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bedoo.json
+++ b/mods/tuxemon/db/monster/bedoo.json
@@ -1,79 +1,88 @@
 {
-    "slug": "bedoo",
-    "category": "bed_trap",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 13,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 16,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 19,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 25,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 37,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 55,
-            "technique": "dreamwalk"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "jelillow",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["mountains", "woodland"],
-    "tags": ["mental", "megafauna"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 208,
-    "height": 200,
-    "weight": 15,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "bedoo",
+  "category": "bed_trap",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 13,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 16,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 19,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 25,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 37,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 55,
+      "technique": "dreamwalk"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "jelillow",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "woodland"
+  ],
+  "tags": [
+    "mental",
+    "megafauna"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 208,
+  "height": 200,
+  "weight": 15,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -1,73 +1,83 @@
 {
-    "slug": "beenstalker",
-    "category": "scarytale",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 28,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "wendigger"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "turnipper",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "wendigger",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "woodland"],
-    "tags": ["plant", "ground", "bite", "ice"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 199,
-    "height": 98,
-    "weight": 41,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "beenstalker",
+  "category": "scarytale",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 28,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "wendigger"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "turnipper",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "wendigger",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ground",
+    "bite",
+    "ice"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 199,
+  "height": 98,
+  "weight": 41,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/bewhich.json
+++ b/mods/tuxemon/db/monster/bewhich.json
@@ -1,60 +1,70 @@
 {
-    "slug": "bewhich",
-    "category": "hexer",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 19,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "cackleen",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "brumi",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["any"],
-    "tags": ["ghost", "shapeshifter", "darkness", "mental", "gemstone"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 342,
-    "height": 152,
-    "weight": 0.1,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "bewhich",
+  "category": "hexer",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 19,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "cackleen",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "brumi",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "any"
+  ],
+  "tags": [
+    "ghost",
+    "shapeshifter",
+    "darkness",
+    "mental",
+    "gemstone"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 342,
+  "height": 152,
+  "weight": 0.1,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -1,67 +1,80 @@
 {
-    "slug": "bigfin",
-    "category": "island",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 19,
-            "technique": "font"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "dollfin",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["water", "megafauna", "plant", "summoner", "ground"],
-    "shape": "leviathan",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 25,
-    "height": 1200,
-    "weight": 50000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "bigfin",
+  "category": "island",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 19,
+      "technique": "font"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "dollfin",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "megafauna",
+    "plant",
+    "summoner",
+    "ground"
+  ],
+  "shape": "leviathan",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 25,
+  "height": 1200,
+  "weight": 50000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/birdee.json
+++ b/mods/tuxemon/db/monster/birdee.json
@@ -1,72 +1,80 @@
 {
-    "slug": "birdee",
-    "category": "chickenhawk",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 4,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 10,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 22,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 25,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chickadee",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "woodland"],
-    "tags": ["bird", "bite"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 366,
-    "height": 26,
-    "weight": 2,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "birdee",
+  "category": "chickenhawk",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 4,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 10,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 22,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 25,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chickadee",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "bite"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 366,
+  "height": 26,
+  "weight": 2,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -1,63 +1,72 @@
 {
-    "slug": "birdling",
-    "category": "bird_brain",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 7,
-            "technique": "egg_smash"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 25,
-            "technique": "altitude"
-        },
-        {
-            "level_learned": 28,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 31,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 34,
-            "technique": "one_two"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "hatchling",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["bird"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 82,
-    "height": 40,
-    "weight": 8,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "birdling",
+  "category": "bird_brain",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 7,
+      "technique": "egg_smash"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 25,
+      "technique": "altitude"
+    },
+    {
+      "level_learned": 28,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 31,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 34,
+      "technique": "one_two"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "hatchling",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 82,
+  "height": 40,
+  "weight": 8,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/bishosand.json
+++ b/mods/tuxemon/db/monster/bishosand.json
@@ -1,68 +1,77 @@
 {
-    "slug": "bishosand",
-    "category": "sand_bishop",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 19,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 22,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pawsand",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["ground", "water", "sharp"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "earth", "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 373,
-    "height": 180,
-    "weight": 100,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "bishosand",
+  "category": "sand_bishop",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 19,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 22,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pawsand",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "ground",
+    "water",
+    "sharp"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 373,
+  "height": 180,
+  "weight": 100,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/blasdoor.json
+++ b/mods/tuxemon/db/monster/blasdoor.json
@@ -1,71 +1,80 @@
 {
-    "slug": "blasdoor",
-    "category": "trapdoor",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 16,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 25,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 28,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 31,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "woodoor",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["bite", "ghost", "steel"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 251,
-    "height": 2040,
-    "weight": 204,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "blasdoor",
+  "category": "trapdoor",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 16,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 25,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 28,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 31,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "woodoor",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "bite",
+    "ghost",
+    "steel"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 251,
+  "height": 2040,
+  "weight": 204,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -1,72 +1,79 @@
 {
-    "slug": "bolt",
-    "category": "hardware",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 10,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 12,
-            "monster_slug": "arthrobolt"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "nut",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "arthrobolt",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "bomber", "gadgets", "light"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 5,
-    "height": 90,
-    "weight": 15.6,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "bolt",
+  "category": "hardware",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 10,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 12,
+      "monster_slug": "arthrobolt"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "nut",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "arthrobolt",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "bomber",
+    "gadgets",
+    "light"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 5,
+  "height": 90,
+  "weight": 15.6,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -1,65 +1,74 @@
 {
-    "slug": "boltnu",
-    "category": "screwdriver",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 4,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_of_steel"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "exclawvate"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "exclawvate",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["ground", "steel", "machine"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 194,
-    "height": 47,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "boltnu",
+  "category": "screwdriver",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 4,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_of_steel"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "exclawvate"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "exclawvate",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "ground",
+    "steel",
+    "machine"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 194,
+  "height": 47,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -1,84 +1,90 @@
 {
-    "slug": "botbot",
-    "category": "socket",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "av8r",
-            "item": "booster_tech"
-        },
-        {
-            "monster_slug": "picc",
-            "item": "booster_tech"
-        },
-        {
-            "monster_slug": "mrmoswitch",
-            "item": "booster_tech"
-        },
-        {
-            "monster_slug": "k9",
-            "item": "booster_tech"
-        },
-        {
-            "monster_slug": "b_ver_1",
-            "item": "booster_tech"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "b_ver_1",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "k9",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mrmoswitch",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "picc",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "av8r",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["machine"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 125,
-    "height": 40,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "botbot",
+  "category": "socket",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "av8r",
+      "item": "booster_tech"
+    },
+    {
+      "monster_slug": "picc",
+      "item": "booster_tech"
+    },
+    {
+      "monster_slug": "mrmoswitch",
+      "item": "booster_tech"
+    },
+    {
+      "monster_slug": "k9",
+      "item": "booster_tech"
+    },
+    {
+      "monster_slug": "b_ver_1",
+      "item": "booster_tech"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "b_ver_1",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "k9",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mrmoswitch",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "picc",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "av8r",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "machine"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 125,
+  "height": 40,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -1,71 +1,80 @@
 {
-    "slug": "boxali",
-    "category": "macropod",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 7,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 13,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 16,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 19,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 25,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 28,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 31,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 37,
-            "technique": "pouch"
-        },
-        {
-            "level_learned": 40,
-            "technique": "all_in"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["desert", "grassland"],
-    "tags": ["fists", "claws", "soldier"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 295,
-    "height": 180,
-    "weight": 90,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "boxali",
+  "category": "macropod",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 7,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 13,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 16,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 19,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 25,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 28,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 31,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 37,
+      "technique": "pouch"
+    },
+    {
+      "level_learned": 40,
+      "technique": "all_in"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "desert",
+    "grassland"
+  ],
+  "tags": [
+    "fists",
+    "claws",
+    "soldier"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 295,
+  "height": 180,
+  "weight": 90,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/boxorox.json
+++ b/mods/tuxemon/db/monster/boxorox.json
@@ -1,46 +1,51 @@
 {
-    "slug": "boxorox",
-    "category": "pugilist",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 10,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 19,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["rock", "fists"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 316,
-    "height": 187,
-    "weight": 154,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "boxorox",
+  "category": "pugilist",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 10,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 19,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "fists"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 316,
+  "height": 187,
+  "weight": 154,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/brachifor.json
+++ b/mods/tuxemon/db/monster/brachifor.json
@@ -1,75 +1,86 @@
 {
-    "slug": "brachifor",
-    "category": "petrified",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spiky_strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 16,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "trample"
-        },
-        {
-            "level_learned": 31,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 40,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "fordin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "stegofor",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "shielded", "healing", "megafauna"],
-    "shape": "landrace",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 213,
-    "height": 2000,
-    "weight": 40000,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "brachifor",
+  "category": "petrified",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spiky_strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 16,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "trample"
+    },
+    {
+      "level_learned": 31,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 40,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "fordin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "stegofor",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "shielded",
+    "healing",
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 213,
+  "height": 2000,
+  "weight": 40000,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/breem.json
+++ b/mods/tuxemon/db/monster/breem.json
@@ -1,60 +1,68 @@
 {
-    "slug": "breem",
-    "category": "parasitized",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 10,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 16,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 19,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 34,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "duggot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "toxic", "bug", "sharp"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "earth",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 344,
-    "height": 100,
-    "weight": 25,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "breem",
+  "category": "parasitized",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 10,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 16,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 19,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 34,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "duggot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "toxic",
+    "bug",
+    "sharp"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 344,
+  "height": 100,
+  "weight": 25,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -1,75 +1,84 @@
 {
-    "slug": "brewdin",
-    "category": "genie",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 4,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 13,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 16,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 19,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 28,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 31,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 37,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 40,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["ruins", "urban"],
-    "tags": ["ghost", "shielded", "water", "flame"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 215,
-    "height": 22,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "brewdin",
+  "category": "genie",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 4,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 13,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 16,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 19,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 28,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 31,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 37,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 40,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "ghost",
+    "shielded",
+    "water",
+    "flame"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 215,
+  "height": 22,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -1,80 +1,91 @@
 {
-    "slug": "bricgard",
-    "category": "brick_wall",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 43,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 46,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 52,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "brickhemoth"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "imbrickcile",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "brickhemoth",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["fists", "rock", "fury", "shielded"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 260,
-    "height": 50,
-    "weight": 35,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "bricgard",
+  "category": "brick_wall",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 43,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 46,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 52,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "brickhemoth"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "imbrickcile",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "brickhemoth",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "fists",
+    "rock",
+    "fury",
+    "shielded"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 260,
+  "height": 50,
+  "weight": 35,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/brickhemoth.json
+++ b/mods/tuxemon/db/monster/brickhemoth.json
@@ -1,75 +1,86 @@
 {
-    "slug": "brickhemoth",
-    "category": "brick_wall",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 43,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 46,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 52,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "imbrickcile",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "bricgard",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["fists", "rock", "fury", "shielded"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 261,
-    "height": 180,
-    "weight": 120,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "brickhemoth",
+  "category": "brick_wall",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 43,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 46,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 52,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "imbrickcile",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "bricgard",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "fists",
+    "rock",
+    "fury",
+    "shielded"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 261,
+  "height": 180,
+  "weight": 120,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/brumi.json
+++ b/mods/tuxemon/db/monster/brumi.json
@@ -1,65 +1,75 @@
 {
-    "slug": "brumi",
-    "category": "hexer",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 19,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "bewhich",
-            "variable": "daytime:false"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cackleen",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "bewhich",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["any"],
-    "tags": ["ghost", "shapeshifter", "darkness", "mental", "gemstone"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 341,
-    "height": 123,
-    "weight": 0.1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "brumi",
+  "category": "hexer",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 19,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "bewhich",
+      "variable": "daytime:false"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cackleen",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "bewhich",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "any"
+  ],
+  "tags": [
+    "ghost",
+    "shapeshifter",
+    "darkness",
+    "mental",
+    "gemstone"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 341,
+  "height": 123,
+  "weight": 0.1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -1,68 +1,78 @@
 {
-    "slug": "budaye",
-    "category": "mutual",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ram"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "bamboon",
-            "item": "wood_booster"
-        },
-        {
-            "monster_slug": "bamboon",
-            "item": "lucky_bamboo"
-        },
-        {
-            "monster_slug": "frondly",
-            "item": "water_booster"
-        },
-        {
-            "monster_slug": "frondly",
-            "item": "peace_lily"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "bamboon",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "frondly",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["plant", "leadership", "food", "tail"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 27,
-    "height": 80,
-    "weight": 20,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "budaye",
+  "category": "mutual",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ram"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "bamboon",
+      "item": "wood_booster"
+    },
+    {
+      "monster_slug": "bamboon",
+      "item": "lucky_bamboo"
+    },
+    {
+      "monster_slug": "frondly",
+      "item": "water_booster"
+    },
+    {
+      "monster_slug": "frondly",
+      "item": "peace_lily"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "bamboon",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "frondly",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "leadership",
+    "food",
+    "tail"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 27,
+  "height": 80,
+  "weight": 20,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -1,76 +1,85 @@
 {
-    "slug": "bugnin",
-    "category": "honour",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 16,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 46,
-            "technique": "vorpal"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "katapill",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "katacoon",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["fists", "bug", "sharp"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 58,
-    "height": 150,
-    "weight": 52,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.8,
-    "upper_catch_resistance": 1.05
+  "slug": "bugnin",
+  "category": "honour",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 16,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 46,
+      "technique": "vorpal"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "katapill",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "katacoon",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "fists",
+    "bug",
+    "sharp"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 58,
+  "height": 150,
+  "weight": 52,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.8,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -1,81 +1,86 @@
 {
-    "slug": "bumbulus",
-    "category": "veiled",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 4,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 7,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 19,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 25,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 37,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "nimbulex"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "nimbulex",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["water", "weather", "light"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 232,
-    "height": 78,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "bumbulus",
+  "category": "veiled",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 4,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 7,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 19,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 25,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 37,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "nimbulex"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "nimbulex",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "water",
+    "weather",
+    "light"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 232,
+  "height": 78,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/burrlock.json
+++ b/mods/tuxemon/db/monster/burrlock.json
@@ -1,60 +1,65 @@
 {
-    "slug": "burrlock",
-    "category": "biting_pear",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pollen_blast"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 28,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "woodsmash"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "cacaburr"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cacaburr",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "sharp"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 325,
-    "height": 50,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "burrlock",
+  "category": "biting_pear",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pollen_blast"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 28,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "woodsmash"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "cacaburr"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cacaburr",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "sharp"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 325,
+  "height": 50,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -1,68 +1,78 @@
 {
-    "slug": "bursa",
-    "category": "too_hot",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 7,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 16,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 37,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 40,
-            "technique": "breathe_fire"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "flambear"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "flambear",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["mountains", "woodland"],
-    "tags": ["mental", "flame", "food"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 83,
-    "height": 180,
-    "weight": 110,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "bursa",
+  "category": "too_hot",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 7,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 16,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 37,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 40,
+      "technique": "breathe_fire"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "flambear"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "flambear",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "woodland"
+  ],
+  "tags": [
+    "mental",
+    "flame",
+    "food"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 83,
+  "height": 180,
+  "weight": 110,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cacaburr.json
+++ b/mods/tuxemon/db/monster/cacaburr.json
@@ -1,59 +1,64 @@
 {
-    "slug": "cacaburr",
-    "category": "biting_pear",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pollen_blast"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 28,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 55,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "burrlock",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "sharp"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 326,
-    "height": 90,
-    "weight": 50,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cacaburr",
+  "category": "biting_pear",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pollen_blast"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 28,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 55,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "burrlock",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "sharp"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 326,
+  "height": 90,
+  "weight": 50,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cackleen.json
+++ b/mods/tuxemon/db/monster/cackleen.json
@@ -1,66 +1,76 @@
 {
-    "slug": "cackleen",
-    "category": "witch_spirit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 19,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 16,
-            "monster_slug": "brumi",
-            "variable": "daytime:false"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "brumi",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "bewhich",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["any"],
-    "tags": ["ghost", "shapeshifter", "darkness", "mental", "gemstone"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 340,
-    "height": 91,
-    "weight": 40,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cackleen",
+  "category": "witch_spirit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 19,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 16,
+      "monster_slug": "brumi",
+      "variable": "daytime:false"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "brumi",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "bewhich",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "any"
+  ],
+  "tags": [
+    "ghost",
+    "shapeshifter",
+    "darkness",
+    "mental",
+    "gemstone"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 340,
+  "height": 91,
+  "weight": 40,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -1,80 +1,85 @@
 {
-    "slug": "cairfrey",
-    "category": "host",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 1,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 7,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 13,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 16,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 31,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 37,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 40,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "possessun"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "possessun",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["mental", "megafauna"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 71,
-    "height": 54,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "cairfrey",
+  "category": "host",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 1,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 7,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 13,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 16,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 31,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 37,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 40,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "possessun"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "possessun",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "mental",
+    "megafauna"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 71,
+  "height": 54,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/caper.json
+++ b/mods/tuxemon/db/monster/caper.json
@@ -1,72 +1,81 @@
 {
-    "slug": "caper",
-    "category": "kid",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "font"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "crankus"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "crankus",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow", "grassland", "mountains"],
-    "tags": ["ice"],
-    "shape": "landrace",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 275,
-    "height": 65,
-    "weight": 36,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "caper",
+  "category": "kid",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "font"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "crankus"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "crankus",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "grassland",
+    "mountains"
+  ],
+  "tags": [
+    "ice"
+  ],
+  "shape": "landrace",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 275,
+  "height": 65,
+  "weight": 36,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/capinyah.json
+++ b/mods/tuxemon/db/monster/capinyah.json
@@ -1,87 +1,93 @@
 {
-    "slug": "capinyah",
-    "category": "woodwose",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 7,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 13,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 16,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 19,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 25,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 28,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 31,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 43,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 49,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 52,
-            "technique": "shadow_boxing"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "capiti",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["fists", "rock"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 103,
-    "height": 160,
-    "weight": 55,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "capinyah",
+  "category": "woodwose",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 7,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 13,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 16,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 19,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 25,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 28,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 31,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 43,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 49,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 52,
+      "technique": "shadow_boxing"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "capiti",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "fists",
+    "rock"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 103,
+  "height": 160,
+  "weight": 55,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -1,92 +1,98 @@
 {
-    "slug": "capiti",
-    "category": "woodwose",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 7,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 13,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 16,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 19,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 25,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 28,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 31,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 43,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 49,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 52,
-            "technique": "shadow_boxing"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "capinyah"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "capinyah",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["fists", "rock"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 102,
-    "height": 100,
-    "weight": 20,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "capiti",
+  "category": "woodwose",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 7,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 13,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 16,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 19,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 25,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 28,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 31,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 43,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 49,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 52,
+      "technique": "shadow_boxing"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "capinyah"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "capinyah",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "fists",
+    "rock"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 102,
+  "height": 100,
+  "weight": 20,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/carcharock.json
+++ b/mods/tuxemon/db/monster/carcharock.json
@@ -1,67 +1,77 @@
 {
-    "slug": "carcharock",
-    "category": "fossil",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 10,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 19,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 25,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 28,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 34,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "jungle"],
-    "tags": ["bite", "amphibian", "megafauna", "fury"],
-    "shape": "dragon",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 385,
-    "height": 120,
-    "weight": 45,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "carcharock",
+  "category": "fossil",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 10,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 19,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 25,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 28,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 34,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "jungle"
+  ],
+  "tags": [
+    "bite",
+    "amphibian",
+    "megafauna",
+    "fury"
+  ],
+  "shape": "dragon",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 385,
+  "height": 120,
+  "weight": 45,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -1,80 +1,90 @@
 {
-    "slug": "cardiling",
-    "category": "firebird",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 25,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 28,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 40,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 46,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "cardiwing"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cardiwing",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "cardinale",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["flame", "bird"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 62,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "cardiling",
+  "category": "firebird",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 25,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 28,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 40,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 46,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "cardiwing"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cardiwing",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "cardinale",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "flame",
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 62,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -1,75 +1,86 @@
 {
-    "slug": "cardinale",
-    "category": "firebird",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 25,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 28,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 40,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 46,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "cardiling",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "cardiwing",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["flame", "bird", "bomber"],
-    "shape": "flier",
-    "stage": "stage2",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 64,
-    "height": 60,
-    "weight": 8,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "cardinale",
+  "category": "firebird",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 25,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 28,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 40,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 46,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "cardiling",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "cardiwing",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "flame",
+    "bird",
+    "bomber"
+  ],
+  "shape": "flier",
+  "stage": "stage2",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 64,
+  "height": 60,
+  "weight": 8,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -1,80 +1,91 @@
 {
-    "slug": "cardiwing",
-    "category": "firebird",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 25,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 28,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 40,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 46,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "cardinale"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cardiling",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "cardinale",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["flame", "bird", "bomber"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 63,
-    "height": 45,
-    "weight": 5,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "cardiwing",
+  "category": "firebird",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 25,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 28,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 40,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 46,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "cardinale"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cardiling",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "cardinale",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "flame",
+    "bird",
+    "bomber"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 63,
+  "height": 45,
+  "weight": 5,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -1,80 +1,86 @@
 {
-    "slug": "cataspike",
-    "category": "pointy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 7,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 16,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 22,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 9,
-            "monster_slug": "puparmor"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "puparmor",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "weavifly",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["sharp", "bug"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 33,
-    "height": 12,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "cataspike",
+  "category": "pointy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 7,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 16,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 22,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 9,
+      "monster_slug": "puparmor"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "puparmor",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "weavifly",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "sharp",
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 33,
+  "height": 12,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -1,70 +1,76 @@
 {
-    "slug": "cateye",
-    "category": "sentinel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 7,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 19,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 25,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 28,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 31,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 37,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["gaze", "claws"],
-    "shape": "hunter",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 235,
-    "height": 45,
-    "weight": 19,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cateye",
+  "category": "sentinel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 7,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 19,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 25,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 28,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 31,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 37,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "gaze",
+    "claws"
+  ],
+  "shape": "hunter",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 235,
+  "height": 45,
+  "weight": 19,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -1,64 +1,69 @@
 {
-    "slug": "chenipode",
-    "category": "travel_bug",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "exapode",
-            "steps": "2500"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "exapode",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 346,
-    "height": 15,
-    "weight": 0.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "chenipode",
+  "category": "travel_bug",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "exapode",
+      "steps": "2500"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "exapode",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 346,
+  "height": 15,
+  "weight": 0.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/cherubat.json
+++ b/mods/tuxemon/db/monster/cherubat.json
@@ -1,70 +1,80 @@
 {
-    "slug": "cherubat",
-    "category": "patu",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 13,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 16,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 28,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 31,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "platinum"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["urban", "woodland"],
-    "tags": ["love", "darkness", "food"],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 248,
-    "height": 30,
-    "weight": 0.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cherubat",
+  "category": "patu",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 13,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 16,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 28,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 31,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "platinum"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "love",
+    "darkness",
+    "food"
+  ],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 248,
+  "height": 30,
+  "weight": 0.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -1,71 +1,76 @@
 {
-    "slug": "chibiro",
-    "category": "false_turnip",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 13,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 19,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "cat_calling"
-        },
-        {
-            "level_learned": 37,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 40,
-            "technique": "clairaudience"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant", "ground"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 296,
-    "height": 36,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "chibiro",
+  "category": "false_turnip",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 13,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 19,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "cat_calling"
+    },
+    {
+      "level_learned": 37,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 40,
+      "technique": "clairaudience"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "ground"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 296,
+  "height": 36,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/chickadee.json
+++ b/mods/tuxemon/db/monster/chickadee.json
@@ -1,69 +1,77 @@
 {
-    "slug": "chickadee",
-    "category": "chickadee",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 4,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 13,
-            "technique": "egg_smash"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 15,
-            "monster_slug": "birdee"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "birdee",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["bird", "weak", "food"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 365,
-    "height": 12,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "chickadee",
+  "category": "chickadee",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 4,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 13,
+      "technique": "egg_smash"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 15,
+      "monster_slug": "birdee"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "birdee",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "weak",
+    "food"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 365,
+  "height": 12,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -1,65 +1,74 @@
 {
-    "slug": "chillimp",
-    "category": "frost_ape",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 4,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 13,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 40,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "snowrilla"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "snowrilla",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow", "mountains"],
-    "tags": ["ice", "fists"],
-    "shape": "brute",
-    "stage": "basic",
-    "types": [
-        "water",
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 154,
-    "height": 115,
-    "weight": 54,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "chillimp",
+  "category": "frost_ape",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 4,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 13,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 40,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "snowrilla"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "snowrilla",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "mountains"
+  ],
+  "tags": [
+    "ice",
+    "fists"
+  ],
+  "shape": "brute",
+  "stage": "basic",
+  "types": [
+    "water",
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 154,
+  "height": 115,
+  "weight": 54,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -1,88 +1,96 @@
 {
-    "slug": "chloragon",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flower_armor"
-        },
-        {
-            "level_learned": 4,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 16,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 55,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 61,
-            "technique": "flower_bloom"
-        },
-        {
-            "level_learned": 64,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 70,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "sapragon"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "sapragon",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "dragarbor",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["plant", "bite"],
-    "shape": "dragon",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 140,
-    "height": 102,
-    "weight": 85,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "chloragon",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flower_armor"
+    },
+    {
+      "level_learned": 4,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 16,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 55,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 61,
+      "technique": "flower_bloom"
+    },
+    {
+      "level_learned": 64,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 70,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "sapragon"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "sapragon",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "dragarbor",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "bite"
+  ],
+  "shape": "dragon",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 140,
+  "height": 102,
+  "weight": 85,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -1,70 +1,72 @@
 {
-    "slug": "chrome_robo",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 13,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 16,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 19,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 31,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 37,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ruby"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "chrome_robo",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 16,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 19,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 31,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 37,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ruby"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -1,104 +1,104 @@
 {
-    "slug": "chromeye",
-    "category": "mixed_emotion",
-    "moveset": [
-      {
-        "level_learned": 1,
-        "technique": "buzz"
-      },
-      {
-        "level_learned": 1,
-        "technique": "bullet"
-      },
-      {
-        "level_learned": 4,
-        "technique": "blade"
-      },
-      {
-        "level_learned": 7,
-        "technique": "strike"
-      },
-      {
-        "level_learned": 13,
-        "technique": "wall_of_steel"
-      }
-    ],
-    "evolutions": [
-      {
-        "at_level": 18,
-        "monster_slug": "angrito",
-        "variables": [
-          {
-            "season": "winter"
-          }
-        ]
-      },
-      {
-        "at_level": 18,
-        "monster_slug": "happito",
-        "variables": [
-          {
-            "season": "summer"
-          }
-        ]
-      },
-      {
-        "at_level": 18,
-        "monster_slug": "neutrito",
-        "variables": [
-          {
-            "season": "spring"
-          }
-        ]
-      },
-      {
-        "at_level": 18,
-        "monster_slug": "sadito",
-        "variables": [
-          {
-            "season": "autumn"
-          }
-        ]
-      }
-    ],
-    "history": [
-      {
-        "mon_slug": "sadito",
-        "evo_stage": "stage1"
-      },
-      {
-        "mon_slug": "neutrito",
-        "evo_stage": "stage1"
-      },
-      {
-        "mon_slug": "happito",
-        "evo_stage": "stage1"
-      },
-      {
-        "mon_slug": "angrito",
-        "evo_stage": "stage1"
-      }
-    ],
-    "terrains": [
-      "extraplanar",
-      "urban"
-    ],
-    "tags": [
-      "mental",
-      "machine"
-    ],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-      "metal"
-    ],
-    "possible_genders": [
-      "neuter"
-    ],
-    "txmn_id": 174,
-    "height": 38,
-    "weight": 3.5,
-    "catch_rate": 100,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
-  }
+  "slug": "chromeye",
+  "category": "mixed_emotion",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "angrito",
+      "variables": [
+        {
+          "season": "winter"
+        }
+      ]
+    },
+    {
+      "at_level": 18,
+      "monster_slug": "happito",
+      "variables": [
+        {
+          "season": "summer"
+        }
+      ]
+    },
+    {
+      "at_level": 18,
+      "monster_slug": "neutrito",
+      "variables": [
+        {
+          "season": "spring"
+        }
+      ]
+    },
+    {
+      "at_level": 18,
+      "monster_slug": "sadito",
+      "variables": [
+        {
+          "season": "autumn"
+        }
+      ]
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "sadito",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "neutrito",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "happito",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "angrito",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "extraplanar",
+    "urban"
+  ],
+  "tags": [
+    "mental",
+    "machine"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 174,
+  "height": 38,
+  "weight": 3.5,
+  "catch_rate": 100,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
+}

--- a/mods/tuxemon/db/monster/claymorior.json
+++ b/mods/tuxemon/db/monster/claymorior.json
@@ -1,85 +1,96 @@
 {
-    "slug": "claymorior",
-    "category": "terracotta",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 16,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 25,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 31,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 37,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 43,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 55,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "regalance",
-            "taste_warm": "hearty"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "regalance",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["soldier", "sharp", "ground", "rock", "gadgets"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 317,
-    "height": 150,
-    "weight": 112,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "claymorior",
+  "category": "terracotta",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 16,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 25,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 31,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 37,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 43,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 55,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "regalance",
+      "taste_warm": "hearty"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "regalance",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "soldier",
+    "sharp",
+    "ground",
+    "rock",
+    "gadgets"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 317,
+  "height": 150,
+  "weight": 112,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/coaldiak.json
+++ b/mods/tuxemon/db/monster/coaldiak.json
@@ -1,64 +1,71 @@
 {
-    "slug": "coaldiak",
-    "category": "ursus",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 7,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 28,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "furnursus",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "statursus",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["mountains"],
-    "tags": ["flame", "mental"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 359,
-    "height": 260,
-    "weight": 300,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "coaldiak",
+  "category": "ursus",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 7,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 28,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "furnursus",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "statursus",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "mental"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 359,
+  "height": 260,
+  "weight": 300,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/cobarett.json
+++ b/mods/tuxemon/db/monster/cobarett.json
@@ -1,68 +1,77 @@
 {
-    "slug": "cobarett",
-    "category": "comet_snake",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 4,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 10,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 31,
-            "technique": "oven"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "pythonova"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "hissiorite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "pythonova",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["flame", "toxic"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 323,
-    "height": 300,
-    "weight": 12,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cobarett",
+  "category": "comet_snake",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 4,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 10,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 31,
+      "technique": "oven"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "pythonova"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "hissiorite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "pythonova",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "flame",
+    "toxic"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 323,
+  "height": 300,
+  "weight": 12,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -1,70 +1,76 @@
 {
-    "slug": "cochini",
-    "category": "tasty",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 7,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 13,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 16,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lust"
-        },
-        {
-            "level_learned": 25,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 40,
-            "technique": "revenge_stance"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["food", "love"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 104,
-    "height": 80,
-    "weight": 15,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cochini",
+  "category": "tasty",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 7,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 13,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 16,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lust"
+    },
+    {
+      "level_learned": 25,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 40,
+      "technique": "revenge_stance"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "food",
+    "love"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 104,
+  "height": 80,
+  "weight": 15,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cocrune.json
+++ b/mods/tuxemon/db/monster/cocrune.json
@@ -1,68 +1,80 @@
 {
-    "slug": "cocrune",
-    "category": "diptera",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 19,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 16,
-            "monster_slug": "runesquito"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "stonifly",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "runesquito",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["freshwater", "ruins", "swamp"],
-    "tags": ["rock", "shielded", "bug", "summoner", "mental"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 333,
-    "height": 33,
-    "weight": 20,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cocrune",
+  "category": "diptera",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 19,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 16,
+      "monster_slug": "runesquito"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "stonifly",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "runesquito",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "ruins",
+    "swamp"
+  ],
+  "tags": [
+    "rock",
+    "shielded",
+    "bug",
+    "summoner",
+    "mental"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 333,
+  "height": 33,
+  "weight": 20,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/cohldrabi.json
+++ b/mods/tuxemon/db/monster/cohldrabi.json
@@ -1,77 +1,87 @@
 {
-    "slug": "cohldrabi",
-    "category": "frozen_produce",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 55,
-            "technique": "woodsmash"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 15,
-            "monster_slug": "lettice"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "lettice",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "frostuce",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["boreal_snow", "grassland", "woodland"],
-    "tags": ["plant", "ice"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "water", "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 382,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "cohldrabi",
+  "category": "frozen_produce",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 55,
+      "technique": "woodsmash"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 15,
+      "monster_slug": "lettice"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "lettice",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "frostuce",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ice"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 382,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -1,71 +1,82 @@
 {
-    "slug": "coleorus",
-    "category": "timeless",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 7,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "web"
-        },
-        {
-            "level_learned": 16,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 19,
-            "technique": "cat_calling"
-        },
-        {
-            "level_learned": 25,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 28,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "fester"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["desert", "grassland", "woodland"],
-    "tags": ["sharp", "rock", "bug"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "wood",
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 105,
-    "height": 39,
-    "weight": 6,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "coleorus",
+  "category": "timeless",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 7,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "web"
+    },
+    {
+      "level_learned": 16,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 19,
+      "technique": "cat_calling"
+    },
+    {
+      "level_learned": 25,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 28,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "fester"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "desert",
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "sharp",
+    "rock",
+    "bug"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 105,
+  "height": 39,
+  "weight": 6,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/conglolem.json
+++ b/mods/tuxemon/db/monster/conglolem.json
@@ -1,83 +1,91 @@
 {
-    "slug": "conglolem",
-    "category": "golem",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 16,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 19,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 28,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 52,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 55,
-            "technique": "thunderball"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "slichen",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "glombroc",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "rock", "ground", "toxic", "mental"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 274,
-    "height": 245,
-    "weight": 197,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "conglolem",
+  "category": "golem",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 16,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 19,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 28,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 52,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 55,
+      "technique": "thunderball"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "slichen",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "glombroc",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "rock",
+    "ground",
+    "toxic",
+    "mental"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 274,
+  "height": 245,
+  "weight": 197,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -1,71 +1,76 @@
 {
-    "slug": "conifrost",
-    "category": "taiga",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 7,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 13,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 16,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 19,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 25,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 28,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 31,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 37,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 43,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ice", "plant"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "water",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 106,
-    "height": 250,
-    "weight": 371,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "conifrost",
+  "category": "taiga",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 7,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 13,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 16,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 19,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 25,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 28,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 31,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 37,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 43,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ice",
+    "plant"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 106,
+  "height": 250,
+  "weight": 371,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -1,70 +1,76 @@
 {
-    "slug": "conileaf",
-    "category": "pitcher",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 25,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 28,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stabilo"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant", "food"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 148,
-    "height": 45,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "conileaf",
+  "category": "pitcher",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 25,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 28,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stabilo"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 148,
+  "height": 45,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/coppi.json
+++ b/mods/tuxemon/db/monster/coppi.json
@@ -1,81 +1,88 @@
 {
-    "slug": "coppi",
-    "category": "spinning_seed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "flower_bloom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stabilo"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "parappi"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "helipi",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "parappi",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["plant", "food"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 377,
-    "height": 50,
-    "weight": 12,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "coppi",
+  "category": "spinning_seed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "flower_bloom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stabilo"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "parappi"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "helipi",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "parappi",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 377,
+  "height": 50,
+  "weight": 12,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -1,70 +1,78 @@
 {
-    "slug": "coproblight",
-    "category": "skull_poo",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 4,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 7,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 16,
-            "technique": "cat_calling"
-        },
-        {
-            "level_learned": 19,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 25,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 28,
-            "technique": "cloud_aether"
-        },
-        {
-            "level_learned": 31,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 37,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 40,
-            "technique": "surge"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["shielded", "ground", "rock", "toxic"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 173,
-    "height": 45,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "coproblight",
+  "category": "skull_poo",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 4,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 7,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 16,
+      "technique": "cat_calling"
+    },
+    {
+      "level_learned": 19,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 25,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 28,
+      "technique": "cloud_aether"
+    },
+    {
+      "level_learned": 31,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 37,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 40,
+      "technique": "surge"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "shielded",
+    "ground",
+    "rock",
+    "toxic"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 173,
+  "height": 45,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -1,80 +1,92 @@
 {
-    "slug": "corvix",
-    "category": "horned_raptor",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 28,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_million_talons"
-        },
-        {
-            "level_learned": 43,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 46,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "gryfix"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "flacono",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "gryfix",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["desert", "grassland", "mountains", "woodland"],
-    "tags": ["bird", "sharp", "shielded"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 157,
-    "height": 55,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "corvix",
+  "category": "horned_raptor",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 28,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_million_talons"
+    },
+    {
+      "level_learned": 43,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 46,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "gryfix"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "flacono",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "gryfix",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "mountains",
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "sharp",
+    "shielded"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 157,
+  "height": 55,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -1,71 +1,82 @@
 {
-    "slug": "cowpignon",
-    "category": "enhancement",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fungal_spore"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 16,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 19,
-            "technique": "hallucinogen_spore"
-        },
-        {
-            "level_learned": 25,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 28,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 37,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 40,
-            "technique": "mind_explosion"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["grassland", "woodland"],
-    "tags": ["plant", "love", "mental", "food"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "wood",
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 107,
-    "height": 30.48,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "cowpignon",
+  "category": "enhancement",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fungal_spore"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 16,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 19,
+      "technique": "hallucinogen_spore"
+    },
+    {
+      "level_learned": 25,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 28,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 37,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 40,
+      "technique": "mind_explosion"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "love",
+    "mental",
+    "food"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "wood",
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 107,
+  "height": 30.48,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/crankus.json
+++ b/mods/tuxemon/db/monster/crankus.json
@@ -1,67 +1,78 @@
 {
-    "slug": "crankus",
-    "category": "cranky",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "font"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "caper",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["boreal_snow", "grassland", "mountains"],
-    "tags": ["ice", "fury", "megafauna"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 276,
-    "height": 180,
-    "weight": 102,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "crankus",
+  "category": "cranky",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "font"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "caper",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "grassland",
+    "mountains"
+  ],
+  "tags": [
+    "ice",
+    "fury",
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 276,
+  "height": 180,
+  "weight": 102,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -1,59 +1,67 @@
 {
-    "slug": "criniotherme",
-    "category": "mercury",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 7,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pantherafira",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame", "bite", "light", "darkness"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 246,
-    "height": 210,
-    "weight": 170,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "criniotherme",
+  "category": "mercury",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 7,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pantherafira",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame",
+    "bite",
+    "light",
+    "darkness"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 246,
+  "height": 210,
+  "weight": 170,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/crustagu.json
+++ b/mods/tuxemon/db/monster/crustagu.json
@@ -1,79 +1,90 @@
 {
-    "slug": "crustagu",
-    "category": "grandfather",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "font"
-        },
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 19,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 25,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 37,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 40,
-            "technique": "poison_courtship"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "lesmagu",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "shelagu",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "sea"],
-    "tags": ["pseudopod", "water", "shielded", "sharp"],
-    "shape": "polliwog",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 279,
-    "height": 90,
-    "weight": 45,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "crustagu",
+  "category": "grandfather",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "font"
+    },
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 19,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 25,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 37,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 40,
+      "technique": "poison_courtship"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "lesmagu",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "shelagu",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "sea"
+  ],
+  "tags": [
+    "pseudopod",
+    "water",
+    "shielded",
+    "sharp"
+  ],
+  "shape": "polliwog",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 279,
+  "height": 90,
+  "weight": 45,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -1,70 +1,72 @@
 {
-    "slug": "d0llf1n",
-    "category": "glitched",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_storm"
-        },
-        {
-            "level_learned": 31,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 40,
-            "technique": "proboscis"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "leviathan",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 25,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "d0llf1n",
+  "category": "glitched",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_storm"
+    },
+    {
+      "level_learned": 31,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 40,
+      "technique": "proboscis"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "leviathan",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 25,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -1,64 +1,70 @@
 {
-    "slug": "dandicub",
-    "category": "floret",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pollen_blast"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 25,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 28,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "dandylion"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "dandylion",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "bite"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 73,
-    "height": 46,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "dandicub",
+  "category": "floret",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pollen_blast"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 25,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 28,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "dandylion"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "dandylion",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "bite"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 73,
+  "height": 46,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -1,59 +1,66 @@
 {
-    "slug": "dandylion",
-    "category": "lions_tooth",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pollen_blast"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 25,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 28,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "dandicub",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "bite", "light"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 74,
-    "height": 138,
-    "weight": 45,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "dandylion",
+  "category": "lions_tooth",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pollen_blast"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 25,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 28,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "dandicub",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "bite",
+    "light"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 74,
+  "height": 138,
+  "weight": 45,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/dankush.json
+++ b/mods/tuxemon/db/monster/dankush.json
@@ -1,72 +1,82 @@
 {
-    "slug": "dankush",
-    "category": "zaza",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 16,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 19,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 25,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 40,
-            "technique": "mind_explosion"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["grassland"],
-    "tags": ["plant", "flame", "mental", "healing", "summoner"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 247,
-    "height": 40,
-    "weight": 0.5,
-    "randomly": false,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "dankush",
+  "category": "zaza",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 16,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 19,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 25,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 40,
+      "technique": "mind_explosion"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "grassland"
+  ],
+  "tags": [
+    "plant",
+    "flame",
+    "mental",
+    "healing",
+    "summoner"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 247,
+  "height": 40,
+  "weight": 0.5,
+  "randomly": false,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -1,70 +1,72 @@
 {
-    "slug": "dark_robo",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 16,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 19,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "gold_digger"
-        },
-        {
-            "level_learned": 31,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 37,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 40,
-            "technique": "undertaker"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "dark_robo",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 16,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 19,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "gold_digger"
+    },
+    {
+      "level_learned": 31,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 37,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 40,
+      "technique": "undertaker"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/delfeco.json
+++ b/mods/tuxemon/db/monster/delfeco.json
@@ -1,75 +1,86 @@
 {
-    "slug": "delfeco",
-    "category": "joyful_dolphin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 19,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 46,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 55,
-            "technique": "blossom"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "dollfin",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["water", "plant", "weather"],
-    "shape": "piscine",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 24,
-    "height": 200,
-    "weight": 150,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "delfeco",
+  "category": "joyful_dolphin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 19,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 46,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 55,
+      "technique": "blossom"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "dollfin",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "plant",
+    "weather"
+  ],
+  "shape": "piscine",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 24,
+  "height": 200,
+  "weight": 150,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -1,76 +1,86 @@
 {
-    "slug": "demosnow",
-    "category": "tempted",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 4,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 7,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 34,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 43,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 46,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 52,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "lucifice"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "waysprite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "lucifice",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["extraplanar"],
-    "tags": ["ice", "leadership", "weather", "darkness", "flame"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 264,
-    "height": 120,
-    "weight": 35,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "demosnow",
+  "category": "tempted",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 34,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 43,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 46,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 52,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "lucifice"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "waysprite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "lucifice",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "ice",
+    "leadership",
+    "weather",
+    "darkness",
+    "flame"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 264,
+  "height": 120,
+  "weight": 35,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/devidin.json
+++ b/mods/tuxemon/db/monster/devidin.json
@@ -1,76 +1,89 @@
 {
-    "slug": "devidin",
-    "category": "dog_toothed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 10,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 19,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 25,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 55,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "devidra"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "devidra",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "deviraptor",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "underground"],
-    "tags": ["ghost", "rock", "bite", "shapeshifter", "darkness"],
-    "shape": "landrace",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 292,
-    "height": 73,
-    "weight": 36,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "devidin",
+  "category": "dog_toothed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 10,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 19,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 25,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 55,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "devidra"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "devidra",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "deviraptor",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "underground"
+  ],
+  "tags": [
+    "ghost",
+    "rock",
+    "bite",
+    "shapeshifter",
+    "darkness"
+  ],
+  "shape": "landrace",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 292,
+  "height": 73,
+  "weight": 36,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/devidra.json
+++ b/mods/tuxemon/db/monster/devidra.json
@@ -1,76 +1,90 @@
 {
-    "slug": "devidra",
-    "category": "dog_toothed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 10,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 19,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 25,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 55,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "deviraptor"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "devidin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "deviraptor",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "underground"],
-    "tags": ["ghost", "rock", "bite", "shapeshifter", "darkness", "claws"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 293,
-    "height": 152,
-    "weight": 113,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "devidra",
+  "category": "dog_toothed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 10,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 19,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 25,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 55,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "deviraptor"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "devidin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "deviraptor",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "underground"
+  ],
+  "tags": [
+    "ghost",
+    "rock",
+    "bite",
+    "shapeshifter",
+    "darkness",
+    "claws"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 293,
+  "height": 152,
+  "weight": 113,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/deviraptor.json
+++ b/mods/tuxemon/db/monster/deviraptor.json
@@ -1,72 +1,86 @@
 {
-    "slug": "deviraptor",
-    "category": "dog_toothed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 10,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 19,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 25,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 55,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "devidin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "devidra",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "underground"],
-    "tags": ["ghost", "rock", "bite", "shapeshifter", "darkness", "claws"],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "earth",
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 294,
-    "height": 183,
-    "weight": 295,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "deviraptor",
+  "category": "dog_toothed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 10,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 19,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 25,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 55,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "devidin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "devidra",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "underground"
+  ],
+  "tags": [
+    "ghost",
+    "rock",
+    "bite",
+    "shapeshifter",
+    "darkness",
+    "claws"
+  ],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "earth",
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 294,
+  "height": 183,
+  "weight": 295,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -1,70 +1,76 @@
 {
-    "slug": "dinoflop",
-    "category": "volte-face",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 7,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 19,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 25,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 28,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 37,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stonehenge"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["sharp", "shielded"],
-    "shape": "dragon",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 166,
-    "height": 120,
-    "weight": 120,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "dinoflop",
+  "category": "volte-face",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 7,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 19,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 25,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 28,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 37,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stonehenge"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "sharp",
+    "shielded"
+  ],
+  "shape": "dragon",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 166,
+  "height": 120,
+  "weight": 120,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -1,74 +1,83 @@
 {
-    "slug": "djinnbo",
-    "category": "vengeance",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 7,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 13,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 16,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 25,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 28,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 37,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraplanar", "ruins"],
-    "tags": ["flame", "ghost", "fury"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 108,
-    "height": 160,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "djinnbo",
+  "category": "vengeance",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 7,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 13,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 16,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 25,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 28,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 37,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraplanar",
+    "ruins"
+  ],
+  "tags": [
+    "flame",
+    "ghost",
+    "fury"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 108,
+  "height": 160,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/doctsky.json
+++ b/mods/tuxemon/db/monster/doctsky.json
@@ -1,92 +1,102 @@
 {
-    "slug": "doctsky",
-    "category": "erythrocyte",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "barking"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 7,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mystic_blending"
-        },
-        {
-            "level_learned": 19,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "saber"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "askylpaws",
-            "item": "ox_stick"
-        },
-        {
-            "monster_slug": "erythroskyte",
-            "item": "peace_lily"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "medipup",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "askylpaws",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "erythroskyte",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["healing", "bite", "darkness", "gadgets"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 282,
-    "height": 94,
-    "weight": 30,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "doctsky",
+  "category": "erythrocyte",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "barking"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 7,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mystic_blending"
+    },
+    {
+      "level_learned": 19,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "saber"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "askylpaws",
+      "item": "ox_stick"
+    },
+    {
+      "monster_slug": "erythroskyte",
+      "item": "peace_lily"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "medipup",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "askylpaws",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "erythroskyte",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "healing",
+    "bite",
+    "darkness",
+    "gadgets"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 282,
+  "height": 94,
+  "weight": 30,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -1,76 +1,85 @@
 {
-    "slug": "dollfin",
-    "category": "joyful",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "bigfin",
-            "item": "water_booster"
-        },
-        {
-            "monster_slug": "bigfin",
-            "item": "sweet_sand"
-        },
-        {
-            "monster_slug": "sharpfin",
-            "item": "metal_booster"
-        },
-        {
-            "monster_slug": "sharpfin",
-            "item": "sea_girdle"
-        },
-        {
-            "monster_slug": "delfeco",
-            "bond": "equals:100"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "bigfin",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "sharpfin",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "delfeco",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["water"],
-    "shape": "leviathan",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 23,
-    "height": 250,
-    "weight": 190,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "dollfin",
+  "category": "joyful",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "bigfin",
+      "item": "water_booster"
+    },
+    {
+      "monster_slug": "bigfin",
+      "item": "sweet_sand"
+    },
+    {
+      "monster_slug": "sharpfin",
+      "item": "metal_booster"
+    },
+    {
+      "monster_slug": "sharpfin",
+      "item": "sea_girdle"
+    },
+    {
+      "monster_slug": "delfeco",
+      "bond": "equals:100"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "bigfin",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "sharpfin",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "delfeco",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "water"
+  ],
+  "shape": "leviathan",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 23,
+  "height": 250,
+  "weight": 190,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -1,80 +1,88 @@
 {
-    "slug": "dracune",
-    "category": "cloaked",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 4,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 13,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 16,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 25,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 12,
-            "monster_slug": "fluttaflap"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "vamporm",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "fluttaflap",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "healing", "bug", "darkness"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 37,
-    "height": 35,
-    "weight": 3.5,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "dracune",
+  "category": "cloaked",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 4,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 13,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 16,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 25,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 12,
+      "monster_slug": "fluttaflap"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "vamporm",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "fluttaflap",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "healing",
+    "bug",
+    "darkness"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 37,
+  "height": 35,
+  "weight": 3.5,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -1,83 +1,92 @@
 {
-    "slug": "dragarbor",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flower_armor"
-        },
-        {
-            "level_learned": 4,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 16,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 55,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 61,
-            "technique": "flower_bloom"
-        },
-        {
-            "level_learned": 64,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 70,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chloragon",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "sapragon",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["plant", "bite", "sharp"],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 142,
-    "height": 397,
-    "weight": 336,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "dragarbor",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flower_armor"
+    },
+    {
+      "level_learned": 4,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 16,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 55,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 61,
+      "technique": "flower_bloom"
+    },
+    {
+      "level_learned": 64,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 70,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chloragon",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "sapragon",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "bite",
+    "sharp"
+  ],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 142,
+  "height": 397,
+  "weight": 336,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -1,82 +1,90 @@
 {
-    "slug": "drashimi",
-    "category": "dragon_roll",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "font"
-        },
-        {
-            "level_learned": 31,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 43,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 46,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "tsushimi"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "tsushimi",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "tobishimi",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["sea", "urban"],
-    "tags": ["food", "celestial"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 185,
-    "height": 38,
-    "weight": 12,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "drashimi",
+  "category": "dragon_roll",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "font"
+    },
+    {
+      "level_learned": 31,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 43,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 46,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "tsushimi"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "tsushimi",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "tobishimi",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "sea",
+    "urban"
+  ],
+  "tags": [
+    "food",
+    "celestial"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 185,
+  "height": 38,
+  "weight": 12,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -1,74 +1,81 @@
 {
-    "slug": "drokoro",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 13,
-            "technique": "firestorm"
-        },
-        {
-            "level_learned": 16,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 19,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 31,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["flame", "bite", "fury"],
-    "shape": "dragon",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 145,
-    "height": 1200,
-    "weight": 10000,
-    "catch_rate": 5.0,
-    "lower_catch_resistance": 0.8,
-    "upper_catch_resistance": 1.05
+  "slug": "drokoro",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 13,
+      "technique": "firestorm"
+    },
+    {
+      "level_learned": 16,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 19,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 31,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "flame",
+    "bite",
+    "fury"
+  ],
+  "shape": "dragon",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 145,
+  "height": 1200,
+  "weight": 10000,
+  "catch_rate": 5.0,
+  "lower_catch_resistance": 0.8,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/duggot.json
+++ b/mods/tuxemon/db/monster/duggot.json
@@ -1,49 +1,58 @@
 {
-    "slug": "duggot",
-    "category": "unwelcome_mouthful",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 10,
-            "technique": "poison_courtship"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "breem",
-            "party": ["tumbleworm"]
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "breem",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "toxic", "bug"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "earth",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 343,
-    "height": 12,
-    "weight": 0.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "duggot",
+  "category": "unwelcome_mouthful",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 10,
+      "technique": "poison_courtship"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "breem",
+      "party": [
+        "tumbleworm"
+      ]
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "breem",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "toxic",
+    "bug"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "earth",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 343,
+  "height": 12,
+  "weight": 0.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -1,70 +1,76 @@
 {
-    "slug": "dune_pincher",
-    "category": "hermit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 7,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 19,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 25,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 28,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 31,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 37,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 40,
-            "technique": "goad"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ground", "sharp"],
-    "shape": "grub",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 109,
-    "height": 37,
-    "weight": 7,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "dune_pincher",
+  "category": "hermit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 7,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 19,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 25,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 28,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 31,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 37,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 40,
+      "technique": "goad"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "sharp"
+  ],
+  "shape": "grub",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 109,
+  "height": 37,
+  "weight": 7,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -1,79 +1,91 @@
 {
-    "slug": "eaglace",
-    "category": "cirrus",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 31,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 34,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 43,
-            "technique": "font"
-        },
-        {
-            "level_learned": 46,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 52,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 61,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tweesher",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "heronquak",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow", "grassland", "mountains"],
-    "tags": ["gemstone", "ice", "bird", "weather"],
-    "shape": "flier",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 9,
-    "height": 150,
-    "weight": 36,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "eaglace",
+  "category": "cirrus",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 31,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 34,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 43,
+      "technique": "font"
+    },
+    {
+      "level_learned": 46,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 52,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 61,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tweesher",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "heronquak",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "grassland",
+    "mountains"
+  ],
+  "tags": [
+    "gemstone",
+    "ice",
+    "bird",
+    "weather"
+  ],
+  "shape": "flier",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 9,
+  "height": 150,
+  "weight": 36,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -1,80 +1,89 @@
 {
-    "slug": "elofly",
-    "category": "cloudburst",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 25,
-            "technique": "altitude"
-        },
-        {
-            "level_learned": 28,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 43,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 52,
-            "technique": "one_million_talons"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "elowind"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "elowind",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "elostorm",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["bird"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 39,
-    "height": 75,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "elofly",
+  "category": "cloudburst",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 25,
+      "technique": "altitude"
+    },
+    {
+      "level_learned": 28,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 43,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 52,
+      "technique": "one_million_talons"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "elowind"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "elowind",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "elostorm",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 39,
+  "height": 75,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -1,75 +1,85 @@
 {
-    "slug": "elostorm",
-    "category": "cloudburst",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 25,
-            "technique": "altitude"
-        },
-        {
-            "level_learned": 28,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 43,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 52,
-            "technique": "one_million_talons"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "elofly",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "elowind",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["bird", "weather"],
-    "shape": "flier",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 41,
-    "height": 144,
-    "weight": 25,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "elostorm",
+  "category": "cloudburst",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 25,
+      "technique": "altitude"
+    },
+    {
+      "level_learned": 28,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 43,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 52,
+      "technique": "one_million_talons"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "elofly",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "elowind",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "weather"
+  ],
+  "shape": "flier",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 41,
+  "height": 144,
+  "weight": 25,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -1,80 +1,90 @@
 {
-    "slug": "elowind",
-    "category": "cloudburst",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 25,
-            "technique": "altitude"
-        },
-        {
-            "level_learned": 28,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 43,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 52,
-            "technique": "one_million_talons"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 42,
-            "monster_slug": "elostorm"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "elofly",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "elostorm",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["bird", "leadership"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 40,
-    "height": 115,
-    "weight": 15,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "elowind",
+  "category": "cloudburst",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 25,
+      "technique": "altitude"
+    },
+    {
+      "level_learned": 28,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 43,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 52,
+      "technique": "one_million_talons"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 42,
+      "monster_slug": "elostorm"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "elofly",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "elostorm",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "leadership"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 40,
+  "height": 115,
+  "weight": 15,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -1,60 +1,73 @@
 {
-    "slug": "embazook",
-    "category": "gunner",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 13,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 16,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 19,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "ignibus",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "mountains"],
-    "tags": ["flame", "rock", "bite", "bomber", "soldier", "gadgets"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "fire",
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 31,
-    "height": 137,
-    "weight": 502,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "embazook",
+  "category": "gunner",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 13,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 16,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 19,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "ignibus",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "rock",
+    "bite",
+    "bomber",
+    "soldier",
+    "gadgets"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "fire",
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 31,
+  "height": 137,
+  "weight": 502,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -1,80 +1,85 @@
 {
-    "slug": "embra",
-    "category": "flicker",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 7,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 13,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 16,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 19,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 28,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 31,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "ruption"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "ruption",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 75,
-    "height": 48,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "embra",
+  "category": "flicker",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 7,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 13,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 16,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 19,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 28,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 31,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "ruption"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "ruption",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 75,
+  "height": 48,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -1,74 +1,80 @@
 {
-    "slug": "enduros",
-    "category": "defensive",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 4,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 16,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 25,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 28,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 31,
-            "technique": "pit"
-        },
-        {
-            "level_learned": 37,
-            "technique": "rocky_barrage"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 55,
-            "technique": "give_all"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["shielded", "fists"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 167,
-    "height": 170,
-    "weight": 65,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "enduros",
+  "category": "defensive",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 4,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 16,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 25,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 28,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 31,
+      "technique": "pit"
+    },
+    {
+      "level_learned": 37,
+      "technique": "rocky_barrage"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 55,
+      "technique": "give_all"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "shielded",
+    "fists"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 167,
+  "height": 170,
+  "weight": 65,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/equill.json
+++ b/mods/tuxemon/db/monster/equill.json
@@ -1,64 +1,71 @@
 {
-    "slug": "equill",
-    "category": "cave_dweller",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 19,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 55,
-            "monster_slug": "hoarseshoo"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "hoarse",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "hoarseshoo",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["megafauna", "darkness", "toxic"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 310,
-    "height": 160,
-    "weight": 500,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "equill",
+  "category": "cave_dweller",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 19,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 55,
+      "monster_slug": "hoarseshoo"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "hoarse",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "hoarseshoo",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "megafauna",
+    "darkness",
+    "toxic"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 310,
+  "height": 160,
+  "weight": 500,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -1,59 +1,71 @@
 {
-    "slug": "eruptibus",
-    "category": "hot_rock",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 13,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 16,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 19,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 25,
-            "technique": "energy_field"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "ignibus",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "mountains"],
-    "tags": ["flame", "bite", "rock", "bomber", "calamity"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 32,
-    "height": 600,
-    "weight": 12000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "eruptibus",
+  "category": "hot_rock",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 13,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 16,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 19,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 25,
+      "technique": "energy_field"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "ignibus",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "bite",
+    "rock",
+    "bomber",
+    "calamity"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 32,
+  "height": 600,
+  "weight": 12000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/erythroskyte.json
+++ b/mods/tuxemon/db/monster/erythroskyte.json
@@ -1,84 +1,95 @@
 {
-    "slug": "erythroskyte",
-    "category": "erythrocyte",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "barking"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 7,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mystic_blending"
-        },
-        {
-            "level_learned": 19,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "medipup",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "doctsky",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban", "grassland"],
-    "tags": ["healing", "gadgets", "bite", "love", "steel"],
-    "shape": "hunter",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 361,
-    "height": 200,
-    "weight": 70,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "erythroskyte",
+  "category": "erythrocyte",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "barking"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 7,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mystic_blending"
+    },
+    {
+      "level_learned": 19,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "medipup",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "doctsky",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban",
+    "grassland"
+  ],
+  "tags": [
+    "healing",
+    "gadgets",
+    "bite",
+    "love",
+    "steel"
+  ],
+  "shape": "hunter",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 361,
+  "height": 200,
+  "weight": 70,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/eskipup.json
+++ b/mods/tuxemon/db/monster/eskipup.json
@@ -1,52 +1,60 @@
 {
-    "slug": "eskipup",
-    "category": "frosty",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 4,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 10,
-            "technique": "ice_storm"
-        },
-        {
-            "level_learned": 19,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "houndice"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "houndice",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow"],
-    "tags": ["ice", "bite"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 327,
-    "height": 56,
-    "weight": 24,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "eskipup",
+  "category": "frosty",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 4,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 10,
+      "technique": "ice_storm"
+    },
+    {
+      "level_learned": 19,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "houndice"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "houndice",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow"
+  ],
+  "tags": [
+    "ice",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 327,
+  "height": 56,
+  "weight": 24,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -1,59 +1,65 @@
 {
-    "slug": "exapode",
-    "category": "big_frightfear",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chenipode",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug", "mental"],
-    "shape": "grub",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 347,
-    "height": 44,
-    "weight": 5,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "exapode",
+  "category": "big_frightfear",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chenipode",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug",
+    "mental"
+  ],
+  "shape": "grub",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 347,
+  "height": 44,
+  "weight": 5,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -1,64 +1,72 @@
 {
-    "slug": "exclawvate",
-    "category": "digger",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 4,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "boltnu",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "steel", "machine", "megafauna", "gadgets"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 195,
-    "height": 213,
-    "weight": 1000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "exclawvate",
+  "category": "digger",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 4,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "boltnu",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "steel",
+    "machine",
+    "megafauna",
+    "gadgets"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 195,
+  "height": 213,
+  "weight": 1000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -1,68 +1,74 @@
 {
-    "slug": "eyenemy",
-    "category": "pupil",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 4,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 28,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 31,
-            "technique": "dreamwalk"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "eyesore"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "eyesore",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["gaze", "mental"],
-    "shape": "serpent",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 46,
-    "height": 104,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "eyenemy",
+  "category": "pupil",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 4,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 28,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 31,
+      "technique": "dreamwalk"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "eyesore"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "eyesore",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "gaze",
+    "mental"
+  ],
+  "shape": "serpent",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 46,
+  "height": 104,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -1,63 +1,69 @@
 {
-    "slug": "eyesore",
-    "category": "overseer",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 4,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 28,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 31,
-            "technique": "dreamwalk"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "eyenemy",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["gaze", "mental"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 47,
-    "height": 135,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "eyesore",
+  "category": "overseer",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 4,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 28,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 31,
+      "technique": "dreamwalk"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "eyenemy",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "gaze",
+    "mental"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 47,
+  "height": 135,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -1,70 +1,72 @@
 {
-    "slug": "f7u1t3ra",
-    "category": "glitched",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 19,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 25,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 28,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 31,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 37,
-            "technique": "feline"
-        },
-        {
-            "level_learned": 40,
-            "technique": "blossom"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 25,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "f7u1t3ra",
+  "category": "glitched",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 19,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 25,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 28,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 31,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 37,
+      "technique": "feline"
+    },
+    {
+      "level_learned": 40,
+      "technique": "blossom"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 25,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -1,60 +1,69 @@
 {
-    "slug": "fancair",
-    "category": "deadly_fan",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "windeye"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "windeye",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "weather", "electricity", "steel", "sharp"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 179,
-    "height": 45,
-    "weight": 18,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "fancair",
+  "category": "deadly_fan",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "windeye"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "windeye",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "weather",
+    "electricity",
+    "steel",
+    "sharp"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 179,
+  "height": 45,
+  "weight": 18,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -1,80 +1,90 @@
 {
-    "slug": "ferricran",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 40,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 43,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 46,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 61,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 64,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 70,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "wrougon",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "allagon",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["ruins", "underground"],
-    "tags": ["steel", "soldier", "sharp", "tail"],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 161,
-    "height": 230,
-    "weight": 214,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "ferricran",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 40,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 43,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 46,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 61,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 64,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 70,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "wrougon",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "allagon",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "underground"
+  ],
+  "tags": [
+    "steel",
+    "soldier",
+    "sharp",
+    "tail"
+  ],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 161,
+  "height": 230,
+  "weight": 214,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/firomenis.json
+++ b/mods/tuxemon/db/monster/firomenis.json
@@ -1,71 +1,78 @@
 {
-    "slug": "firomenis",
-    "category": "dragon_moth",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 16,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 25,
-            "technique": "webs_wind"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 31,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 37,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 40,
-            "technique": "battery_acid"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "merlicun",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug", "bite", "bird"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 210,
-    "height": 183,
-    "weight": 30,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "firomenis",
+  "category": "dragon_moth",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 16,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 25,
+      "technique": "webs_wind"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 31,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 37,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 40,
+      "technique": "battery_acid"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "merlicun",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug",
+    "bite",
+    "bird"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 210,
+  "height": 183,
+  "weight": 30,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -1,80 +1,91 @@
 {
-    "slug": "flacono",
-    "category": "horned_raptor",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 28,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_million_talons"
-        },
-        {
-            "level_learned": 43,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 46,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "corvix"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "corvix",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "gryfix",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["desert", "grassland", "mountains", "woodland"],
-    "tags": ["bird", "sharp"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 156,
-    "height": 70,
-    "weight": 6,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "flacono",
+  "category": "horned_raptor",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 28,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_million_talons"
+    },
+    {
+      "level_learned": 43,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 46,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "corvix"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "corvix",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "gryfix",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "mountains",
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "sharp"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 156,
+  "height": 70,
+  "weight": 6,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -1,63 +1,73 @@
 {
-    "slug": "flambear",
-    "category": "too_hot",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 7,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 16,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 37,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 40,
-            "technique": "pyrokinesis"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "bursa",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["mountains", "woodland"],
-    "tags": ["mental", "flame", "food"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 84,
-    "height": 250,
-    "weight": 500,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "flambear",
+  "category": "too_hot",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 7,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 16,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 37,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 40,
+      "technique": "pyrokinesis"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "bursa",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "woodland"
+  ],
+  "tags": [
+    "mental",
+    "flame",
+    "food"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 84,
+  "height": 250,
+  "weight": 500,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flisces.json
+++ b/mods/tuxemon/db/monster/flisces.json
@@ -1,70 +1,79 @@
 {
-    "slug": "flisces",
-    "category": "cypselurus",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 13,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 16,
-            "technique": "blood_bond"
-        },
-        {
-            "level_learned": 19,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 31,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 37,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "sea"],
-    "tags": ["bird", "water"],
-    "shape": "piscine",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 238,
-    "height": 28,
-    "weight": 1.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "flisces",
+  "category": "cypselurus",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 13,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 16,
+      "technique": "blood_bond"
+    },
+    {
+      "level_learned": 19,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 31,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 37,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "sea"
+  ],
+  "tags": [
+    "bird",
+    "water"
+  ],
+  "shape": "piscine",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 238,
+  "height": 28,
+  "weight": 1.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/flounce.json
+++ b/mods/tuxemon/db/monster/flounce.json
@@ -1,72 +1,79 @@
 {
-    "slug": "flounce",
-    "category": "firestarter",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 4,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 16,
-            "technique": "diet"
-        },
-        {
-            "level_learned": 25,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 28,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 31,
-            "technique": "oven"
-        },
-        {
-            "level_learned": 37,
-            "technique": "magnetic_body"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "knindling"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "knindling",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame", "bite", "electricity"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 329,
-    "height": 49,
-    "weight": 22,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "flounce",
+  "category": "firestarter",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 4,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 16,
+      "technique": "diet"
+    },
+    {
+      "level_learned": 25,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 28,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 31,
+      "technique": "oven"
+    },
+    {
+      "level_learned": 37,
+      "technique": "magnetic_body"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "knindling"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "knindling",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame",
+    "bite",
+    "electricity"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 329,
+  "height": 49,
+  "weight": 22,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/flummack.json
+++ b/mods/tuxemon/db/monster/flummack.json
@@ -1,75 +1,83 @@
 {
-    "slug": "flummack",
-    "category": "cannibal_cake",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "food_fight"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lick_lash"
-        },
-        {
-            "level_learned": 10,
-            "technique": "piece_of_cake"
-        },
-        {
-            "level_learned": 13,
-            "technique": "egg_smash"
-        },
-        {
-            "level_learned": 16,
-            "technique": "potluck"
-        },
-        {
-            "level_learned": 19,
-            "technique": "diet"
-        },
-        {
-            "level_learned": 25,
-            "technique": "just_desserts"
-        },
-        {
-            "level_learned": 28,
-            "technique": "gourmet"
-        },
-        {
-            "level_learned": 31,
-            "technique": "oven"
-        },
-        {
-            "level_learned": 37,
-            "technique": "heavenly_desserts"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "flummby",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban", "other"],
-    "tags": ["food", "soldier"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 308,
-    "height": 90,
-    "weight": 50,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "flummack",
+  "category": "cannibal_cake",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "food_fight"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lick_lash"
+    },
+    {
+      "level_learned": 10,
+      "technique": "piece_of_cake"
+    },
+    {
+      "level_learned": 13,
+      "technique": "egg_smash"
+    },
+    {
+      "level_learned": 16,
+      "technique": "potluck"
+    },
+    {
+      "level_learned": 19,
+      "technique": "diet"
+    },
+    {
+      "level_learned": 25,
+      "technique": "just_desserts"
+    },
+    {
+      "level_learned": 28,
+      "technique": "gourmet"
+    },
+    {
+      "level_learned": 31,
+      "technique": "oven"
+    },
+    {
+      "level_learned": 37,
+      "technique": "heavenly_desserts"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "flummby",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban",
+    "other"
+  ],
+  "tags": [
+    "food",
+    "soldier"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 308,
+  "height": 90,
+  "weight": 50,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/flummby.json
+++ b/mods/tuxemon/db/monster/flummby.json
@@ -1,81 +1,89 @@
 {
-    "slug": "flummby",
-    "category": "pastry",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "food_fight"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lick_lash"
-        },
-        {
-            "level_learned": 10,
-            "technique": "piece_of_cake"
-        },
-        {
-            "level_learned": 13,
-            "technique": "egg_smash"
-        },
-        {
-            "level_learned": 16,
-            "technique": "potluck"
-        },
-        {
-            "level_learned": 19,
-            "technique": "diet"
-        },
-        {
-            "level_learned": 25,
-            "technique": "just_desserts"
-        },
-        {
-            "level_learned": 28,
-            "technique": "gourmet"
-        },
-        {
-            "level_learned": 31,
-            "technique": "oven"
-        },
-        {
-            "level_learned": 37,
-            "technique": "heavenly_desserts"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "flummack",
-            "item": "lima_pie"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "flummack",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban", "other"],
-    "tags": ["food", "soldier"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 307,
-    "height": 90,
-    "weight": 50,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "flummby",
+  "category": "pastry",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "food_fight"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lick_lash"
+    },
+    {
+      "level_learned": 10,
+      "technique": "piece_of_cake"
+    },
+    {
+      "level_learned": 13,
+      "technique": "egg_smash"
+    },
+    {
+      "level_learned": 16,
+      "technique": "potluck"
+    },
+    {
+      "level_learned": 19,
+      "technique": "diet"
+    },
+    {
+      "level_learned": 25,
+      "technique": "just_desserts"
+    },
+    {
+      "level_learned": 28,
+      "technique": "gourmet"
+    },
+    {
+      "level_learned": 31,
+      "technique": "oven"
+    },
+    {
+      "level_learned": 37,
+      "technique": "heavenly_desserts"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "flummack",
+      "item": "lima_pie"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "flummack",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban",
+    "other"
+  ],
+  "tags": [
+    "food",
+    "soldier"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 307,
+  "height": 90,
+  "weight": 50,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -1,80 +1,88 @@
 {
-    "slug": "fluoresfin",
-    "category": "light_fin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 7,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 13,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 28,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 40,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 43,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 46,
-            "technique": "proboscis"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "incandesfin"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "incandesfin",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "lightmare",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["water", "light"],
-    "shape": "piscine",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 68,
-    "height": 80,
-    "weight": 11,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "fluoresfin",
+  "category": "light_fin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 7,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 13,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 28,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 40,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 43,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 46,
+      "technique": "proboscis"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "incandesfin"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "incandesfin",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "lightmare",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "light"
+  ],
+  "shape": "piscine",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 68,
+  "height": 80,
+  "weight": 11,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -1,75 +1,83 @@
 {
-    "slug": "fluttaflap",
-    "category": "sanguine",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 4,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 13,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 16,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 25,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vamporm",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "dracune",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "healing", "bug", "darkness"],
-    "shape": "grub",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 38,
-    "height": 47,
-    "weight": 7,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "fluttaflap",
+  "category": "sanguine",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 4,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 13,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 16,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 25,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vamporm",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "dracune",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "healing",
+    "bug",
+    "darkness"
+  ],
+  "shape": "grub",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 38,
+  "height": 47,
+  "weight": 7,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -1,70 +1,75 @@
 {
-    "slug": "foofle",
-    "category": "woolly",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lust"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 16,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 19,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 25,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 28,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 31,
-            "technique": "mystic_blending"
-        },
-        {
-            "level_learned": 37,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stonehenge"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["love"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 110,
-    "height": 53,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "foofle",
+  "category": "woolly",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lust"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 16,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 19,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 25,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 28,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 31,
+      "technique": "mystic_blending"
+    },
+    {
+      "level_learned": 37,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stonehenge"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "love"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 110,
+  "height": 53,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -1,81 +1,90 @@
 {
-    "slug": "fordin",
-    "category": "petrified",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spiky_strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 16,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "trample"
-        },
-        {
-            "level_learned": 31,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 40,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "stegofor"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "stegofor",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "brachifor",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "shielded", "healing"],
-    "shape": "leviathan",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 211,
-    "height": 56,
-    "weight": 19,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "fordin",
+  "category": "petrified",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spiky_strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 16,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "trample"
+    },
+    {
+      "level_learned": 31,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 40,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "stegofor"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "stegofor",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "brachifor",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "shielded",
+    "healing"
+  ],
+  "shape": "leviathan",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 211,
+  "height": 56,
+  "weight": 19,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -1,68 +1,79 @@
 {
-    "slug": "forturtle",
-    "category": "oracle_bone",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 4,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 19,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 28,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "prophetoise"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "prophetoise",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert", "jungle", "ruins"],
-    "tags": ["flame", "mental", "staff"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 87,
-    "height": 85,
-    "weight": 55,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "forturtle",
+  "category": "oracle_bone",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 4,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 19,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 28,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "prophetoise"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "prophetoise",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "jungle",
+    "ruins"
+  ],
+  "tags": [
+    "flame",
+    "mental",
+    "staff"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 87,
+  "height": 85,
+  "weight": 55,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -1,80 +1,87 @@
 {
-    "slug": "foxfire",
-    "category": "smoke",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 7,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 16,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 25,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 28,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 31,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "vulpyre"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "vulpyre",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame", "calamity", "claws"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 149,
-    "height": 41,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "foxfire",
+  "category": "smoke",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 7,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 16,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 25,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 28,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 31,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "vulpyre"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "vulpyre",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame",
+    "calamity",
+    "claws"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 149,
+  "height": 41,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/foxko.json
+++ b/mods/tuxemon/db/monster/foxko.json
@@ -1,71 +1,73 @@
 {
-    "slug": "foxko",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 4,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 16,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 19,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 25,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 28,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "conjurer"
-        },
-        {
-            "level_learned": 37,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 40,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "serpent",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 71,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "foxko",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 4,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 16,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 19,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 25,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 28,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "conjurer"
+    },
+    {
+      "level_learned": 37,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 40,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "serpent",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 71,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/fribbit.json
+++ b/mods/tuxemon/db/monster/fribbit.json
@@ -1,67 +1,73 @@
 {
-    "slug": "fribbit",
-    "category": "rueful",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "font"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tadcool",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ice", "ghost"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 269,
-    "height": 50,
-    "weight": 20,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "fribbit",
+  "category": "rueful",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "font"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tadcool",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ice",
+    "ghost"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 269,
+  "height": 50,
+  "weight": 20,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -1,67 +1,79 @@
 {
-    "slug": "frondly",
-    "category": "helping_hand",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "budaye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["plant", "leadership", "food", "love", "pseudopod", "tail"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 29,
-    "height": 160,
-    "weight": 60,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.8,
-    "upper_catch_resistance": 1.05
+  "slug": "frondly",
+  "category": "helping_hand",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "budaye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "leadership",
+    "food",
+    "love",
+    "pseudopod",
+    "tail"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 29,
+  "height": 160,
+  "weight": 60,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.8,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/frostuce.json
+++ b/mods/tuxemon/db/monster/frostuce.json
@@ -1,72 +1,80 @@
 {
-    "slug": "frostuce",
-    "category": "freezerburn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 55,
-            "technique": "woodsmash"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "cohldrabi",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "lettice",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow"],
-    "tags": ["plant", "ice"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "water", "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 384,
-    "height": 100,
-    "weight": 18,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "frostuce",
+  "category": "freezerburn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 55,
+      "technique": "woodsmash"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "cohldrabi",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "lettice",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow"
+  ],
+  "tags": [
+    "plant",
+    "ice"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 384,
+  "height": 100,
+  "weight": 18,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -1,84 +1,90 @@
 {
-    "slug": "fruitera",
-    "category": "tiny_bat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 16,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 40,
-            "technique": "clairaudience"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "megafruitera"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "megafruitera",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "spectera",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "food"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 169,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "fruitera",
+  "category": "tiny_bat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 16,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 40,
+      "technique": "clairaudience"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "megafruitera"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "megafruitera",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "spectera",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 169,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -1,69 +1,73 @@
 {
-    "slug": "furnursus",
-    "category": "fireplace",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 7,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 28,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tinder"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "statursus"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "statursus",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "coaldiak",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 190,
-    "height": 110,
-    "weight": 47,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "furnursus",
+  "category": "fireplace",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 7,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 28,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tinder"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "statursus"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "statursus",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "coaldiak",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 190,
+  "height": 110,
+  "weight": 47,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/fuzzina.json
+++ b/mods/tuxemon/db/monster/fuzzina.json
@@ -1,75 +1,82 @@
 {
-    "slug": "fuzzina",
-    "category": "toy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 16,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 19,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 40,
-            "technique": "pit"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "fuzzlet",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ghost", "love", "healing", "soldier"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 237,
-    "height": 50,
-    "weight": 1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "fuzzina",
+  "category": "toy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 16,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 19,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 40,
+      "technique": "pit"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "fuzzlet",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ghost",
+    "love",
+    "healing",
+    "soldier"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 237,
+  "height": 50,
+  "weight": 1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -1,80 +1,87 @@
 {
-    "slug": "fuzzlet",
-    "category": "toy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 16,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 19,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 40,
-            "technique": "pit"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "fuzzina"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "fuzzina",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ghost", "love", "healing", "soldier"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 236,
-    "height": 33,
-    "weight": 0.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "fuzzlet",
+  "category": "toy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 16,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 19,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 40,
+      "technique": "pit"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "fuzzina"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "fuzzina",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ghost",
+    "love",
+    "healing",
+    "soldier"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 236,
+  "height": 33,
+  "weight": 0.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/galasces.json
+++ b/mods/tuxemon/db/monster/galasces.json
@@ -1,57 +1,66 @@
 {
-    "slug": "galasces",
-    "category": "sea_angel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 10,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "spit_poison"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "novaquarius"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "nebufin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "novaquarius",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["celestial", "water", "toxic", "gemstone"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 320,
-    "height": 60,
-    "weight": 30,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "galasces",
+  "category": "sea_angel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 10,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "spit_poison"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "novaquarius"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "nebufin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "novaquarius",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "celestial",
+    "water",
+    "toxic",
+    "gemstone"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 320,
+  "height": 60,
+  "weight": 30,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -1,70 +1,78 @@
 {
-    "slug": "galnec",
-    "category": "dry_desert",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 13,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 16,
-            "technique": "lantern"
-        },
-        {
-            "level_learned": 19,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 25,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 37,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["desert"],
-    "tags": ["ground", "rock"],
-    "shape": "hunter",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 168,
-    "height": 40,
-    "weight": 6,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "galnec",
+  "category": "dry_desert",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 13,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 16,
+      "technique": "lantern"
+    },
+    {
+      "level_learned": 19,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 25,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 37,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "desert"
+  ],
+  "tags": [
+    "ground",
+    "rock"
+  ],
+  "shape": "hunter",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 168,
+  "height": 40,
+  "weight": 6,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/gastronium.json
+++ b/mods/tuxemon/db/monster/gastronium.json
@@ -1,67 +1,73 @@
 {
-    "slug": "gastronium",
-    "category": "plutonium",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 13,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 16,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 31,
-            "technique": "magnetic_body"
-        },
-        {
-            "level_learned": 37,
-            "technique": "gourmet"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "stomic",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["steel", "toxic", "bomber"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 339,
-    "height": 100,
-    "weight": 40,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "gastronium",
+  "category": "plutonium",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 13,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 16,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 31,
+      "technique": "magnetic_body"
+    },
+    {
+      "level_learned": 37,
+      "technique": "gourmet"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "stomic",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "steel",
+    "toxic",
+    "bomber"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 339,
+  "height": 100,
+  "weight": 40,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -1,80 +1,89 @@
 {
-    "slug": "gectile",
-    "category": "climbing",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 13,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 40,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "velocitile"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "anoleaf",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "velocitile",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "speed"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 66,
-    "height": 54,
-    "weight": 7,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "gectile",
+  "category": "climbing",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 13,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 40,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "velocitile"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "anoleaf",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "velocitile",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "speed"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 66,
+  "height": 54,
+  "weight": 7,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -1,74 +1,81 @@
 {
-    "slug": "ghosteeth",
-    "category": "cheshire",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blood_bond"
-        },
-        {
-            "level_learned": 4,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 7,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 13,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 37,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 40,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ghost", "bite", "mental", "darkness"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 111,
-    "height": 70,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "ghosteeth",
+  "category": "cheshire",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blood_bond"
+    },
+    {
+      "level_learned": 4,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 7,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 13,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 37,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 40,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ghost",
+    "bite",
+    "mental",
+    "darkness"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 111,
+  "height": 70,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/gladiatorbug.json
+++ b/mods/tuxemon/db/monster/gladiatorbug.json
@@ -1,75 +1,85 @@
 {
-    "slug": "gladiatorbug",
-    "category": "bustuarius",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 16,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 19,
-            "technique": "steel_jaws"
-        },
-        {
-            "level_learned": 25,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 31,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 37,
-            "technique": "magnetic_body"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "katapill",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "katacoon",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban", "woodland"],
-    "tags": ["fists", "bug", "shielded"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 60,
-    "height": 178,
-    "weight": 78,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "gladiatorbug",
+  "category": "bustuarius",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 16,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 19,
+      "technique": "steel_jaws"
+    },
+    {
+      "level_learned": 25,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 31,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 37,
+      "technique": "magnetic_body"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "katapill",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "katacoon",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "fists",
+    "bug",
+    "shielded"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 60,
+  "height": 178,
+  "weight": 78,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/gliffary.json
+++ b/mods/tuxemon/db/monster/gliffary.json
@@ -1,50 +1,57 @@
 {
-    "slug": "gliffary",
-    "category": "toothsome",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 10,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 13,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 19,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 40,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["mental", "summoner", "shapeshifter", "bite"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 315,
-    "height": 50,
-    "weight": 1.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "gliffary",
+  "category": "toothsome",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 10,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 13,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 19,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 40,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "mental",
+    "summoner",
+    "shapeshifter",
+    "bite"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 315,
+  "height": 50,
+  "weight": 1.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -1,89 +1,97 @@
 {
-    "slug": "glombroc",
-    "category": "aggregate",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 16,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 19,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 28,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 52,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 55,
-            "technique": "thunderball"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 50,
-            "monster_slug": "conglolem"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "slichen",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "conglolem",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "rock", "ground", "toxic", "mental"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "earth",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 273,
-    "height": 87,
-    "weight": 35,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "glombroc",
+  "category": "aggregate",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 16,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 19,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 28,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 52,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 55,
+      "technique": "thunderball"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 50,
+      "monster_slug": "conglolem"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "slichen",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "conglolem",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "rock",
+    "ground",
+    "toxic",
+    "mental"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 273,
+  "height": 87,
+  "weight": 35,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/glomon.json
+++ b/mods/tuxemon/db/monster/glomon.json
@@ -1,71 +1,81 @@
 {
-    "slug": "glomon",
-    "category": "bacteria",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bubbles"
-        },
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 10,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 16,
-            "technique": "hallucinogen_spore"
-        },
-        {
-            "level_learned": 19,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 25,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 34,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 40,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 46,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["ruins", "urban"],
-    "tags": ["fists", "gaze", "water", "rock"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "earth", "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 381,
-    "height": 150,
-    "weight": 20,
-    "catch_rate": 50.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "glomon",
+  "category": "bacteria",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bubbles"
+    },
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 10,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 16,
+      "technique": "hallucinogen_spore"
+    },
+    {
+      "level_learned": 19,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 25,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 34,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 40,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 46,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "fists",
+    "gaze",
+    "water",
+    "rock"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "earth",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 381,
+  "height": 150,
+  "weight": 20,
+  "catch_rate": 50.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/golnagi.json
+++ b/mods/tuxemon/db/monster/golnagi.json
@@ -1,84 +1,92 @@
 {
-    "slug": "golnagi",
-    "category": "boiling_goldfish",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 19,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 31,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 34,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 52,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 55,
-            "technique": "firestorm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "gupphish",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "gupphire",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["flame", "water"],
-    "shape": "piscine",
-    "stage": "stage2",
-    "types": [
-        "fire", "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 393,
-    "height": 130,
-    "weight": 16,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "golnagi",
+  "category": "boiling_goldfish",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 19,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 31,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 34,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 52,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 55,
+      "technique": "firestorm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "gupphish",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "gupphire",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "flame",
+    "water"
+  ],
+  "shape": "piscine",
+  "stage": "stage2",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 393,
+  "height": 130,
+  "weight": 16,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/gourda.json
+++ b/mods/tuxemon/db/monster/gourda.json
@@ -1,46 +1,53 @@
 {
-    "slug": "gourda",
-    "category": "pumpkin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 19,
-            "technique": "nest"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant", "food", "healing"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 331,
-    "height": 40,
-    "weight": 28,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "gourda",
+  "category": "pumpkin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 19,
+      "technique": "nest"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "food",
+    "healing"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 331,
+  "height": 40,
+  "weight": 28,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -1,71 +1,80 @@
 {
-    "slug": "graffiki",
-    "category": "gamut",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 4,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 16,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 19,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 31,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 40,
-            "technique": "meltdown"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["soldier", "bomber", "gadgets", "summoner", "shapeshifter", "tail"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 302,
-    "height": 65,
-    "weight": 13,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "graffiki",
+  "category": "gamut",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 16,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 19,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 31,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 40,
+      "technique": "meltdown"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "soldier",
+    "bomber",
+    "gadgets",
+    "summoner",
+    "shapeshifter",
+    "tail"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 302,
+  "height": 65,
+  "weight": 13,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -1,68 +1,74 @@
 {
-    "slug": "grimachin",
-    "category": "spook",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 31,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 37,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shuriken"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "tigrock"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "tigrock",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "gadgets"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 93,
-    "height": 45,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "grimachin",
+  "category": "spook",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 31,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 37,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shuriken"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "tigrock"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "tigrock",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "gadgets"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 93,
+  "height": 45,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -1,60 +1,69 @@
 {
-    "slug": "grinflare",
-    "category": "igneous",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 19,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "grintot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["rock", "ground", "fists", "flame", "gemstone"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "earth",
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 17,
-    "height": 160,
-    "weight": 3000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "grinflare",
+  "category": "igneous",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 19,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "grintot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "ground",
+    "fists",
+    "flame",
+    "gemstone"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 17,
+  "height": 160,
+  "weight": 3000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -1,68 +1,75 @@
 {
-    "slug": "grintot",
-    "category": "pebble",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "grinflare",
-            "item": "earth_booster"
-        },
-        {
-            "monster_slug": "grinflare",
-            "item": "flintstone"
-        },
-        {
-            "monster_slug": "grintrock",
-            "item": "metal_booster"
-        },
-        {
-            "monster_slug": "grintrock",
-            "item": "thunderstone"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "grinflare",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "grintrock",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["rock", "ground", "fists"],
-    "shape": "brute",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 16,
-    "height": 70,
-    "weight": 375,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "grintot",
+  "category": "pebble",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "grinflare",
+      "item": "earth_booster"
+    },
+    {
+      "monster_slug": "grinflare",
+      "item": "flintstone"
+    },
+    {
+      "monster_slug": "grintrock",
+      "item": "metal_booster"
+    },
+    {
+      "monster_slug": "grintrock",
+      "item": "thunderstone"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "grinflare",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "grintrock",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "ground",
+    "fists"
+  ],
+  "shape": "brute",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 16,
+  "height": 70,
+  "weight": 375,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -1,60 +1,70 @@
 {
-    "slug": "grintrock",
-    "category": "thunderstone",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 16,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 25,
-            "technique": "hammerhead"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "grintot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["rock", "ground", "fists", "electricity", "gemstone", "weather"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "earth",
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 18,
-    "height": 160,
-    "weight": 3000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "grintrock",
+  "category": "thunderstone",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 16,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 25,
+      "technique": "hammerhead"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "grintot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "ground",
+    "fists",
+    "electricity",
+    "gemstone",
+    "weather"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 18,
+  "height": 160,
+  "weight": 3000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -1,72 +1,77 @@
 {
-    "slug": "grumpi",
-    "category": "gummy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 7,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 13,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 19,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 25,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 28,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 31,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 37,
-            "technique": "pit"
-        },
-        {
-            "level_learned": 40,
-            "technique": "greenstone"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["pseudopod", "bite"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "earth",
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 354,
-    "height": 150,
-    "weight": 160,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "grumpi",
+  "category": "gummy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 7,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 13,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 19,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 25,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 28,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 31,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 37,
+      "technique": "pit"
+    },
+    {
+      "level_learned": 40,
+      "technique": "greenstone"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "pseudopod",
+    "bite"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "earth",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 354,
+  "height": 150,
+  "weight": 160,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -1,76 +1,88 @@
 {
-    "slug": "gryfix",
-    "category": "horned_raptor",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 28,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_million_talons"
-        },
-        {
-            "level_learned": 43,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 46,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "flacono",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "corvix",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert", "grassland", "mountains", "woodland"],
-    "tags": ["bird", "sharp", "shielded", "steel"],
-    "shape": "flier",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 158,
-    "height": 180,
-    "weight": 31,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "gryfix",
+  "category": "horned_raptor",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 28,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_million_talons"
+    },
+    {
+      "level_learned": 43,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 46,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "flacono",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "corvix",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "mountains",
+    "woodland"
+  ],
+  "tags": [
+    "bird",
+    "sharp",
+    "shielded",
+    "steel"
+  ],
+  "shape": "flier",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 158,
+  "height": 180,
+  "weight": 31,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/gupphire.json
+++ b/mods/tuxemon/db/monster/gupphire.json
@@ -1,85 +1,94 @@
 {
-    "slug": "gupphire",
-    "category": "boiling_goldfish",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 19,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 31,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 34,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 52,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 38,
-            "monster_slug": "golnagi"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "gupphish",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "golnagi",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["freshwater", "sea"],
-    "tags": ["flame", "water"],
-    "shape": "piscine",
-    "stage": "stage1",
-    "types": [
-        "fire", "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 392,
-    "height": 80,
-    "weight": 7,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "gupphire",
+  "category": "boiling_goldfish",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 19,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 31,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 34,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 52,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 38,
+      "monster_slug": "golnagi"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "gupphish",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "golnagi",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "flame",
+    "water"
+  ],
+  "shape": "piscine",
+  "stage": "stage1",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 392,
+  "height": 80,
+  "weight": 7,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/gupphish.json
+++ b/mods/tuxemon/db/monster/gupphish.json
@@ -1,85 +1,94 @@
 {
-    "slug": "gupphish",
-    "category": "boiling_goldfish",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 19,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 31,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 34,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 52,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "gupphire"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "gupphire",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "golnagi",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["freshwater", "sea"],
-    "tags": ["flame", "water"],
-    "shape": "piscine",
-    "stage": "basic",
-    "types": [
-        "fire", "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 391,
-    "height": 40,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "gupphish",
+  "category": "boiling_goldfish",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 19,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 31,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 34,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 52,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "gupphire"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "gupphire",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "golnagi",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "flame",
+    "water"
+  ],
+  "shape": "piscine",
+  "stage": "basic",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 391,
+  "height": 40,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -1,70 +1,77 @@
 {
-    "slug": "hampotamos",
-    "category": "hungry",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 7,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 16,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 28,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 31,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 37,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 40,
-            "technique": "strangulation"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ground", "megafauna", "water"],
-    "shape": "landrace",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 358,
-    "height": 150,
-    "weight": 180,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hampotamos",
+  "category": "hungry",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 7,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 16,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 28,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 31,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 37,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 40,
+      "technique": "strangulation"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "megafauna",
+    "water"
+  ],
+  "shape": "landrace",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 358,
+  "height": 150,
+  "weight": 180,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -1,60 +1,70 @@
 {
-    "slug": "happito",
-    "category": "ecstatic_emotion",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 7,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rock"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chromeye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["extraplanar", "urban"],
-    "tags": ["mental", "machine", "healing", "light"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "earth",
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 176,
-    "height": 90,
-    "weight": 55,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "happito",
+  "category": "ecstatic_emotion",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rock"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chromeye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "extraplanar",
+    "urban"
+  ],
+  "tags": [
+    "mental",
+    "machine",
+    "healing",
+    "light"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 176,
+  "height": 90,
+  "weight": 55,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -1,68 +1,77 @@
 {
-    "slug": "hatchling",
-    "category": "egg",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 7,
-            "technique": "egg_smash"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 25,
-            "technique": "altitude"
-        },
-        {
-            "level_learned": 28,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 31,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 34,
-            "technique": "one_two"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "birdling"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "birdling",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["bird"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 81,
-    "height": 20,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "hatchling",
+  "category": "egg",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 7,
+      "technique": "egg_smash"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 25,
+      "technique": "altitude"
+    },
+    {
+      "level_learned": 28,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 31,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 34,
+      "technique": "one_two"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "birdling"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "birdling",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 81,
+  "height": 20,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/hectapod.json
+++ b/mods/tuxemon/db/monster/hectapod.json
@@ -1,63 +1,69 @@
 {
-    "slug": "hectapod",
-    "category": "sea_storm",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "squink",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["water", "weather"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 271,
-    "height": 120,
-    "weight": 45,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hectapod",
+  "category": "sea_storm",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "squink",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "water",
+    "weather"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 271,
+  "height": 120,
+  "weight": 45,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/helipi.json
+++ b/mods/tuxemon/db/monster/helipi.json
@@ -1,81 +1,90 @@
 {
-    "slug": "helipi",
-    "category": "samsara",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stabilo"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 15,
-            "monster_slug": "coppi"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "coppi",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "parappi",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "urban", "woodland"],
-    "tags": ["plant", "food"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 376,
-    "height": 30,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "helipi",
+  "category": "samsara",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stabilo"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 15,
+      "monster_slug": "coppi"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "coppi",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "parappi",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 376,
+  "height": 30,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -1,80 +1,91 @@
 {
-    "slug": "heronquak",
-    "category": "crested",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 31,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 34,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 43,
-            "technique": "font"
-        },
-        {
-            "level_learned": 46,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 52,
-            "technique": "snowstorm"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "eaglace"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "tweesher",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "eaglace",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["boreal_snow", "grassland", "mountains"],
-    "tags": ["gemstone", "ice", "bird"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 8,
-    "height": 150,
-    "weight": 12,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "heronquak",
+  "category": "crested",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 31,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 34,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 43,
+      "technique": "font"
+    },
+    {
+      "level_learned": 46,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 52,
+      "technique": "snowstorm"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "eaglace"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "tweesher",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "eaglace",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "grassland",
+    "mountains"
+  ],
+  "tags": [
+    "gemstone",
+    "ice",
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 8,
+  "height": 150,
+  "weight": 12,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hissiorite.json
+++ b/mods/tuxemon/db/monster/hissiorite.json
@@ -1,60 +1,69 @@
 {
-    "slug": "hissiorite",
-    "category": "meteor_snake",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 4,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 10,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "cobarett"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cobarett",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "pythonova",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["flame", "toxic"],
-    "shape": "serpent",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 322,
-    "height": 100,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hissiorite",
+  "category": "meteor_snake",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 4,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 10,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "cobarett"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cobarett",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "pythonova",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "flame",
+    "toxic"
+  ],
+  "shape": "serpent",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 322,
+  "height": 100,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hoarse.json
+++ b/mods/tuxemon/db/monster/hoarse.json
@@ -1,56 +1,61 @@
 {
-    "slug": "hoarse",
-    "category": "field_dweller",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 19,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "equill"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "equill",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "hoarseshoo",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["megafauna"],
-    "shape": "landrace",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 309,
-    "height": 130,
-    "weight": 130,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hoarse",
+  "category": "field_dweller",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 19,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "equill"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "equill",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "hoarseshoo",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 309,
+  "height": 130,
+  "weight": 130,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hoarseshoo.json
+++ b/mods/tuxemon/db/monster/hoarseshoo.json
@@ -1,59 +1,66 @@
 {
-    "slug": "hoarseshoo",
-    "category": "attercob",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 19,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_beam"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "hoarse",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "equill",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["megafauna", "darkness", "toxic"],
-    "shape": "blob",
-    "stage": "stage2",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 311,
-    "height": 300,
-    "weight": 1300,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hoarseshoo",
+  "category": "attercob",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 19,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_beam"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "hoarse",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "equill",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "megafauna",
+    "darkness",
+    "toxic"
+  ],
+  "shape": "blob",
+  "stage": "stage2",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 311,
+  "height": 300,
+  "weight": 1300,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hoodoll.json
+++ b/mods/tuxemon/db/monster/hoodoll.json
@@ -1,76 +1,85 @@
 {
-    "slug": "hoodoll",
-    "category": "old_man",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 7,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 19,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 25,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 28,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 55,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "wolololl"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "wolololl",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert"],
-    "tags": ["sharp", "plant", "toxic", "staff"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 389,
-    "height": 80,
-    "weight": 6,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hoodoll",
+  "category": "old_man",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 7,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 19,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 25,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 28,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 55,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "wolololl"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "wolololl",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert"
+  ],
+  "tags": [
+    "sharp",
+    "plant",
+    "toxic",
+    "staff"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 389,
+  "height": 80,
+  "weight": 6,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/hotline.json
+++ b/mods/tuxemon/db/monster/hotline.json
@@ -1,71 +1,80 @@
 {
-    "slug": "hotline",
-    "category": "ma_bell",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 16,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 19,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 25,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 37,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 40,
-            "technique": "sunburst"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["urban"],
-    "tags": ["love", "steel", "machine", "gadgets"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 255,
-    "height": 150,
-    "weight": 50,
-    "randomly": false,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hotline",
+  "category": "ma_bell",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 16,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 19,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 25,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 37,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 40,
+      "technique": "sunburst"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "love",
+    "steel",
+    "machine",
+    "gadgets"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 255,
+  "height": 150,
+  "weight": 50,
+  "randomly": false,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/houndice.json
+++ b/mods/tuxemon/db/monster/houndice.json
@@ -1,48 +1,56 @@
 {
-    "slug": "houndice",
-    "category": "snowy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 4,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 10,
-            "technique": "ice_storm"
-        },
-        {
-            "level_learned": 19,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "eskipup",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["boreal_snow"],
-    "tags": ["ice", "bite"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 328,
-    "height": 63,
-    "weight": 16,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "houndice",
+  "category": "snowy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 4,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 10,
+      "technique": "ice_storm"
+    },
+    {
+      "level_learned": 19,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "eskipup",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "boreal_snow"
+  ],
+  "tags": [
+    "ice",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 328,
+  "height": 63,
+  "weight": 16,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/howl.json
+++ b/mods/tuxemon/db/monster/howl.json
@@ -1,70 +1,75 @@
 {
-    "slug": "howl",
-    "category": "athena",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 1,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 4,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 7,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 16,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 19,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 25,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 31,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 37,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 40,
-            "technique": "sylvan"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["bird"],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 234,
-    "height": 63,
-    "weight": 2.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "howl",
+  "category": "athena",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 1,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 4,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 7,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 16,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 19,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 25,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 31,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 37,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 40,
+      "technique": "sylvan"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 234,
+  "height": 63,
+  "weight": 2.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -1,71 +1,79 @@
 {
-    "slug": "hydrone",
-    "category": "short_circuit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 1,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 16,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 19,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 25,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 28,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 37,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "lineage"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["machine", "water", "gadgets", "electricity"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 112,
-    "height": 155,
-    "weight": 200,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "hydrone",
+  "category": "short_circuit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 1,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 16,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 19,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 25,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 28,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 37,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "lineage"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "water",
+    "gadgets",
+    "electricity"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 112,
+  "height": 155,
+  "weight": 200,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -1,68 +1,79 @@
 {
-    "slug": "ignibus",
-    "category": "hot_rock",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 13,
-            "technique": "tinder"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "eruptibus",
-            "item": "earth_booster"
-        },
-        {
-            "monster_slug": "eruptibus",
-            "item": "tectonic_drill"
-        },
-        {
-            "monster_slug": "embazook",
-            "item": "metal_booster"
-        },
-        {
-            "monster_slug": "embazook",
-            "item": "stovepipe"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "embazook",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "eruptibus",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert", "mountains"],
-    "tags": ["flame", "rock", "bite", "bomber"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 30,
-    "height": 68,
-    "weight": 27,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "ignibus",
+  "category": "hot_rock",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 13,
+      "technique": "tinder"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "eruptibus",
+      "item": "earth_booster"
+    },
+    {
+      "monster_slug": "eruptibus",
+      "item": "tectonic_drill"
+    },
+    {
+      "monster_slug": "embazook",
+      "item": "metal_booster"
+    },
+    {
+      "monster_slug": "embazook",
+      "item": "stovepipe"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "embazook",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "eruptibus",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "rock",
+    "bite",
+    "bomber"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 30,
+  "height": 68,
+  "weight": 27,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/imbrickcile.json
+++ b/mods/tuxemon/db/monster/imbrickcile.json
@@ -1,80 +1,91 @@
 {
-    "slug": "imbrickcile",
-    "category": "brick",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 43,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 46,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 52,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "bricgard"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "bricgard",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "brickhemoth",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["fists", "rock", "fury", "shielded"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 259,
-    "height": 35,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "imbrickcile",
+  "category": "brick",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 43,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 46,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 52,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "bricgard"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "bricgard",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "brickhemoth",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "fists",
+    "rock",
+    "fury",
+    "shielded"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 259,
+  "height": 35,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -1,80 +1,89 @@
 {
-    "slug": "incandesfin",
-    "category": "light_fin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 7,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 13,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 28,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 40,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 43,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 46,
-            "technique": "proboscis"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "lightmare"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "fluoresfin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "lightmare",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["water", "light", "bite"],
-    "shape": "piscine",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 69,
-    "height": 250,
-    "weight": 150,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "incandesfin",
+  "category": "light_fin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 7,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 13,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 28,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 40,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 43,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 46,
+      "technique": "proboscis"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "lightmare"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "fluoresfin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "lightmare",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "light",
+    "bite"
+  ],
+  "shape": "piscine",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 69,
+  "height": 250,
+  "weight": 150,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -1,85 +1,89 @@
 {
-    "slug": "jelillow",
-    "category": "jelly_pillow",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 13,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 16,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 19,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 25,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 37,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 55,
-            "technique": "dreamwalk"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 41,
-            "monster_slug": "bedoo"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "bedoo",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["mental"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 207,
-    "height": 66,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "jelillow",
+  "category": "jelly_pillow",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 13,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 16,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 19,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 25,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 37,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 55,
+      "technique": "dreamwalk"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 41,
+      "monster_slug": "bedoo"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "bedoo",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "mental"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 207,
+  "height": 66,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/jeluna.json
+++ b/mods/tuxemon/db/monster/jeluna.json
@@ -1,58 +1,69 @@
 {
-    "slug": "jeluna",
-    "category": "moon_phase",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "shooting_star"
-        },
-        {
-            "level_learned": 4,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 10,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 22,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 40,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 46,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["boreal_snow", "extraterrestrial", "ruins", "sea"],
-    "tags": ["celestial", "light", "darkness"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 305,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "jeluna",
+  "category": "moon_phase",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "shooting_star"
+    },
+    {
+      "level_learned": 4,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 10,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 22,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 40,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 46,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "boreal_snow",
+    "extraterrestrial",
+    "ruins",
+    "sea"
+  ],
+  "tags": [
+    "celestial",
+    "light",
+    "darkness"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 305,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -1,79 +1,91 @@
 {
-    "slug": "jemuar",
-    "category": "precious_boulder",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 43,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 46,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 52,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 61,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "rockitten",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "rockat",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["mountains", "urban"],
-    "tags": ["rock", "love", "claws", "bite", "gemstone"],
-    "shape": "hunter",
-    "stage": "stage2",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 3,
-    "height": 160,
-    "weight": 150,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "jemuar",
+  "category": "precious_boulder",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 43,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 46,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 52,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 61,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "rockitten",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "rockat",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "urban"
+  ],
+  "tags": [
+    "rock",
+    "love",
+    "claws",
+    "bite",
+    "gemstone"
+  ],
+  "shape": "hunter",
+  "stage": "stage2",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 3,
+  "height": 160,
+  "weight": 150,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/joulraton.json
+++ b/mods/tuxemon/db/monster/joulraton.json
@@ -1,74 +1,80 @@
 {
-    "slug": "joulraton",
-    "category": "amped",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 4,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 7,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 13,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 19,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 31,
-            "technique": "conjurer"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 55,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["electricity", "food"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 244,
-    "height": 30,
-    "weight": 2.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "joulraton",
+  "category": "amped",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 4,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 7,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 13,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 19,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 31,
+      "technique": "conjurer"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 55,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "electricity",
+    "food"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 244,
+  "height": 30,
+  "weight": 2.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -1,59 +1,66 @@
 {
-    "slug": "k9",
-    "category": "cute",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 19,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "botbot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["machine", "bite"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 129,
-    "height": 60,
-    "weight": 5,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "k9",
+  "category": "cute",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 19,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "botbot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "machine",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 129,
+  "height": 60,
+  "weight": 5,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -1,80 +1,88 @@
 {
-    "slug": "katacoon",
-    "category": "stance",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 12,
-            "monster_slug": "bugnin",
-            "stats": "dodge:greater_than:speed"
-        },
-        {
-            "at_level": 12,
-            "monster_slug": "sumchon",
-            "stats": "speed:greater_than:dodge"
-        },
-        {
-            "at_level": 12,
-            "monster_slug": "gladiatorbug",
-            "stats": "speed:equals:dodge"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "katapill",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "bugnin",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "sumchon",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "gladiatorbug",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["fists", "bug"],
-    "shape": "grub",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 57,
-    "height": 58,
-    "weight": 12,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "katacoon",
+  "category": "stance",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 12,
+      "monster_slug": "bugnin",
+      "stats": "dodge:greater_than:speed"
+    },
+    {
+      "at_level": 12,
+      "monster_slug": "sumchon",
+      "stats": "speed:greater_than:dodge"
+    },
+    {
+      "at_level": 12,
+      "monster_slug": "gladiatorbug",
+      "stats": "speed:equals:dodge"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "katapill",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "bugnin",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "sumchon",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "gladiatorbug",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "fists",
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 57,
+  "height": 58,
+  "weight": 12,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -1,69 +1,77 @@
 {
-    "slug": "katapill",
-    "category": "beat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 9,
-            "monster_slug": "katacoon"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "katacoon",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "bugnin",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "sumchon",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "gladiatorbug",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["fists", "bug"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 56,
-    "height": 32,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "katapill",
+  "category": "beat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 9,
+      "monster_slug": "katacoon"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "katacoon",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "bugnin",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "sumchon",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "gladiatorbug",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "fists",
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 56,
+  "height": 32,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/kernel.json
+++ b/mods/tuxemon/db/monster/kernel.json
@@ -1,70 +1,79 @@
 {
-    "slug": "kernel",
-    "category": "virtual",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gold_digger"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 16,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 19,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 31,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 37,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 40,
-            "technique": "undertaker"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraplanar"],
-    "tags": ["gadgets", "machine", "mental", "summoner"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 253,
-    "height": 30,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "kernel",
+  "category": "virtual",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gold_digger"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 16,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 19,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 31,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 37,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 40,
+      "technique": "undertaker"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "gadgets",
+    "machine",
+    "mental",
+    "summoner"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 253,
+  "height": 30,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/knightsand.json
+++ b/mods/tuxemon/db/monster/knightsand.json
@@ -1,68 +1,77 @@
 {
-    "slug": "knightsand",
-    "category": "sand_knight",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 19,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 22,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 55,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pawsand",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["ground", "water", "sharp"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "earth", "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 374,
-    "height": 180,
-    "weight": 140,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "knightsand",
+  "category": "sand_knight",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 19,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 22,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 55,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pawsand",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "ground",
+    "water",
+    "sharp"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 374,
+  "height": 180,
+  "weight": 140,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/knindling.json
+++ b/mods/tuxemon/db/monster/knindling.json
@@ -1,67 +1,74 @@
 {
-    "slug": "knindling",
-    "category": "firestarter",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 4,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 16,
-            "technique": "diet"
-        },
-        {
-            "level_learned": 25,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 28,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 31,
-            "technique": "oven"
-        },
-        {
-            "level_learned": 37,
-            "technique": "magnetic_body"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "flounce",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame", "bite", "electricity"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 330,
-    "height": 50,
-    "weight": 22,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "knindling",
+  "category": "firestarter",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 4,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 16,
+      "technique": "diet"
+    },
+    {
+      "level_learned": 25,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 28,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 31,
+      "technique": "oven"
+    },
+    {
+      "level_learned": 37,
+      "technique": "magnetic_body"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "flounce",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame",
+    "bite",
+    "electricity"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 330,
+  "height": 50,
+  "weight": 22,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -1,84 +1,95 @@
 {
-    "slug": "komodraw",
-    "category": "quickdraw",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 25,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "komoduel"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "komoduel",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert", "grassland", "urban"],
-    "tags": ["bomber", "soldier", "gadgets"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 92,
-    "height": 155,
-    "weight": 55,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "komodraw",
+  "category": "quickdraw",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 25,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "komoduel"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "komoduel",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "urban"
+  ],
+  "tags": [
+    "bomber",
+    "soldier",
+    "gadgets"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 92,
+  "height": 155,
+  "weight": 55,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/komoduel.json
+++ b/mods/tuxemon/db/monster/komoduel.json
@@ -1,79 +1,90 @@
 {
-    "slug": "komoduel",
-    "category": "gunslinger",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 25,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 31,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "komodraw",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "grassland", "urban"],
-    "tags": ["bomber", "soldier", "gadgets"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 297,
-    "height": 165,
-    "weight": 75,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "komoduel",
+  "category": "gunslinger",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 25,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 31,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "komodraw",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "urban"
+  ],
+  "tags": [
+    "bomber",
+    "soldier",
+    "gadgets"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 297,
+  "height": 165,
+  "weight": 75,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/konuit.json
+++ b/mods/tuxemon/db/monster/konuit.json
@@ -1,50 +1,55 @@
 {
-    "slug": "konuit",
-    "category": "marsupial",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 25,
-            "technique": "pouch"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 306,
-    "height": 65,
-    "weight": 14,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "konuit",
+  "category": "marsupial",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 25,
+      "technique": "pouch"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 306,
+  "height": 65,
+  "weight": 14,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/kroki.json
+++ b/mods/tuxemon/db/monster/kroki.json
@@ -1,81 +1,89 @@
 {
-    "slug": "kroki",
-    "category": "crocodile",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 7,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 13,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 19,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 31,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 37,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 15,
-            "monster_slug": "krokivip"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "krokivip",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "leviadile",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["swamp"],
-    "tags": ["amphibian", "bite", "water"],
-    "shape": "leviathan",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 369,
-    "height": 30,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "kroki",
+  "category": "crocodile",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 7,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 13,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 19,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 31,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 37,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 15,
+      "monster_slug": "krokivip"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "krokivip",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "leviadile",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "swamp"
+  ],
+  "tags": [
+    "amphibian",
+    "bite",
+    "water"
+  ],
+  "shape": "leviathan",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 369,
+  "height": 30,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/krokivip.json
+++ b/mods/tuxemon/db/monster/krokivip.json
@@ -1,81 +1,91 @@
 {
-    "slug": "krokivip",
-    "category": "crocodile",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 7,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 13,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 19,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 31,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 37,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 35,
-            "monster_slug": "leviadile"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "kroki",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "leviadile",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "swamp"],
-    "tags": ["bite", "water", "amphibian", "fury"],
-    "shape": "leviathan",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 370,
-    "height": 120,
-    "weight": 45,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "krokivip",
+  "category": "crocodile",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 7,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 13,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 19,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 31,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 37,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 35,
+      "monster_slug": "leviadile"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "kroki",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "leviadile",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "swamp"
+  ],
+  "tags": [
+    "bite",
+    "water",
+    "amphibian",
+    "fury"
+  ],
+  "shape": "leviathan",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 370,
+  "height": 120,
+  "weight": 45,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -1,70 +1,72 @@
 {
-    "slug": "l3gk0",
-    "category": "glitched",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 4,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 7,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 13,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 19,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 25,
-            "technique": "feline"
-        },
-        {
-            "level_learned": 28,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 31,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 37,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 40,
-            "technique": "chameleon"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "serpent",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 25,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "l3gk0",
+  "category": "glitched",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 4,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 7,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 13,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 19,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 25,
+      "technique": "feline"
+    },
+    {
+      "level_learned": 28,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 31,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 37,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 40,
+      "technique": "chameleon"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "serpent",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 25,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -1,80 +1,86 @@
 {
-    "slug": "lambert",
-    "category": "gumnut",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 13,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 31,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 34,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 43,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 46,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 52,
-            "technique": "invictus"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "legko"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "legko",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "moloch",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "fists"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 10,
-    "height": 69,
-    "weight": 37,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "lambert",
+  "category": "gumnut",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 13,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 31,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 34,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 43,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 46,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 52,
+      "technique": "invictus"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "legko"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "legko",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "moloch",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "fists"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 10,
+  "height": 69,
+  "weight": 37,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -1,70 +1,76 @@
 {
-    "slug": "lapinou",
-    "category": "thlay",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 19,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 25,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 28,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 31,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 37,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 40,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ground", "love"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 113,
-    "height": 60,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "lapinou",
+  "category": "thlay",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 19,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 25,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 28,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 31,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 37,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 40,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "love"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 113,
+  "height": 60,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -1,80 +1,86 @@
 {
-    "slug": "legko",
-    "category": "lizard",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 13,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 31,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 34,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 43,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 46,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 52,
-            "technique": "invictus"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "moloch"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "lambert",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "moloch",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "plant"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 11,
-    "height": 123,
-    "weight": 52,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "legko",
+  "category": "lizard",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 13,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 31,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 34,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 43,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 46,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 52,
+      "technique": "invictus"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "moloch"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "lambert",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "moloch",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "plant"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 11,
+  "height": 123,
+  "weight": 52,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/legoplaste.json
+++ b/mods/tuxemon/db/monster/legoplaste.json
@@ -1,46 +1,52 @@
 {
-    "slug": "legoplaste",
-    "category": "amoeba",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 1,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 10,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 19,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["any"],
-    "tags": ["pseudopod"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 314,
-    "height": 100,
-    "weight": 60,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "legoplaste",
+  "category": "amoeba",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 1,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 10,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 19,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "any"
+  ],
+  "tags": [
+    "pseudopod"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 314,
+  "height": 100,
+  "weight": 60,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/lendos.json
+++ b/mods/tuxemon/db/monster/lendos.json
@@ -1,75 +1,81 @@
 {
-    "slug": "lendos",
-    "category": "vision",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 16,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 25,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 28,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 31,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "uneye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["gaze", "darkness", "mental"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 241,
-    "height": 97,
-    "weight": 7,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "lendos",
+  "category": "vision",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 16,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 25,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 28,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 31,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "uneye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "gaze",
+    "darkness",
+    "mental"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 241,
+  "height": 97,
+  "weight": 7,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/lesmagu.json
+++ b/mods/tuxemon/db/monster/lesmagu.json
@@ -1,85 +1,93 @@
 {
-    "slug": "lesmagu",
-    "category": "vagrant",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "font"
-        },
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 19,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 25,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 37,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 40,
-            "technique": "poison_courtship"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "shelagu"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "shelagu",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "crustagu",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "sea"],
-    "tags": ["pseudopod", "water"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 277,
-    "height": 42,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "lesmagu",
+  "category": "vagrant",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "font"
+    },
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 19,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 25,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 37,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 40,
+      "technique": "poison_courtship"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "shelagu"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "shelagu",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "crustagu",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "sea"
+  ],
+  "tags": [
+    "pseudopod",
+    "water"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 277,
+  "height": 42,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/lettice.json
+++ b/mods/tuxemon/db/monster/lettice.json
@@ -1,77 +1,88 @@
 {
-    "slug": "lettice",
-    "category": "freezerburn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 55,
-            "technique": "woodsmash"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "frostuce"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cohldrabi",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "frostuce",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["mountains", "boreal_snow", "grassland", "woodland"],
-    "tags": ["plant", "ice"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "water", "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 383,
-    "height": 60,
-    "weight": 8,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "lettice",
+  "category": "freezerburn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 55,
+      "technique": "woodsmash"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "frostuce"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cohldrabi",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "frostuce",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "boreal_snow",
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ice"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 383,
+  "height": 60,
+  "weight": 8,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/leviadile.json
+++ b/mods/tuxemon/db/monster/leviadile.json
@@ -1,76 +1,86 @@
 {
-    "slug": "leviadile",
-    "category": "crocodile",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 7,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 13,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 19,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 31,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 37,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "kroki",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "krokivip",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["ice", "water", "bite", "toxic", "fury"],
-    "shape": "leviathan",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 371,
-    "height": 680,
-    "weight": 2500,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "leviadile",
+  "category": "crocodile",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 7,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 13,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 19,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 31,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 37,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "kroki",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "krokivip",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "ice",
+    "water",
+    "bite",
+    "toxic",
+    "fury"
+  ],
+  "shape": "leviathan",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 371,
+  "height": 680,
+  "weight": 2500,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -1,75 +1,84 @@
 {
-    "slug": "lightmare",
-    "category": "nightmare_fuel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 7,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 13,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 28,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 40,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 43,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 46,
-            "technique": "proboscis"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "fluoresfin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "incandesfin",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["water", "light", "bite"],
-    "shape": "leviathan",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 70,
-    "height": 300,
-    "weight": 200,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "lightmare",
+  "category": "nightmare_fuel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 7,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 13,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 28,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 40,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 43,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 46,
+      "technique": "proboscis"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "fluoresfin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "incandesfin",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "light",
+    "bite"
+  ],
+  "shape": "leviathan",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 70,
+  "height": 300,
+  "weight": 200,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -1,64 +1,71 @@
 {
-    "slug": "loliferno",
-    "category": "spirit_fire",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 28,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "seirein",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["swamp"],
-    "tags": ["flame", "light", "ghost"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 163,
-    "height": 60,
-    "weight": 0.1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "loliferno",
+  "category": "spirit_fire",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 28,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "seirein",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "swamp"
+  ],
+  "tags": [
+    "flame",
+    "light",
+    "ghost"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 163,
+  "height": 60,
+  "weight": 0.1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/lucifice.json
+++ b/mods/tuxemon/db/monster/lucifice.json
@@ -1,71 +1,82 @@
 {
-    "slug": "lucifice",
-    "category": "ninth_circle",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 4,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 7,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 34,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 43,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 46,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 52,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "waysprite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "demosnow",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["extraplanar"],
-    "tags": ["ice", "leadership", "weather", "darkness", "flame", "calamity"],
-    "shape": "sprite",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 265,
-    "height": 180,
-    "weight": 90,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "lucifice",
+  "category": "ninth_circle",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 34,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 43,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 46,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 52,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "waysprite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "demosnow",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "ice",
+    "leadership",
+    "weather",
+    "darkness",
+    "flame",
+    "calamity"
+  ],
+  "shape": "sprite",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 265,
+  "height": 180,
+  "weight": 90,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -1,72 +1,81 @@
 {
-    "slug": "lunight",
-    "category": "quasar",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 13,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 16,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "gold_digger"
-        },
-        {
-            "level_learned": 37,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "perfect_cut"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraplanar", "ruins"],
-    "tags": ["darkness", "celestial", "steel", "calamity"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 229,
-    "height": 55,
-    "weight": 17,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "lunight",
+  "category": "quasar",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 13,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 16,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "gold_digger"
+    },
+    {
+      "level_learned": 37,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "perfect_cut"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraplanar",
+    "ruins"
+  ],
+  "tags": [
+    "darkness",
+    "celestial",
+    "steel",
+    "calamity"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 229,
+  "height": 55,
+  "weight": 17,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -1,70 +1,76 @@
 {
-    "slug": "manosting",
-    "category": "balloon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 19,
-            "technique": "font"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 31,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 37,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["toxic", "pseudopod"],
-    "shape": "polliwog",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 114,
-    "height": 180,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "manosting",
+  "category": "balloon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 19,
+      "technique": "font"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 31,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 37,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "toxic",
+    "pseudopod"
+  ],
+  "shape": "polliwog",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 114,
+  "height": 180,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/marvantis.json
+++ b/mods/tuxemon/db/monster/marvantis.json
@@ -1,64 +1,74 @@
 {
-    "slug": "marvantis",
-    "category": "mantid",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 7,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 16,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 25,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "marvillar",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "woodland"],
-    "tags": ["bug", "shapeshifter", "bite"],
-    "shape": "grub",
-    "stage": "stage1",
-    "types": [
-        "fire",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 288,
-    "height": 214,
-    "weight": 270,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "marvantis",
+  "category": "mantid",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 7,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 16,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 25,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "marvillar",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "bug",
+    "shapeshifter",
+    "bite"
+  ],
+  "shape": "grub",
+  "stage": "stage1",
+  "types": [
+    "fire",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 288,
+  "height": 214,
+  "weight": 270,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/marvillar.json
+++ b/mods/tuxemon/db/monster/marvillar.json
@@ -1,69 +1,76 @@
 {
-    "slug": "marvillar",
-    "category": "ant_mimic",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 7,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 16,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 25,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 15,
-            "monster_slug": "marvantis"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "marvantis",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug", "shapeshifter", "bite"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "fire",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 287,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "marvillar",
+  "category": "ant_mimic",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 7,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 16,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 25,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 15,
+      "monster_slug": "marvantis"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "marvantis",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug",
+    "shapeshifter",
+    "bite"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "fire",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 287,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -1,70 +1,76 @@
 {
-    "slug": "masknake",
-    "category": "serpents_tooth",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 4,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 13,
-            "technique": "firestorm"
-        },
-        {
-            "level_learned": 16,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 19,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 25,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 37,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["light", "mental"],
-    "shape": "serpent",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 115,
-    "height": 112,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "masknake",
+  "category": "serpents_tooth",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 4,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 13,
+      "technique": "firestorm"
+    },
+    {
+      "level_learned": 16,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 19,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 25,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 37,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "light",
+    "mental"
+  ],
+  "shape": "serpent",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 115,
+  "height": 112,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mauai.json
+++ b/mods/tuxemon/db/monster/mauai.json
@@ -1,63 +1,73 @@
 {
-    "slug": "mauai",
-    "category": "anubis",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 19,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 28,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "memnomnom",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "claws", "summoner", "ghost", "darkness", "staff"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 22,
-    "height": 203,
-    "weight": 139,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "mauai",
+  "category": "anubis",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 19,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 28,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "memnomnom",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "claws",
+    "summoner",
+    "ghost",
+    "darkness",
+    "staff"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 22,
+  "height": 203,
+  "weight": 139,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/medipup.json
+++ b/mods/tuxemon/db/monster/medipup.json
@@ -1,92 +1,99 @@
 {
-    "slug": "medipup",
-    "category": "erythrocyte",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "barking"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 7,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mystic_blending"
-        },
-        {
-            "level_learned": 19,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 49,
-            "technique": "needle"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "doctsky"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "doctsky",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "askylpaws",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "erythroskyte",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["healing"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 281,
-    "height": 30,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "medipup",
+  "category": "erythrocyte",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "barking"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 7,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mystic_blending"
+    },
+    {
+      "level_learned": 19,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 49,
+      "technique": "needle"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "doctsky"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "doctsky",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "askylpaws",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "erythroskyte",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "healing"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 281,
+  "height": 30,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -1,72 +1,80 @@
 {
-    "slug": "medushock",
-    "category": "jellyfish",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 7,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 16,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 19,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 31,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 37,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 40,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["freshwater"],
-    "tags": ["electricity", "toxic", "sharp"],
-    "shape": "polliwog",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 345,
-    "height": 133,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "medushock",
+  "category": "jellyfish",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 7,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 16,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 19,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 31,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 37,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 40,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "freshwater"
+  ],
+  "tags": [
+    "electricity",
+    "toxic",
+    "sharp"
+  ],
+  "shape": "polliwog",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 345,
+  "height": 133,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/megafruitera.json
+++ b/mods/tuxemon/db/monster/megafruitera.json
@@ -1,84 +1,90 @@
 {
-    "slug": "megafruitera",
-    "category": "flying_fox_bat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 16,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 40,
-            "technique": "clairaudience"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "spectera"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "fruitera",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "spectera",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "food"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 170,
-    "height": 60,
-    "weight": 5,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "megafruitera",
+  "category": "flying_fox_bat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 16,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 40,
+      "technique": "clairaudience"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "spectera"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "fruitera",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "spectera",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 170,
+  "height": 60,
+  "weight": 5,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -1,80 +1,88 @@
 {
-    "slug": "memnomnom",
-    "category": "relic",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "miaownolith",
-            "item": "earth_booster"
-        },
-        {
-            "monster_slug": "miaownolith",
-            "item": "miaow_milk"
-        },
-        {
-            "monster_slug": "pyraminx",
-            "item": "metal_booster"
-        },
-        {
-            "monster_slug": "pyraminx",
-            "item": "pyramidion"
-        },
-        {
-            "monster_slug": "mauai",
-            "item": "fire_booster"
-        },
-        {
-            "monster_slug": "mauai",
-            "item": "pyramidion"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "pyraminx",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "miaownolith",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mauai",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "claws", "summoner", "ghost"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 19,
-    "height": 70,
-    "weight": 7,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "memnomnom",
+  "category": "relic",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "miaownolith",
+      "item": "earth_booster"
+    },
+    {
+      "monster_slug": "miaownolith",
+      "item": "miaow_milk"
+    },
+    {
+      "monster_slug": "pyraminx",
+      "item": "metal_booster"
+    },
+    {
+      "monster_slug": "pyraminx",
+      "item": "pyramidion"
+    },
+    {
+      "monster_slug": "mauai",
+      "item": "fire_booster"
+    },
+    {
+      "monster_slug": "mauai",
+      "item": "pyramidion"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "pyraminx",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "miaownolith",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mauai",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "claws",
+    "summoner",
+    "ghost"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 19,
+  "height": 70,
+  "weight": 7,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -1,73 +1,77 @@
 {
-    "slug": "merlicun",
-    "category": "dragon_worm",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 16,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 31,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 37,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 40,
-            "technique": "battery_acid"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "firomenis"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "firomenis",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 209,
-    "height": 28,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "merlicun",
+  "category": "dragon_worm",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 16,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 31,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 37,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 40,
+      "technique": "battery_acid"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "firomenis"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "firomenis",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 209,
+  "height": 28,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -1,78 +1,87 @@
 {
-    "slug": "metesaur",
-    "category": "meteor",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 16,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 19,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 43,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 46,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 52,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 40,
-            "monster_slug": "qetzlrokilus"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "qetzlrokilus",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle", "mountains"],
-    "tags": ["rock", "flame", "bird"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "earth",
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 202,
-    "height": 95,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "metesaur",
+  "category": "meteor",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 16,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 19,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 43,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 46,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 52,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 40,
+      "monster_slug": "qetzlrokilus"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "qetzlrokilus",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "mountains"
+  ],
+  "tags": [
+    "rock",
+    "flame",
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "earth",
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 202,
+  "height": 95,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/metoxic.json
+++ b/mods/tuxemon/db/monster/metoxic.json
@@ -1,51 +1,62 @@
 {
-    "slug": "metoxic",
-    "category": "toxic_flag",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 10,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 19,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 25,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 31,
-            "technique": "viper"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "desert", "jungle"],
-    "tags": ["toxic", "weather", "leadership", "summoner"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 312,
-    "height": 100,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "metoxic",
+  "category": "toxic_flag",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 10,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 19,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 25,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 31,
+      "technique": "viper"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "desert",
+    "jungle"
+  ],
+  "tags": [
+    "toxic",
+    "weather",
+    "leadership",
+    "summoner"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 312,
+  "height": 100,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -1,64 +1,73 @@
 {
-    "slug": "miaownolith",
-    "category": "desolate",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 19,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 37,
-            "technique": "oedipus"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "memnomnom",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "claws", "summoner", "ghost", "rock"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 20,
-    "height": 210,
-    "weight": 255,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "miaownolith",
+  "category": "desolate",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 19,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 37,
+      "technique": "oedipus"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "memnomnom",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "claws",
+    "summoner",
+    "ghost",
+    "rock"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 20,
+  "height": 210,
+  "weight": 255,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/mingdyn.json
+++ b/mods/tuxemon/db/monster/mingdyn.json
@@ -1,74 +1,84 @@
 {
-    "slug": "mingdyn",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 4,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 7,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 25,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 28,
-            "technique": "gold_digger"
-        },
-        {
-            "level_learned": 31,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 37,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 40,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["mountains"],
-    "tags": ["flame", "celestial", "healing", "calamity"],
-    "shape": "dragon",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 239,
-    "height": 274,
-    "weight": 124,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "mingdyn",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 4,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 7,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 25,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 28,
+      "technique": "gold_digger"
+    },
+    {
+      "level_learned": 31,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 37,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 40,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "mountains"
+  ],
+  "tags": [
+    "flame",
+    "celestial",
+    "healing",
+    "calamity"
+  ],
+  "shape": "dragon",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 239,
+  "height": 274,
+  "weight": 124,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -1,80 +1,82 @@
 {
-    "slug": "mk01_alpha",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 16,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 19,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lineage"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "mk01_delta"
-        },
-        {
-            "at_level": 32,
-            "monster_slug": "mk01_gamma"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "mk01_proto",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "mk01_gamma",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "mk01_delta",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": [],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "mk01_alpha",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 16,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 19,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lineage"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "mk01_delta"
+    },
+    {
+      "at_level": 32,
+      "monster_slug": "mk01_gamma"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "mk01_proto",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "mk01_gamma",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "mk01_delta",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -1,80 +1,82 @@
 {
-    "slug": "mk01_beta",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 25,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lineage"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "mk01_delta"
-        },
-        {
-            "at_level": 32,
-            "monster_slug": "mk01_omega"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "mk01_proto",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "mk01_delta",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "mk01_omega",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": [],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "mk01_beta",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 25,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lineage"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "mk01_delta"
+    },
+    {
+      "at_level": 32,
+      "monster_slug": "mk01_omega"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "mk01_proto",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "mk01_delta",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "mk01_omega",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_delta.json
+++ b/mods/tuxemon/db/monster/mk01_delta.json
@@ -1,83 +1,85 @@
 {
-    "slug": "mk01_delta",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 16,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 19,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 40,
-            "technique": "gold_digger"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "mk01_proto",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "mk01_alpha",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mk01_beta",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": [],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "mk01_delta",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 16,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 19,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 40,
+      "technique": "gold_digger"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "mk01_proto",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "mk01_alpha",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mk01_beta",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_gamma.json
+++ b/mods/tuxemon/db/monster/mk01_gamma.json
@@ -1,79 +1,81 @@
 {
-    "slug": "mk01_gamma",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 16,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 19,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 40,
-            "technique": "gold_digger"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "mk01_alpha",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mk01_proto",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": [],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "mk01_gamma",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 16,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 19,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 40,
+      "technique": "gold_digger"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "mk01_alpha",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mk01_proto",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -1,79 +1,81 @@
 {
-    "slug": "mk01_omega",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 25,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 37,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 40,
-            "technique": "acid"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "mk01_beta",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mk01_proto",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": [],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "mk01_omega",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 25,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 37,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 40,
+      "technique": "acid"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "mk01_beta",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mk01_proto",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -1,68 +1,70 @@
 {
-    "slug": "mk01_proto",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "amnesia"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 10,
-            "monster_slug": "mk01_alpha"
-        },
-        {
-            "at_level": 10,
-            "monster_slug": "mk01_beta"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "mk01_alpha",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mk01_beta",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "mk01_gamma",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "mk01_omega",
-            "evo_stage": "stage2"
-        },
-        {
-            "mon_slug": "mk01_delta",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": [],
-    "shape": "dragon",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "mk01_proto",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "amnesia"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 10,
+      "monster_slug": "mk01_alpha"
+    },
+    {
+      "at_level": 10,
+      "monster_slug": "mk01_beta"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "mk01_alpha",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mk01_beta",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "mk01_gamma",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "mk01_omega",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "mk01_delta",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [],
+  "shape": "dragon",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -1,79 +1,87 @@
 {
-    "slug": "moloch",
-    "category": "devil",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 4,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 7,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 13,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 31,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 34,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 43,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 46,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 52,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "lambert",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "legko",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["claws", "bite", "megafauna", "plant"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 12,
-    "height": 216,
-    "weight": 90,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "moloch",
+  "category": "devil",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 4,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 7,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 13,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 31,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 34,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 43,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 46,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 52,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "lambert",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "legko",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "claws",
+    "bite",
+    "megafauna",
+    "plant"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 12,
+  "height": 216,
+  "weight": 90,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -1,59 +1,66 @@
 {
-    "slug": "mrmoswitch",
-    "category": "gremlin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "glower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "botbot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["machine", "light"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 128,
-    "height": 56,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "mrmoswitch",
+  "category": "gremlin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "glower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "botbot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "machine",
+    "light"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 128,
+  "height": 56,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/myrmison.json
+++ b/mods/tuxemon/db/monster/myrmison.json
@@ -1,72 +1,87 @@
 {
-    "slug": "myrmison",
-    "category": "myrmidon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 10,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 25,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 46,
-            "technique": "all_in"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "scarlant",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "shull",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "mountains", "swamp", "urban", "woodland"],
-    "tags": ["bug", "bite", "shielded", "sharp"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "fire",
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 291,
-    "height": 120,
-    "weight": 50,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "myrmison",
+  "category": "myrmidon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 10,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 25,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 46,
+      "technique": "all_in"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "scarlant",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "shull",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "mountains",
+    "swamp",
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "bug",
+    "bite",
+    "shielded",
+    "sharp"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "fire",
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 291,
+  "height": 120,
+  "weight": 50,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -1,71 +1,79 @@
 {
-    "slug": "mystikapi",
-    "category": "prescient",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 16,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 31,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 37,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 40,
-            "technique": "whirlwind"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["jungle"],
-    "tags": ["mental", "light", "megafauna"],
-    "shape": "landrace",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 223,
-    "height": 160,
-    "weight": 250,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "mystikapi",
+  "category": "prescient",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 16,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 31,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 37,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 40,
+      "technique": "whirlwind"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "mental",
+    "light",
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 223,
+  "height": 160,
+  "weight": 250,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -1,67 +1,73 @@
 {
-    "slug": "narcileaf",
-    "category": "gardener",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 1,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 7,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flower_armor"
-        },
-        {
-            "level_learned": 52,
-            "technique": "flower_bloom"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "shybulb",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "mental"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 78,
-    "height": 42,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "narcileaf",
+  "category": "gardener",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 1,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 7,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flower_armor"
+    },
+    {
+      "level_learned": 52,
+      "technique": "flower_bloom"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "shybulb",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "mental"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 78,
+  "height": 42,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nebufin.json
+++ b/mods/tuxemon/db/monster/nebufin.json
@@ -1,57 +1,66 @@
 {
-    "slug": "nebufin",
-    "category": "sea_angel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 10,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "spit_poison"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 16,
-            "monster_slug": "galasces"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "galasces",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "novaquarius",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["sea"],
-    "tags": ["celestial", "water", "toxic", "gemstone"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 319,
-    "height": 20,
-    "weight": 0.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "nebufin",
+  "category": "sea_angel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 10,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "spit_poison"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 16,
+      "monster_slug": "galasces"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "galasces",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "novaquarius",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "celestial",
+    "water",
+    "toxic",
+    "gemstone"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 319,
+  "height": 20,
+  "weight": 0.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ned.json
+++ b/mods/tuxemon/db/monster/ned.json
@@ -1,50 +1,55 @@
 {
-    "slug": "ned",
-    "category": "red_hands",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 10,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 19,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "pouch"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["fists"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 313,
-    "height": 87,
-    "weight": 32,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "ned",
+  "category": "red_hands",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 10,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 19,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "pouch"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "fists"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 313,
+  "height": 87,
+  "weight": 32,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -1,60 +1,69 @@
 {
-    "slug": "neutrito",
-    "category": "calm_emotion",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 7,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 25,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "whirlwind"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chromeye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["extraplanar", "urban"],
-    "tags": ["mental", "machine", "gadgets"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 177,
-    "height": 90,
-    "weight": 55,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "neutrito",
+  "category": "calm_emotion",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 25,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "whirlwind"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chromeye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "extraplanar",
+    "urban"
+  ],
+  "tags": [
+    "mental",
+    "machine",
+    "gadgets"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 177,
+  "height": 90,
+  "weight": 55,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/nimbulex.json
+++ b/mods/tuxemon/db/monster/nimbulex.json
@@ -1,75 +1,83 @@
 {
-    "slug": "nimbulex",
-    "category": "veiled",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 4,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 7,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 16,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 19,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 25,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shapechange"
-        },
-        {
-            "level_learned": 37,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "bumbulus",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["water", "weather", "light", "electricity", "calamity"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 233,
-    "height": 141,
-    "weight": 1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "nimbulex",
+  "category": "veiled",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 4,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 7,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 16,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 19,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 25,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shapechange"
+    },
+    {
+      "level_learned": 37,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "bumbulus",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "water",
+    "weather",
+    "light",
+    "electricity",
+    "calamity"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 233,
+  "height": 141,
+  "weight": 1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/ninjasmine.json
+++ b/mods/tuxemon/db/monster/ninjasmine.json
@@ -1,79 +1,90 @@
 {
-    "slug": "ninjasmine",
-    "category": "every_thorn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 16,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 28,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flower_bloom"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "rosarin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "toxiris",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["love", "plant", "toxic", "bomber", "sharp"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 206,
-    "height": 160,
-    "weight": 60,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "ninjasmine",
+  "category": "every_thorn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 16,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 28,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flower_bloom"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "rosarin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "toxiris",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "love",
+    "plant",
+    "toxic",
+    "bomber",
+    "sharp"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 206,
+  "height": 160,
+  "weight": 60,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -1,63 +1,68 @@
 {
-    "slug": "noctalo",
-    "category": "nightcrawler",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 28,
-            "technique": "font"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "noctula",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["darkness"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 51,
-    "height": 100,
-    "weight": 12,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "noctalo",
+  "category": "nightcrawler",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 28,
+      "technique": "font"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "noctula",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "darkness"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 51,
+  "height": 100,
+  "weight": 12,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -1,64 +1,69 @@
 {
-    "slug": "noctula",
-    "category": "nightcrawler",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 28,
-            "technique": "font"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chill_mist"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "noctalo"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "noctalo",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["darkness"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 50,
-    "height": 50,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "noctula",
+  "category": "nightcrawler",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 28,
+      "technique": "font"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chill_mist"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "noctalo"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "noctalo",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "darkness"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 50,
+  "height": 50,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -1,72 +1,79 @@
 {
-    "slug": "nostray",
-    "category": "proboscis",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "font"
-        },
-        {
-            "level_learned": 7,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 28,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 31,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 40,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "shnark"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "shnark",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "water", "darkness"],
-    "shape": "piscine",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 152,
-    "height": 120,
-    "weight": 30,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "nostray",
+  "category": "proboscis",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "font"
+    },
+    {
+      "level_learned": 7,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 28,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 31,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 40,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "shnark"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "shnark",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "water",
+    "darkness"
+  ],
+  "shape": "piscine",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 152,
+  "height": 120,
+  "weight": 30,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/novaquarius.json
+++ b/mods/tuxemon/db/monster/novaquarius.json
@@ -1,52 +1,59 @@
 {
-    "slug": "novaquarius",
-    "category": "sea_angel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 10,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "spit_poison"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "nebufin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "galasces",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["celestial", "water", "toxic", "gemstone"],
-    "shape": "polliwog",
-    "stage": "stage2",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 321,
-    "height": 100,
-    "weight": 100,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "novaquarius",
+  "category": "sea_angel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 10,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "spit_poison"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "nebufin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "galasces",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "celestial",
+    "water",
+    "toxic",
+    "gemstone"
+  ],
+  "shape": "polliwog",
+  "stage": "stage2",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 321,
+  "height": 100,
+  "weight": 100,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -1,64 +1,69 @@
 {
-    "slug": "nudiflot_female",
-    "category": "flopped",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 13,
-            "technique": "suck_poison"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "nudimind"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "nudimind",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["freshwater", "mental"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["female"],
-    "txmn_id": 54,
-    "height": 29,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "nudiflot_female",
+  "category": "flopped",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 13,
+      "technique": "suck_poison"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "nudimind"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "nudimind",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "freshwater",
+    "mental"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "female"
+  ],
+  "txmn_id": 54,
+  "height": 29,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -1,64 +1,69 @@
 {
-    "slug": "nudiflot_male",
-    "category": "flotsam",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 13,
-            "technique": "suck_poison"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "venom"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "nudikill"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "nudikill",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["freshwater", "toxic"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male"],
-    "txmn_id": 52,
-    "height": 36,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "nudiflot_male",
+  "category": "flotsam",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 13,
+      "technique": "suck_poison"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "venom"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "nudikill"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "nudikill",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "freshwater",
+    "toxic"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male"
+  ],
+  "txmn_id": 52,
+  "height": 36,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -1,59 +1,69 @@
 {
-    "slug": "nudikill",
-    "category": "dark_bishop",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 13,
-            "technique": "suck_poison"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "venom"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "nudiflot_male",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["toxic", "darkness", "mental"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male"],
-    "txmn_id": 53,
-    "height": 122,
-    "weight": 35,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "nudikill",
+  "category": "dark_bishop",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 13,
+      "technique": "suck_poison"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "venom"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "nudiflot_male",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "toxic",
+    "darkness",
+    "mental"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male"
+  ],
+  "txmn_id": 53,
+  "height": 122,
+  "weight": 35,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -1,59 +1,67 @@
 {
-    "slug": "nudimind",
-    "category": "reverie",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 13,
-            "technique": "suck_poison"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "nudiflot_female",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["mental"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["female"],
-    "txmn_id": 55,
-    "height": 98,
-    "weight": 34,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "nudimind",
+  "category": "reverie",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 13,
+      "technique": "suck_poison"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "nudiflot_female",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "mental"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "female"
+  ],
+  "txmn_id": 55,
+  "height": 98,
+  "weight": 34,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -1,71 +1,77 @@
 {
-    "slug": "nuenflu",
-    "category": "snowball",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blood_bond"
-        },
-        {
-            "level_learned": 7,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 16,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 19,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 25,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 28,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 37,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 40,
-            "technique": "snowstorm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ice", "love", "toxic"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 224,
-    "height": 75,
-    "weight": 21,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "nuenflu",
+  "category": "snowball",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blood_bond"
+    },
+    {
+      "level_learned": 7,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 16,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 19,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 25,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 28,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 37,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 40,
+      "technique": "snowstorm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ice",
+    "love",
+    "toxic"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 224,
+  "height": 75,
+  "weight": 21,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -1,72 +1,79 @@
 {
-    "slug": "nut",
-    "category": "hardware",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "static_field"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 10,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 9,
-            "monster_slug": "bolt"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "bolt",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "arthrobolt",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "bomber", "gadgets", "light"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 4,
-    "height": 45,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "nut",
+  "category": "hardware",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "static_field"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 10,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 9,
+      "monster_slug": "bolt"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "bolt",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "arthrobolt",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "bomber",
+    "gadgets",
+    "light"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 4,
+  "height": 45,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -1,64 +1,69 @@
 {
-    "slug": "octabode",
-    "category": "hermit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "font"
-        },
-        {
-            "level_learned": 19,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 25,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 28,
-            "technique": "venomous_tentacle"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "skwib",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["pseudopod", "shielded"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 184,
-    "height": 44,
-    "weight": 19,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "octabode",
+  "category": "hermit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "font"
+    },
+    {
+      "level_learned": 19,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 25,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 28,
+      "technique": "venomous_tentacle"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "skwib",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "pseudopod",
+    "shielded"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 184,
+  "height": 44,
+  "weight": 19,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -1,60 +1,66 @@
 {
-    "slug": "ouroboutlet",
-    "category": "infinite_energy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 19,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pythwire",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["electricity"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "fire"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 90,
-    "height": 62,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "ouroboutlet",
+  "category": "infinite_energy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 19,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pythwire",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "electricity"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "fire"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 90,
+  "height": 62,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -1,67 +1,72 @@
 {
-    "slug": "pairagrim",
-    "category": "bird",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 4,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 13,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "ten_thousand_feathers"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pairagrin",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bird"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 182,
-    "height": 110,
-    "weight": 10,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "pairagrim",
+  "category": "bird",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 4,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 13,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "ten_thousand_feathers"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pairagrin",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 182,
+  "height": 110,
+  "weight": 10,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -1,68 +1,75 @@
 {
-    "slug": "pairagrin",
-    "category": "bird",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 4,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 13,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 37,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 26,
-            "monster_slug": "pairagrim"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "pairagrim",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["bird"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 181,
-    "height": 70,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "pairagrin",
+  "category": "bird",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 4,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 13,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 37,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 26,
+      "monster_slug": "pairagrim"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "pairagrim",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 181,
+  "height": 70,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -1,65 +1,74 @@
 {
-    "slug": "pantherafira",
-    "category": "mercury",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 7,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "criniotherme"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "criniotherme",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert", "grassland"],
-    "tags": ["flame", "bite", "light"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 245,
-    "height": 90,
-    "weight": 25,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "pantherafira",
+  "category": "mercury",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 7,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "criniotherme"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "criniotherme",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland"
+  ],
+  "tags": [
+    "flame",
+    "bite",
+    "light"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 245,
+  "height": 90,
+  "weight": 25,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/parappi.json
+++ b/mods/tuxemon/db/monster/parappi.json
@@ -1,80 +1,87 @@
 {
-    "slug": "parappi",
-    "category": "spinning_seed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "flower_bloom"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "helipi",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "coppi",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["plant", "food"],
-    "shape": "blob",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 378,
-    "height": 120,
-    "weight": 20,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "parappi",
+  "category": "spinning_seed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "flower_bloom"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "helipi",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "coppi",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "blob",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 378,
+  "height": 120,
+  "weight": 20,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/pawsand.json
+++ b/mods/tuxemon/db/monster/pawsand.json
@@ -1,89 +1,97 @@
 {
-    "slug": "pawsand",
-    "category": "sand_pawn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 19,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 22,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 55,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "knightsand",
-            "item": "sweet_sand"
-        },
-        {
-            "monster_slug": "bishosand",
-            "item": "earth_booster"
-        },
-        {
-            "monster_slug": "rooksand",
-            "item": "pyramidion"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "knightsand",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "bishosand",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "rooksand",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["fists", "ground", "water"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 372,
-    "height": 90,
-    "weight": 20,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "pawsand",
+  "category": "sand_pawn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 19,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 22,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 55,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "knightsand",
+      "item": "sweet_sand"
+    },
+    {
+      "monster_slug": "bishosand",
+      "item": "earth_booster"
+    },
+    {
+      "monster_slug": "rooksand",
+      "item": "pyramidion"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "knightsand",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "bishosand",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "rooksand",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "fists",
+    "ground",
+    "water"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 372,
+  "height": 90,
+  "weight": 20,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/pearamanca.json
+++ b/mods/tuxemon/db/monster/pearamanca.json
@@ -1,62 +1,68 @@
 {
-    "slug": "pearamanca",
-    "category": "biting_pear",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "changeling"
-        },
-        {
-            "level_learned": 10,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 19,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 34,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 40,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 46,
-            "technique": "undertaker"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["bite", "plant", "shapeshifter"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 284,
-    "height": 90,
-    "weight": 50,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "pearamanca",
+  "category": "biting_pear",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "changeling"
+    },
+    {
+      "level_learned": 10,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 19,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 34,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 40,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 46,
+      "technique": "undertaker"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "plant",
+    "shapeshifter"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 284,
+  "height": 90,
+  "weight": 50,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pharavion.json
+++ b/mods/tuxemon/db/monster/pharavion.json
@@ -1,80 +1,90 @@
 {
-    "slug": "pharavion",
-    "category": "spirit_elephant",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 13,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 16,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 19,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 37,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pharfan",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["megafauna", "leadership", "water", "mental", "pseudopod"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 362,
-    "height": 300,
-    "weight": 2000,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "pharavion",
+  "category": "spirit_elephant",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 13,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 16,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 19,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 37,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pharfan",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "megafauna",
+    "leadership",
+    "water",
+    "mental",
+    "pseudopod"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 362,
+  "height": 300,
+  "weight": 2000,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -1,84 +1,91 @@
 {
-    "slug": "pharfan",
-    "category": "little_elephant",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 13,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 16,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 19,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 37,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "pharavion"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "pharavion",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["megafauna", "water", "pseudopod"],
-    "shape": "landrace",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 151,
-    "height": 200,
-    "weight": 500,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "pharfan",
+  "category": "little_elephant",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 13,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 16,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 19,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 37,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "pharavion"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "pharavion",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "megafauna",
+    "water",
+    "pseudopod"
+  ],
+  "shape": "landrace",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 151,
+  "height": 200,
+  "weight": 500,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -1,59 +1,66 @@
 {
-    "slug": "picc",
-    "category": "bladder",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "botbot",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["freshwater"],
-    "tags": ["machine", "water"],
-    "shape": "piscine",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 127,
-    "height": 55,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "picc",
+  "category": "bladder",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "botbot",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "freshwater"
+  ],
+  "tags": [
+    "machine",
+    "water"
+  ],
+  "shape": "piscine",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 127,
+  "height": 55,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pickoon.json
+++ b/mods/tuxemon/db/monster/pickoon.json
@@ -1,65 +1,75 @@
 {
-    "slug": "pickoon",
-    "category": "raccoon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 19,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 25,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rust_bomb"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "raccscal"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "raccscal",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban", "woodland"],
-    "tags": ["gadgets", "claws", "fists"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "earth", "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 367,
-    "height": 40,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "pickoon",
+  "category": "raccoon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 19,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 25,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rust_bomb"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "raccscal"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "raccscal",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "gadgets",
+    "claws",
+    "fists"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 367,
+  "height": 40,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -1,70 +1,76 @@
 {
-    "slug": "pigabyte",
-    "category": "electric_pig",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 16,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 19,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 28,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rift_dash"
-        },
-        {
-            "level_learned": 37,
-            "technique": "battery_acid"
-        },
-        {
-            "level_learned": 40,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["megafauna", "machine", "food"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 116,
-    "height": 155,
-    "weight": 180,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "pigabyte",
+  "category": "electric_pig",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 16,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 19,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 28,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rift_dash"
+    },
+    {
+      "level_learned": 37,
+      "technique": "battery_acid"
+    },
+    {
+      "level_learned": 40,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "megafauna",
+    "machine",
+    "food"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 116,
+  "height": 155,
+  "weight": 180,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -1,70 +1,77 @@
 {
-    "slug": "pilthropus",
-    "category": "tool_maker",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 7,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 16,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 19,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 25,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 28,
-            "technique": "battery_acid"
-        },
-        {
-            "level_learned": 31,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 37,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "berserk"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ground", "soldier", "staff"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 172,
-    "height": 154,
-    "weight": 82,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "pilthropus",
+  "category": "tool_maker",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 7,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 16,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 19,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 25,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 28,
+      "technique": "battery_acid"
+    },
+    {
+      "level_learned": 31,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 37,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "berserk"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "soldier",
+    "staff"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 172,
+  "height": 154,
+  "weight": 82,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -1,64 +1,69 @@
 {
-    "slug": "pipis",
-    "category": "echo",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 7,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_two"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "strella"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "strella",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["darkness"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 48,
-    "height": 40,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "pipis",
+  "category": "echo",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 7,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_two"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "strella"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "strella",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "darkness"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 48,
+  "height": 40,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -1,64 +1,72 @@
 {
-    "slug": "poinchin",
-    "category": "spiny",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "font"
-        },
-        {
-            "level_learned": 22,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chill_mist"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "saurchin"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "saurchin",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal"],
-    "tags": ["sharp", "toxic"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 348,
-    "height": 30,
-    "weight": 6,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "poinchin",
+  "category": "spiny",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "font"
+    },
+    {
+      "level_learned": 22,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chill_mist"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "saurchin"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "saurchin",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal"
+  ],
+  "tags": [
+    "sharp",
+    "toxic"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 348,
+  "height": 30,
+  "weight": 6,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -1,70 +1,77 @@
 {
-    "slug": "polyrock",
-    "category": "grasshopper",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 16,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 19,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 25,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "pit"
-        },
-        {
-            "level_learned": 31,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "one_two"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["rock", "fists", "shapeshifter"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 117,
-    "height": 133,
-    "weight": 66,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "polyrock",
+  "category": "grasshopper",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 16,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 19,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 25,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "pit"
+    },
+    {
+      "level_learned": 31,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "one_two"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "fists",
+    "shapeshifter"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 117,
+  "height": 133,
+  "weight": 66,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -1,75 +1,81 @@
 {
-    "slug": "possessun",
-    "category": "visitor",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 1,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 7,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 13,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 16,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 25,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 28,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 31,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 37,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 40,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "cairfrey",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["mental", "megafauna", "ghost"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 72,
-    "height": 69,
-    "weight": 0.1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "possessun",
+  "category": "visitor",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 1,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 7,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 13,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 16,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 25,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 28,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 31,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 37,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 40,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "cairfrey",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "mental",
+    "megafauna",
+    "ghost"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 72,
+  "height": 69,
+  "weight": 0.1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/potturmeist.json
+++ b/mods/tuxemon/db/monster/potturmeist.json
@@ -1,76 +1,82 @@
 {
-    "slug": "potturmeist",
-    "category": "pottery",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 16,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 25,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 28,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "potturney"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "potturney",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ghost", "shielded", "shapeshifter"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 257,
-    "height": 48,
-    "weight": 2.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "potturmeist",
+  "category": "pottery",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 16,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 25,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 28,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "potturney"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "potturney",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ghost",
+    "shielded",
+    "shapeshifter"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 257,
+  "height": 48,
+  "weight": 2.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/potturney.json
+++ b/mods/tuxemon/db/monster/potturney.json
@@ -1,71 +1,77 @@
 {
-    "slug": "potturney",
-    "category": "pottery",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 13,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 16,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 25,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 28,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "potturmeist",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ghost", "shielded", "shapeshifter"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 258,
-    "height": 45,
-    "weight": 6,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "potturney",
+  "category": "pottery",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 13,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 16,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 25,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 28,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "potturmeist",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ghost",
+    "shielded",
+    "shapeshifter"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 258,
+  "height": 45,
+  "weight": 6,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/primordia.json
+++ b/mods/tuxemon/db/monster/primordia.json
@@ -1,59 +1,70 @@
 {
-    "slug": "primordia",
-    "category": "microbe",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 10,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 13,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 19,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "firestorm"
-        },
-        {
-            "level_learned": 34,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shooting_star"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "extraterrestrial", "other"],
-    "tags": ["water", "pseudopod", "fire", "amphibian"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "fire", "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 386,
-    "height": 1,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "primordia",
+  "category": "microbe",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 10,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 13,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 19,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "firestorm"
+    },
+    {
+      "level_learned": 34,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shooting_star"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "extraterrestrial",
+    "other"
+  ],
+  "tags": [
+    "water",
+    "pseudopod",
+    "fire",
+    "amphibian"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 386,
+  "height": 1,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -1,70 +1,76 @@
 {
-    "slug": "propellercat",
-    "category": "eureka",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 7,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 13,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 25,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 28,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 37,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 40,
-            "technique": "meltdown"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["bird", "sharp"],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 118,
-    "height": 55,
-    "weight": 6,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "propellercat",
+  "category": "eureka",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 25,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 28,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 37,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 40,
+      "technique": "meltdown"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "bird",
+    "sharp"
+  ],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 118,
+  "height": 55,
+  "weight": 6,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -1,63 +1,75 @@
 {
-    "slug": "prophetoise",
-    "category": "dragon_bone",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 4,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 19,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 28,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "forturtle",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "jungle", "ruins"],
-    "tags": ["flame", "mental", "celestial", "staff"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 88,
-    "height": 108,
-    "weight": 88,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "prophetoise",
+  "category": "dragon_bone",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 4,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 19,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 28,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "forturtle",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "jungle",
+    "ruins"
+  ],
+  "tags": [
+    "flame",
+    "mental",
+    "celestial",
+    "staff"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 88,
+  "height": 108,
+  "weight": 88,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -1,80 +1,87 @@
 {
-    "slug": "puparmor",
-    "category": "fortified",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 7,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 16,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 22,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 12,
-            "monster_slug": "weavifly"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cataspike",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "weavifly",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["sharp", "bug", "bomber"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 34,
-    "height": 35,
-    "weight": 8.5,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "puparmor",
+  "category": "fortified",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 7,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 16,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 22,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 12,
+      "monster_slug": "weavifly"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cataspike",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "weavifly",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "sharp",
+    "bug",
+    "bomber"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 34,
+  "height": 35,
+  "weight": 8.5,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -1,63 +1,72 @@
 {
-    "slug": "pyraminx",
-    "category": "noble",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 7,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 28,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "memnomnom",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "claws", "summoner", "ghost", "water"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 21,
-    "height": 210,
-    "weight": 190,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "pyraminx",
+  "category": "noble",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 7,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 28,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "memnomnom",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "claws",
+    "summoner",
+    "ghost",
+    "water"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 21,
+  "height": 210,
+  "weight": 190,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -1,68 +1,78 @@
 {
-    "slug": "pythock",
-    "category": "puppet_master",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 16,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 25,
-            "technique": "battery_acid"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "snock",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["darkness", "pseudopod", "ghost", "shapeshifter", "summoner", "bite", "claws"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 226,
-    "height": 154,
-    "weight": 32,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "pythock",
+  "category": "puppet_master",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 16,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 25,
+      "technique": "battery_acid"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "snock",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "darkness",
+    "pseudopod",
+    "ghost",
+    "shapeshifter",
+    "summoner",
+    "bite",
+    "claws"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 226,
+  "height": 154,
+  "weight": 32,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/pythonova.json
+++ b/mods/tuxemon/db/monster/pythonova.json
@@ -1,63 +1,73 @@
 {
-    "slug": "pythonova",
-    "category": "nova_snake",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_fire"
-        },
-        {
-            "level_learned": 4,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 10,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 31,
-            "technique": "oven"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "hissiorite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "cobarett",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["flame", "toxic", "calamity"],
-    "shape": "serpent",
-    "stage": "stage2",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 324,
-    "height": 600,
-    "weight": 120,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "pythonova",
+  "category": "nova_snake",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_fire"
+    },
+    {
+      "level_learned": 4,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 10,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 31,
+      "technique": "oven"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "hissiorite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "cobarett",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "flame",
+    "toxic",
+    "calamity"
+  ],
+  "shape": "serpent",
+  "stage": "stage2",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 324,
+  "height": 600,
+  "weight": 120,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -1,60 +1,66 @@
 {
-    "slug": "pythwire",
-    "category": "power_socket",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "ouroboutlet",
-            "item": "fire_booster"
-        },
-        {
-            "monster_slug": "sockeserp",
-            "item": "metal_booster"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "ouroboutlet",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "sockeserp",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["electricity"],
-    "shape": "serpent",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 89,
-    "height": 200,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "pythwire",
+  "category": "power_socket",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "ouroboutlet",
+      "item": "fire_booster"
+    },
+    {
+      "monster_slug": "sockeserp",
+      "item": "metal_booster"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "ouroboutlet",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "sockeserp",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "electricity"
+  ],
+  "shape": "serpent",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 89,
+  "height": 200,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -1,73 +1,85 @@
 {
-    "slug": "qetzlrokilus",
-    "category": "long_winged",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 16,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 19,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 43,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 46,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 52,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "metesaur",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["jungle", "mountains"],
-    "tags": ["rock", "flame", "bird", "celestial", "calamity", "weather"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "earth",
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 203,
-    "height": 183,
-    "weight": 41,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "qetzlrokilus",
+  "category": "long_winged",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 16,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 19,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 43,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 46,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 52,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "metesaur",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "mountains"
+  ],
+  "tags": [
+    "rock",
+    "flame",
+    "bird",
+    "celestial",
+    "calamity",
+    "weather"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 203,
+  "height": 183,
+  "weight": 41,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -1,70 +1,72 @@
 {
-    "slug": "r0ck1tt3n",
-    "category": "glitched",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 7,
-            "technique": "lust"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 25,
-            "technique": "cavity"
-        },
-        {
-            "level_learned": 28,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 31,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 37,
-            "technique": "pit"
-        },
-        {
-            "level_learned": 40,
-            "technique": "avalanche"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "hunter",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 25,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "r0ck1tt3n",
+  "category": "glitched",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 7,
+      "technique": "lust"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 25,
+      "technique": "cavity"
+    },
+    {
+      "level_learned": 28,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 31,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 37,
+      "technique": "pit"
+    },
+    {
+      "level_learned": 40,
+      "technique": "avalanche"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "hunter",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 25,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -1,67 +1,74 @@
 {
-    "slug": "rabbitosaur",
-    "category": "rabbit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 31,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 37,
-            "technique": "burrow_blast"
-        },
-        {
-            "level_learned": 43,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "squabbit",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["soldier", "fists", "ground"],
-    "shape": "varmint",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 45,
-    "height": 120,
-    "weight": 80,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "rabbitosaur",
+  "category": "rabbit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 31,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 37,
+      "technique": "burrow_blast"
+    },
+    {
+      "level_learned": 43,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "squabbit",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "soldier",
+    "fists",
+    "ground"
+  ],
+  "shape": "varmint",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 45,
+  "height": 120,
+  "weight": 80,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/raccscal.json
+++ b/mods/tuxemon/db/monster/raccscal.json
@@ -1,64 +1,74 @@
 {
-    "slug": "raccscal",
-    "category": "raccoon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 19,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 25,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 34,
-            "technique": "pouch"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pickoon",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["bomber", "gadgets", "claws", "darkness"],
-    "shape": "varmint",
-    "stage": "stage1",
-    "types": [
-        "earth", "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 368,
-    "height": 80,
-    "weight": 20,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "raccscal",
+  "category": "raccoon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 19,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 25,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 34,
+      "technique": "pouch"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pickoon",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "bomber",
+    "gadgets",
+    "claws",
+    "darkness"
+  ],
+  "shape": "varmint",
+  "stage": "stage1",
+  "types": [
+    "earth",
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 368,
+  "height": 80,
+  "weight": 20,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/raptoucan.json
+++ b/mods/tuxemon/db/monster/raptoucan.json
@@ -1,76 +1,84 @@
 {
-    "slug": "raptoucan",
-    "category": "tropical",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 4,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 7,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "panjandrum"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 19,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 25,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_million_talons"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 55,
-            "technique": "fluff_up"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "toucanary",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["bird", "bite", "claws"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 388,
-    "height": 160,
-    "weight": 18,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "raptoucan",
+  "category": "tropical",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 4,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 7,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "panjandrum"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 19,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 25,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_million_talons"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 55,
+      "technique": "fluff_up"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "toucanary",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "bird",
+    "bite",
+    "claws"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 388,
+  "height": 160,
+  "weight": 18,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/regalance.json
+++ b/mods/tuxemon/db/monster/regalance.json
@@ -1,79 +1,92 @@
 {
-    "slug": "regalance",
-    "category": "terracotta",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 13,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 16,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 25,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 28,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 31,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 37,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 43,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 55,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "claymorior",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["soldier", "sharp", "ground", "rock", "gadgets", "leadership", "gemstone"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 318,
-    "height": 182,
-    "weight": 137,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "regalance",
+  "category": "terracotta",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 13,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 16,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 25,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 28,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 31,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 37,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 43,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 55,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "claymorior",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "soldier",
+    "sharp",
+    "ground",
+    "rock",
+    "gadgets",
+    "leadership",
+    "gemstone"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 318,
+  "height": 182,
+  "weight": 137,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -1,74 +1,80 @@
 {
-    "slug": "rhincus",
-    "category": "missing_link",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 13,
-            "technique": "air_chain"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 19,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 25,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 31,
-            "technique": "altitude"
-        },
-        {
-            "level_learned": 37,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 40,
-            "technique": "lantern"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["rock", "bird"],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 143,
-    "height": 92,
-    "weight": 17,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "rhincus",
+  "category": "missing_link",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 13,
+      "technique": "air_chain"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 19,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 25,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 31,
+      "technique": "altitude"
+    },
+    {
+      "level_learned": 37,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 40,
+      "technique": "lantern"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 143,
+  "height": 92,
+  "weight": 17,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rhinocarpe.json
+++ b/mods/tuxemon/db/monster/rhinocarpe.json
@@ -1,70 +1,80 @@
 {
-    "slug": "rhinocarpe",
-    "category": "big_head",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 16,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 19,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 25,
-            "technique": "font"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 31,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 37,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["water", "fury"],
-    "shape": "piscine",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 252,
-    "height": 225,
-    "weight": 95,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "rhinocarpe",
+  "category": "big_head",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 16,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 19,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 25,
+      "technique": "font"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 31,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 37,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "fury"
+  ],
+  "shape": "piscine",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 252,
+  "height": 225,
+  "weight": 95,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rinocereed.json
+++ b/mods/tuxemon/db/monster/rinocereed.json
@@ -1,70 +1,80 @@
 {
-    "slug": "rinocereed",
-    "category": "calf",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 4,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 13,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 16,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 25,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 31,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 37,
-            "technique": "steel_jaws"
-        },
-        {
-            "level_learned": 40,
-            "technique": "negation"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["grassland", "jungle"],
-    "tags": ["plant", "megafauna", "bite"],
-    "shape": "landrace",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 256,
-    "height": 92,
-    "weight": 402,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "rinocereed",
+  "category": "calf",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 4,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 13,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 16,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 25,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 31,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 37,
+      "technique": "steel_jaws"
+    },
+    {
+      "level_learned": 40,
+      "technique": "negation"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "grassland",
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "megafauna",
+    "bite"
+  ],
+  "shape": "landrace",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 256,
+  "height": 92,
+  "weight": 402,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -1,80 +1,91 @@
 {
-    "slug": "rockat",
-    "category": "sleek_boulder",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 43,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 46,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 52,
-            "technique": "biting_winds"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "jemuar"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "rockitten",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "jemuar",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["mountains", "urban"],
-    "tags": ["rock", "love", "claws", "bite"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 2,
-    "height": 120,
-    "weight": 60,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "rockat",
+  "category": "sleek_boulder",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 43,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 46,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 52,
+      "technique": "biting_winds"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "jemuar"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "rockitten",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "jemuar",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "urban"
+  ],
+  "tags": [
+    "rock",
+    "love",
+    "claws",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 2,
+  "height": 120,
+  "weight": 60,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -1,80 +1,91 @@
 {
-    "slug": "rockitten",
-    "category": "cute_boulder",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 28,
-            "technique": "glower"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 43,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 46,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 52,
-            "technique": "biting_winds"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "rockat"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "rockat",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "jemuar",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["mountains", "urban"],
-    "tags": ["rock", "love", "claws", "bite"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 1,
-    "height": 55,
-    "weight": 9,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "rockitten",
+  "category": "cute_boulder",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 28,
+      "technique": "glower"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 43,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 46,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 52,
+      "technique": "biting_winds"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "rockat"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "rockat",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "jemuar",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "mountains",
+    "urban"
+  ],
+  "tags": [
+    "rock",
+    "love",
+    "claws",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 1,
+  "height": 55,
+  "weight": 9,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -1,70 +1,72 @@
 {
-    "slug": "rocktot",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 4,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 19,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 25,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 28,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 31,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 37,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 40,
-            "technique": "lust"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 62,
-    "weight": 58,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "rocktot",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 4,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 19,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 25,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 28,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 31,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 37,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 40,
+      "technique": "lust"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 62,
+  "weight": 58,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/rooksand.json
+++ b/mods/tuxemon/db/monster/rooksand.json
@@ -1,68 +1,76 @@
 {
-    "slug": "rooksand",
-    "category": "sand_rock",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 19,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 22,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rocky_barrage"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pawsand",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "desert"],
-    "tags": ["fists", "ground", "water"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 375,
-    "height": 300,
-    "weight": 1000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "rooksand",
+  "category": "sand_rock",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 19,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 22,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rocky_barrage"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pawsand",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "desert"
+  ],
+  "tags": [
+    "fists",
+    "ground",
+    "water"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 375,
+  "height": 300,
+  "weight": 1000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -1,85 +1,95 @@
 {
-    "slug": "rosarin",
-    "category": "every_thorn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 16,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 28,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flower_bloom"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "toxiris"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "toxiris",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "ninjasmine",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["love", "plant", "toxic"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 204,
-    "height": 48,
-    "weight": 14,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "rosarin",
+  "category": "every_thorn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 16,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 28,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flower_bloom"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "toxiris"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "toxiris",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "ninjasmine",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "love",
+    "plant",
+    "toxic"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 204,
+  "height": 48,
+  "weight": 14,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/ruffalo.json
+++ b/mods/tuxemon/db/monster/ruffalo.json
@@ -1,42 +1,51 @@
 {
-    "slug": "ruffalo",
-    "category": "buffalo",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 19,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["grassland", "woodland"],
-    "tags": ["megafauna", "sharp"],
-    "shape": "landrace",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 283,
-    "height": 180,
-    "weight": 350,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "ruffalo",
+  "category": "buffalo",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 19,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "megafauna",
+    "sharp"
+  ],
+  "shape": "landrace",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 283,
+  "height": 180,
+  "weight": 350,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/runesquito.json
+++ b/mods/tuxemon/db/monster/runesquito.json
@@ -1,63 +1,77 @@
 {
-    "slug": "runesquito",
-    "category": "diptera",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 19,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "stonifly",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "cocrune",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["freshwater", "ruins", "swamp"],
-    "tags": ["rock", "shielded", "bug", "summoner", "mental", "shapeshifter", "darkness"],
-    "shape": "flier",
-    "stage": "stage2",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 334,
-    "height": 66,
-    "weight": 6,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "runesquito",
+  "category": "diptera",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 19,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "stonifly",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "cocrune",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "ruins",
+    "swamp"
+  ],
+  "tags": [
+    "rock",
+    "shielded",
+    "bug",
+    "summoner",
+    "mental",
+    "shapeshifter",
+    "darkness"
+  ],
+  "shape": "flier",
+  "stage": "stage2",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 334,
+  "height": 66,
+  "weight": 6,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -1,75 +1,80 @@
 {
-    "slug": "ruption",
-    "category": "bonfire",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 7,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 13,
-            "technique": "tinder"
-        },
-        {
-            "level_learned": 16,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 19,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 28,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 31,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 37,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "embra",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 76,
-    "height": 169,
-    "weight": 16,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "ruption",
+  "category": "bonfire",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 7,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 13,
+      "technique": "tinder"
+    },
+    {
+      "level_learned": 16,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 19,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 28,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 31,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 37,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "embra",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 76,
+  "height": 169,
+  "weight": 16,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -1,60 +1,70 @@
 {
-    "slug": "sadito",
-    "category": "lamenting_emotion",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 7,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 25,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 28,
-            "technique": "shrapnel"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chromeye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["extraplanar", "urban"],
-    "tags": ["mental", "machine", "leadership", "gadgets"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 178,
-    "height": 90,
-    "weight": 55,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "sadito",
+  "category": "lamenting_emotion",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 7,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 25,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 28,
+      "technique": "shrapnel"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chromeye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "extraplanar",
+    "urban"
+  ],
+  "tags": [
+    "mental",
+    "machine",
+    "leadership",
+    "gadgets"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 178,
+  "height": 90,
+  "weight": 55,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -1,70 +1,78 @@
 {
-    "slug": "sampsack",
-    "category": "brawn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 16,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 19,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 25,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 28,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 31,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "insanity"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["urban"],
-    "tags": ["fists", "fury"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 97,
-    "height": 225,
-    "weight": 235,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "sampsack",
+  "category": "brawn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 16,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 19,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 25,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 28,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 31,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "insanity"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "fists",
+    "fury"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 97,
+  "height": 225,
+  "weight": 235,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -1,70 +1,77 @@
 {
-    "slug": "sampsage",
-    "category": "brains",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 28,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 31,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 37,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 40,
-            "technique": "slice"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["urban"],
-    "tags": ["mental"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 98,
-    "height": 180,
-    "weight": 122,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "sampsage",
+  "category": "brains",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 28,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 31,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 37,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 40,
+      "technique": "slice"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "mental"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 98,
+  "height": 180,
+  "weight": 122,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -1,88 +1,97 @@
 {
-    "slug": "sapragon",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flower_armor"
-        },
-        {
-            "level_learned": 4,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 7,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 16,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 55,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 61,
-            "technique": "flower_bloom"
-        },
-        {
-            "level_learned": 64,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 70,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 54,
-            "monster_slug": "dragarbor"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "chloragon",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "dragarbor",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["plant", "bite", "sharp"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 141,
-    "height": 122,
-    "weight": 115,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "sapragon",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flower_armor"
+    },
+    {
+      "level_learned": 4,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 7,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 16,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 55,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 61,
+      "technique": "flower_bloom"
+    },
+    {
+      "level_learned": 64,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 70,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 54,
+      "monster_slug": "dragarbor"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "chloragon",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "dragarbor",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "bite",
+    "sharp"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 141,
+  "height": 122,
+  "weight": 115,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -1,59 +1,66 @@
 {
-    "slug": "sapsnap",
-    "category": "barbed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "trapsnap",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "sharp", "fury"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 86,
-    "height": 210,
-    "weight": 125,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "sapsnap",
+  "category": "barbed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "trapsnap",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "sharp",
+    "fury"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 86,
+  "height": 210,
+  "weight": 125,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -1,71 +1,81 @@
 {
-    "slug": "saurchin",
-    "category": "spiny",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "font"
-        },
-        {
-            "level_learned": 22,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 40,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thorn_burst"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "poinchin",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal"],
-    "tags": ["sharp", "toxic", "bite", "megafauna"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 349,
-    "height": 800,
-    "weight": 3000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "saurchin",
+  "category": "spiny",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "font"
+    },
+    {
+      "level_learned": 22,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 40,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thorn_burst"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "poinchin",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal"
+  ],
+  "tags": [
+    "sharp",
+    "toxic",
+    "bite",
+    "megafauna"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 349,
+  "height": 800,
+  "weight": 3000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/scarlant.json
+++ b/mods/tuxemon/db/monster/scarlant.json
@@ -1,60 +1,73 @@
 {
-    "slug": "scarlant",
-    "category": "myrmidon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 10,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "energy_claws"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 8,
-            "monster_slug": "shull"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "shull",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "myrmison",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "mountains", "swamp", "urban", "woodland"],
-    "tags": ["bug", "bite"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 289,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "scarlant",
+  "category": "myrmidon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 10,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "energy_claws"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 8,
+      "monster_slug": "shull"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "shull",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "myrmison",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "mountains",
+    "swamp",
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "bug",
+    "bite"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 289,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -1,70 +1,77 @@
 {
-    "slug": "sclairus",
-    "category": "fallow",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "pollen_blast"
-        },
-        {
-            "level_learned": 4,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 16,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 19,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 25,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 28,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant", "darkness", "summoner"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 119,
-    "height": 85,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "sclairus",
+  "category": "fallow",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "pollen_blast"
+    },
+    {
+      "level_learned": 4,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 16,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 19,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 25,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 28,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "darkness",
+    "summoner"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 119,
+  "height": 85,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -1,81 +1,88 @@
 {
-    "slug": "seirein",
-    "category": "spirit_fire",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 28,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "loliferno",
-            "item": "flintstone"
-        },
-        {
-            "at_level": 20,
-            "monster_slug": "spirain"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "loliferno",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "spirain",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "tornicane",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["swamp"],
-    "tags": ["flame", "light"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "fire",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 162,
-    "height": 30,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "seirein",
+  "category": "spirit_fire",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 28,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "loliferno",
+      "item": "flintstone"
+    },
+    {
+      "at_level": 20,
+      "monster_slug": "spirain"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "loliferno",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "spirain",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "tornicane",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "swamp"
+  ],
+  "tags": [
+    "flame",
+    "light"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 162,
+  "height": 30,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -1,65 +1,71 @@
 {
-    "slug": "selket",
-    "category": "sand_scorpion",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 7,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 31,
-            "technique": "avalanche"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "selmatek"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "selmatek",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "toxic", "rock"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 188,
-    "height": 17,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "selket",
+  "category": "sand_scorpion",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 7,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 31,
+      "technique": "avalanche"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "selmatek"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "selmatek",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "toxic",
+    "rock"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 188,
+  "height": 17,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -1,60 +1,66 @@
 {
-    "slug": "selmatek",
-    "category": "sand_steed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 4,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 7,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 31,
-            "technique": "avalanche"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "selket",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "toxic", "rock"],
-    "shape": "grub",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 189,
-    "height": 155,
-    "weight": 80,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "selmatek",
+  "category": "sand_steed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 4,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 7,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 31,
+      "technique": "avalanche"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "selket",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "toxic",
+    "rock"
+  ],
+  "shape": "grub",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 189,
+  "height": 155,
+  "weight": 80,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/seraphice.json
+++ b/mods/tuxemon/db/monster/seraphice.json
@@ -1,71 +1,82 @@
 {
-    "slug": "seraphice",
-    "category": "carol",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 4,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 7,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 13,
-            "technique": "neutralize"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fiery"
-        },
-        {
-            "level_learned": 34,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 43,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 46,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 52,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "waysprite",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "angesnow",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["extraplanar"],
-    "tags": ["ice", "leadership", "weather", "light", "healing", "calamity"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 266,
-    "height": 180,
-    "weight": 85,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "seraphice",
+  "category": "carol",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "neutralize"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fiery"
+    },
+    {
+      "level_learned": 34,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 43,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 46,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 52,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "waysprite",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "angesnow",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "ice",
+    "leadership",
+    "weather",
+    "light",
+    "healing",
+    "calamity"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 266,
+  "height": 180,
+  "weight": 85,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -1,70 +1,76 @@
 {
-    "slug": "shammer",
-    "category": "fossil",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 7,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 13,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 16,
-            "technique": "crushing_bite"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lust"
-        },
-        {
-            "level_learned": 25,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 31,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 37,
-            "technique": "steel_jaws"
-        },
-        {
-            "level_learned": 40,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["rock", "bite"],
-    "shape": "hunter",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 144,
-    "height": 80,
-    "weight": 40,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "shammer",
+  "category": "fossil",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 7,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 13,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 16,
+      "technique": "crushing_bite"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lust"
+    },
+    {
+      "level_learned": 25,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 31,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 37,
+      "technique": "steel_jaws"
+    },
+    {
+      "level_learned": 40,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 144,
+  "height": 80,
+  "weight": 40,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -1,72 +1,84 @@
 {
-    "slug": "sharpfin",
-    "category": "rip",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 19,
-            "technique": "web"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 40,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 55,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "dollfin",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["water", "bite", "sharp", "plant"],
-    "shape": "piscine",
-    "stage": "stage1",
-    "types": [
-        "water",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 26,
-    "height": 300,
-    "weight": 200,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "sharpfin",
+  "category": "rip",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 19,
+      "technique": "web"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 40,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 55,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "dollfin",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "water",
+    "bite",
+    "sharp",
+    "plant"
+  ],
+  "shape": "piscine",
+  "stage": "stage1",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 26,
+  "height": 300,
+  "weight": 200,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -1,85 +1,95 @@
 {
-    "slug": "shelagu",
-    "category": "sheltering",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "font"
-        },
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 19,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 25,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 37,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 40,
-            "technique": "poison_courtship"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "crustagu"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "lesmagu",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "crustagu",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["coastal", "sea"],
-    "tags": ["pseudopod", "water", "shielded", "sharp"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 278,
-    "height": 60,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "shelagu",
+  "category": "sheltering",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "font"
+    },
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 19,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 25,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 37,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 40,
+      "technique": "poison_courtship"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "crustagu"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "lesmagu",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "crustagu",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "sea"
+  ],
+  "tags": [
+    "pseudopod",
+    "water",
+    "shielded",
+    "sharp"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 278,
+  "height": 60,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/sheye.json
+++ b/mods/tuxemon/db/monster/sheye.json
@@ -1,56 +1,67 @@
 {
-    "slug": "sheye",
-    "category": "crabby_mussel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 4,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flow"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "shrab",
-            "bond": "greater_than:40"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "shrab",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["mental", "bite", "shielded"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 285,
-    "height": 40,
-    "weight": 19,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "sheye",
+  "category": "crabby_mussel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 4,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flow"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "shrab",
+      "bond": "greater_than:40"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "shrab",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "mental",
+    "bite",
+    "shielded"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 285,
+  "height": 40,
+  "weight": 19,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/shimmerain.json
+++ b/mods/tuxemon/db/monster/shimmerain.json
@@ -1,59 +1,69 @@
 {
-    "slug": "shimmerain",
-    "category": "percomorph_fish",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bubbles"
-        },
-        {
-            "level_learned": 4,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 10,
-            "technique": "ice_storm"
-        },
-        {
-            "level_learned": 16,
-            "technique": "surf"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 34,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["weather", "water", "speed"],
-    "shape": "piscine",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 364,
-    "height": 80,
-    "weight": 20,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "shimmerain",
+  "category": "percomorph_fish",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bubbles"
+    },
+    {
+      "level_learned": 4,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 10,
+      "technique": "ice_storm"
+    },
+    {
+      "level_learned": 16,
+      "technique": "surf"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 34,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "weather",
+    "water",
+    "speed"
+  ],
+  "shape": "piscine",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 364,
+  "height": 80,
+  "weight": 20,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -1,68 +1,74 @@
 {
-    "slug": "shnark",
-    "category": "disguised",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "font"
-        },
-        {
-            "level_learned": 7,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 28,
-            "technique": "kraken"
-        },
-        {
-            "level_learned": 31,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 40,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "nostray",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "water", "darkness"],
-    "shape": "piscine",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 153,
-    "height": 205,
-    "weight": 120,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "shnark",
+  "category": "disguised",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "font"
+    },
+    {
+      "level_learned": 7,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 28,
+      "technique": "kraken"
+    },
+    {
+      "level_learned": 31,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 40,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "nostray",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "water",
+    "darkness"
+  ],
+  "shape": "piscine",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 153,
+  "height": 205,
+  "weight": 120,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/shrab.json
+++ b/mods/tuxemon/db/monster/shrab.json
@@ -1,51 +1,62 @@
 {
-    "slug": "shrab",
-    "category": "muscly_crab",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 4,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flow"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "sheye",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["mental", "bite", "shielded"],
-    "shape": "polliwog",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 286,
-    "height": 100,
-    "weight": 100,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "shrab",
+  "category": "muscly_crab",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 4,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flow"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "sheye",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "mental",
+    "bite",
+    "shielded"
+  ],
+  "shape": "polliwog",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 286,
+  "height": 100,
+  "weight": 100,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/shull.json
+++ b/mods/tuxemon/db/monster/shull.json
@@ -1,61 +1,75 @@
 {
-    "slug": "shull",
-    "category": "myrmidon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 10,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 19,
-            "technique": "energy_claws"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "myrmison",
-            "variable": "daytime:false"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "scarlant",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "myrmison",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "mountains", "swamp", "urban", "woodland"],
-    "tags": ["bug", "bite", "shielded"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 290,
-    "height": 40,
-    "weight": 55,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "shull",
+  "category": "myrmidon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 10,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 19,
+      "technique": "energy_claws"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "myrmison",
+      "variable": "daytime:false"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "scarlant",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "myrmison",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "mountains",
+    "swamp",
+    "urban",
+    "woodland"
+  ],
+  "tags": [
+    "bug",
+    "bite",
+    "shielded"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 290,
+  "height": 40,
+  "weight": 55,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -1,64 +1,69 @@
 {
-    "slug": "shybulb",
-    "category": "gardener",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 1,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 4,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 7,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 28,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blossom"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "narcileaf"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "narcileaf",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 77,
-    "height": 29,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "shybulb",
+  "category": "gardener",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 1,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 4,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 7,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 28,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blossom"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "narcileaf"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "narcileaf",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 77,
+  "height": 29,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -1,68 +1,73 @@
 {
-    "slug": "skwib",
-    "category": "naive",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "font"
-        },
-        {
-            "level_learned": 19,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 25,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 28,
-            "technique": "venomous_tentacle"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "octabode"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "octabode",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["pseudopod"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 183,
-    "height": 30,
-    "weight": 9,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "skwib",
+  "category": "naive",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "font"
+    },
+    {
+      "level_learned": 19,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 25,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 28,
+      "technique": "venomous_tentacle"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "octabode"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "octabode",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "pseudopod"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 183,
+  "height": 30,
+  "weight": 9,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -1,88 +1,98 @@
 {
-    "slug": "slichen",
-    "category": "gel",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 16,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 19,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 28,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 31,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 34,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 52,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 55,
-            "technique": "thunderball"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 26,
-            "monster_slug": "glombroc"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "glombroc",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "conglolem",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["swamp", "underground"],
-    "tags": ["plant", "rock", "ground", "toxic"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 272,
-    "height": 37,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "slichen",
+  "category": "gel",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 16,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 19,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 28,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 31,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 34,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 52,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 55,
+      "technique": "thunderball"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 26,
+      "monster_slug": "glombroc"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "glombroc",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "conglolem",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "swamp",
+    "underground"
+  ],
+  "tags": [
+    "plant",
+    "rock",
+    "ground",
+    "toxic"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 272,
+  "height": 37,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -1,70 +1,79 @@
 {
-    "slug": "sludgehog",
-    "category": "garbage",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 4,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 7,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 19,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 28,
-            "technique": "lust"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blood_nets"
-        },
-        {
-            "level_learned": 37,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 40,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["sharp", "food", "toxic", "ground", "megafauna"],
-    "shape": "landrace",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 120,
-    "height": 125,
-    "weight": 95,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "sludgehog",
+  "category": "garbage",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 4,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 7,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 19,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 28,
+      "technique": "lust"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blood_nets"
+    },
+    {
+      "level_learned": 37,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 40,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "sharp",
+    "food",
+    "toxic",
+    "ground",
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 120,
+  "height": 125,
+  "weight": 95,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -1,69 +1,74 @@
 {
-    "slug": "snaki",
-    "category": "false_serpent",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electric_multibite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tsunami"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "snokari"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "snokari",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["toxic", "bite"],
-    "shape": "serpent",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 227,
-    "height": 70,
-    "weight": 15,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "snaki",
+  "category": "false_serpent",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electric_multibite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tsunami"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "snokari"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "snokari",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "toxic",
+    "bite"
+  ],
+  "shape": "serpent",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 227,
+  "height": 70,
+  "weight": 15,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -1,74 +1,80 @@
 {
-    "slug": "snarlon",
-    "category": "westerly",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 1,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 7,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 13,
-            "technique": "battery_acid"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 19,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 28,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 31,
-            "technique": "mystic_blending"
-        },
-        {
-            "level_learned": 37,
-            "technique": "lust"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["celestial", "healing"],
-    "shape": "hunter",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 147,
-    "height": 160,
-    "weight": 130,
-    "catch_rate": 5.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "snarlon",
+  "category": "westerly",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 1,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 7,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 13,
+      "technique": "battery_acid"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 19,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 28,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 31,
+      "technique": "mystic_blending"
+    },
+    {
+      "level_learned": 37,
+      "technique": "lust"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "celestial",
+    "healing"
+  ],
+  "shape": "hunter",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 147,
+  "height": 160,
+  "weight": 130,
+  "catch_rate": 5.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -1,69 +1,78 @@
 {
-    "slug": "snock",
-    "category": "sock",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 16,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 25,
-            "technique": "battery_acid"
-        },
-        {
-            "level_learned": 28,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 31,
-            "technique": "shrapnel"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "pythock"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "pythock",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["darkness", "pseudopod", "ghost", "shapeshifter"],
-    "shape": "serpent",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 225,
-    "height": 30,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "snock",
+  "category": "sock",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 16,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 25,
+      "technique": "battery_acid"
+    },
+    {
+      "level_learned": 28,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 31,
+      "technique": "shrapnel"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "pythock"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "pythock",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "darkness",
+    "pseudopod",
+    "ghost",
+    "shapeshifter"
+  ],
+  "shape": "serpent",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 225,
+  "height": 30,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -1,64 +1,69 @@
 {
-    "slug": "snokari",
-    "category": "hydra",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 28,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electric_multibite"
-        },
-        {
-            "level_learned": 40,
-            "technique": "tsunami"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "snaki",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["toxic", "bite"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 228,
-    "height": 145,
-    "weight": 45,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "snokari",
+  "category": "hydra",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 28,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electric_multibite"
+    },
+    {
+      "level_learned": 40,
+      "technique": "tsunami"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "snaki",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "toxic",
+    "bite"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 228,
+  "height": 145,
+  "weight": 45,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -1,60 +1,68 @@
 {
-    "slug": "snowrilla",
-    "category": "yeti",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "punch"
-        },
-        {
-            "level_learned": 4,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 13,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 40,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "chillimp",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["boreal_snow", "mountains"],
-    "tags": ["ice", "fists"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 155,
-    "height": 192,
-    "weight": 112,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "snowrilla",
+  "category": "yeti",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "punch"
+    },
+    {
+      "level_learned": 4,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 13,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 40,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "chillimp",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "mountains"
+  ],
+  "tags": [
+    "ice",
+    "fists"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 155,
+  "height": 192,
+  "weight": 112,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -1,59 +1,65 @@
 {
-    "slug": "sockeserp",
-    "category": "power_socket_snake",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 25,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blade"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pythwire",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["urban"],
-    "tags": ["electricity"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 91,
-    "height": 100,
-    "weight": 1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "sockeserp",
+  "category": "power_socket_snake",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 25,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blade"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pythwire",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "urban"
+  ],
+  "tags": [
+    "electricity"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 91,
+  "height": 100,
+  "weight": 1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -1,72 +1,81 @@
 {
-    "slug": "solight",
-    "category": "pulsar",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 16,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 19,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 28,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 37,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 40,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraplanar", "ruins"],
-    "tags": ["celestial", "light", "steel", "calamity"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 230,
-    "height": 55,
-    "weight": 17,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "solight",
+  "category": "pulsar",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 16,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 19,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 28,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 37,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 40,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraplanar",
+    "ruins"
+  ],
+  "tags": [
+    "celestial",
+    "light",
+    "steel",
+    "calamity"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 230,
+  "height": 55,
+  "weight": 17,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/spectera.json
+++ b/mods/tuxemon/db/monster/spectera.json
@@ -1,83 +1,91 @@
 {
-    "slug": "spectera",
-    "category": "flying_fox_bat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 16,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 28,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 31,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 37,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 40,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "fruitera",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "megafruitera",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["plant", "food"],
-    "shape": "flier",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 171,
-    "height": 140,
-    "weight": 20,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "spectera",
+  "category": "flying_fox_bat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 16,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 28,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 31,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 37,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 40,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "fruitera",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "megafruitera",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "plant",
+    "food"
+  ],
+  "shape": "flier",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 171,
+  "height": 140,
+  "weight": 20,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/sphake.json
+++ b/mods/tuxemon/db/monster/sphake.json
@@ -1,51 +1,57 @@
 {
-    "slug": "sphake",
-    "category": "galvanised",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 10,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 16,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "sprorm",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["steel", "ground", "calamity"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 304,
-    "height": 600,
-    "weight": 2000,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "sphake",
+  "category": "galvanised",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 10,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 16,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "sprorm",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "steel",
+    "ground",
+    "calamity"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 304,
+  "height": 600,
+  "weight": 2000,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -1,70 +1,76 @@
 {
-    "slug": "spighter",
-    "category": "eyerachnid",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 16,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 19,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 25,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 28,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 31,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 37,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 40,
-            "technique": "stonehenge"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["gaze", "darkness"],
-    "shape": "grub",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 121,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "spighter",
+  "category": "eyerachnid",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 16,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 19,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 25,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 28,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 31,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 37,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 40,
+      "technique": "stonehenge"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "gaze",
+    "darkness"
+  ],
+  "shape": "grub",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 121,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/spirain.json
+++ b/mods/tuxemon/db/monster/spirain.json
@@ -1,72 +1,81 @@
 {
-    "slug": "spirain",
-    "category": "water_sprite",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 28,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "tornicane"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "seirein",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "tornicane",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["freshwater", "swamp"],
-    "tags": ["water", "darkness", "ghost"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 164,
-    "height": 100,
-    "weight": 0.1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "spirain",
+  "category": "water_sprite",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 28,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "tornicane"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "seirein",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "tornicane",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "swamp"
+  ],
+  "tags": [
+    "water",
+    "darkness",
+    "ghost"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 164,
+  "height": 100,
+  "weight": 0.1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -1,71 +1,76 @@
 {
-    "slug": "spoilurm",
-    "category": "detritus",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 4,
-            "technique": "web"
-        },
-        {
-            "level_learned": 7,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 16,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 19,
-            "technique": "clock"
-        },
-        {
-            "level_learned": 25,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 31,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 37,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 40,
-            "technique": "assault"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["bug", "toxic"],
-    "shape": "serpent",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 214,
-    "height": 41,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "spoilurm",
+  "category": "detritus",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 4,
+      "technique": "web"
+    },
+    {
+      "level_learned": 7,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 16,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 19,
+      "technique": "clock"
+    },
+    {
+      "level_learned": 25,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 31,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 37,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 40,
+      "technique": "assault"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "bug",
+    "toxic"
+  ],
+  "shape": "serpent",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 214,
+  "height": 41,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/sprightly.json
+++ b/mods/tuxemon/db/monster/sprightly.json
@@ -1,56 +1,65 @@
 {
-    "slug": "sprightly",
-    "category": "rootball",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "nest"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "uprout"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "uprout",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["plant"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 336,
-    "height": 30,
-    "weight": 9,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "sprightly",
+  "category": "rootball",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "nest"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "uprout"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "uprout",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 336,
+  "height": 30,
+  "weight": 9,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/sprorm.json
+++ b/mods/tuxemon/db/monster/sprorm.json
@@ -1,56 +1,61 @@
 {
-    "slug": "sprorm",
-    "category": "galvanised",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 10,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 16,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "earthquake"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "sphake"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "sphake",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["steel", "ground"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 303,
-    "height": 30,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "sprorm",
+  "category": "galvanised",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 10,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 16,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "earthquake"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "sphake"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "sphake",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "steel",
+    "ground"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 303,
+  "height": 30,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -1,72 +1,78 @@
 {
-    "slug": "spycozeus",
-    "category": "willpower",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 4,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 13,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 25,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 28,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 31,
-            "technique": "negation"
-        },
-        {
-            "level_learned": 37,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 40,
-            "technique": "dreamwalk"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant", "mental", "leadership"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 222,
-    "height": 60,
-    "weight": 18,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "spycozeus",
+  "category": "willpower",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 4,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 13,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 25,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 28,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 31,
+      "technique": "negation"
+    },
+    {
+      "level_learned": 37,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 40,
+      "technique": "dreamwalk"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "mental",
+    "leadership"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 222,
+  "height": 60,
+  "weight": 18,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -1,68 +1,75 @@
 {
-    "slug": "squabbit",
-    "category": "rabbit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "thunderball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fledgling"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 25,
-            "technique": "stampede"
-        },
-        {
-            "level_learned": 28,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 31,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "rabbitosaur"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "rabbitosaur",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["soldier", "fists", "ground"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 44,
-    "height": 60,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "squabbit",
+  "category": "rabbit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "thunderball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fledgling"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 25,
+      "technique": "stampede"
+    },
+    {
+      "level_learned": 28,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 31,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "rabbitosaur"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "rabbitosaur",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "soldier",
+    "fists",
+    "ground"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 44,
+  "height": 60,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/squink.json
+++ b/mods/tuxemon/db/monster/squink.json
@@ -1,68 +1,73 @@
 {
-    "slug": "squink",
-    "category": "sea_spray",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "hectapod"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "hectapod",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["water"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 270,
-    "height": 70,
-    "weight": 24,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "squink",
+  "category": "sea_spray",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "hectapod"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "hectapod",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "water"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 270,
+  "height": 70,
+  "weight": 24,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -1,69 +1,74 @@
 {
-    "slug": "statursus",
-    "category": "inner_fire",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 7,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 28,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electrical_storm"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "coaldiak"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "furnursus",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "coaldiak",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["flame", "mental"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 191,
-    "height": 190,
-    "weight": 160,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "statursus",
+  "category": "inner_fire",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 7,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 28,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electrical_storm"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "coaldiak"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "furnursus",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "coaldiak",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "flame",
+    "mental"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 191,
+  "height": 190,
+  "weight": 160,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/stegofor.json
+++ b/mods/tuxemon/db/monster/stegofor.json
@@ -1,80 +1,91 @@
 {
-    "slug": "stegofor",
-    "category": "petrified",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spiky_strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "tip"
-        },
-        {
-            "level_learned": 4,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 16,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 28,
-            "technique": "trample"
-        },
-        {
-            "level_learned": 31,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 40,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "brachifor"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "fordin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "brachifor",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["plant", "shielded", "healing", "megafauna"],
-    "shape": "landrace",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 212,
-    "height": 650,
-    "weight": 2800,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "stegofor",
+  "category": "petrified",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spiky_strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "tip"
+    },
+    {
+      "level_learned": 4,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 16,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 28,
+      "technique": "trample"
+    },
+    {
+      "level_learned": 31,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 40,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "brachifor"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "fordin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "brachifor",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "shielded",
+    "healing",
+    "megafauna"
+  ],
+  "shape": "landrace",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 212,
+  "height": 650,
+  "weight": 2800,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/stomic.json
+++ b/mods/tuxemon/db/monster/stomic.json
@@ -1,72 +1,78 @@
 {
-    "slug": "stomic",
-    "category": "radioactive",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 13,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 16,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 19,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 31,
-            "technique": "magnetic_body"
-        },
-        {
-            "level_learned": 37,
-            "technique": "gourmet"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "gastronium"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "gastronium",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["steel", "toxic", "bomber"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 338,
-    "height": 30,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "stomic",
+  "category": "radioactive",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 13,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 16,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 19,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 31,
+      "technique": "magnetic_body"
+    },
+    {
+      "level_learned": 37,
+      "technique": "gourmet"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "gastronium"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "gastronium",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "steel",
+    "toxic",
+    "bomber"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 338,
+  "height": 30,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/stonifly.json
+++ b/mods/tuxemon/db/monster/stonifly.json
@@ -1,68 +1,74 @@
 {
-    "slug": "stonifly",
-    "category": "diptera",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 19,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 9,
-            "monster_slug": "cocrune"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "cocrune",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "runesquito",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["rock", "shielded", "bug"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 332,
-    "height": 30,
-    "weight": 16,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "stonifly",
+  "category": "diptera",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 19,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 9,
+      "monster_slug": "cocrune"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "cocrune",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "runesquito",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "rock",
+    "shielded",
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 332,
+  "height": 30,
+  "weight": 16,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -1,63 +1,68 @@
 {
-    "slug": "strella",
-    "category": "trailing",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overfeed"
-        },
-        {
-            "level_learned": 7,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "take_cover"
-        },
-        {
-            "level_learned": 25,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "pipis",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["darkness"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 49,
-    "height": 80,
-    "weight": 8,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "strella",
+  "category": "trailing",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overfeed"
+    },
+    {
+      "level_learned": 7,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "take_cover"
+    },
+    {
+      "level_learned": 25,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "pipis",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "darkness"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 49,
+  "height": 80,
+  "weight": 8,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -1,76 +1,84 @@
 {
-    "slug": "sumchon",
-    "category": "wrestling",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 1,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 19,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 25,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 46,
-            "technique": "suplex"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "katapill",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "katacoon",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["woodland"],
-    "tags": ["fists", "bug"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "metal",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 59,
-    "height": 150,
-    "weight": 125,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "sumchon",
+  "category": "wrestling",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 1,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 19,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 25,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 46,
+      "technique": "suplex"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "katapill",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "katacoon",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "woodland"
+  ],
+  "tags": [
+    "fists",
+    "bug"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "metal",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 59,
+  "height": 150,
+  "weight": 125,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tadcool.json
+++ b/mods/tuxemon/db/monster/tadcool.json
@@ -1,72 +1,77 @@
 {
-    "slug": "tadcool",
-    "category": "alarm",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 4,
-            "technique": "geyser"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "font"
-        },
-        {
-            "level_learned": 25,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 31,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "fribbit"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "fribbit",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ice"],
-    "shape": "polliwog",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 268,
-    "height": 25,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "tadcool",
+  "category": "alarm",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 4,
+      "technique": "geyser"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "font"
+    },
+    {
+      "level_learned": 25,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 31,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "fribbit"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "fribbit",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ice"
+  ],
+  "shape": "polliwog",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 268,
+  "height": 25,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -1,69 +1,75 @@
 {
-    "slug": "tarpeur",
-    "category": "restful",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 13,
-            "technique": "diet"
-        },
-        {
-            "level_learned": 25,
-            "technique": "hallucinogen_spore"
-        },
-        {
-            "level_learned": 28,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "vigueur"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "vigueur",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "plant", "rock"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 217,
-    "height": 19,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tarpeur",
+  "category": "restful",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 13,
+      "technique": "diet"
+    },
+    {
+      "level_learned": 25,
+      "technique": "hallucinogen_spore"
+    },
+    {
+      "level_learned": 28,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "vigueur"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "vigueur",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "plant",
+    "rock"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 217,
+  "height": 19,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -1,71 +1,75 @@
 {
-    "slug": "taupypus",
-    "category": "flatfoot",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 7,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "ice_shield"
-        },
-        {
-            "level_learned": 19,
-            "technique": "pouch"
-        },
-        {
-            "level_learned": 25,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 28,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 31,
-            "technique": "ice_storm"
-        },
-        {
-            "level_learned": 37,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "kraken"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["water"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 219,
-    "height": 60,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "taupypus",
+  "category": "flatfoot",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 7,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "ice_shield"
+    },
+    {
+      "level_learned": 19,
+      "technique": "pouch"
+    },
+    {
+      "level_learned": 25,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 28,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 31,
+      "technique": "ice_storm"
+    },
+    {
+      "level_learned": 37,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "kraken"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "water"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 219,
+  "height": 60,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -1,70 +1,81 @@
 {
-    "slug": "teddisun",
-    "category": "cute_teddy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 7,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 13,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 16,
-            "technique": "kindling_flame"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 25,
-            "technique": "firestorm"
-        },
-        {
-            "level_learned": 28,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sunburst"
-        },
-        {
-            "level_learned": 40,
-            "technique": "berserk"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["mountains", "ruins"],
-    "tags": ["light", "flame", "love", "claws"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 335,
-    "height": 110,
-    "weight": 60,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "teddisun",
+  "category": "cute_teddy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 7,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 13,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 16,
+      "technique": "kindling_flame"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 25,
+      "technique": "firestorm"
+    },
+    {
+      "level_learned": 28,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sunburst"
+    },
+    {
+      "level_learned": 40,
+      "technique": "berserk"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "mountains",
+    "ruins"
+  ],
+  "tags": [
+    "light",
+    "flame",
+    "love",
+    "claws"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 335,
+  "height": 110,
+  "weight": 60,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -1,69 +1,75 @@
 {
-    "slug": "tetrchimp",
-    "category": "chip",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 4,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 7,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 10,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 13,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 28,
-            "technique": "wall_of_steel"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "apeoro"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "apeoro",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["mental", "gadgets", "tail"],
-    "shape": "humanoid",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 196,
-    "height": 45,
-    "weight": 4,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tetrchimp",
+  "category": "chip",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 4,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 7,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 10,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 13,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 28,
+      "technique": "wall_of_steel"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "apeoro"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "apeoro",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "mental",
+    "gadgets",
+    "tail"
+  ],
+  "shape": "humanoid",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 196,
+  "height": 45,
+  "weight": 4,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/thumpurn.json
+++ b/mods/tuxemon/db/monster/thumpurn.json
@@ -1,56 +1,66 @@
 {
-    "slug": "thumpurn",
-    "category": "lagomorph",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 10,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 13,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "volconey"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "volconey",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["desert", "grassland", "woodland"],
-    "tags": ["flame", "ground"],
-    "shape": "brute",
-    "stage": "basic",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 298,
-    "height": 65,
-    "weight": 23,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "thumpurn",
+  "category": "lagomorph",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 10,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 13,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "volconey"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "volconey",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "flame",
+    "ground"
+  ],
+  "shape": "brute",
+  "stage": "basic",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 298,
+  "height": 65,
+  "weight": 23,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -1,67 +1,73 @@
 {
-    "slug": "tigrock",
-    "category": "ex_machina",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 4,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 7,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 31,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 37,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "grimachin",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "gadgets"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 94,
-    "height": 200,
-    "weight": 220,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tigrock",
+  "category": "ex_machina",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 4,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 7,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 31,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 37,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "grimachin",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "gadgets"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 94,
+  "height": 200,
+  "weight": 220,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -1,65 +1,72 @@
 {
-    "slug": "tikoal",
-    "category": "taboo",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 4,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 7,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 13,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 37,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "tikorch"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "tikorch",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "flame", "summoner"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "fire",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 79,
-    "height": 68,
-    "weight": 11,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "tikoal",
+  "category": "taboo",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 4,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 7,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 13,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 37,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "tikorch"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "tikorch",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "flame",
+    "summoner"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "fire",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 79,
+  "height": 68,
+  "weight": 11,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -1,64 +1,71 @@
 {
-    "slug": "tikorch",
-    "category": "taboo",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 4,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 7,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 13,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rock"
-        },
-        {
-            "level_learned": 37,
-            "technique": "berserk"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tikoal",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["plant", "flame", "summoner"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "fire",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 80,
-    "height": 136,
-    "weight": 44,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tikorch",
+  "category": "taboo",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 4,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 7,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 13,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rock"
+    },
+    {
+      "level_learned": 37,
+      "technique": "berserk"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tikoal",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "flame",
+    "summoner"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "fire",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 80,
+  "height": 136,
+  "weight": 44,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -1,77 +1,86 @@
 {
-    "slug": "tobishimi",
-    "category": "dragon_roll",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "font"
-        },
-        {
-            "level_learned": 31,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 43,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 46,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "drashimi",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "tsushimi",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["sea", "urban"],
-    "tags": ["food", "celestial", "shielded"],
-    "shape": "dragon",
-    "stage": "stage2",
-    "types": [
-        "water",
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 187,
-    "height": 180,
-    "weight": 169,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tobishimi",
+  "category": "dragon_roll",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "font"
+    },
+    {
+      "level_learned": 31,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 43,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 46,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "drashimi",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "tsushimi",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "sea",
+    "urban"
+  ],
+  "tags": [
+    "food",
+    "celestial",
+    "shielded"
+  ],
+  "shape": "dragon",
+  "stage": "stage2",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 187,
+  "height": 180,
+  "weight": 169,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/tornicane.json
+++ b/mods/tuxemon/db/monster/tornicane.json
@@ -1,67 +1,77 @@
 {
-    "slug": "tornicane",
-    "category": "water_sprite",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 7,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 28,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "seirein",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "spirain",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "swamp"],
-    "tags": ["water", "darkness", "ghost", "weather"],
-    "shape": "sprite",
-    "stage": "stage2",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 165,
-    "height": 300,
-    "weight": 0.1,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "tornicane",
+  "category": "water_sprite",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 7,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 28,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "seirein",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "spirain",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "swamp"
+  ],
+  "tags": [
+    "water",
+    "darkness",
+    "ghost",
+    "weather"
+  ],
+  "shape": "sprite",
+  "stage": "stage2",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 165,
+  "height": 300,
+  "weight": 0.1,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/toucanary.json
+++ b/mods/tuxemon/db/monster/toucanary.json
@@ -1,81 +1,89 @@
 {
-    "slug": "toucanary",
-    "category": "tropical",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 4,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 7,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "panjandrum"
-        },
-        {
-            "level_learned": 16,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 19,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 25,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_million_talons"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ten_thousand_feathers"
-        },
-        {
-            "level_learned": 55,
-            "technique": "fluff_up"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 20,
-            "monster_slug": "raptoucan"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "raptoucan",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle"],
-    "tags": ["bird", "claws", "bite"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 387,
-    "height": 12,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "toucanary",
+  "category": "tropical",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 4,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 7,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "panjandrum"
+    },
+    {
+      "level_learned": 16,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 19,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 25,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_million_talons"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ten_thousand_feathers"
+    },
+    {
+      "level_learned": 55,
+      "technique": "fluff_up"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 20,
+      "monster_slug": "raptoucan"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "raptoucan",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle"
+  ],
+  "tags": [
+    "bird",
+    "claws",
+    "bite"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 387,
+  "height": 12,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -1,71 +1,76 @@
 {
-    "slug": "toufigel",
-    "category": "powder",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 4,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 7,
-            "technique": "ram"
-        },
-        {
-            "level_learned": 13,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 16,
-            "technique": "avalanche"
-        },
-        {
-            "level_learned": 19,
-            "technique": "slime"
-        },
-        {
-            "level_learned": 25,
-            "technique": "evasion"
-        },
-        {
-            "level_learned": 28,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 31,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 37,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 40,
-            "technique": "mending"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ice"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "earth",
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 122,
-    "height": 40,
-    "weight": 3,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "toufigel",
+  "category": "powder",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 4,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 7,
+      "technique": "ram"
+    },
+    {
+      "level_learned": 13,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 16,
+      "technique": "avalanche"
+    },
+    {
+      "level_learned": 19,
+      "technique": "slime"
+    },
+    {
+      "level_learned": 25,
+      "technique": "evasion"
+    },
+    {
+      "level_learned": 28,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 31,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 37,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 40,
+      "technique": "mending"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ice"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "earth",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 122,
+  "height": 40,
+  "weight": 3,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -1,70 +1,77 @@
 {
-    "slug": "tourbidi",
-    "category": "elf_ring",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "pollen_blast"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 7,
-            "technique": "walls"
-        },
-        {
-            "level_learned": 13,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "web"
-        },
-        {
-            "level_learned": 19,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 25,
-            "technique": "ring"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 31,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "all_in"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["light", "plant", "healing"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 123,
-    "height": 42,
-    "weight": 14,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tourbidi",
+  "category": "elf_ring",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "pollen_blast"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 7,
+      "technique": "walls"
+    },
+    {
+      "level_learned": 13,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "web"
+    },
+    {
+      "level_learned": 19,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 25,
+      "technique": "ring"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 31,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "all_in"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "light",
+    "plant",
+    "healing"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 123,
+  "height": 42,
+  "weight": 14,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/toxiris.json
+++ b/mods/tuxemon/db/monster/toxiris.json
@@ -1,84 +1,95 @@
 {
-    "slug": "toxiris",
-    "category": "every_thorn",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 4,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 16,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "clairaudience"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 28,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 37,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flower_bloom"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 30,
-            "monster_slug": "ninjasmine"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "rosarin",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "ninjasmine",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["jungle", "woodland"],
-    "tags": ["love", "plant", "toxic", "bomber"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 205,
-    "height": 100,
-    "weight": 25,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "toxiris",
+  "category": "every_thorn",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 4,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 16,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "clairaudience"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 28,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 37,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flower_bloom"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 30,
+      "monster_slug": "ninjasmine"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "rosarin",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "ninjasmine",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "love",
+    "plant",
+    "toxic",
+    "bomber"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 205,
+  "height": 100,
+  "weight": 25,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -1,64 +1,74 @@
 {
-    "slug": "trapsnap",
-    "category": "barb",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 7,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 13,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 37,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 40,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "sapsnap"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "sapsnap",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["jungle", "swamp"],
-    "tags": ["plant", "sharp", "fury"],
-    "shape": "brute",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 85,
-    "height": 120,
-    "weight": 60,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "trapsnap",
+  "category": "barb",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 7,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 13,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 37,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 40,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "sapsnap"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "sapsnap",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "jungle",
+    "swamp"
+  ],
+  "tags": [
+    "plant",
+    "sharp",
+    "fury"
+  ],
+  "shape": "brute",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 85,
+  "height": 120,
+  "weight": 60,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/trojerror.json
+++ b/mods/tuxemon/db/monster/trojerror.json
@@ -1,80 +1,86 @@
 {
-    "slug": "trojerror",
-    "category": "virtual",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 16,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 19,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 25,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 28,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 37,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "magnetic_body"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "virware",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["extraplanar"],
-    "tags": ["machine", "steel"],
-    "shape": "sprite",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 380,
-    "height": 30,
-    "weight": 0.1,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "trojerror",
+  "category": "virtual",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 16,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 19,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 25,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 28,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 37,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "magnetic_body"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "virware",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "machine",
+    "steel"
+  ],
+  "shape": "sprite",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 380,
+  "height": 30,
+  "weight": 0.1,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -1,81 +1,90 @@
 {
-    "slug": "tsushimi",
-    "category": "dragon_roll",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 13,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 25,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 28,
-            "technique": "font"
-        },
-        {
-            "level_learned": 31,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 40,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 43,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 46,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 36,
-            "monster_slug": "tobishimi"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "drashimi",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "tobishimi",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["sea", "urban"],
-    "tags": ["food", "celestial", "shielded"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 186,
-    "height": 136,
-    "weight": 85,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tsushimi",
+  "category": "dragon_roll",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 13,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 25,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 28,
+      "technique": "font"
+    },
+    {
+      "level_learned": 31,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 40,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 43,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 46,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 36,
+      "monster_slug": "tobishimi"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "drashimi",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "tobishimi",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "sea",
+    "urban"
+  ],
+  "tags": [
+    "food",
+    "celestial",
+    "shielded"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 186,
+  "height": 136,
+  "weight": 85,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -1,59 +1,64 @@
 {
-    "slug": "tumblebee",
-    "category": "drone",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "web"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 7,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 13,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 25,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 31,
-            "technique": "whirlwind"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tumbleworm",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 96,
-    "height": 66,
-    "weight": 23,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tumblebee",
+  "category": "drone",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "web"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 7,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 13,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 25,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 31,
+      "technique": "whirlwind"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tumbleworm",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 96,
+  "height": 66,
+  "weight": 23,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumbledillo.json
+++ b/mods/tuxemon/db/monster/tumbledillo.json
@@ -1,75 +1,82 @@
 {
-    "slug": "tumbledillo",
-    "category": "ermine",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 7,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 16,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 31,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 37,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 40,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tumblequill",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "sharp", "bite"],
-    "shape": "varmint",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 221,
-    "height": 64,
-    "weight": 14,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tumbledillo",
+  "category": "ermine",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 7,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 16,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 31,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 37,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 40,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tumblequill",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "sharp",
+    "bite"
+  ],
+  "shape": "varmint",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 221,
+  "height": 64,
+  "weight": 14,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -1,81 +1,86 @@
 {
-    "slug": "tumblequill",
-    "category": "urchin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 7,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 16,
-            "technique": "surge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 25,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "mending"
-        },
-        {
-            "level_learned": 31,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 37,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 40,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "tumbledillo"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "tumbledillo",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["ground", "sharp"],
-    "shape": "varmint",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 220,
-    "height": 27,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "tumblequill",
+  "category": "urchin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 7,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 16,
+      "technique": "surge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 25,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "mending"
+    },
+    {
+      "level_learned": 31,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 37,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 40,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "tumbledillo"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "tumbledillo",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "sharp"
+  ],
+  "shape": "varmint",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 220,
+  "height": 27,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -1,64 +1,69 @@
 {
-    "slug": "tumbleworm",
-    "category": "buzzkill",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "web"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 7,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 13,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 25,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 28,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 31,
-            "technique": "whirlwind"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "tumblebee"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "tumblebee",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bug"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 95,
-    "height": 21,
-    "weight": 5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "tumbleworm",
+  "category": "buzzkill",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "web"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 7,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 13,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 25,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 28,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 31,
+      "technique": "whirlwind"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "tumblebee"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "tumblebee",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 95,
+  "height": 21,
+  "weight": 5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -1,73 +1,82 @@
 {
-    "slug": "turnipper",
-    "category": "scarytale",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 28,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 18,
-            "monster_slug": "beenstalker"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "beenstalker",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "wendigger",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["grassland", "woodland"],
-    "tags": ["plant", "ground", "bite"],
-    "shape": "hunter",
-    "stage": "basic",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 198,
-    "height": 65,
-    "weight": 25,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "turnipper",
+  "category": "scarytale",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 28,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 18,
+      "monster_slug": "beenstalker"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "beenstalker",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "wendigger",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ground",
+    "bite"
+  ],
+  "shape": "hunter",
+  "stage": "basic",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 198,
+  "height": 65,
+  "weight": 25,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/tux.json
+++ b/mods/tuxemon/db/monster/tux.json
@@ -1,70 +1,81 @@
 {
-    "slug": "tux",
-    "category": "penguin",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "font"
-        },
-        {
-            "level_learned": 16,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 19,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blood_bond"
-        },
-        {
-            "level_learned": 28,
-            "technique": "tux_attack"
-        },
-        {
-            "level_learned": 31,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 37,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shapechange"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["boreal_snow", "coastal"],
-    "tags": ["water", "ice", "leadership", "rock"],
-    "shape": "flier",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 254,
-    "height": 115,
-    "weight": 55,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "tux",
+  "category": "penguin",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "font"
+    },
+    {
+      "level_learned": 16,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 19,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blood_bond"
+    },
+    {
+      "level_learned": 28,
+      "technique": "tux_attack"
+    },
+    {
+      "level_learned": 31,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 37,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shapechange"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "boreal_snow",
+    "coastal"
+  ],
+  "tags": [
+    "water",
+    "ice",
+    "leadership",
+    "rock"
+  ],
+  "shape": "flier",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 254,
+  "height": 115,
+  "weight": 55,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -1,80 +1,91 @@
 {
-    "slug": "tweesher",
-    "category": "halcyon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "peck"
-        },
-        {
-            "level_learned": 4,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 7,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 13,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 31,
-            "technique": "biting_winds"
-        },
-        {
-            "level_learned": 34,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 43,
-            "technique": "font"
-        },
-        {
-            "level_learned": 46,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 52,
-            "technique": "snowstorm"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 24,
-            "monster_slug": "heronquak"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "heronquak",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "eaglace",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["boreal_snow", "grassland", "mountains"],
-    "tags": ["gemstone", "ice", "bird"],
-    "shape": "flier",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 7,
-    "height": 45,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "tweesher",
+  "category": "halcyon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "peck"
+    },
+    {
+      "level_learned": 4,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 7,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 13,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 31,
+      "technique": "biting_winds"
+    },
+    {
+      "level_learned": 34,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 43,
+      "technique": "font"
+    },
+    {
+      "level_learned": 46,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 52,
+      "technique": "snowstorm"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 24,
+      "monster_slug": "heronquak"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "heronquak",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "eaglace",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "grassland",
+    "mountains"
+  ],
+  "tags": [
+    "gemstone",
+    "ice",
+    "bird"
+  ],
+  "shape": "flier",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 7,
+  "height": 45,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/uf0.json
+++ b/mods/tuxemon/db/monster/uf0.json
@@ -1,70 +1,80 @@
 {
-    "slug": "uf0",
-    "category": "space_cutie",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 1,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 13,
-            "technique": "time_crisis"
-        },
-        {
-            "level_learned": 16,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 25,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 28,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 37,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 40,
-            "technique": "radiance"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraterrestrial"],
-    "tags": ["steel", "gadgets", "shielded", "summoner", "shapeshifter"],
-    "shape": "grub",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 267,
-    "height": 80,
-    "weight": 7,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "uf0",
+  "category": "space_cutie",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 1,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 13,
+      "technique": "time_crisis"
+    },
+    {
+      "level_learned": 16,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 25,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 28,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 37,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 40,
+      "technique": "radiance"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraterrestrial"
+  ],
+  "tags": [
+    "steel",
+    "gadgets",
+    "shielded",
+    "summoner",
+    "shapeshifter"
+  ],
+  "shape": "grub",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 267,
+  "height": 80,
+  "weight": 7,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/uglip.json
+++ b/mods/tuxemon/db/monster/uglip.json
@@ -1,70 +1,79 @@
 {
-    "slug": "uglip",
-    "category": "deepsea",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 1,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 7,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 16,
-            "technique": "starfall"
-        },
-        {
-            "level_learned": 19,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 25,
-            "technique": "blood_bond"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 37,
-            "technique": "tsunami"
-        },
-        {
-            "level_learned": 40,
-            "technique": "poison_courtship"
-        }
-    ],  
-    "evolutions": [],
-    "history": [],
-    "terrains": ["coastal", "freshwater", "sea"],
-    "tags": ["water"],
-    "shape": "piscine",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 301,
-    "height": 30,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "uglip",
+  "category": "deepsea",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 1,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 7,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 16,
+      "technique": "starfall"
+    },
+    {
+      "level_learned": 19,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 25,
+      "technique": "blood_bond"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 37,
+      "technique": "tsunami"
+    },
+    {
+      "level_learned": 40,
+      "technique": "poison_courtship"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "coastal",
+    "freshwater",
+    "sea"
+  ],
+  "tags": [
+    "water"
+  ],
+  "shape": "piscine",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 301,
+  "height": 30,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/uneye.json
+++ b/mods/tuxemon/db/monster/uneye.json
@@ -1,80 +1,86 @@
 {
-    "slug": "uneye",
-    "category": "vision",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 1,
-            "technique": "mind_vise"
-        },
-        {
-            "level_learned": 4,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 7,
-            "technique": "radiance"
-        },
-        {
-            "level_learned": 13,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 16,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 25,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 28,
-            "technique": "acid"
-        },
-        {
-            "level_learned": 31,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 37,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 38,
-            "monster_slug": "lendos"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "lendos",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["gaze", "darkness", "mental"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 240,
-    "height": 45,
-    "weight": 3.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "uneye",
+  "category": "vision",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 1,
+      "technique": "mind_vise"
+    },
+    {
+      "level_learned": 4,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 7,
+      "technique": "radiance"
+    },
+    {
+      "level_learned": 13,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 16,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 25,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 28,
+      "technique": "acid"
+    },
+    {
+      "level_learned": 31,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 37,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 38,
+      "monster_slug": "lendos"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "lendos",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "gaze",
+    "darkness",
+    "mental"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 240,
+  "height": 45,
+  "weight": 3.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/uprout.json
+++ b/mods/tuxemon/db/monster/uprout.json
@@ -1,67 +1,77 @@
 {
-    "slug": "uprout",
-    "category": "rootball",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 10,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 13,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 19,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 25,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "potluck"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 37,
-            "technique": "cutting_leaves"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "sprightly",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["plant", "bird"],
-    "shape": "blob",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 337,
-    "height": 100,
-    "weight": 10,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "uprout",
+  "category": "rootball",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 10,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 13,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 19,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 25,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "potluck"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 37,
+      "technique": "cutting_leaves"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "sprightly",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "bird"
+  ],
+  "shape": "blob",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 337,
+  "height": 100,
+  "weight": 10,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/urcheedle.json
+++ b/mods/tuxemon/db/monster/urcheedle.json
@@ -1,70 +1,79 @@
 {
-    "slug": "urcheedle",
-    "category": "spiked",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "spiky_strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 4,
-            "technique": "flow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 13,
-            "technique": "mobbing"
-        },
-        {
-            "level_learned": 16,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 25,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 31,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 37,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 40,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["sea"],
-    "tags": ["sharp", "toxic", "water"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 243,
-    "height": 30,
-    "weight": 0.5,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "urcheedle",
+  "category": "spiked",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "spiky_strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 4,
+      "technique": "flow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 13,
+      "technique": "mobbing"
+    },
+    {
+      "level_learned": 16,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 25,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 31,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 37,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 40,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "sea"
+  ],
+  "tags": [
+    "sharp",
+    "toxic",
+    "water"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 243,
+  "height": 30,
+  "weight": 0.5,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -1,75 +1,82 @@
 {
-    "slug": "urcine",
-    "category": "temper",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "boulder"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 7,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 19,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 25,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 28,
-            "technique": "poison_courtship"
-        },
-        {
-            "level_learned": 31,
-            "technique": "orbs"
-        },
-        {
-            "level_learned": 37,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 40,
-            "technique": "steel_jaws"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["fists", "fury", "bite", "soldier"],
-    "shape": "brute",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 216,
-    "height": 115,
-    "weight": 45,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "urcine",
+  "category": "temper",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "boulder"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 7,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 19,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 25,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 28,
+      "technique": "poison_courtship"
+    },
+    {
+      "level_learned": 31,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 37,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 40,
+      "technique": "steel_jaws"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "fists",
+    "fury",
+    "bite",
+    "soldier"
+  ],
+  "shape": "brute",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 216,
+  "height": 115,
+  "weight": 45,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -1,80 +1,87 @@
 {
-    "slug": "vamporm",
-    "category": "clot",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "proboscis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 4,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 7,
-            "technique": "font"
-        },
-        {
-            "level_learned": 10,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 13,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 16,
-            "technique": "tonguespear"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleeping_powder"
-        },
-        {
-            "level_learned": 25,
-            "technique": "venomous_tentacle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 9,
-            "monster_slug": "dracune"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "dracune",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "fluttaflap",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "healing", "bug"],
-    "shape": "grub",
-    "stage": "basic",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 36,
-    "height": 17,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "vamporm",
+  "category": "clot",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "proboscis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 4,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 7,
+      "technique": "font"
+    },
+    {
+      "level_learned": 10,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 13,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 16,
+      "technique": "tonguespear"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleeping_powder"
+    },
+    {
+      "level_learned": 25,
+      "technique": "venomous_tentacle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 9,
+      "monster_slug": "dracune"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "dracune",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "fluttaflap",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "healing",
+    "bug"
+  ],
+  "shape": "grub",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 36,
+  "height": 17,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -1,75 +1,85 @@
 {
-    "slug": "velocitile",
-    "category": "restless",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 1,
-            "technique": "feint"
-        },
-        {
-            "level_learned": 4,
-            "technique": "assault"
-        },
-        {
-            "level_learned": 7,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 13,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 25,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 28,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 31,
-            "technique": "leaf_barrage"
-        },
-        {
-            "level_learned": 40,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 43,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 46,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "anoleaf",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "gectile",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "woodland"],
-    "tags": ["plant", "speed"],
-    "shape": "humanoid",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 67,
-    "height": 150,
-    "weight": 75,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "velocitile",
+  "category": "restless",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 1,
+      "technique": "feint"
+    },
+    {
+      "level_learned": 4,
+      "technique": "assault"
+    },
+    {
+      "level_learned": 7,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 13,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 25,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 28,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 31,
+      "technique": "leaf_barrage"
+    },
+    {
+      "level_learned": 40,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 43,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 46,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "anoleaf",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "gectile",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "speed"
+  ],
+  "shape": "humanoid",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 67,
+  "height": 150,
+  "weight": 75,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -1,64 +1,71 @@
 {
-    "slug": "vigueur",
-    "category": "energised",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "chameleon"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 13,
-            "technique": "diet"
-        },
-        {
-            "level_learned": 25,
-            "technique": "hallucinogen_spore"
-        },
-        {
-            "level_learned": 28,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 31,
-            "technique": "life_surge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "rocky_barrage"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "tarpeur",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["bite", "plant", "fists", "rock"],
-    "shape": "brute",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 218,
-    "height": 38,
-    "weight": 4,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "vigueur",
+  "category": "energised",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "chameleon"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 13,
+      "technique": "diet"
+    },
+    {
+      "level_learned": 25,
+      "technique": "hallucinogen_spore"
+    },
+    {
+      "level_learned": 28,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 31,
+      "technique": "life_surge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "rocky_barrage"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "tarpeur",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "bite",
+    "plant",
+    "fists",
+    "rock"
+  ],
+  "shape": "brute",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 218,
+  "height": 38,
+  "weight": 4,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/virware.json
+++ b/mods/tuxemon/db/monster/virware.json
@@ -1,85 +1,91 @@
 {
-    "slug": "virware",
-    "category": "virtual",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "meltdown"
-        },
-        {
-            "level_learned": 16,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 19,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 25,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 28,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "electroplate"
-        },
-        {
-            "level_learned": 37,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "magnetic_body"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "trojerror",
-            "item": "metal_booster"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "trojerror",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["extraplanar"],
-    "tags": ["machine", "steel"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 379,
-    "height": 30,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "virware",
+  "category": "virtual",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "meltdown"
+    },
+    {
+      "level_learned": 16,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 19,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 25,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 28,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "electroplate"
+    },
+    {
+      "level_learned": 37,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "magnetic_body"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "trojerror",
+      "item": "metal_booster"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "trojerror",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "machine",
+    "steel"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 379,
+  "height": 30,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -1,67 +1,78 @@
 {
-    "slug": "vivicinder",
-    "category": "lit",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "salamander"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 25,
-            "technique": "refresh"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 40,
-            "technique": "firestorm"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["ruins", "underground", "urban"],
-    "tags": ["shapeshifter", "bite", "flame"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 133,
-    "height": 95,
-    "weight": 6,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "vivicinder",
+  "category": "lit",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "salamander"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 25,
+      "technique": "refresh"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 40,
+      "technique": "firestorm"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "underground",
+    "urban"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "flame"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 133,
+  "height": 95,
+  "weight": 6,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -1,68 +1,77 @@
 {
-    "slug": "vividactil",
-    "category": "exhumed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "wing_tip"
-        },
-        {
-            "level_learned": 19,
-            "technique": "crushing_bite"
-        },
-        {
-            "level_learned": 25,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 31,
-            "technique": "burrow_blast"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["other"],
-    "tags": ["shapeshifter", "bite", "rock", "healing"],
-    "shape": "flier",
-    "stage": "stage1",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 138,
-    "height": 97,
-    "weight": 10,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "vividactil",
+  "category": "exhumed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "wing_tip"
+    },
+    {
+      "level_learned": 19,
+      "technique": "crushing_bite"
+    },
+    {
+      "level_learned": 25,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 31,
+      "technique": "burrow_blast"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "other"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "rock",
+    "healing"
+  ],
+  "shape": "flier",
+  "stage": "stage1",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 138,
+  "height": 97,
+  "weight": 10,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -1,110 +1,123 @@
 {
-    "slug": "vivipere",
-    "category": "potentia",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "vivicinder",
-            "tech": "flamethrower"
-        },
-        {
-            "monster_slug": "viviphyta",
-            "element": "wood"
-        },
-        {
-            "at_level": 24,
-            "monster_slug": "viviteel",
-            "gender": "female"
-        },
-        {
-            "monster_slug": "vivitrans",
-            "inside": true
-        },
-        {
-            "at_level": 26,
-            "monster_slug": "vivitron"
-        },
-        {
-            "monster_slug": "vividactil",
-            "item": "petrified_dung"
-        },
-        {
-            "monster_slug": "vividactil",
-            "item": "shammer_fossil"
-        },
-        {
-            "monster_slug": "vividactil",
-            "item": "rhincus_fossil"
-        },
-        {
-            "at_level": 24,
-            "monster_slug": "vivisource",
-            "gender": "male"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "vivisource",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "vividactil",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "vivitron",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "vivitrans",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "viviteel",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "viviphyta",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "vivicinder",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "mountains", "ruins", "underground", "woodland"],
-    "tags": ["shapeshifter", "bite"],
-    "shape": "serpent",
-    "stage": "basic",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 132,
-    "height": 85,
-    "weight": 8,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "vivipere",
+  "category": "potentia",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "vivicinder",
+      "tech": "flamethrower"
+    },
+    {
+      "monster_slug": "viviphyta",
+      "element": "wood"
+    },
+    {
+      "at_level": 24,
+      "monster_slug": "viviteel",
+      "gender": "female"
+    },
+    {
+      "monster_slug": "vivitrans",
+      "inside": true
+    },
+    {
+      "at_level": 26,
+      "monster_slug": "vivitron"
+    },
+    {
+      "monster_slug": "vividactil",
+      "item": "petrified_dung"
+    },
+    {
+      "monster_slug": "vividactil",
+      "item": "shammer_fossil"
+    },
+    {
+      "monster_slug": "vividactil",
+      "item": "rhincus_fossil"
+    },
+    {
+      "at_level": 24,
+      "monster_slug": "vivisource",
+      "gender": "male"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "vivisource",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "vividactil",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "vivitron",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "vivitrans",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "viviteel",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "viviphyta",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "vivicinder",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "mountains",
+    "ruins",
+    "underground",
+    "woodland"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite"
+  ],
+  "shape": "serpent",
+  "stage": "basic",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 132,
+  "height": 85,
+  "weight": 8,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -1,63 +1,76 @@
 {
-    "slug": "viviphyta",
-    "category": "germinated",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 19,
-            "technique": "infectious_bite"
-        },
-        {
-            "level_learned": 25,
-            "technique": "flower_armor"
-        },
-        {
-            "level_learned": 31,
-            "technique": "flower_bloom"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "ruins", "woodland"],
-    "tags": ["shapeshifter", "bite", "plant", "leadership"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 134,
-    "height": 87,
-    "weight": 9,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "viviphyta",
+  "category": "germinated",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 19,
+      "technique": "infectious_bite"
+    },
+    {
+      "level_learned": 25,
+      "technique": "flower_armor"
+    },
+    {
+      "level_learned": 31,
+      "technique": "flower_bloom"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "ruins",
+    "woodland"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "plant",
+    "leadership"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 134,
+  "height": 87,
+  "weight": 9,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -1,64 +1,75 @@
 {
-    "slug": "vivisource",
-    "category": "purified",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 19,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "depth_charge"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["freshwater", "grassland", "jungle", "ruins"],
-    "tags": ["shapeshifter", "bite", "water", "toxic"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "water"
-    ],
-    "possible_genders": ["male"],
-    "txmn_id": 139,
-    "height": 107,
-    "weight": 9,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "vivisource",
+  "category": "purified",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 19,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "depth_charge"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "freshwater",
+    "grassland",
+    "jungle",
+    "ruins"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "water",
+    "toxic"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "male"
+  ],
+  "txmn_id": 139,
+  "height": 107,
+  "weight": 9,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -1,67 +1,78 @@
 {
-    "slug": "viviteel",
-    "category": "galvanised",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 19,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 25,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 31,
-            "technique": "crushing_bite"
-        },
-        {
-            "level_learned": 37,
-            "technique": "steel_jaws"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "mountains", "ruins", "underground"],
-    "tags": ["shapeshifter", "bite", "steel"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["female"],
-    "txmn_id": 135,
-    "height": 102,
-    "weight": 18,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
+  "slug": "viviteel",
+  "category": "galvanised",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 19,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 25,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 31,
+      "technique": "crushing_bite"
+    },
+    {
+      "level_learned": 37,
+      "technique": "steel_jaws"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "mountains",
+    "ruins",
+    "underground"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "steel"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "female"
+  ],
+  "txmn_id": 135,
+  "height": 102,
+  "weight": 18,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
 }

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -1,60 +1,74 @@
 {
-    "slug": "vivitrans",
-    "category": "sublimated",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "chill_mist"
-        },
-        {
-            "level_learned": 19,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 25,
-            "technique": "frostbite"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "mountains", "ruins", "underground"],
-    "tags": ["shapeshifter", "bite", "mental", "ice"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal",
-        "water"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 136,
-    "height": 98,
-    "weight": 11,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "vivitrans",
+  "category": "sublimated",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "chill_mist"
+    },
+    {
+      "level_learned": 19,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 25,
+      "technique": "frostbite"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "mountains",
+    "ruins",
+    "underground"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "mental",
+    "ice"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal",
+    "water"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 136,
+  "height": 98,
+  "weight": 11,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -1,67 +1,81 @@
 {
-    "slug": "vivitron",
-    "category": "sparked",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "stone_rot"
-        },
-        {
-            "level_learned": 1,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 4,
-            "technique": "quicksand"
-        },
-        {
-            "level_learned": 7,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 16,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 25,
-            "technique": "battery_acid"
-        },
-        {
-            "level_learned": 31,
-            "technique": "rift_dash"
-        },
-        {
-            "level_learned": 40,
-            "technique": "electric_multibite"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "vivipere",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["grassland", "jungle", "mountains", "ruins", "underground", "woodland"],
-    "tags": ["shapeshifter", "bite", "electricity"],
-    "shape": "serpent",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 137,
-    "height": 92,
-    "weight": 12,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "vivitron",
+  "category": "sparked",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "stone_rot"
+    },
+    {
+      "level_learned": 1,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 4,
+      "technique": "quicksand"
+    },
+    {
+      "level_learned": 7,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 16,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 25,
+      "technique": "battery_acid"
+    },
+    {
+      "level_learned": 31,
+      "technique": "rift_dash"
+    },
+    {
+      "level_learned": 40,
+      "technique": "electric_multibite"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "vivipere",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "grassland",
+    "jungle",
+    "mountains",
+    "ruins",
+    "underground",
+    "woodland"
+  ],
+  "tags": [
+    "shapeshifter",
+    "bite",
+    "electricity"
+  ],
+  "shape": "serpent",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 137,
+  "height": 92,
+  "weight": 12,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -1,70 +1,75 @@
 {
-    "slug": "volcoli",
-    "category": "seasonal",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_shield"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sudden_glow"
-        },
-        {
-            "level_learned": 7,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 13,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 16,
-            "technique": "conjurer"
-        },
-        {
-            "level_learned": 19,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 25,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 28,
-            "technique": "thunderclap"
-        },
-        {
-            "level_learned": 31,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 37,
-            "technique": "flamethrower"
-        },
-        {
-            "level_learned": 40,
-            "technique": "supernova"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["plant", "shapeshifter"],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 124,
-    "height": 53,
-    "weight": 18,
-    "catch_rate": 5.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "volcoli",
+  "category": "seasonal",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_shield"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sudden_glow"
+    },
+    {
+      "level_learned": 7,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 13,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 16,
+      "technique": "conjurer"
+    },
+    {
+      "level_learned": 19,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 25,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 28,
+      "technique": "thunderclap"
+    },
+    {
+      "level_learned": 31,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 37,
+      "technique": "flamethrower"
+    },
+    {
+      "level_learned": 40,
+      "technique": "supernova"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "plant",
+    "shapeshifter"
+  ],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 124,
+  "height": 53,
+  "weight": 18,
+  "catch_rate": 5.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/volconey.json
+++ b/mods/tuxemon/db/monster/volconey.json
@@ -1,51 +1,62 @@
 {
-    "slug": "volconey",
-    "category": "roaming",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gnaw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fire_claw"
-        },
-        {
-            "level_learned": 10,
-            "technique": "mudslide"
-        },
-        {
-            "level_learned": 13,
-            "technique": "earthquake"
-        },
-        {
-            "level_learned": 19,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "thumpurn",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "grassland", "woodland"],
-    "tags": ["flame", "ground", "calamity"],
-    "shape": "varmint",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 299,
-    "height": 85,
-    "weight": 32,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "volconey",
+  "category": "roaming",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gnaw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fire_claw"
+    },
+    {
+      "level_learned": 10,
+      "technique": "mudslide"
+    },
+    {
+      "level_learned": 13,
+      "technique": "earthquake"
+    },
+    {
+      "level_learned": 19,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "thumpurn",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland",
+    "woodland"
+  ],
+  "tags": [
+    "flame",
+    "ground",
+    "calamity"
+  ],
+  "shape": "varmint",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 299,
+  "height": 85,
+  "weight": 32,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/vulpyre.json
+++ b/mods/tuxemon/db/monster/vulpyre.json
@@ -1,75 +1,85 @@
 {
-    "slug": "vulpyre",
-    "category": "firefox",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fire_ball"
-        },
-        {
-            "level_learned": 1,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 4,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 7,
-            "technique": "breathe_fire"
-        },
-        {
-            "level_learned": 13,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 16,
-            "technique": "torch"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lava"
-        },
-        {
-            "level_learned": 25,
-            "technique": "all_in"
-        },
-        {
-            "level_learned": 28,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 31,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 37,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 40,
-            "technique": "flamethrower"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "foxfire",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert", "grassland"],
-    "tags": ["flame", "calamity", "claws"],
-    "shape": "hunter",
-    "stage": "stage1",
-    "types": [
-        "fire"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 150,
-    "height": 100,
-    "weight": 50,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "vulpyre",
+  "category": "firefox",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fire_ball"
+    },
+    {
+      "level_learned": 1,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 4,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 7,
+      "technique": "breathe_fire"
+    },
+    {
+      "level_learned": 13,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 16,
+      "technique": "torch"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lava"
+    },
+    {
+      "level_learned": 25,
+      "technique": "all_in"
+    },
+    {
+      "level_learned": 28,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 31,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 37,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 40,
+      "technique": "flamethrower"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "foxfire",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert",
+    "grassland"
+  ],
+  "tags": [
+    "flame",
+    "calamity",
+    "claws"
+  ],
+  "shape": "hunter",
+  "stage": "stage1",
+  "types": [
+    "fire"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 150,
+  "height": 100,
+  "weight": 50,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -1,86 +1,86 @@
 {
-    "slug": "waysprite",
-    "category": "wavering",
-    "moveset": [
-      {
-        "level_learned": 1,
-        "technique": "ice_claw"
-      },
-      {
-        "level_learned": 1,
-        "technique": "goad"
-      },
-      {
-        "level_learned": 4,
-        "technique": "beam"
-      },
-      {
-        "level_learned": 7,
-        "technique": "orbs"
-      },
-      {
-        "level_learned": 13,
-        "technique": "neutralize"
-      }
-    ],
-    "evolutions": [
-      {
-        "at_level": 14,
-        "monster_slug": "angesnow",
-        "variables": [
-          {
-            "daytime": "true"
-          }
-        ]
-      },
-      {
-        "at_level": 14,
-        "monster_slug": "demosnow",
-        "variables": [
-          {
-            "daytime": "false"
-          }
-        ]
-      }
-    ],
-    "history": [
-      {
-        "mon_slug": "angesnow",
-        "evo_stage": "stage1"
-      },
-      {
-        "mon_slug": "demosnow",
-        "evo_stage": "stage1"
-      },
-      {
-        "mon_slug": "lucifice",
-        "evo_stage": "stage2"
-      },
-      {
-        "mon_slug": "seraphice",
-        "evo_stage": "stage2"
-      }
-    ],
-    "terrains": [
-      "extraplanar"
-    ],
-    "tags": [
-      "ice",
-      "leadership",
-      "weather"
-    ],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-      "water"
-    ],
-    "possible_genders": [
-      "neuter"
-    ],
-    "txmn_id": 262,
-    "height": 15,
-    "weight": 1,
-    "catch_rate": 100,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.25
-  }
+  "slug": "waysprite",
+  "category": "wavering",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 7,
+      "technique": "orbs"
+    },
+    {
+      "level_learned": 13,
+      "technique": "neutralize"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 14,
+      "monster_slug": "angesnow",
+      "variables": [
+        {
+          "daytime": "true"
+        }
+      ]
+    },
+    {
+      "at_level": 14,
+      "monster_slug": "demosnow",
+      "variables": [
+        {
+          "daytime": "false"
+        }
+      ]
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "angesnow",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "demosnow",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "lucifice",
+      "evo_stage": "stage2"
+    },
+    {
+      "mon_slug": "seraphice",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "extraplanar"
+  ],
+  "tags": [
+    "ice",
+    "leadership",
+    "weather"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 262,
+  "height": 15,
+  "weight": 1,
+  "catch_rate": 100,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.25
+}

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -1,75 +1,82 @@
 {
-    "slug": "weavifly",
-    "category": "brood",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wallow"
-        },
-        {
-            "level_learned": 4,
-            "technique": "buzz"
-        },
-        {
-            "level_learned": 7,
-            "technique": "hibernate"
-        },
-        {
-            "level_learned": 10,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 13,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 16,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 19,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 22,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 25,
-            "technique": "eyebite"
-        },
-        {
-            "level_learned": 55,
-            "technique": "tornado"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "cataspike",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "puparmor",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": [],
-    "tags": ["sharp", "bug", "bomber"],
-    "shape": "grub",
-    "stage": "stage2",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 35,
-    "height": 52,
-    "weight": 17,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "weavifly",
+  "category": "brood",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wallow"
+    },
+    {
+      "level_learned": 4,
+      "technique": "buzz"
+    },
+    {
+      "level_learned": 7,
+      "technique": "hibernate"
+    },
+    {
+      "level_learned": 10,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 13,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 16,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 19,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 22,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 25,
+      "technique": "eyebite"
+    },
+    {
+      "level_learned": 55,
+      "technique": "tornado"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "cataspike",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "puparmor",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "sharp",
+    "bug",
+    "bomber"
+  ],
+  "shape": "grub",
+  "stage": "stage2",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 35,
+  "height": 52,
+  "weight": 17,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/weedlantis.json
+++ b/mods/tuxemon/db/monster/weedlantis.json
@@ -1,72 +1,83 @@
 {
-    "slug": "weedlantis",
-    "category": "reef",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 10,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 37,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 40,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "weedsea",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["coastal", "sea"],
-    "tags": ["plant", "water", "rock", "calamity", "leadership"],
-    "shape": "dragon",
-    "stage": "stage1",
-    "types": [
-        "water",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 353,
-    "height": 185,
-    "weight": 120,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "weedlantis",
+  "category": "reef",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 10,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 37,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 40,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "weedsea",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "sea"
+  ],
+  "tags": [
+    "plant",
+    "water",
+    "rock",
+    "calamity",
+    "leadership"
+  ],
+  "shape": "dragon",
+  "stage": "stage1",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 353,
+  "height": 185,
+  "weight": 120,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/weedsea.json
+++ b/mods/tuxemon/db/monster/weedsea.json
@@ -1,81 +1,93 @@
 {
-    "slug": "weedsea",
-    "category": "seaweed",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "water_bullet"
-        },
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 4,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 10,
-            "technique": "flood"
-        },
-        {
-            "level_learned": 13,
-            "technique": "stabilo"
-        },
-        {
-            "level_learned": 19,
-            "technique": "nest"
-        },
-        {
-            "level_learned": 25,
-            "technique": "water_blast"
-        },
-        {
-            "level_learned": 31,
-            "technique": "blossom"
-        },
-        {
-            "level_learned": 37,
-            "technique": "energy_field"
-        },
-        {
-            "level_learned": 40,
-            "technique": "woodsmash"
-        },
-        {
-            "level_learned": 55,
-            "technique": "energy_beam"
-        }
-    ],
-    "evolutions": [
-        {
-            "monster_slug": "weedlantis",
-            "party": ["shrab"]
-        },
-        {
-            "monster_slug": "weedlantis",
-            "party": ["lesmagu"]
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "weedlantis",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["coastal", "sea"],
-    "tags": ["plant", "water"],
-    "shape": "blob",
-    "stage": "basic",
-    "types": [
-        "water",
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 352,
-    "height": 100,
-    "weight": 10,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "weedsea",
+  "category": "seaweed",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "water_bullet"
+    },
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 4,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 10,
+      "technique": "flood"
+    },
+    {
+      "level_learned": 13,
+      "technique": "stabilo"
+    },
+    {
+      "level_learned": 19,
+      "technique": "nest"
+    },
+    {
+      "level_learned": 25,
+      "technique": "water_blast"
+    },
+    {
+      "level_learned": 31,
+      "technique": "blossom"
+    },
+    {
+      "level_learned": 37,
+      "technique": "energy_field"
+    },
+    {
+      "level_learned": 40,
+      "technique": "woodsmash"
+    },
+    {
+      "level_learned": 55,
+      "technique": "energy_beam"
+    }
+  ],
+  "evolutions": [
+    {
+      "monster_slug": "weedlantis",
+      "party": [
+        "shrab"
+      ]
+    },
+    {
+      "monster_slug": "weedlantis",
+      "party": [
+        "lesmagu"
+      ]
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "weedlantis",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "coastal",
+    "sea"
+  ],
+  "tags": [
+    "plant",
+    "water"
+  ],
+  "shape": "blob",
+  "stage": "basic",
+  "types": [
+    "water",
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 352,
+  "height": 100,
+  "weight": 10,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/wendigger.json
+++ b/mods/tuxemon/db/monster/wendigger.json
@@ -1,67 +1,81 @@
 {
-    "slug": "wendigger",
-    "category": "scarytale",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 1,
-            "technique": "leaf_stab"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sylvan"
-        },
-        {
-            "level_learned": 7,
-            "technique": "pseudopod"
-        },
-        {
-            "level_learned": 13,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fester"
-        },
-        {
-            "level_learned": 28,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 31,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "turnipper",
-            "evo_stage": "basic"
-        },
-        {
-            "mon_slug": "beenstalker",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["boreal_snow", "underground", "woodland"],
-    "tags": ["plant", "ground", "bite", "ice", "darkness", "ghost"],
-    "shape": "brute",
-    "stage": "stage2",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 200,
-    "height": 210,
-    "weight": 75,
-    "catch_rate": 35.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "wendigger",
+  "category": "scarytale",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 1,
+      "technique": "leaf_stab"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sylvan"
+    },
+    {
+      "level_learned": 7,
+      "technique": "pseudopod"
+    },
+    {
+      "level_learned": 13,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fester"
+    },
+    {
+      "level_learned": 28,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 31,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "turnipper",
+      "evo_stage": "basic"
+    },
+    {
+      "mon_slug": "beenstalker",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "boreal_snow",
+    "underground",
+    "woodland"
+  ],
+  "tags": [
+    "plant",
+    "ground",
+    "bite",
+    "ice",
+    "darkness",
+    "ghost"
+  ],
+  "shape": "brute",
+  "stage": "stage2",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 200,
+  "height": 210,
+  "weight": 75,
+  "catch_rate": 35.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -1,59 +1,68 @@
 {
-    "slug": "windeye",
-    "category": "tower",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 1,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 4,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 19,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 25,
-            "technique": "adamantine"
-        },
-        {
-            "level_learned": 28,
-            "technique": "constrict"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "fancair",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": [],
-    "tags": ["machine", "weather", "electricity", "steel", "sharp"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 180,
-    "height": 300,
-    "weight": 600,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "windeye",
+  "category": "tower",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 1,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 4,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 19,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 25,
+      "technique": "adamantine"
+    },
+    {
+      "level_learned": 28,
+      "technique": "constrict"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "fancair",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [],
+  "tags": [
+    "machine",
+    "weather",
+    "electricity",
+    "steel",
+    "sharp"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 180,
+  "height": 300,
+  "weight": 600,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/wolffsky.json
+++ b/mods/tuxemon/db/monster/wolffsky.json
@@ -1,70 +1,80 @@
 {
-    "slug": "wolffsky",
-    "category": "lupine",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "fluff_up"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 4,
-            "technique": "stonehenge"
-        },
-        {
-            "level_learned": 7,
-            "technique": "barking"
-        },
-        {
-            "level_learned": 13,
-            "technique": "canine"
-        },
-        {
-            "level_learned": 16,
-            "technique": "frostbite"
-        },
-        {
-            "level_learned": 19,
-            "technique": "icicle_spear"
-        },
-        {
-            "level_learned": 25,
-            "technique": "fume"
-        },
-        {
-            "level_learned": 28,
-            "technique": "greenstone"
-        },
-        {
-            "level_learned": 31,
-            "technique": "invictus"
-        },
-        {
-            "level_learned": 37,
-            "technique": "ice_storm"
-        },
-        {
-            "level_learned": 40,
-            "technique": "overgrowth"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["boreal_snow", "woodland"],
-    "tags": ["bite", "ice", "darkness"],
-    "shape": "hunter",
-    "stage": "standalone",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 231,
-    "height": 130,
-    "weight": 50,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "wolffsky",
+  "category": "lupine",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "fluff_up"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 4,
+      "technique": "stonehenge"
+    },
+    {
+      "level_learned": 7,
+      "technique": "barking"
+    },
+    {
+      "level_learned": 13,
+      "technique": "canine"
+    },
+    {
+      "level_learned": 16,
+      "technique": "frostbite"
+    },
+    {
+      "level_learned": 19,
+      "technique": "icicle_spear"
+    },
+    {
+      "level_learned": 25,
+      "technique": "fume"
+    },
+    {
+      "level_learned": 28,
+      "technique": "greenstone"
+    },
+    {
+      "level_learned": 31,
+      "technique": "invictus"
+    },
+    {
+      "level_learned": 37,
+      "technique": "ice_storm"
+    },
+    {
+      "level_learned": 40,
+      "technique": "overgrowth"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "boreal_snow",
+    "woodland"
+  ],
+  "tags": [
+    "bite",
+    "ice",
+    "darkness"
+  ],
+  "shape": "hunter",
+  "stage": "standalone",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 231,
+  "height": 130,
+  "weight": 50,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/wolololl.json
+++ b/mods/tuxemon/db/monster/wolololl.json
@@ -1,72 +1,79 @@
 {
-    "slug": "wolololl",
-    "category": "cactus",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "sting"
-        },
-        {
-            "level_learned": 1,
-            "technique": "revenge_stance"
-        },
-        {
-            "level_learned": 4,
-            "technique": "sand_spray"
-        },
-        {
-            "level_learned": 7,
-            "technique": "solar_synthesis"
-        },
-        {
-            "level_learned": 13,
-            "technique": "spit_poison"
-        },
-        {
-            "level_learned": 16,
-            "technique": "splinter"
-        },
-        {
-            "level_learned": 19,
-            "technique": "overgrowth"
-        },
-        {
-            "level_learned": 25,
-            "technique": "staff_smash"
-        },
-        {
-            "level_learned": 28,
-            "technique": "needle"
-        },
-        {
-            "level_learned": 40,
-            "technique": "venom"
-        },
-        {
-            "level_learned": 55,
-            "technique": "thorn_burst"
-        }
-    ],
-    "evolutions": [],
-    "history": [
-        {
-            "mon_slug": "hoodoll",
-            "evo_stage": "basic"
-        }
-    ],
-    "terrains": ["desert"],
-    "tags": ["sharp", "plant", "staff"],
-    "shape": "humanoid",
-    "stage": "stage1",
-    "types": [
-        "wood"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 390,
-    "height": 130,
-    "weight": 40,
-    "catch_rate": 70.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "wolololl",
+  "category": "cactus",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "sting"
+    },
+    {
+      "level_learned": 1,
+      "technique": "revenge_stance"
+    },
+    {
+      "level_learned": 4,
+      "technique": "sand_spray"
+    },
+    {
+      "level_learned": 7,
+      "technique": "solar_synthesis"
+    },
+    {
+      "level_learned": 13,
+      "technique": "spit_poison"
+    },
+    {
+      "level_learned": 16,
+      "technique": "splinter"
+    },
+    {
+      "level_learned": 19,
+      "technique": "overgrowth"
+    },
+    {
+      "level_learned": 25,
+      "technique": "staff_smash"
+    },
+    {
+      "level_learned": 28,
+      "technique": "needle"
+    },
+    {
+      "level_learned": 40,
+      "technique": "venom"
+    },
+    {
+      "level_learned": 55,
+      "technique": "thorn_burst"
+    }
+  ],
+  "evolutions": [],
+  "history": [
+    {
+      "mon_slug": "hoodoll",
+      "evo_stage": "basic"
+    }
+  ],
+  "terrains": [
+    "desert"
+  ],
+  "tags": [
+    "sharp",
+    "plant",
+    "staff"
+  ],
+  "shape": "humanoid",
+  "stage": "stage1",
+  "types": [
+    "wood"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 390,
+  "height": 130,
+  "weight": 40,
+  "catch_rate": 70.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/woodoor.json
+++ b/mods/tuxemon/db/monster/woodoor.json
@@ -1,76 +1,86 @@
 {
-    "slug": "woodoor",
-    "category": "portal",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 7,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 16,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 19,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 25,
-            "technique": "terror"
-        },
-        {
-            "level_learned": 28,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 31,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 40,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 26,
-            "monster_slug": "blasdoor"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "blasdoor",
-            "evo_stage": "stage1"
-        }
-    ],
-    "terrains": ["ruins", "urban"],
-    "tags": ["bite", "plant", "ghost", "shielded"],
-    "shape": "sprite",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 250,
-    "height": 2040,
-    "weight": 46,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "woodoor",
+  "category": "portal",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 7,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 16,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 19,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 25,
+      "technique": "terror"
+    },
+    {
+      "level_learned": 28,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 31,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 40,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 26,
+      "monster_slug": "blasdoor"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "blasdoor",
+      "evo_stage": "stage1"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "urban"
+  ],
+  "tags": [
+    "bite",
+    "plant",
+    "ghost",
+    "shielded"
+  ],
+  "shape": "sprite",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 250,
+  "height": 2040,
+  "weight": 46,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -1,84 +1,94 @@
 {
-    "slug": "wrougon",
-    "category": "dragon",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "tail_lash"
-        },
-        {
-            "level_learned": 1,
-            "technique": "bullet"
-        },
-        {
-            "level_learned": 4,
-            "technique": "viper"
-        },
-        {
-            "level_learned": 7,
-            "technique": "insanity"
-        },
-        {
-            "level_learned": 13,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 16,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 40,
-            "technique": "rust_bomb"
-        },
-        {
-            "level_learned": 43,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 46,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 61,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 64,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 70,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [
-        {
-            "at_level": 32,
-            "monster_slug": "allagon"
-        }
-    ],
-    "history": [
-        {
-            "mon_slug": "allagon",
-            "evo_stage": "stage1"
-        },
-        {
-            "mon_slug": "ferricran",
-            "evo_stage": "stage2"
-        }
-    ],
-    "terrains": ["ruins", "underground"],
-    "tags": ["steel", "soldier", "tail"],
-    "shape": "dragon",
-    "stage": "basic",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 159,
-    "height": 120,
-    "weight": 96,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.85,
-    "upper_catch_resistance": 1.1
+  "slug": "wrougon",
+  "category": "dragon",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "tail_lash"
+    },
+    {
+      "level_learned": 1,
+      "technique": "bullet"
+    },
+    {
+      "level_learned": 4,
+      "technique": "viper"
+    },
+    {
+      "level_learned": 7,
+      "technique": "insanity"
+    },
+    {
+      "level_learned": 13,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 16,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 40,
+      "technique": "rust_bomb"
+    },
+    {
+      "level_learned": 43,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 46,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 61,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 64,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 70,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [
+    {
+      "at_level": 32,
+      "monster_slug": "allagon"
+    }
+  ],
+  "history": [
+    {
+      "mon_slug": "allagon",
+      "evo_stage": "stage1"
+    },
+    {
+      "mon_slug": "ferricran",
+      "evo_stage": "stage2"
+    }
+  ],
+  "terrains": [
+    "ruins",
+    "underground"
+  ],
+  "tags": [
+    "steel",
+    "soldier",
+    "tail"
+  ],
+  "shape": "dragon",
+  "stage": "basic",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 159,
+  "height": 120,
+  "weight": 96,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.85,
+  "upper_catch_resistance": 1.1
 }

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -1,70 +1,72 @@
 {
-    "slug": "xeon",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 16,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shadow_boxing"
-        },
-        {
-            "level_learned": 28,
-            "technique": "whirlwind"
-        },
-        {
-            "level_learned": 31,
-            "technique": "lightning_spheres"
-        },
-        {
-            "level_learned": 37,
-            "technique": "undertaker"
-        },
-        {
-            "level_learned": 40,
-            "technique": "insanity"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "xeon",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 16,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shadow_boxing"
+    },
+    {
+      "level_learned": 28,
+      "technique": "whirlwind"
+    },
+    {
+      "level_learned": 31,
+      "technique": "lightning_spheres"
+    },
+    {
+      "level_learned": 37,
+      "technique": "undertaker"
+    },
+    {
+      "level_learned": 40,
+      "technique": "insanity"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -1,70 +1,72 @@
 {
-    "slug": "xeon_2",
-    "category": "threat",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 1,
-            "technique": "wall_of_steel"
-        },
-        {
-            "level_learned": 4,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 7,
-            "technique": "peregrine"
-        },
-        {
-            "level_learned": 13,
-            "technique": "shuriken"
-        },
-        {
-            "level_learned": 16,
-            "technique": "beam"
-        },
-        {
-            "level_learned": 19,
-            "technique": "ruby"
-        },
-        {
-            "level_learned": 25,
-            "technique": "amnesia"
-        },
-        {
-            "level_learned": 28,
-            "technique": "blade"
-        },
-        {
-            "level_learned": 31,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 37,
-            "technique": "platinum"
-        },
-        {
-            "level_learned": 40,
-            "technique": "crystal"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": [],
-    "shape": "humanoid",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 0,
-    "height": 0.1,
-    "weight": 100,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "xeon_2",
+  "category": "threat",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 1,
+      "technique": "wall_of_steel"
+    },
+    {
+      "level_learned": 4,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 7,
+      "technique": "peregrine"
+    },
+    {
+      "level_learned": 13,
+      "technique": "shuriken"
+    },
+    {
+      "level_learned": 16,
+      "technique": "beam"
+    },
+    {
+      "level_learned": 19,
+      "technique": "ruby"
+    },
+    {
+      "level_learned": 25,
+      "technique": "amnesia"
+    },
+    {
+      "level_learned": 28,
+      "technique": "blade"
+    },
+    {
+      "level_learned": 31,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 37,
+      "technique": "platinum"
+    },
+    {
+      "level_learned": 40,
+      "technique": "crystal"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [],
+  "shape": "humanoid",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 0,
+  "height": 0.1,
+  "weight": 100,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/yamada.json
+++ b/mods/tuxemon/db/monster/yamada.json
@@ -1,63 +1,73 @@
 {
-    "slug": "yamada",
-    "category": "samurai_ghost",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "phantasmal_force"
-        },
-        {
-            "level_learned": 1,
-            "technique": "lineage"
-        },
-        {
-            "level_learned": 4,
-            "technique": "saber"
-        },
-        {
-            "level_learned": 10,
-            "technique": "riposte"
-        },
-        {
-            "level_learned": 16,
-            "technique": "slice"
-        },
-        {
-            "level_learned": 25,
-            "technique": "levitate"
-        },
-        {
-            "level_learned": 28,
-            "technique": "petrify"
-        },
-        {
-            "level_learned": 34,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 40,
-            "technique": "give_all"
-        },
-        {
-            "level_learned": 55,
-            "technique": "shadow_blast"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": ["extraplanar", "ruins"],
-    "tags": ["ghost", "soldier", "sharp", "leadership", "darkness"],
-    "shape": "sprite",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 363,
-    "height": 150,
-    "weight": 0.1,
-    "catch_rate": 50.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "yamada",
+  "category": "samurai_ghost",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "phantasmal_force"
+    },
+    {
+      "level_learned": 1,
+      "technique": "lineage"
+    },
+    {
+      "level_learned": 4,
+      "technique": "saber"
+    },
+    {
+      "level_learned": 10,
+      "technique": "riposte"
+    },
+    {
+      "level_learned": 16,
+      "technique": "slice"
+    },
+    {
+      "level_learned": 25,
+      "technique": "levitate"
+    },
+    {
+      "level_learned": 28,
+      "technique": "petrify"
+    },
+    {
+      "level_learned": 34,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 40,
+      "technique": "give_all"
+    },
+    {
+      "level_learned": 55,
+      "technique": "shadow_blast"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [
+    "extraplanar",
+    "ruins"
+  ],
+  "tags": [
+    "ghost",
+    "soldier",
+    "sharp",
+    "leadership",
+    "darkness"
+  ],
+  "shape": "sprite",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 363,
+  "height": 150,
+  "weight": 0.1,
+  "catch_rate": 50.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }
-

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -1,75 +1,82 @@
 {
-    "slug": "yiinaang",
-    "category": "balance",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "gust"
-        },
-        {
-            "level_learned": 1,
-            "technique": "midnight_mantle"
-        },
-        {
-            "level_learned": 4,
-            "technique": "electrical_storm"
-        },
-        {
-            "level_learned": 7,
-            "technique": "firestorm"
-        },
-        {
-            "level_learned": 13,
-            "technique": "magma"
-        },
-        {
-            "level_learned": 16,
-            "technique": "energy_claws"
-        },
-        {
-            "level_learned": 19,
-            "technique": "bubble_trap"
-        },
-        {
-            "level_learned": 25,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 28,
-            "technique": "snowstorm"
-        },
-        {
-            "level_learned": 31,
-            "technique": "one_two"
-        },
-        {
-            "level_learned": 37,
-            "technique": "arcane_eye"
-        },
-        {
-            "level_learned": 40,
-            "technique": "supernova"
-        },
-        {
-            "level_learned": 55,
-            "technique": "divinity_beam"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["celestial", "healing", "light", "darkness"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "fire",
-        "water"
-    ],
-    "possible_genders": ["neuter"],
-    "txmn_id": 146,
-    "height": 200,
-    "weight": 0.1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "yiinaang",
+  "category": "balance",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "gust"
+    },
+    {
+      "level_learned": 1,
+      "technique": "midnight_mantle"
+    },
+    {
+      "level_learned": 4,
+      "technique": "electrical_storm"
+    },
+    {
+      "level_learned": 7,
+      "technique": "firestorm"
+    },
+    {
+      "level_learned": 13,
+      "technique": "magma"
+    },
+    {
+      "level_learned": 16,
+      "technique": "energy_claws"
+    },
+    {
+      "level_learned": 19,
+      "technique": "bubble_trap"
+    },
+    {
+      "level_learned": 25,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 28,
+      "technique": "snowstorm"
+    },
+    {
+      "level_learned": 31,
+      "technique": "one_two"
+    },
+    {
+      "level_learned": 37,
+      "technique": "arcane_eye"
+    },
+    {
+      "level_learned": 40,
+      "technique": "supernova"
+    },
+    {
+      "level_learned": 55,
+      "technique": "divinity_beam"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "celestial",
+    "healing",
+    "light",
+    "darkness"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "fire",
+    "water"
+  ],
+  "possible_genders": [
+    "neuter"
+  ],
+  "txmn_id": 146,
+  "height": 200,
+  "weight": 0.1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/mods/tuxemon/db/monster/ziggurat.json
+++ b/mods/tuxemon/db/monster/ziggurat.json
@@ -1,70 +1,78 @@
 {
-    "slug": "ziggurat",
-    "category": "mazerunner",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "ice_claw"
-        },
-        {
-            "level_learned": 1,
-            "technique": "ants"
-        },
-        {
-            "level_learned": 4,
-            "technique": "muck"
-        },
-        {
-            "level_learned": 7,
-            "technique": "hammerhead"
-        },
-        {
-            "level_learned": 13,
-            "technique": "infectious_bite"
-        },
-        {
-            "level_learned": 16,
-            "technique": "breath"
-        },
-        {
-            "level_learned": 19,
-            "technique": "grinding"
-        },
-        {
-            "level_learned": 25,
-            "technique": "gourmet"
-        },
-        {
-            "level_learned": 28,
-            "technique": "strangulation"
-        },
-        {
-            "level_learned": 31,
-            "technique": "cat_calling"
-        },
-        {
-            "level_learned": 37,
-            "technique": "burrow_blast"
-        },
-        {
-            "level_learned": 40,
-            "technique": "evasion"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["ground", "toxic", "food", "claws"],
-    "shape": "varmint",
-    "stage": "standalone",
-    "types": [
-        "earth"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 242,
-    "height": 30,
-    "weight": 1,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.9,
-    "upper_catch_resistance": 1.15
+  "slug": "ziggurat",
+  "category": "mazerunner",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "ice_claw"
+    },
+    {
+      "level_learned": 1,
+      "technique": "ants"
+    },
+    {
+      "level_learned": 4,
+      "technique": "muck"
+    },
+    {
+      "level_learned": 7,
+      "technique": "hammerhead"
+    },
+    {
+      "level_learned": 13,
+      "technique": "infectious_bite"
+    },
+    {
+      "level_learned": 16,
+      "technique": "breath"
+    },
+    {
+      "level_learned": 19,
+      "technique": "grinding"
+    },
+    {
+      "level_learned": 25,
+      "technique": "gourmet"
+    },
+    {
+      "level_learned": 28,
+      "technique": "strangulation"
+    },
+    {
+      "level_learned": 31,
+      "technique": "cat_calling"
+    },
+    {
+      "level_learned": 37,
+      "technique": "burrow_blast"
+    },
+    {
+      "level_learned": 40,
+      "technique": "evasion"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "ground",
+    "toxic",
+    "food",
+    "claws"
+  ],
+  "shape": "varmint",
+  "stage": "standalone",
+  "types": [
+    "earth"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 242,
+  "height": 30,
+  "weight": 1,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.9,
+  "upper_catch_resistance": 1.15
 }

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -1,70 +1,75 @@
 {
-    "slug": "zunna",
-    "category": "slurpy",
-    "moveset": [
-        {
-            "level_learned": 1,
-            "technique": "constrict"
-        },
-        {
-            "level_learned": 1,
-            "technique": "goad"
-        },
-        {
-            "level_learned": 4,
-            "technique": "strike"
-        },
-        {
-            "level_learned": 7,
-            "technique": "perfect_cut"
-        },
-        {
-            "level_learned": 13,
-            "technique": "roll"
-        },
-        {
-            "level_learned": 16,
-            "technique": "muddle"
-        },
-        {
-            "level_learned": 19,
-            "technique": "sleep_bomb"
-        },
-        {
-            "level_learned": 25,
-            "technique": "shrapnel"
-        },
-        {
-            "level_learned": 28,
-            "technique": "crystal"
-        },
-        {
-            "level_learned": 31,
-            "technique": "battery_discharge"
-        },
-        {
-            "level_learned": 37,
-            "technique": "clamp_on"
-        },
-        {
-            "level_learned": 40,
-            "technique": "sunburst"
-        }
-    ],
-    "evolutions": [],
-    "history": [],
-    "terrains": [],
-    "tags": ["food"],
-    "shape": "blob",
-    "stage": "standalone",
-    "types": [
-        "metal"
-    ],
-    "possible_genders": ["male", "female"],
-    "txmn_id": 131,
-    "height": 90,
-    "weight": 2,
-    "catch_rate": 100.0,
-    "lower_catch_resistance": 0.95,
-    "upper_catch_resistance": 1.05
+  "slug": "zunna",
+  "category": "slurpy",
+  "moveset": [
+    {
+      "level_learned": 1,
+      "technique": "constrict"
+    },
+    {
+      "level_learned": 1,
+      "technique": "goad"
+    },
+    {
+      "level_learned": 4,
+      "technique": "strike"
+    },
+    {
+      "level_learned": 7,
+      "technique": "perfect_cut"
+    },
+    {
+      "level_learned": 13,
+      "technique": "roll"
+    },
+    {
+      "level_learned": 16,
+      "technique": "muddle"
+    },
+    {
+      "level_learned": 19,
+      "technique": "sleep_bomb"
+    },
+    {
+      "level_learned": 25,
+      "technique": "shrapnel"
+    },
+    {
+      "level_learned": 28,
+      "technique": "crystal"
+    },
+    {
+      "level_learned": 31,
+      "technique": "battery_discharge"
+    },
+    {
+      "level_learned": 37,
+      "technique": "clamp_on"
+    },
+    {
+      "level_learned": 40,
+      "technique": "sunburst"
+    }
+  ],
+  "evolutions": [],
+  "history": [],
+  "terrains": [],
+  "tags": [
+    "food"
+  ],
+  "shape": "blob",
+  "stage": "standalone",
+  "types": [
+    "metal"
+  ],
+  "possible_genders": [
+    "male",
+    "female"
+  ],
+  "txmn_id": 131,
+  "height": 90,
+  "weight": 2,
+  "catch_rate": 100.0,
+  "lower_catch_resistance": 0.95,
+  "upper_catch_resistance": 1.05
 }

--- a/scripts/json_beautifier.py
+++ b/scripts/json_beautifier.py
@@ -13,7 +13,7 @@ Beautify all JSON files in a directory with 2-space indent, recursively and forc
     python json_beautifier.py my_json_folder -r -i 2 -f
 
 Example (moving in scripts folder):
-    python yaml_beautifier.py ../mods/tuxemon/PATH/ -r
+    python json_beautifier.py ../mods/tuxemon/PATH/ -r
 
 Get help/usage information:
     python json_beautifier.py --help
@@ -23,7 +23,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 DEFAULT_INDENT: int = 2
-SORT_KEYS: bool = True
+SORT_KEYS: bool = False
 
 
 def beautify_json_file(

--- a/scripts/yaml_beautifier.py
+++ b/scripts/yaml_beautifier.py
@@ -24,9 +24,12 @@ from pathlib import Path
 import yaml
 
 DEFAULT_INDENT: int = 2
+SORT_KEYS: bool = False
 
 
-def beautify_yaml_file(file_path: Path, indent: int = DEFAULT_INDENT) -> None:
+def beautify_yaml_file(
+    file_path: Path, indent: int = DEFAULT_INDENT, sort_keys: bool = SORT_KEYS
+) -> None:
     """
     Reads a YAML file, pretty-prints its content, and overwrites the original file.
     """
@@ -36,7 +39,13 @@ def beautify_yaml_file(file_path: Path, indent: int = DEFAULT_INDENT) -> None:
             data = yaml.safe_load(f)
 
         with file_path.open("w", encoding="utf-8") as f:
-            yaml.dump(data, f, indent=indent, default_flow_style=False)
+            yaml.dump(
+                data,
+                f,
+                indent=indent,
+                default_flow_style=False,
+                sort_keys=sort_keys,
+            )
         print(f"Successfully beautified '{file_path}'.")
     except FileNotFoundError:
         print(f"Error: File not found at '{file_path}'.")


### PR DESCRIPTION
PR formats the monster JSON files for improved readability and sets `sort_keys=False` by default in both scripts (YAML and JSON) to preserve the original key order. The Technique and Status folders remain unformatted and will be beautified later.