### PR TITLE
add new macOS Sequoia+uv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,7 @@ ulimit -n 10000; python run_tuxemon.py
 ```shell
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew update
-brew install python
-brew install uv
-brew install python git sdl sdl2_image sdl2_ttf sdl2_mixer portmidi libvorbis
+brew install uv python git sdl sdl2_image sdl2_ttf sdl2_mixer portmidi libvorbis
 git clone https://github.com/Tuxemon/Tuxemon.git
 cd Tuxemon
 uv sync

--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ git clone https://github.com/Tuxemon/Tuxemon.git
 ulimit -n 10000; python run_tuxemon.py
 ```
 
+### macOS Sequoia with [uv](https://github.com/astral-sh/uv)
+
+```shell
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew update
+brew install python
+brew install uv
+brew install python git sdl sdl2_image sdl2_ttf sdl2_mixer portmidi libvorbis
+git clone https://github.com/Tuxemon/Tuxemon.git
+cd Tuxemon
+uv sync
+uv run python run_tuxemon.py
+```
+
 Controls
 --------
 


### PR DESCRIPTION
I setup the most recent development branch on macOS Sequoia 15.5 (24F74) and it worked great! 

The standard instructions weren't working on my machine since homebrew seems to have stopped supporting args like `--with-libvorbis` and it also makes you choose between sdl v2 and v3. 

These were the commands I used to get it working: 

```shell
ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
brew update
brew install python
brew install uv
brew install python git sdl sdl2_image sdl2_ttf sdl2_mixer portmidi libvorbis
git clone https://github.com/Tuxemon/Tuxemon.git
cd Tuxemon
uv sync
uv run python run_tuxemon.py
```


uv can be nicer on macOS because it creates a special environment for the app with all the needed versions as opposed to the latest of everything. 

In theory, this should make these instructions a bit more evergreen. 

https://github.com/user-attachments/assets/d66d8dd2-2137-468d-a79f-9e8f7f190515



