### PR TITLE
Simplify Monster Creation and Shift Combat Trigger Logic to `RandomEncounter`

### DIFF
--- a/tuxemon/encounter.py
+++ b/tuxemon/encounter.py
@@ -88,3 +88,9 @@ class Encounter:
             )
         else:
             return encounter.level_range[0]
+
+    def get_held_item(self, encounter: EncounterItemModel) -> Optional[str]:
+        """Returns a random held item for the encounter."""
+        if not encounter.held_items:
+            return None
+        return random.choice(encounter.held_items)

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -32,7 +32,6 @@ class AddMonsterAction(EventAction):
             defaults to the current player.
         exp_mod: Experience modifier
         money_mod: Money modifier
-
     """
 
     name = "add_monster"
@@ -59,11 +58,8 @@ class AddMonsterAction(EventAction):
         else:
             monster_slug = self.monster_slug
 
-        monster = Monster.create(monster_slug)
-        monster.set_level(self.monster_level)
-        monster.moves.set_moves(self.monster_level)
+        monster = Monster.spawn_base(monster_slug, self.monster_level)
         monster.set_capture(today_ordinal())
-        monster.current_hp = monster.hp
 
         if self.exp is not None:
             monster.experience_modifier = self.exp

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -99,12 +99,9 @@ def load_party_monsters(
 
 def party_monster(npc_monster: PartyMemberModel) -> Monster:
     """Creates a new monster object from the database details."""
-    monster = Monster.create(npc_monster.slug)
+    monster = Monster.spawn_base(npc_monster.slug, npc_monster.level)
     monster.money_modifier = npc_monster.money_mod
     monster.experience_modifier = npc_monster.exp_req_mod
-    monster.set_level(npc_monster.level)
-    monster.moves.set_moves(npc_monster.level)
-    monster.current_hp = monster.hp
     monster.gender = npc_monster.gender
     return monster
 

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -14,7 +14,6 @@ from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 from tuxemon.time_handler import today_ordinal
 
 logger = logging.getLogger(__name__)
@@ -79,11 +78,8 @@ class RandomBattleAction(EventAction):
         monsters = random.sample(monster_filters, self.nr_txmns)
         for monster in monsters:
             level = random.randint(self.min_level, self.max_level)
-            current_monster = Monster.create(monster.slug)
-            current_monster.set_level(level)
-            current_monster.moves.set_moves(level)
+            current_monster = Monster.spawn_base(monster.slug, level)
             current_monster.set_capture(today_ordinal())
-            current_monster.current_hp = current_monster.hp
             current_monster.money_modifier = level
             current_monster.experience_modifier = level
             npc.add_monster(current_monster, len(npc.monsters))
@@ -117,7 +113,6 @@ class RandomBattleAction(EventAction):
 
     def cleanup(self, session: Session) -> None:
         npc = None
-        world = session.client.get_state_by_name(WorldState)
         session.client.npc_manager.remove_npc(self.opponent.slug)
 
 

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -91,12 +91,9 @@ class SpawnMonsterAction(EventAction):
         level = (father.level + mother.level) // 2
 
         # Create a new child monster
-        child = Monster.create(seed_slug)
-        child.set_level(level)
-        child.moves.set_moves(level)
+        child = Monster.spawn_base(seed_slug, level)
         child.set_capture(today_ordinal())
         child.name = name
-        child.current_hp = child.hp
 
         # Give the child a random move from the father
         father_moves = len(father.moves.current_moves)

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -70,11 +70,8 @@ class TradingAction(EventAction):
 
 def _create_traded_monster(removed: Monster, added: str) -> Monster:
     """Create a new monster with the same level and moves as the removed monster."""
-    new = Monster.create(added)
-    new.set_level(removed.level)
-    new.moves.set_moves(removed.level)
+    new = Monster.spawn_base(added, removed.level)
     new.set_capture(today_ordinal())
-    new.current_hp = new.hp
     new.traded = True
     return new
 

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -60,11 +60,9 @@ class WildEncounterAction(EventAction):
 
         logger.info("Starting wild encounter!")
 
-        current_monster = Monster.create(self.monster_slug)
-        current_monster.level = self.monster_level
-        current_monster.set_level(self.monster_level)
-        current_monster.moves.set_moves(self.monster_level)
-        current_monster.current_hp = current_monster.hp
+        current_monster = Monster.spawn_base(
+            self.monster_slug, self.monster_level
+        )
         if self.exp is not None:
             current_monster.experience_modifier = self.exp
         if self.money is not None:

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -190,6 +190,14 @@ class Monster:
         method.load(slug)
         return method
 
+    @classmethod
+    def spawn_base(cls, slug: str, level: int) -> Monster:
+        monster = cls.create(slug)
+        monster.set_level(level)
+        monster.moves.set_moves(level)
+        monster.current_hp = monster.hp
+        return monster
+
     @property
     def hp_ratio(self) -> float:
         return min(self.current_hp / self.hp if self.hp > 0 else 0.0, 1.0)


### PR DESCRIPTION
PR introduces the `spawn_base` class method in the `Monster` class to simplify monster creation across the codebase. It consolidates repeated logic - such as `set_level`, `set_moves`, and initializing `current_hp` to match `hp` - into a single, reusable method.

Additionally, it refactors combat initiation logic: instead of being triggered from `WildEncounter`, the responsibility now lies within `RandomEncounter`. Previously, `RandomEncounter` was only serialized and sent to the client, but with this change, it also handles monster creation and combat state setup directly. This prepares the ground for future use cases like triggering battles without assigning the monster to an NPC.

`WildEncounter` will be limited to a single opponent (Monster)
`RandomEncounter` will support multiple monsters spawning simultaneously