### PR TITLE
Fix: Corrects logic in NPCBagHandler.find_item

### DIFF
--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -652,7 +652,7 @@ class NPCBagHandler:
         Finds the first item in the NPC's bag with the given slug.
         """
         for itm in self._items:
-            if self.has_item(item_slug):
+            if itm.slug == item_slug:
                 return itm
         return None
 


### PR DESCRIPTION
PR fixes a bug in the `NPCBagHandler` class that was causing incorrect item retrieval based on slug matching.

- the `find_item` method was using `self.has_item(item_slug)` inside a loop, which checked the entire item list repeatedly rather than inspecting individual items
- this flawed logic led to the method returning the first item in the bag - even if it didn’t match the requested slug
- as a result, in the shop interface, players were able to purchase an item, but the item quantity in their bag appeared not to increase. The shop behavior relied on `find_item`, so it couldn't properly detect or stack the correct item
- the bug was discovered while refactoring parts of the economy system, and the fix replaces the logic with a proper per-item comparison on `slug`