### PR TITLE
Split `Economy` responsibilities into dedicated components

### DIFF
--- a/mods/tuxemon/db/item/super_potion.json
+++ b/mods/tuxemon/db/item/super_potion.json
@@ -21,12 +21,15 @@
   "sort": "potion",
   "sprite": "gfx/items/super_potion.png",
   "category": "potion",
+  "cost": 100,
   "usable_in": [
     "MainCombatMenuState",
     "WorldState"
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "resellable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/economy.py
+++ b/tuxemon/economy.py
@@ -4,34 +4,56 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional, Union
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
 
-from tuxemon.db import EconomyItemModel, EconomyModel, EconomyMonsterModel, db
+from tuxemon.db import EconomyItemModel, EconomyModel, db
 from tuxemon.item.item import Item
 from tuxemon.monster import Monster
 from tuxemon.prepare import GRAD_BLUE
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
+    from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class ShopInventory:
+    items: list[Item] = field(default_factory=list)
+    monsters: list[Monster] = field(default_factory=list)
+
+    def has_item(self, slug: str) -> bool:
+        return any(item.slug == slug for item in self.items)
+
+    def has_monster(self, slug: str) -> bool:
+        return any(monster.slug == slug for monster in self.monsters)
+
+
 class Economy:
     """
-    Represents an economy in the game, containing items and monsters.
+    Represents an economy's data in the game, containing items and monsters definitions
+    with their associated prices, costs, and initial inventory values.
+    It provides methods for looking up and updating these definitions.
     """
 
     def __init__(self, slug: Optional[str] = None) -> None:
+        self.model: EconomyModel
+
         if slug:
+            self.load(slug)
+        else:
             self.model = EconomyModel(
-                slug=slug,
+                slug="",
                 resale_multiplier=0.0,
                 background=GRAD_BLUE,
                 items=[],
                 monsters=[],
             )
-            self.load(slug)
+            logger.warning(
+                "Economy initialized without a slug. It's an empty economy."
+            )
 
     def load(self, slug: str) -> None:
         """
@@ -44,25 +66,22 @@ class Economy:
             RuntimeError: If the economy with the given slug is not found
             in the database.
         """
-        results = EconomyModel.lookup(slug, db)
-        self.model.slug = results.slug
-        self.model.resale_multiplier = results.resale_multiplier
-        self.model.background = results.background
-        self.model.items = [
-            EconomyItemModel.model_validate(item) for item in results.items
-        ]
-        self.model.monsters = [
-            EconomyMonsterModel.model_validate(monster)
-            for monster in results.monsters
-        ]
+        try:
+            results = EconomyModel.lookup(slug, db)
+            self.model = results
+        except Exception as e:
+            logger.error(f"Failed to load economy '{slug}': {e}")
+            raise RuntimeError(
+                f"Economy with slug '{slug}' not found in database."
+            ) from e
 
     def lookup_item_field(self, item_slug: str, field: str) -> Optional[int]:
         """
-        Looks up the value of a field for an item in the economy.
+        Looks up the value of a field for an item definition in the economy.
 
         Parameters:
-            item_slug: The slug of the item to look up.
-            field: The field to look up.
+            item_slug: The slug of the item definition to look up.
+            field: The field to look up (e.g., "price", "cost", "inventory").
 
         Returns:
             The value of the field if found, otherwise None.
@@ -77,11 +96,11 @@ class Economy:
 
     def lookup_item(self, item_slug: str, field: str) -> Optional[int]:
         """
-        Looks up the value of a field for an item in the economy, raising an
-        error if not found.
+        Looks up the value of a field for an item definition in the economy.
+        This is an alias for lookup_item_field.
 
         Parameters:
-            item_slug: The slug of the item to look up.
+            item_slug: The slug of the item definition to look up.
             field: The field to look up.
 
         Returns:
@@ -91,74 +110,86 @@ class Economy:
 
     def lookup_item_price(self, item_slug: str) -> int:
         """
-        Looks up the price of an item in the economy.
+        Looks up the price of an item definition in the economy.
 
         Parameters:
-            item_slug: The slug of the item to look up.
+            item_slug: The slug of the item definition to look up.
 
         Returns:
             The price of the item.
+
+        Raises:
+            RuntimeError: If the item definition is not found in the economy.
         """
         value = self.lookup_item(item_slug, "price")
         if value is None:
             raise RuntimeError(
-                f"'{item_slug}' not found in economy '{self.model.slug}'"
+                f"Item '{item_slug}' has no price defined in economy '{self.model.slug}'"
             )
         return value
 
     def lookup_item_cost(self, item_slug: str) -> int:
         """
-        Looks up the cost of an item in the economy.
+        Looks up the cost of an item definition in the economy.
 
         Parameters:
-            item_slug: The slug of the item to look up.
+            item_slug: The slug of the item definition to look up.
 
         Returns:
             The cost of the item.
+
+        Raises:
+            RuntimeError: If the item definition is not found in the economy.
         """
         value = self.lookup_item(item_slug, "cost")
         if value is None:
             raise RuntimeError(
-                f"'{item_slug}' not found in economy '{self.model.slug}'"
+                f"Item '{item_slug}' has no cost defined in economy '{self.model.slug}'"
             )
         return value
 
     def lookup_item_inventory(self, item_slug: str) -> int:
         """
-        Looks up the inventory of an item in the economy.
+        Looks up the initial inventory quantity of an item definition in the economy.
+        This represents the default quantity specified in the economy data.
 
         Parameters:
-            item_slug: The slug of the item to look up.
+            item_slug: The slug of the item definition to look up.
 
         Returns:
-            The inventory of the item.
+            The initial inventory quantity of the item.
+
+        Raises:
+            RuntimeError: If the item definition is not found in the economy.
         """
         value = self.lookup_item(item_slug, "inventory")
         if value is None:
             raise RuntimeError(
-                f"'{item_slug}' not found in economy '{self.model.slug}'"
+                f"Item '{item_slug}' has no inventory defined in economy '{self.model.slug}'"
             )
         return value
 
     def update_item_quantity(self, item_slug: str, quantity: int) -> None:
         """
-        Updates the quantity of an item in the economy.
+        Updates the inventory quantity field of an item definition within this economy.
+        This primarily affects the data model for the economy itself, not
+        an NPC's actual inventory.
 
         Parameters:
-            item_slug: The slug of the item to update.
-            quantity: The new quantity of the item.
+            item_slug: The slug of the item definition to update.
+            quantity: The new quantity for the item definition.
         """
         self.update_item_field(item_slug, "inventory", quantity)
 
     def get_item(self, item_slug: str) -> Optional[EconomyItemModel]:
         """
-        Gets an item from the economy by its slug.
+        Gets an EconomyItemModel definition from the economy by its slug.
 
         Parameters:
-            item_slug: The slug of the item to get.
+            item_slug: The slug of the item definition to get.
 
         Returns:
-            The item if found, otherwise None.
+            The EconomyItemModel if found, otherwise None.
         """
         return next(
             (item for item in self.model.items if item.name == item_slug),
@@ -167,98 +198,54 @@ class Economy:
 
     def get_item_field(self, item_slug: str, field: str) -> Optional[int]:
         """
-        Gets the value of a field for an item in the economy.
+        Gets the value of a field for an item definition in the economy.
+        This is an alias for lookup_item_field.
 
         Parameters:
-            item_slug: The slug of the item to get.
+            item_slug: The slug of the item definition to get.
             field: The field to get.
 
         Returns:
             The value of the field if found, otherwise None.
         """
-        item = self.get_item(item_slug)
-        if item and hasattr(item, field):
-            return int(getattr(item, field))
-        return None
+        return self.lookup_item_field(item_slug, field)
 
     def update_item_field(
         self, item_slug: str, field: str, value: int
     ) -> None:
         """
-        Updates the value of a field for an item in the economy.
+        Updates the value of a specific field for an item definition in the economy.
 
         Parameters:
-            item_slug: The slug of the item to update.
+            item_slug: The slug of the item definition to update.
             field: The field to update.
             value: The new value of the field.
 
         Raises:
-            RuntimeError: If the item is not found in the economy.
+            RuntimeError: If the item definition is not found in the economy.
         """
         item = self.get_item(item_slug)
         if item:
-            setattr(item, field, value)
+            if hasattr(item, field):
+                setattr(item, field, value)
+            else:
+                raise AttributeError(
+                    f"Item definition '{item_slug}' has no field '{field}'"
+                )
         else:
             raise RuntimeError(
-                f"Item '{item_slug}' not found in economy '{self.model.slug}'"
+                f"Item definition '{item_slug}' not found in economy '{self.model.slug}'"
             )
-
-    def load_economy_items(self, character: NPC) -> list[Union[Item, Monster]]:
-        """
-        Loads the items and monsters from the economy for the given character.
-
-        Parameters:
-            character: The character to load the items and monsters for.
-
-        Returns:
-            The loaded items and monsters.
-        """
-        entities: list[Union[Item, Monster]] = []
-        for item in self.model.items:
-            label = f"{self.model.slug}:{item.name}"
-            if label not in character.game_variables:
-                character.game_variables[label] = self.get_item_field(
-                    item.name, "inventory"
-                )
-
-            itm_in_shop = Item.create(item.name)
-            if item.variables:
-                if self.variable(item.variables, character):
-                    itm_in_shop.set_quantity(
-                        int(character.game_variables[label])
-                    )
-                    entities.append(itm_in_shop)
-            else:
-                itm_in_shop.set_quantity(int(character.game_variables[label]))
-                entities.append(itm_in_shop)
-
-        for monster in self.model.monsters:
-            label = f"{self.model.slug}:{monster.name}"
-            if label not in character.game_variables:
-                character.game_variables[label] = self.get_monster_field(
-                    monster.name, "inventory"
-                )
-
-            monster_in_shop = Monster.create(monster.name)
-            monster_in_shop.level = monster.level
-            monster_in_shop.current_hp = monster_in_shop.hp
-            if monster.variables:
-                if self.variable(monster.variables, character):
-                    entities.append(monster_in_shop)
-            else:
-                entities.append(monster_in_shop)
-
-        return entities
 
     def get_monster_field(
         self, monster_name: str, field: str
     ) -> Optional[int]:
         """
-        Gets the value of a field for a monster in the economy.
+        Gets the value of a field for a monster definition in the economy.
 
         Parameters:
-            monster_name: The name of the monster to get.
-            field: The field to get.
+            monster_name: The name of the monster definition to get.
+            field: The field to get (e.g., "level", "inventory").
 
         Returns:
             The value of the field if found, otherwise None.
@@ -279,14 +266,18 @@ class Economy:
         self, variables: Sequence[dict[str, str]], character: NPC
     ) -> bool:
         """
-        Checks if the given variables match the character's game variables.
+        Checks if the given variables (conditions from economy data) match
+        the character's game variables.
 
         Parameters:
-            variables: The variables to check.
-            character: The character to check against.
+            variables: A sequence of dictionaries, each representing a set of
+                variable-value pairs to check.
+            character: The character (NPC or player) whose game variables are
+                checked.
 
         Returns:
-            True if the variables match, otherwise False.
+            True if all specified variable conditions match the character's
+            game variables, otherwise False.
         """
         return all(
             all(
@@ -296,18 +287,82 @@ class Economy:
             for variable in variables
         )
 
-    def add_economy_to_npc(
-        self, character: NPC, items: list[Union[Monster, Item]]
+
+class EconomyApplier:
+    """
+    Manages the application of an Economy's definitions to a character (e.g., NPC),
+    creating actual game entities (Items, Monsters) and populating their inventories
+    based on economy data and character game variables.
+    """
+
+    def apply_economy_to_character(
+        self, session: Session, economy: Economy, character: NPC
     ) -> None:
         """
-        Adds the given items and monsters to the character's inventory.
-
-        Parameters:
-            character: The character to add the items and monsters to.
-            items: The items and monsters to add.
+        Applies economy-defined items and monsters to a character, populating a separate
+        shop inventory based on the player's game variables and availability conditions.
         """
-        for item in items:
-            if isinstance(item, Item):
-                character.items.add_item(item)
-            else:
-                character.add_monster(item, len(character.monsters))
+        player = session.player
+        shop_items = []
+        shop_monsters = []
+
+        # Process items
+        for eco_item_model in economy.model.items:
+            label = f"{economy.model.slug}:{eco_item_model.name}"
+
+            if label not in player.game_variables:
+                initial_quantity = economy.lookup_item_inventory(
+                    eco_item_model.name
+                )
+                player.game_variables[label] = initial_quantity
+
+            if eco_item_model.variables and not economy.variable(
+                eco_item_model.variables, player
+            ):
+                logger.debug(f"Skipping item '{eco_item_model.name}'")
+                continue
+
+            try:
+                item_instance = Item.create(eco_item_model.name)
+                item_instance.set_quantity(int(player.game_variables[label]))
+                shop_items.append(item_instance)
+            except Exception as e:
+                logger.error(
+                    f"Could not create Item '{eco_item_model.name}': {e}"
+                )
+
+        # Process monsters
+        for eco_monster_model in economy.model.monsters:
+            label = f"{economy.model.slug}:{eco_monster_model.name}"
+
+            if label not in player.game_variables:
+                default = (
+                    economy.get_monster_field(
+                        eco_monster_model.name, "inventory"
+                    )
+                    or 1
+                )
+                player.game_variables[label] = default
+
+            if eco_monster_model.variables and not economy.variable(
+                eco_monster_model.variables, player
+            ):
+                logger.debug(f"Skipping monster '{eco_monster_model.name}'")
+                continue
+
+            try:
+                monster_instance = Monster.create(eco_monster_model.name)
+                monster_instance.level = eco_monster_model.level
+                monster_instance.current_hp = monster_instance.hp
+                shop_monsters.append(monster_instance)
+            except Exception as e:
+                logger.error(
+                    f"Could not create Monster '{eco_monster_model.name}': {e}"
+                )
+
+        character.shop_inventory = ShopInventory(
+            items=shop_items, monsters=shop_monsters
+        )
+        logger.info(
+            f"Shop inventory set for '{character.slug}' with {len(shop_items)} items and {len(shop_monsters)} monsters."
+        )

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -36,7 +36,7 @@ from tuxemon.tracker import TrackingData, decode_tracking, encode_tracking
 from tuxemon.tuxepedia import Tuxepedia, decode_tuxepedia, encode_tuxepedia
 
 if TYPE_CHECKING:
-    from tuxemon.economy import Economy
+    from tuxemon.economy import Economy, ShopInventory
     from tuxemon.states.world.worldstate import WorldState
 
 
@@ -123,6 +123,7 @@ class NPC(Entity[NPCState]):
         self.monsters: list[Monster] = []
         self.mission_controller = MissionController(self)
         self.economy: Optional[Economy] = None
+        self.shop_inventory: Optional[ShopInventory] = None
         self.teleport_faint = TeleportFaint()
         self.tracker = TrackingData()
         self.step_tracker = StepTrackerManager()
@@ -652,7 +653,7 @@ class NPCBagHandler:
         Finds the first item in the NPC's bag with the given slug.
         """
         for itm in self._items:
-            if self.has_item(item_slug):
+            if itm.slug == item_slug:
                 return itm
         return None
 


### PR DESCRIPTION
PR restructures the economy system to separate concerns and reduce coupling with NPC internals. The old `Economy` class was doing too much, leading to difficult maintenance and tight entanglement with NPC logic.

Key issues with the previous setup:
- the `Economy` class combined multiple responsibilities: it stored data, loaded definitions from disk, set up NPC shops, and modified NPC inventories, this made it fragile and hard to extend

PR introduces a cleaner design by:
- removing overloaded methods from `Economy` (`load_economy_items`, `add_economy_to_npc`) and keeping only the data-centric API (e.g., `lookup_item_price`, `update_item_quantity`, etc.)
- adding a new `EconomyApplier` class to handle applying item/monster definitions to an NPC, so it cleanly separates data from behavior and manages conditional logic, instantiation, and inventory updates
- updating `SetEconomyAction` to delegate its shop-setup responsibility to the new applier, preserving all previous behavior without burying that logic inside `Economy`
- during testing, I also noticed that Super Potion wasn't flagged as resellable, so I updated its economy definition to allow reselling
- introducing a new `ShopInventory` container that is assigned to the NPC, this holds the shop's available items and monsters independently of the NPC's personal inventory and team
- avoiding hard game limitations by not storing monsters in the NPC’s actual party, for example, shops can now offer more than six monsters without conflicting with party size restrictions

While this refactoring keeps the functionality and NPC relationship fully intact, it lays the groundwork for a future step that will further decouple economy logic from NPC internals.