### PR TITLE
Decouple `ChangeStateAction` into Targeted `EventAction` Classes

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -1,3 +1,4 @@
+.. autoscriptinfoclass:: tuxemon.event.actions.access_pc.AccessPCAction
 .. autoscriptinfoclass:: tuxemon.event.actions.add_collision.AddCollisionAction
 .. autoscriptinfoclass:: tuxemon.event.actions.add_contacts.AddContactsAction
 .. autoscriptinfoclass:: tuxemon.event.actions.add_held_item.AddHeldItemction
@@ -60,6 +61,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.modify_monster_bond.ModifyMonsterBondAction
 .. autoscriptinfoclass:: tuxemon.event.actions.modify_monster_health.ModifyMonsterHealthAction
 .. autoscriptinfoclass:: tuxemon.event.actions.modify_monster_stats.ModifyMonsterStatsAction
+.. autoscriptinfoclass:: tuxemon.event.actions.open_journal.OpenJournalAction
 .. autoscriptinfoclass:: tuxemon.event.actions.open_shop.OpenShopAction
 .. autoscriptinfoclass:: tuxemon.event.actions.overwrite_tech.OverwriteTechAction
 .. autoscriptinfoclass:: tuxemon.event.actions.pathfind_to_char.PathfindToCharAction
@@ -114,6 +116,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.set_template.SetTemplateAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_tuxepedia.SetTuxepediaAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_variable.SetVariableAction
+.. autoscriptinfoclass:: tuxemon.event.actions.show_monster.ShowMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.spawn_monster.SpawnMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.start_battle.StartBattleAction
 .. autoscriptinfoclass:: tuxemon.event.actions.start_cinema_mode.StartCinemaModeAction

--- a/mods/tuxemon/maps/bedroom_test.tmx
+++ b/mods/tuxemon/maps/bedroom_test.tmx
@@ -55,7 +55,7 @@
   </object>
   <object id="10" name="Use Computer" type="event" x="48" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="change_state PCState,player"/>
+    <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -94,7 +94,7 @@
   </object>
   <object id="30" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="change_state PCState,player"/>
+    <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -140,7 +140,7 @@
   </object>
   <object id="37" name="Use Computer" type="event" x="160" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="change_state PCState,player"/>
+    <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/maple_bedroom.tmx
+++ b/mods/tuxemon/maps/maple_bedroom.tmx
@@ -50,7 +50,7 @@
   </object>
   <object id="31" name="Use Computer" type="event" x="64" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="change_state PCState,player"/>
+    <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -82,7 +82,7 @@ events:
     y: 2
   Use Computer:
     actions:
-    - change_state PCState,player
+    - access_pc player
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -60,7 +60,7 @@
    <properties>
     <property name="act1" value="pathfind professor,9,9"/>
     <property name="act2" value="char_face professor,up"/>
-    <property name="act3" value="change_state JournalInfoState,rockitten"/>
+    <property name="act3" value="open_journal rockitten"/>
     <property name="act5" value="translated_dialog chooseyerfateRockitten"/>
     <property name="act6" value="translated_dialog_choice yes:no,rockittenchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
@@ -73,7 +73,7 @@
    <properties>
     <property name="act1" value="pathfind professor,10,9"/>
     <property name="act2" value="char_face professor,up"/>
-    <property name="act3" value="change_state JournalInfoState,cardiling"/>
+    <property name="act3" value="open_journal cardiling"/>
     <property name="act5" value="translated_dialog chooseyerfateCardiling"/>
     <property name="act6" value="translated_dialog_choice yes:no,cardilingchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
@@ -86,7 +86,7 @@
    <properties>
     <property name="act1" value="pathfind professor,11,9"/>
     <property name="act2" value="char_face professor,up"/>
-    <property name="act3" value="change_state JournalInfoState,tweesher"/>
+    <property name="act3" value="open_journal tweesher"/>
     <property name="act5" value="translated_dialog chooseyerfateTweesher"/>
     <property name="act6" value="translated_dialog_choice yes:no,tweesherchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -77,7 +77,7 @@
   </object>
   <object id="26" name="Use Computer" type="event" x="160" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="change_state PCState,player"/>
+    <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_bedroom.yaml
@@ -85,7 +85,7 @@ events:
     type: event
   Use Computer:
     actions:
-    - change_state PCState,player
+    - access_pc player
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/mods/tuxemon/maps/spyder_candy_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_candy_cafe.yaml
@@ -139,7 +139,7 @@ events:
     type: event
   Use Computer:
     actions:
-    - change_state PCState,player
+    - access_pc player
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/mods/tuxemon/maps/spyder_cathedral.yaml
+++ b/mods/tuxemon/maps/spyder_cathedral.yaml
@@ -140,7 +140,7 @@ events:
     type: event
   Use Computer:
     actions:
-    - change_state PCState,player
+    - access_pc player
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/mods/tuxemon/maps/spyder_lion_mountain_middle.tmx
+++ b/mods/tuxemon/maps/spyder_lion_mountain_middle.tmx
@@ -90,7 +90,7 @@
     <property name="act4" value="translated_dialog spyder_lionmountain_enforcer4"/>
     <property name="act5" value="set_variable lionmountainenforcer:yes"/>
     <property name="act6" value="add_monster chromeye,15"/>
-    <property name="act7" value="change_state JournalInfoState,chromeye"/>
+    <property name="act7" value="open_journal chromeye"/>
     <property name="behav1" value="talk spyder_lionmountain_enforcer"/>
     <property name="cond1" value="not variable_set lionmountainenforcer:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
@@ -89,7 +89,7 @@ events:
     type: event
   Use Computer:
     actions:
-    - change_state PCState,player
+    - access_pc player
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/mods/tuxemon/maps/spyder_paper_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_paper_scoop.yaml
@@ -36,7 +36,7 @@ events:
     type: event
   CapDev 1st:
     actions:
-    - change_state JournalInfoState,dollfin
+    - open_journal dollfin
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -45,7 +45,7 @@ events:
     y: 8
   CapDev 2nd:
     actions:
-    - change_state JournalInfoState,memnomnom
+    - open_journal memnomnom
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -54,7 +54,7 @@ events:
     y: 8
   CapDev 3rd:
     actions:
-    - change_state JournalInfoState,budaye
+    - open_journal budaye
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -63,7 +63,7 @@ events:
     y: 8
   CapDev 4th:
     actions:
-    - change_state JournalInfoState,grintot
+    - open_journal grintot
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
@@ -72,7 +72,7 @@ events:
     y: 8
   CapDev 5th:
     actions:
-    - change_state JournalInfoState,ignibus
+    - open_journal ignibus
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -515,7 +515,7 @@
   <object id="241" name="Rockitten" type="event" x="352" y="144" width="16" height="32">
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
-    <property name="act10" value="change_state JournalInfoState,rockitten"/>
+    <property name="act10" value="open_journal rockitten"/>
     <property name="act25" value="translated_dialog spyder_papertown_rockitten"/>
     <property name="act30" value="translated_dialog_choice yes:no,rockittenchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -526,7 +526,7 @@
   <object id="242" name="Lambert" type="event" x="352" y="176" width="16" height="32">
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
-    <property name="act10" value="change_state JournalInfoState,lambert"/>
+    <property name="act10" value="open_journal lambert"/>
     <property name="act25" value="translated_dialog spyder_papertown_lambert"/>
     <property name="act30" value="translated_dialog_choice yes:no,lambertchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -537,7 +537,7 @@
   <object id="243" name="Nut" type="event" x="432" y="144" width="32" height="16">
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
-    <property name="act10" value="change_state JournalInfoState,nut"/>
+    <property name="act10" value="open_journal nut"/>
     <property name="act25" value="translated_dialog spyder_papertown_nut"/>
     <property name="act30" value="translated_dialog_choice yes:no,nutchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -548,7 +548,7 @@
   <object id="245" name="Tweesher" type="event" x="464" y="144" width="32" height="16">
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
-    <property name="act10" value="change_state JournalInfoState,tweesher"/>
+    <property name="act10" value="open_journal tweesher"/>
     <property name="act25" value="translated_dialog spyder_papertown_tweesher"/>
     <property name="act30" value="translated_dialog_choice yes:no,tweesherchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
@@ -559,7 +559,7 @@
   <object id="246" name="Agnite" type="event" x="480" y="176" width="16" height="32">
    <properties>
     <property name="act05" value="translated_dialog spyder_papertown_thereis"/>
-    <property name="act10" value="change_state JournalInfoState,agnite"/>
+    <property name="act10" value="open_journal agnite"/>
     <property name="act25" value="translated_dialog spyder_papertown_agnite"/>
     <property name="act30" value="translated_dialog_choice yes:no,agnitechosen"/>
     <property name="cond1" value="is char_facing_tile player"/>

--- a/mods/tuxemon/maps/spyder_timber_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_timber_cafe.yaml
@@ -126,7 +126,7 @@ events:
     type: event
   Use Computer:
     actions:
-    - change_state PCState,player
+    - access_pc player
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN

--- a/tuxemon/event/actions/open_journal.py
+++ b/tuxemon/event/actions/open_journal.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.db import MonsterModel, db
+from tuxemon.event.eventaction import EventAction
+from tuxemon.session import Session
+
+logger = logging.getLogger()
+
+
+@final
+@dataclass
+class OpenJournalAction(EventAction):
+    """
+    Change to JournalInfoState.
+
+    This action transitions to the JournalInfoState, displaying information
+    about a specific monster in the player's journal.
+
+    Script usage:
+        .. code-block::
+
+            open_journal <monster_slug>
+
+    Script parameters:
+        monster_slug: The slug of the monster to display in the journal.
+    """
+
+    name = "open_journal"
+    monster_slug: str
+
+    def start(self, session: Session) -> None:
+        self.session = session
+        self.client = session.client
+        self.action = self.client.event_engine
+
+        if self.client.current_state is None:
+            raise RuntimeError("No current state active. This is unexpected.")
+
+        if self.client.current_state.name == "JournalInfoState":
+            logger.error(
+                f"The state 'JournalInfoState' is already active. No action taken."
+            )
+            return
+
+        journal = MonsterModel.lookup(self.monster_slug, db)
+        if journal is None:
+            logger.error(
+                f"Monster with slug '{self.monster_slug}' not found for JournalInfoState."
+            )
+            return
+
+        self.client.push_state(
+            "JournalInfoState",
+            character=self.session.player,
+            monster=journal,
+            source=self.name,
+            reveal=True,
+        )
+
+    def update(self, session: Session) -> None:
+        try:
+            session.client.get_state_by_name("JournalInfoState")
+        except ValueError:
+            self.stop()

--- a/tuxemon/event/actions/show_monster.py
+++ b/tuxemon/event/actions/show_monster.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, final
+from uuid import UUID
+
+from tuxemon.event import get_monster_by_iid
+from tuxemon.event.eventaction import EventAction
+from tuxemon.monster import Monster
+from tuxemon.session import Session
+
+logger = logging.getLogger()
+
+
+@final
+@dataclass
+class ShowMonsterAction(EventAction):
+    """
+    Change to MonsterInfoState.
+
+    This action transitions to the MonsterInfoState, displaying detailed
+    information about a specific monster.
+
+    Script usage:
+        .. code-block::
+
+            monster_info_state <monster_variable>
+
+    Script parameters:
+        monster_variable: The name of the game variable holding the monster's UUID.
+    """
+
+    name = "show_monster"
+    monster_variable: str
+
+    def start(self, session: Session) -> None:
+        self.session = session
+        self.client = session.client
+
+        if self.client.current_state is None:
+            raise RuntimeError("No current state active. This is unexpected.")
+
+        if self.client.current_state.name == "MonsterInfoState":
+            logger.error(
+                f"The state 'MonsterInfoState' is already active. No action taken."
+            )
+            return
+
+        monster = self._retrieve_monster(session)
+        if monster is None:
+            logger.error("Monster not found for MonsterInfoState.")
+            return
+
+        params = {"monster": monster, "source": self.name}
+        self.client.push_state("MonsterInfoState", kwargs=params)
+
+    def update(self, session: Session) -> None:
+        try:
+            session.client.get_state_by_name("MonsterInfoState")
+        except ValueError:
+            self.stop()
+
+    def _retrieve_monster(self, session: Session) -> Optional[Monster]:
+        """Retrieve a monster from the game database."""
+        player = session.player
+        if self.monster_variable not in player.game_variables:
+            logger.error(f"Game variable {self.monster_variable} not found")
+            return None
+        try:
+            monster_id = UUID(player.game_variables[self.monster_variable])
+        except ValueError:
+            logger.error(
+                f"Invalid UUID in game variable {self.monster_variable}: "
+                f"{player.game_variables[self.monster_variable]}"
+            )
+            return None
+        return get_monster_by_iid(session, monster_id)

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -123,7 +123,7 @@ class JournalInfoState(PygameMenuState):
             menu.add.image(type_image_1, float=True).translate(
                 fix_measure(width, 0.17), fix_measure(height, 0.29)
             )
-        types = types if self.caught else "-----"
+        types = self._safe_display(types)
         lab5: Any = menu.add.label(
             title=types,
             label_id="type_loaded",
@@ -146,7 +146,7 @@ class JournalInfoState(PygameMenuState):
         lab6.translate(fix_measure(width, 0.50), fix_measure(height, 0.40))
         # species
         spec = T.translate(f"cat_{monster.category}")
-        spec = spec if self.caught else "-----"
+        spec = self._safe_display(spec)
         species = T.translate("monster_menu_species") + ": " + spec
         lab7: Any = menu.add.label(
             title=species,
@@ -168,7 +168,7 @@ class JournalInfoState(PygameMenuState):
         lab8.translate(fix_measure(width, 0.50), fix_measure(height, 0.10))
         # description
         desc = T.translate(f"{monster.slug}_description")
-        desc = desc if self.caught else "-----"
+        desc = self._safe_display(desc)
         lab9: Any = menu.add.label(
             title=desc,
             label_id="description",
@@ -179,7 +179,7 @@ class JournalInfoState(PygameMenuState):
         )
         lab9.translate(fix_measure(width, 0.01), fix_measure(height, 0.56))
         # evolution
-        evo = evo if self.caught else "-----"
+        evo = self._safe_display(evo)
         lab10: Any = menu.add.label(
             title=evo,
             label_id="evolution",
@@ -191,7 +191,7 @@ class JournalInfoState(PygameMenuState):
         lab10.translate(fix_measure(width, 0.01), fix_measure(height, 0.76))
 
         # evolution monsters
-        if self.caught:
+        if self.is_visible:
             f = menu.add.frame_h(
                 float=True,
                 width=fix_measure(width, 0.95),
@@ -214,7 +214,7 @@ class JournalInfoState(PygameMenuState):
                 f.pack(elements)
         # image
         _path = f"gfx/sprites/battle/{monster.slug}-front.png"
-        _path = _path if self.caught else prepare.MISSING_IMAGE
+        _path = _path if self.is_visible else prepare.MISSING_IMAGE
         new_image = self._create_image(_path)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
@@ -224,7 +224,11 @@ class JournalInfoState(PygameMenuState):
         )
 
     def __init__(
-        self, character: NPC, monster: Optional[MonsterModel], source: str
+        self,
+        character: NPC,
+        monster: Optional[MonsterModel],
+        source: str,
+        reveal: bool = False,
     ) -> None:
         if not lookup_cache:
             _lookup_monsters()
@@ -240,11 +244,13 @@ class JournalInfoState(PygameMenuState):
 
         self.char = character
         self.source = source
-        checks = self.char.tuxepedia.is_caught(monster.slug)
-        self.caught = checks
+        self.is_visible = self.char.tuxepedia.is_caught(monster.slug) or reveal
         self._monster = monster
         self.add_menu_items(self.menu, monster)
         self.reset_theme()
+
+    def _safe_display(self, value: str) -> str:
+        return value if self.is_visible else "-----"
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         client = self.client


### PR DESCRIPTION
PR introduces specific `EventAction` classes to replace the generalized `change_state` action for state transitions.

Changes:
- refactored `ChangeStateAction` by moving logic for special cases into dedicated EventAction subclasses: `AccessPCAction`, `OpenJournalAction`, `ShowMonsterAction`
- the original `ChangeStateAction` is retained as a minimal, generic fallback: now handles only unconditional state transitions and primarily useful for internal testing and transitions that don't require additional parameters or validation
- updated `JournalInfoState` to support an optional `reveal` boolean, allowing uncaught monster data to be displayed, previously, the information was only shown if the monster was registered in the tuxepedia; now, reveal logic is explicitly controlled through this parameter