### PR TITLE
`TasteModel` with Rarity Support and Flexible `ChangeTasteAction`

### DIFF
--- a/mods/tuxemon/db/taste/taste.json
+++ b/mods/tuxemon/db/taste/taste.json
@@ -10,6 +10,7 @@
       }
     ],
     "name": "taste_mild",
+    "rarity_score": 1.0,
     "slug": "mild",
     "taste_type": "cold"
   },
@@ -24,6 +25,7 @@
       }
     ],
     "name": "taste_sweet",
+    "rarity_score": 1.0,
     "slug": "sweet",
     "taste_type": "cold"
   },
@@ -38,6 +40,7 @@
       }
     ],
     "name": "taste_soft",
+    "rarity_score": 1.0,
     "slug": "soft",
     "taste_type": "cold"
   },
@@ -52,6 +55,7 @@
       }
     ],
     "name": "taste_flakey",
+    "rarity_score": 1.0,
     "slug": "flakey",
     "taste_type": "cold"
   },
@@ -66,6 +70,7 @@
       }
     ],
     "name": "taste_dry",
+    "rarity_score": 1.0,
     "slug": "dry",
     "taste_type": "cold"
   },
@@ -80,6 +85,7 @@
       }
     ],
     "name": "taste_peppy",
+    "rarity_score": 1.0,
     "slug": "peppy",
     "taste_type": "warm"
   },
@@ -94,6 +100,7 @@
       }
     ],
     "name": "taste_salty",
+    "rarity_score": 1.0,
     "slug": "salty",
     "taste_type": "warm"
   },
@@ -108,6 +115,7 @@
       }
     ],
     "name": "taste_hearty",
+    "rarity_score": 1.0,
     "slug": "hearty",
     "taste_type": "warm"
   },
@@ -122,6 +130,7 @@
       }
     ],
     "name": "taste_zesty",
+    "rarity_score": 1.0,
     "slug": "zesty",
     "taste_type": "warm"
   },
@@ -136,6 +145,7 @@
       }
     ],
     "name": "taste_refined",
+    "rarity_score": 1.0,
     "slug": "refined",
     "taste_type": "warm"
   }

--- a/mods/tuxemon/maps/spyder_dojo1.yaml
+++ b/mods/tuxemon/maps/spyder_dojo1.yaml
@@ -323,7 +323,7 @@ events:
     type: event
   Talk Zhu Cold:
     actions:
-    - change_taste tasteful_zhu,cold
+    - change_taste tasteful_zhu,cold,random
     - set_variable zhu_taste_done:yes
     conditions:
     - is variable_set which_taste:taste_cold
@@ -365,7 +365,7 @@ events:
     type: event
   Talk Zhu Warm:
     actions:
-    - change_taste tasteful_zhu,warm
+    - change_taste tasteful_zhu,warm,random
     - set_variable zhu_taste_done:yes
     conditions:
     - is variable_set which_taste:taste_warm

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1468,6 +1468,12 @@ class TasteModel(BaseModel):
     modifiers: Sequence[Modifier] = Field(
         ..., description="Modifiers associated with the taste"
     )
+    rarity_score: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Rarity score between 0 (rare) and 1 (common)",
+    )
 
     @classmethod
     def lookup(cls, slug: str, db: ModData) -> TasteModel:


### PR DESCRIPTION
PR introduces the following improvements to the taste and event action systems:
- upgrades the `ChangeTasteAction` event to support both assigning a specific taste and generating a new one randomly
- validates that assigned tastes match the expected type (`warm` or `cold`) and prevents explicitly setting the `"tasteless"` fallback
- adds a `rarity_score` field (from 0.0 to 1.0) to the `TasteModel`, allowing tastes to be assigned with rarity weighting
- implements a new class method `get_random_taste_excluding`, which selects a taste of a given type while excluding specified slugs, and uses `rarity_score` to weight the selection
- refactors the `Taste.generate()` method to utilize this new weighted selection logic, making rare tastes genuinely rare during random assignment