### PR TITLE
Refactor hit chance assignment for monsters

### DIFF
--- a/tuxemon/core/effects/cooldown.py
+++ b/tuxemon/core/effects/cooldown.py
@@ -47,7 +47,7 @@ class CoolDownEffect(CoreEffect):
             )
 
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         if not tech.hit:
             return TechEffectResult(name=tech.name)
 

--- a/tuxemon/core/effects/damage.py
+++ b/tuxemon/core/effects/damage.py
@@ -34,7 +34,7 @@ class DamageEffect(CoreEffect):
         targets: list[Monster] = []
 
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if tech.hit and not target.out_of_range:
             damage, mult = formula.simple_damage_calculate(tech, user, target)

--- a/tuxemon/core/effects/empty.py
+++ b/tuxemon/core/effects/empty.py
@@ -27,5 +27,5 @@ class EmptyEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         return TechEffectResult(name=tech.name, success=tech.hit)

--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -42,7 +42,7 @@ class GiveEffect(CoreEffect):
 
         objectives = self.objectives.split(":")
         potency = random.random()
-        value = combat._random_tech_hit.get(user, 0.0)
+        value = combat.get_tech_hit(user)
         success = tech.potency >= potency and tech.accuracy >= value
 
         if success:

--- a/tuxemon/core/effects/healing.py
+++ b/tuxemon/core/effects/healing.py
@@ -34,7 +34,7 @@ class HealingEffect(CoreEffect):
         done: bool = False
 
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if tech.hit:
             targets = combat.get_targets(tech, user, target)

--- a/tuxemon/core/effects/life_share.py
+++ b/tuxemon/core/effects/life_share.py
@@ -34,7 +34,7 @@ class LifeShareEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         done = False
         if tech.hit:
             source, dest = (

--- a/tuxemon/core/effects/life_swap.py
+++ b/tuxemon/core/effects/life_swap.py
@@ -29,7 +29,7 @@ class LifeSwapEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         done = False
         if tech.hit:
             if not user.is_fainted and not target.is_fainted:

--- a/tuxemon/core/effects/money.py
+++ b/tuxemon/core/effects/money.py
@@ -34,7 +34,7 @@ class MoneyEffect(CoreEffect):
         extra: list[str] = []
         player = user.get_owner()
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         damage, mult = formula.simple_damage_calculate(tech, user, target)
 

--- a/tuxemon/core/effects/multiattack.py
+++ b/tuxemon/core/effects/multiattack.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,8 +32,7 @@ class MultiAttackEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        value = random.random()
-        combat._random_tech_hit[user] = value
+        combat.set_tech_hit(user)
         # Track previous actions with the same technique, user, and target
         log = combat._action_queue.history.get_actions_by_turn(combat._turn)
         track = [
@@ -47,7 +45,7 @@ class MultiAttackEffect(CoreEffect):
         # Check if the technique has been used the maximum number of times
         done = len(track) < self.times
         # Check if the technique hits
-        hit = tech.accuracy >= value
+        hit = tech.accuracy >= combat.get_tech_hit(user)
         # If the technique is done and hits, enqueue the action
         if done and hit:
             combat.enqueue_action(user, tech, target)

--- a/tuxemon/core/effects/photogenesis.py
+++ b/tuxemon/core/effects/photogenesis.py
@@ -41,7 +41,7 @@ class PhotogenesisEffect(CoreEffect):
         extra: list[str] = []
         done: bool = False
 
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         hour = int(player.game_variables.get("hour", 0))
         shape = Shape(user.shape).attributes

--- a/tuxemon/core/effects/prop_damage.py
+++ b/tuxemon/core/effects/prop_damage.py
@@ -45,7 +45,7 @@ class PropDamageEffect(CoreEffect):
         combat = tech.get_combat_state()
 
         objectives = self.objectives.split(":")
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         reference_hp = target.hp
 
         if tech.hit:

--- a/tuxemon/core/effects/prop_healing.py
+++ b/tuxemon/core/effects/prop_healing.py
@@ -44,7 +44,7 @@ class PropHealingEffect(CoreEffect):
         combat = tech.get_combat_state()
 
         objectives = self.objectives.split(":")
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         reference_hp = user.hp
 
         if tech.hit:

--- a/tuxemon/core/effects/remove.py
+++ b/tuxemon/core/effects/remove.py
@@ -41,7 +41,7 @@ class RemoveEffect(CoreEffect):
 
         objectives = self.objectives.split(":")
         potency = random.random()
-        value = combat._random_tech_hit.get(user, 0.0)
+        value = combat.get_tech_hit(user)
         success = tech.potency >= potency and tech.accuracy >= value
 
         if success:

--- a/tuxemon/core/effects/reverse.py
+++ b/tuxemon/core/effects/reverse.py
@@ -36,7 +36,7 @@ class ReverseEffect(CoreEffect):
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
 
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if not tech.hit:
             return TechEffectResult(name=tech.name, success=tech.hit)

--- a/tuxemon/core/effects/sacrifice.py
+++ b/tuxemon/core/effects/sacrifice.py
@@ -40,7 +40,7 @@ class SacrificeEffect(CoreEffect):
             raise ValueError("Multiplier must be a float between 0 and 1")
 
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if tech.hit:
             damage = int(user.current_hp * self.multiplier)

--- a/tuxemon/core/effects/splash.py
+++ b/tuxemon/core/effects/splash.py
@@ -28,7 +28,7 @@ class SplashEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         damage, mult = formula.simple_damage_calculate(tech, user, target)
         targets = combat.get_targets(tech, user, target)

--- a/tuxemon/core/effects/step_damage.py
+++ b/tuxemon/core/effects/step_damage.py
@@ -43,7 +43,7 @@ class StepDamageEffect(CoreEffect):
         combat = tech.get_combat_state()
 
         objectives = self.objectives.split(":")
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if tech.hit:
             monsters = get_target_monsters(objectives, tech, user, target)

--- a/tuxemon/core/effects/step_healing.py
+++ b/tuxemon/core/effects/step_healing.py
@@ -44,7 +44,7 @@ class StepHealingEffect(CoreEffect):
         combat = tech.get_combat_state()
 
         objectives = self.objectives.split(":")
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if tech.hit:
             monsters = get_target_monsters(objectives, tech, user, target)

--- a/tuxemon/core/effects/switch.py
+++ b/tuxemon/core/effects/switch.py
@@ -44,7 +44,7 @@ class SwitchEffect(CoreEffect):
         elements = list(db.database["element"])
         combat = tech.get_combat_state()
 
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
         if not tech.hit:
             return TechEffectResult(name=tech.name, success=tech.hit)

--- a/tuxemon/core/effects/transfer.py
+++ b/tuxemon/core/effects/transfer.py
@@ -32,7 +32,7 @@ class TransferEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        tech.hit = tech.accuracy >= combat._random_tech_hit.get(user, 0.0)
+        tech.hit = tech.accuracy >= combat.get_tech_hit(user)
         done = False
         if tech.hit:
             source, dest = (

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -341,6 +341,7 @@ class CombatState(CombatAnimations):
             self.update_icons_for_monsters()
             self.animate_update_party_hud()
             if not self._decision_queue:
+                self.initialize_hit_chances()
                 self.process_player_decisions()
 
         elif phase == CombatPhase.ACTION:
@@ -674,8 +675,6 @@ class CombatState(CombatAnimations):
             self.update_hud(player, False)
             monsters = self.field_monsters.get_monsters(player)
             for monster in monsters:
-                value = random.random()
-                self._random_tech_hit[monster] = value
                 if player in self.human_players:
                     self._decision_queue.append(monster)
                 else:
@@ -1143,6 +1142,23 @@ class CombatState(CombatAnimations):
         self.award_experience_and_money(monster)
         # Remove monster from damage map
         self._damage_map.remove_monster(monster)
+
+    def initialize_hit_chances(self) -> None:
+        """Initializes random hit chance values for all active monsters."""
+        for monster in self.active_monsters:
+            self.set_tech_hit(monster)
+
+    def set_tech_hit(
+        self, monster: Monster, value: Optional[float] = None
+    ) -> None:
+        """Assigns a random hit chance to the given monster."""
+        if value is None:
+            value = random.random()
+        self._random_tech_hit[monster] = value
+
+    def get_tech_hit(self, monster: Monster) -> float:
+        """Retrieves the stored hit chance, defaulting to 0.0 if not found."""
+        return self._random_tech_hit.get(monster, 0.0)
 
     @property
     def active_players(self) -> Iterable[NPC]:


### PR DESCRIPTION
PR introduces a small refactor to streamline how hit chance values are assigned and retrieved across the codebase. 

Changes:
- introduced `initialize_hit_chances`, a new method that assigns random hit values to all `active_monsters`, encapsulating behavior that was previously duplicated
- removed inline hit chance assignment, previously, `process_player_decisions` manually set random hit values for each monster, that logic is now handled by `initialize_hit_chances`, and the method call has been added just before recursion into `process_player_decisions`
- added `get_tech_hit`, a simple getter method that retrieves a monster’s hit value, returning `0.0` if unset, this replaces repetitive raw dictionary lookups like: `combat._random_tech_hit.get(user, 0.0)` with `combat.get_tech_hit(user)`