### PR TITLE
Centralization `fix_measure` function in `tools.py`

### DIFF
--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -10,21 +10,17 @@ from pygame_menu import locals
 
 from tuxemon import formula
 from tuxemon import prepare as pre
-from tuxemon.db import MonsterModel, OutputBattle, db
+from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.npc import NPC
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.time_handler import today_ordinal
+from tuxemon.tools import fix_measure
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 def _lookup_monsters() -> None:
@@ -50,8 +46,8 @@ class CharacterState(PygameMenuState):
         self,
         menu: pygame_menu.Menu,
     ) -> None:
-        width = menu._width
-        height = menu._height
+        fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
+        fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
 
         name = (
             T.translate(self.char.slug)
@@ -126,7 +122,7 @@ class CharacterState(PygameMenuState):
             underline=True,
             float=True,
         )
-        lab1.translate(fix_measure(width, 0.45), fix_measure(height, 0.15))
+        lab1.translate(fxw(0.45), fxh(0.15))
         # money
         money = self.char.money_controller.money_manager.get_money()
         lab2: Any = menu.add.label(
@@ -136,7 +132,7 @@ class CharacterState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fix_measure(width, 0.45), fix_measure(height, 0.25))
+        lab2.translate(fxw(0.45), fxh(0.25))
         # seen
         lab3: Any = menu.add.label(
             title=msg_seen,
@@ -145,7 +141,7 @@ class CharacterState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fix_measure(width, 0.45), fix_measure(height, 0.30))
+        lab3.translate(fxw(0.45), fxh(0.30))
         # caught
         lab4: Any = menu.add.label(
             title=msg_caught,
@@ -154,7 +150,7 @@ class CharacterState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fix_measure(width, 0.45), fix_measure(height, 0.35))
+        lab4.translate(fxw(0.45), fxh(0.35))
         # begin adventure
         lab5: Any = menu.add.label(
             title=msg_begin,
@@ -163,7 +159,7 @@ class CharacterState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fix_measure(width, 0.45), fix_measure(height, 0.40))
+        lab5.translate(fxw(0.45), fxh(0.40))
         # walked
         if steps > 0.0:
             lab6: Any = menu.add.label(
@@ -173,7 +169,7 @@ class CharacterState(PygameMenuState):
                 align=locals.ALIGN_LEFT,
                 float=True,
             )
-            lab6.translate(fix_measure(width, 0.45), fix_measure(height, 0.45))
+            lab6.translate(fxw(0.45), fxh(0.45))
         # battles
         lab7: Any = menu.add.label(
             title=msg_battles,
@@ -182,7 +178,7 @@ class CharacterState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fix_measure(width, 0.45), fix_measure(height, 0.50))
+        lab7.translate(fxw(0.45), fxh(0.50))
         # % tuxepedia
         lab8: Any = menu.add.label(
             title=msg_progress,
@@ -191,7 +187,7 @@ class CharacterState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fix_measure(width, 0.45), fix_measure(height, 0.10))
+        lab8.translate(fxw(0.45), fxh(0.10))
         # image
         combat_front = self.char.template.combat_front
         _path = f"gfx/sprites/player/{combat_front}.png"
@@ -199,9 +195,7 @@ class CharacterState(PygameMenuState):
         new_image.scale(pre.SCALE, pre.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(
-            fix_measure(width, 0.20), fix_measure(height, 0.08)
-        )
+        image_widget.translate(fxw(0.20), fxh(0.08))
 
     def __init__(self, **kwargs: Any) -> None:
         if not lookup_cache:

--- a/tuxemon/states/choice/choice_item.py
+++ b/tuxemon/states/choice/choice_item.py
@@ -12,6 +12,7 @@ from tuxemon import prepare
 from tuxemon.db import ItemModel, db
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
+from tuxemon.tools import fix_measure
 
 ChoiceMenuGameObj = Callable[[], None]
 LENGTH_NAME_ITEM = 10
@@ -22,11 +23,6 @@ WINDOW_WIDTH_PERCENTAGE_LONG = 0.4
 WINDOW_WIDTH_PERCENTAGE_SHORT = 0.3
 TRANSLATE_PERCENTAGE_LONG = 0.4
 TRANSLATE_PERCENTAGE_SHORT = 0.3
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 class ChoiceItem(PygameMenuState):

--- a/tuxemon/states/choice/choice_npc.py
+++ b/tuxemon/states/choice/choice_npc.py
@@ -26,11 +26,6 @@ SCALE_SPRITE = 0.4
 VERTICAL_FILL = 10
 
 
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
-
-
 class ChoiceNpc(PygameMenuState):
     """
     Game state with a graphic box and NPCs (images) + labels.

--- a/tuxemon/states/journal/journal.py
+++ b/tuxemon/states/journal/journal.py
@@ -15,6 +15,7 @@ from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
+from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
@@ -23,11 +24,6 @@ MAX_PAGE = 20
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 def _lookup_monsters() -> None:
@@ -46,12 +42,10 @@ class JournalState(PygameMenuState):
         menu: pygame_menu.Menu,
         monsters: list[MonsterModel],
     ) -> None:
-        width = menu._width
-        height = menu._height
-        menu._column_max_width = [
-            fix_measure(width, 0.35),
-            fix_measure(width, 0.35),
-        ]
+        column_width = fix_measure(menu._width, 0.35)
+        btn_x_offset = fix_measure(menu._width, 0.25)
+        btn_y_offset = fix_measure(menu._height, 0.01)
+        menu._column_max_width = [column_width, column_width]
 
         def change_state(state: str, **kwargs: Any) -> MenuGameObj:
             return partial(self.client.push_state, state, **kwargs)
@@ -72,9 +66,7 @@ class JournalState(PygameMenuState):
                         ),
                         font_size=self.font_size_small,
                         button_id=mon.slug,
-                    ).translate(
-                        fix_measure(width, 0.25), fix_measure(height, 0.01)
-                    )
+                    ).translate(btn_x_offset, btn_y_offset)
                 elif self.char.tuxepedia.is_caught(mon.slug):
                     menu.add.button(
                         label + "◉",
@@ -87,9 +79,7 @@ class JournalState(PygameMenuState):
                         font_size=self.font_size_small,
                         button_id=mon.slug,
                         underline=True,
-                    ).translate(
-                        fix_measure(width, 0.25), fix_measure(height, 0.01)
-                    )
+                    ).translate(btn_x_offset, btn_y_offset)
             else:
                 label = f"{mon.txmn_id}. -----"
                 lab: Any = menu.add.label(
@@ -98,9 +88,7 @@ class JournalState(PygameMenuState):
                     font_color=prepare.DIMGRAY_COLOR,
                     label_id=mon.slug,
                 )
-                lab.translate(
-                    fix_measure(width, 0.25), fix_measure(height, 0.01)
-                )
+                lab.translate(btn_x_offset, btn_y_offset)
 
     def __init__(
         self, character: NPC, monsters: list[MonsterModel], page: int

--- a/tuxemon/states/journal/journal_choice.py
+++ b/tuxemon/states/journal/journal_choice.py
@@ -14,6 +14,7 @@ from tuxemon import prepare
 from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
+from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
@@ -23,11 +24,6 @@ MAX_PAGE = 20
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 def _lookup_monsters() -> None:
@@ -46,8 +42,6 @@ class JournalChoice(PygameMenuState):
         menu: pygame_menu.Menu,
         monsters: list[MonsterModel],
     ) -> None:
-        width = menu._width
-        height = menu._height
 
         def change_state(state: str, **kwargs: Any) -> MenuGameObj:
             return partial(self.client.push_state, state, **kwargs)
@@ -55,10 +49,10 @@ class JournalChoice(PygameMenuState):
         total_monster = len(monsters)
         pages = math.ceil(total_monster / MAX_PAGE)
 
-        menu._column_max_width = [
-            fix_measure(width, 0.40),
-            fix_measure(width, 0.40),
-        ]
+        column_width = fix_measure(menu._width, 0.40)
+        btn_x_offset = fix_measure(menu._width, 0.18)
+        btn_y_offset = fix_measure(menu._height, 0.01)
+        menu._column_max_width = [column_width, column_width]
 
         for page in range(pages):
             start = page * MAX_PAGE
@@ -83,18 +77,14 @@ class JournalChoice(PygameMenuState):
                         page=page,
                     ),
                     font_size=self.font_size_small,
-                ).translate(
-                    fix_measure(width, 0.18), fix_measure(height, 0.01)
-                )
+                ).translate(btn_x_offset, btn_y_offset)
             else:
                 lab1: Any = menu.add.label(
                     label,
                     font_color=prepare.DIMGRAY_COLOR,
                     font_size=self.font_size_small,
                 )
-                lab1.translate(
-                    fix_measure(width, 0.18), fix_measure(height, 0.01)
-                )
+                lab1.translate(btn_x_offset, btn_y_offset)
 
     def __init__(self, character: NPC) -> None:
         if not lookup_cache:

--- a/tuxemon/states/journal/journal_info.py
+++ b/tuxemon/states/journal/journal_info.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
@@ -13,16 +14,12 @@ from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
+from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
 lookup_cache: dict[str, MonsterModel] = {}
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 def _lookup_monsters() -> None:
@@ -41,9 +38,9 @@ class JournalInfoState(PygameMenuState):
         menu: pygame_menu.Menu,
         monster: MonsterModel,
     ) -> None:
-        width = menu._width
-        height = menu._height
-        menu._width = fix_measure(menu._width, 0.97)
+        fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
+        fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
+        menu._width = fxw(0.97)
 
         # evolutions
         evo = T.translate("no_evolution")
@@ -77,7 +74,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fix_measure(width, 0.50), fix_measure(height, 0.15))
+        lab1.translate(fxw(0.50), fxh(0.15))
         # weight
         _weight = f"{mon_weight} {unit_weight}"
         lab2: Any = menu.add.label(
@@ -87,7 +84,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fix_measure(width, 0.50), fix_measure(height, 0.25))
+        lab2.translate(fxw(0.50), fxh(0.25))
         # height
         _height = f"{mon_height} {unit_height}"
         lab3: Any = menu.add.label(
@@ -97,7 +94,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fix_measure(width, 0.65), fix_measure(height, 0.25))
+        lab3.translate(fxw(0.65), fxh(0.25))
         # type
         _type = T.translate("monster_menu_type")
         lab4: Any = menu.add.label(
@@ -107,21 +104,21 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fix_measure(width, 0.50), fix_measure(height, 0.30))
+        lab4.translate(fxw(0.50), fxh(0.30))
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type.png"
         type_image_1 = self._create_image(path1)
         if len(monster.types) > 1:
             path2 = f"gfx/ui/icons/element/{monster.types[1]}_type.png"
             type_image_2 = self._create_image(path2)
             menu.add.image(type_image_1, float=True).translate(
-                fix_measure(width, 0.17), fix_measure(height, 0.29)
+                fxw(0.17), fxh(0.29)
             )
             menu.add.image(type_image_2, float=True).translate(
-                fix_measure(width, 0.19), fix_measure(height, 0.29)
+                fxw(0.19), fxh(0.29)
             )
         else:
             menu.add.image(type_image_1, float=True).translate(
-                fix_measure(width, 0.17), fix_measure(height, 0.29)
+                fxw(0.17), fxh(0.29)
             )
         types = types if self.caught else "-----"
         lab5: Any = menu.add.label(
@@ -131,7 +128,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fix_measure(width, 0.50), fix_measure(height, 0.35))
+        lab5.translate(fxw(0.50), fxh(0.35))
         # shape
         menu_shape = T.translate("monster_menu_shape")
         _shape = T.translate(monster.shape)
@@ -143,7 +140,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab6.translate(fix_measure(width, 0.50), fix_measure(height, 0.40))
+        lab6.translate(fxw(0.50), fxh(0.40))
         # species
         spec = T.translate(f"cat_{monster.category}")
         spec = spec if self.caught else "-----"
@@ -155,7 +152,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fix_measure(width, 0.50), fix_measure(height, 0.45))
+        lab7.translate(fxw(0.50), fxh(0.45))
         # txmn_id
         _txmn_id = f"ID: {monster.txmn_id}"
         lab8: Any = menu.add.label(
@@ -165,7 +162,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fix_measure(width, 0.50), fix_measure(height, 0.10))
+        lab8.translate(fxw(0.50), fxh(0.10))
         # description
         desc = T.translate(f"{monster.slug}_description")
         desc = desc if self.caught else "-----"
@@ -177,7 +174,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab9.translate(fix_measure(width, 0.01), fix_measure(height, 0.56))
+        lab9.translate(fxw(0.01), fxh(0.56))
         # evolution
         evo = evo if self.caught else "-----"
         lab10: Any = menu.add.label(
@@ -188,17 +185,17 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab10.translate(fix_measure(width, 0.01), fix_measure(height, 0.76))
+        lab10.translate(fxw(0.01), fxh(0.76))
 
         # evolution monsters
         if self.caught:
             f = menu.add.frame_h(
                 float=True,
-                width=fix_measure(width, 0.95),
-                height=fix_measure(width, 0.05),
+                width=fxw(0.95),
+                height=fxw(0.05),
                 frame_id="histories",
             )
-            f.translate(fix_measure(width, 0.02), fix_measure(height, 0.80))
+            f.translate(fxw(0.02), fxh(0.80))
             f._relax = True
             slugs = [ele.monster_slug for ele in monster.evolutions]
             elements = list(dict.fromkeys(slugs))
@@ -219,9 +216,7 @@ class JournalInfoState(PygameMenuState):
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(
-            fix_measure(width, 0.20), fix_measure(height, 0.05)
-        )
+        image_widget.translate(fxw(0.20), fxh(0.05))
 
     def __init__(
         self, character: NPC, monster: Optional[MonsterModel], source: str

--- a/tuxemon/states/minigame/__init__.py
+++ b/tuxemon/states/minigame/__init__.py
@@ -14,15 +14,10 @@ from tuxemon import prepare
 from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.tools import open_dialog
+from tuxemon.tools import fix_measure, open_dialog
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 def _lookup_monsters() -> None:
@@ -75,10 +70,9 @@ class MinigameState(PygameMenuState):
                 open_dialog(self.client, [T.translate("generic_wrong")])
 
         # replies
-        width = menu._width
         f = menu.add.frame_h(
-            width=fix_measure(width, 0.95),
-            height=fix_measure(width, 0.05),
+            width=fix_measure(menu._width, 0.95),
+            height=fix_measure(menu._width, 0.05),
             frame_id="evolutions",
             align=locals.ALIGN_CENTER,
         )

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any, Optional
 
 import pygame_menu
@@ -15,6 +16,7 @@ from tuxemon.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.time_handler import today_ordinal
+from tuxemon.tools import fix_measure
 
 lookup_cache: dict[str, MonsterModel] = {}
 
@@ -25,11 +27,6 @@ def _lookup_monsters() -> None:
         results = MonsterModel.lookup(mon, db)
         if results.txmn_id > 0:
             lookup_cache[mon] = results
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 class MonsterInfoState(PygameMenuState):
@@ -43,9 +40,9 @@ class MonsterInfoState(PygameMenuState):
         menu: pygame_menu.Menu,
         monster: Monster,
     ) -> None:
-        width = menu._width
-        height = menu._height
-        menu._width = fix_measure(menu._width, 0.97)
+        fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
+        fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
+        menu._width = fxw(0.97)
         # evolutions
         evo = T.translate("no_evolution")
         if monster.evolutions:
@@ -87,7 +84,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fix_measure(width, 0.50), fix_measure(height, 0.10))
+        lab1.translate(fxw(0.50), fxh(0.10))
         # level + exp
         exp = monster.total_experience
         lab2: Any = menu.add.label(
@@ -97,7 +94,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fix_measure(width, 0.50), fix_measure(height, 0.15))
+        lab2.translate(fxw(0.50), fxh(0.15))
         # exp next level
         exp_lv = monster.experience_required(1) - monster.total_experience
         lv = monster.level + 1
@@ -108,7 +105,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fix_measure(width, 0.50), fix_measure(height, 0.20))
+        lab3.translate(fxw(0.50), fxh(0.20))
         # weight
         lab4: Any = menu.add.label(
             title=f"{mon_weight} {unit_weight} ({diff_weight}%)",
@@ -117,7 +114,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fix_measure(width, 0.50), fix_measure(height, 0.25))
+        lab4.translate(fxw(0.50), fxh(0.25))
         # height
         lab5: Any = menu.add.label(
             title=f"{mon_height} {unit_height} ({diff_height}%)",
@@ -126,7 +123,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fix_measure(width, 0.50), fix_measure(height, 0.30))
+        lab5.translate(fxw(0.50), fxh(0.30))
         # type
         lab6: Any = menu.add.label(
             title=types,
@@ -135,7 +132,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab6.translate(fix_measure(width, 0.50), fix_measure(height, 0.35))
+        lab6.translate(fxw(0.50), fxh(0.35))
         # shape
         lab7: Any = menu.add.label(
             title=T.translate(monster.shape),
@@ -144,7 +141,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fix_measure(width, 0.65), fix_measure(height, 0.35))
+        lab7.translate(fxw(0.65), fxh(0.35))
         # species
         lab8: Any = menu.add.label(
             title=monster.category,
@@ -153,7 +150,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fix_measure(width, 0.50), fix_measure(height, 0.40))
+        lab8.translate(fxw(0.50), fxh(0.40))
         # taste
         tastes = T.translate("tastes")
         cold = T.translate(f"taste_{monster.taste_cold.lower()}")
@@ -165,7 +162,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab9.translate(fix_measure(width, 0.50), fix_measure(height, 0.45))
+        lab9.translate(fxw(0.50), fxh(0.45))
         # capture
         doc = today_ordinal() - monster.capture
         if doc >= 1:
@@ -187,7 +184,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab10.translate(fix_measure(width, 0.50), fix_measure(height, 0.50))
+        lab10.translate(fxw(0.50), fxh(0.50))
         # hp
         lab11: Any = menu.add.label(
             title=f"{T.translate('short_hp')}: {monster.hp}",
@@ -196,7 +193,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab11.translate(fix_measure(width, 0.80), fix_measure(height, 0.15))
+        lab11.translate(fxw(0.80), fxh(0.15))
         # armour
         lab12: Any = menu.add.label(
             title=f"{T.translate('short_armour')}: {monster.armour}",
@@ -205,7 +202,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab12.translate(fix_measure(width, 0.80), fix_measure(height, 0.20))
+        lab12.translate(fxw(0.80), fxh(0.20))
         # dodge
         lab13: Any = menu.add.label(
             title=f"{T.translate('short_dodge')}: {monster.dodge}",
@@ -214,7 +211,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab13.translate(fix_measure(width, 0.80), fix_measure(height, 0.25))
+        lab13.translate(fxw(0.80), fxh(0.25))
         # melee
         lab14: Any = menu.add.label(
             title=f"{T.translate('short_melee')}: {monster.melee}",
@@ -223,7 +220,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab14.translate(fix_measure(width, 0.80), fix_measure(height, 0.30))
+        lab14.translate(fxw(0.80), fxh(0.30))
         # ranged
         lab15: Any = menu.add.label(
             title=f"{T.translate('short_ranged')}: {monster.ranged}",
@@ -232,7 +229,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab15.translate(fix_measure(width, 0.80), fix_measure(height, 0.35))
+        lab15.translate(fxw(0.80), fxh(0.35))
         # speed
         lab16: Any = menu.add.label(
             title=f"{T.translate('short_speed')}: {monster.speed}",
@@ -241,7 +238,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab16.translate(fix_measure(width, 0.80), fix_measure(height, 0.40))
+        lab16.translate(fxw(0.80), fxh(0.40))
         # description
         lab17: Any = menu.add.label(
             title=monster.description,
@@ -251,7 +248,7 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab17.translate(fix_measure(width, 0.01), fix_measure(height, 0.56))
+        lab17.translate(fxw(0.01), fxh(0.56))
         # evolution
         lab18: Any = menu.add.label(
             title=evo,
@@ -261,16 +258,16 @@ class MonsterInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab18.translate(fix_measure(width, 0.01), fix_measure(height, 0.76))
+        lab18.translate(fxw(0.01), fxh(0.76))
 
         # evolution monsters
         f = menu.add.frame_h(
             float=True,
-            width=fix_measure(width, 0.95),
-            height=fix_measure(width, 0.05),
+            width=fxw(0.95),
+            height=fxw(0.05),
             frame_id="histories",
         )
-        f.translate(fix_measure(width, 0.02), fix_measure(height, 0.80))
+        f.translate(fxw(0.02), fxh(0.80))
         f._relax = True
         slugs = [ele.monster_slug for ele in monster.evolutions]
         elements = list(dict.fromkeys(slugs))
@@ -289,18 +286,14 @@ class MonsterInfoState(PygameMenuState):
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(
-            fix_measure(width, 0.20), fix_measure(height, 0.05)
-        )
+        image_widget.translate(fxw(0.20), fxh(0.05))
         # tuxeball
         tuxeball = self._create_image(
             f"gfx/items/{monster.capture_device}.png"
         )
         capture_device = menu.add.image(image_path=tuxeball)
         capture_device.set_float(origin_position=True)
-        capture_device.translate(
-            fix_measure(width, 0.50), fix_measure(height, 0.445)
-        )
+        capture_device.translate(fxw(0.50), fxh(0.445))
 
     def __init__(self, **kwargs: Any) -> None:
         if not lookup_cache:

--- a/tuxemon/states/monster_item/__init__.py
+++ b/tuxemon/states/monster_item/__init__.py
@@ -19,11 +19,6 @@ from tuxemon.platform.events import PlayerInput
 from tuxemon.states.items.item_menu import ItemMenuState
 
 
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
-
-
 class MonsterItemState(PygameMenuState):
     """
     Shows details of the single monster held item.

--- a/tuxemon/states/monster_moves/__init__.py
+++ b/tuxemon/states/monster_moves/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
@@ -15,6 +16,7 @@ from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons
 from tuxemon.technique.technique import Technique
+from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -31,11 +33,6 @@ def _lookup_monsters() -> None:
             lookup_cache[mon] = results
 
 
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
-
-
 class MonsterMovesState(PygameMenuState):
     """
     Shows details of the single monster with the journal
@@ -47,9 +44,9 @@ class MonsterMovesState(PygameMenuState):
         menu: pygame_menu.Menu,
         monster: Monster,
     ) -> None:
-        width = menu._width
-        height = menu._height
-        menu._width = fix_measure(menu._width, 0.97)
+        fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
+        fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
+        menu._width = fxw(0.97)
 
         # name
         menu._auto_centering = False
@@ -60,7 +57,7 @@ class MonsterMovesState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fix_measure(width, 0.50), fix_measure(height, 0.10))
+        lab1.translate(fxw(0.50), fxh(0.10))
         # moves
         moveset: list[Technique] = []
         moveset = monster.moves.get_moves()
@@ -76,20 +73,17 @@ class MonsterMovesState(PygameMenuState):
                 font_size=self.font_size_small,
                 align=locals.ALIGN_LEFT,
                 float=True,
-            ).translate(fix_measure(width, 0.50), fix_measure(height, _height))
+            ).translate(fxw(0.50), fxh(_height))
 
         # image
         new_image = self._create_image(monster.sprite_handler.front_path)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(
-            fix_measure(width, 0.20), fix_measure(height, 0.05)
-        )
+        image_widget.translate(fxw(0.20), fxh(0.05))
 
     def add_menu_technique(self, menu: pygame_menu.Menu, slug: str) -> None:
-        width, height = prepare.SCREEN_SIZE
-        menu._width = fix_measure(width, 0.97)
+        menu._width = fix_measure(prepare.SCREEN_SIZE[0], 0.97)
 
         technique = Technique.create(slug)
 

--- a/tuxemon/states/party/__init__.py
+++ b/tuxemon/states/party/__init__.py
@@ -14,13 +14,9 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
+from tuxemon.tools import fix_measure
 
 MenuGameObj = Callable[[], object]
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 class PartyState(PygameMenuState):
@@ -55,8 +51,8 @@ class PartyState(PygameMenuState):
         menu: pygame_menu.Menu,
         monsters: list[Monster],
     ) -> None:
-        width = menu._width
-        height = menu._height
+        fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
+        fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
         self.char = monsters[0].get_owner()
         menu._auto_centering = False
         # party
@@ -67,7 +63,7 @@ class PartyState(PygameMenuState):
             underline=True,
             float=True,
         )
-        lab1.translate(fix_measure(width, 0.05), fix_measure(height, 0.15))
+        lab1.translate(fxw(0.05), fxh(0.15))
         # levels
         levels = [monster.level for monster in self.char.monsters]
         level_lowest = min(levels)
@@ -81,7 +77,7 @@ class PartyState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fix_measure(width, 0.05), fix_measure(height, 0.25))
+        lab2.translate(fxw(0.05), fxh(0.25))
         # average
         average = T.translate("menu_party_level_average")
         lab3: Any = menu.add.label(
@@ -90,7 +86,7 @@ class PartyState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fix_measure(width, 0.05), fix_measure(height, 0.30))
+        lab3.translate(fxw(0.05), fxh(0.30))
         # lowest
         lowest = T.translate("menu_party_level_lowest")
         lab4: Any = menu.add.label(
@@ -99,7 +95,7 @@ class PartyState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fix_measure(width, 0.05), fix_measure(height, 0.35))
+        lab4.translate(fxw(0.05), fxh(0.35))
 
         total = sum(monster.steps for monster in monsters)
         # bond
@@ -111,7 +107,7 @@ class PartyState(PygameMenuState):
                 underline=True,
                 float=True,
             )
-            lab5.translate(fix_measure(width, 0.05), fix_measure(height, 0.45))
+            lab5.translate(fxw(0.05), fxh(0.45))
             if total > 0:
                 _sorted = sorted(monsters, key=lambda x: x.steps, reverse=True)
                 _bond = 0.50
@@ -126,9 +122,7 @@ class PartyState(PygameMenuState):
                         progress_text_enabled=False,
                         float=True,
                     )
-                    bar.translate(
-                        fix_measure(width, 0.05), fix_measure(height, _bond)
-                    )
+                    bar.translate(fxw(0.05), fxh(_bond))
         # steps
         if total > 0:
             _sorted = sorted(monsters, key=lambda x: x.steps, reverse=True)
@@ -152,9 +146,7 @@ class PartyState(PygameMenuState):
                     font_size=self.font_size_smaller,
                     align=locals.ALIGN_LEFT,
                 )
-                lab6.translate(
-                    fix_measure(width, 0.35), fix_measure(height, 0.25)
-                )
+                lab6.translate(fxw(0.35), fxh(0.25))
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         params = {"character": self.char}

--- a/tuxemon/states/pc_kennel/__init__.py
+++ b/tuxemon/states/pc_kennel/__init__.py
@@ -20,7 +20,7 @@ from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.state import State
 from tuxemon.states.monster import MonsterMenuState
-from tuxemon.tools import open_choice_dialog, open_dialog
+from tuxemon.tools import fix_measure, open_choice_dialog, open_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +31,6 @@ if TYPE_CHECKING:
 
 
 MenuGameObj = Callable[[], object]
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 HIDDEN = "hidden_kennel"
@@ -252,10 +247,11 @@ class MonsterTakeState(PygameMenuState):
             height=height, width=width, columns=columns, rows=rows
         )
 
+        column_width = fix_measure(self.menu._width, 0.33)
         self.menu._column_max_width = [
-            fix_measure(self.menu._width, 0.33),
-            fix_measure(self.menu._width, 0.33),
-            fix_measure(self.menu._width, 0.33),
+            column_width,
+            column_width,
+            column_width,
         ]
 
         menu_items_map = []

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -21,7 +21,7 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.quantity import QuantityMenu
 from tuxemon.state import State
 from tuxemon.states.items.item_menu import ItemMenuState
-from tuxemon.tools import open_choice_dialog, open_dialog
+from tuxemon.tools import fix_measure, open_choice_dialog, open_dialog
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +32,6 @@ if TYPE_CHECKING:
 
 
 MenuGameObj = Callable[[], object]
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 HIDDEN_LOCKER = "hidden_locker"
@@ -234,10 +229,11 @@ class ItemTakeState(PygameMenuState):
             height=height, width=width, columns=columns, rows=rows
         )
 
+        column_width = fix_measure(self.menu._width, 0.33)
         self.menu._column_max_width = [
-            fix_measure(self.menu._width, 0.33),
-            fix_measure(self.menu._width, 0.33),
-            fix_measure(self.menu._width, 0.33),
+            column_width,
+            column_width,
+            column_width,
         ]
 
         menu_items_map = []

--- a/tuxemon/states/phone/phone.py
+++ b/tuxemon/states/phone/phone.py
@@ -16,17 +16,12 @@ from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.map_manager import MAP_TYPES
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.tools import open_dialog
+from tuxemon.tools import fix_measure, open_dialog
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
 MenuGameObj = Callable[[], Any]
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 class NuPhone(PygameMenuState):
@@ -61,11 +56,12 @@ class NuPhone(PygameMenuState):
                     [T.translate("uninstall_app")],
                 )
 
+        column_width = fix_measure(menu._width, 0.25)
         menu._column_max_width = [
-            fix_measure(menu._width, 0.25),
-            fix_measure(menu._width, 0.25),
-            fix_measure(menu._width, 0.25),
-            fix_measure(menu._width, 0.25),
+            column_width,
+            column_width,
+            column_width,
+            column_width,
         ]
 
         # menu

--- a/tuxemon/states/phone/phone_banking.py
+++ b/tuxemon/states/phone/phone_banking.py
@@ -21,11 +21,6 @@ if TYPE_CHECKING:
 MenuGameObj = Callable[[], Any]
 
 
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
-
-
 class NuPhoneBanking(PygameMenuState):
     def add_menu_items(
         self,

--- a/tuxemon/states/phone/phone_contacts.py
+++ b/tuxemon/states/phone/phone_contacts.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
 MenuGameObj = Callable[[], Any]
 
 
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
-
-
 class NuPhoneContacts(PygameMenuState):
     def add_menu_items(
         self,

--- a/tuxemon/states/phone/phone_map.py
+++ b/tuxemon/states/phone/phone_map.py
@@ -16,6 +16,7 @@ from tuxemon import prepare
 from tuxemon.constants import paths
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
+from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
@@ -69,11 +70,6 @@ class Loader:
 
 
 data = Loader.get_config_nuphone_map("nu_phone_map.yaml")
-
-
-def fix_measure(measure: int, percentage: float) -> int:
-    """it returns the correct measure based on percentage"""
-    return round(measure * percentage)
 
 
 class NuPhoneMap(PygameMenuState):

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -129,6 +129,11 @@ def scale(number: int) -> int:
     return prepare.SCALE * number
 
 
+def fix_measure(measure: int, percentage: float) -> int:
+    """it returns the correct measure based on percentage"""
+    return round(measure * percentage)
+
+
 def calc_dialog_rect(screen_rect: Rect, position: str) -> Rect:
     """
     Return a rect that is the area for a dialog box on the screen.


### PR DESCRIPTION
PR centralizes the `fix_measure` function in `tools.py`, and replaces repeated inline calls with local lambda callables (`fxw`, `fxh`) and named constants (e.g., `x_center`, `y_top`) to streamline layout calculations and improve code clarity.