### PR TITLE
Change `current_status` from property to method for safer access

### DIFF
--- a/tests/tuxemon/test_monster_status_handler.py
+++ b/tests/tuxemon/test_monster_status_handler.py
@@ -21,13 +21,6 @@ class TestMonsterStatusHandler(unittest.TestCase):
     def test_init_with_status(self):
         self.assertEqual(self.handler.status, [self.status])
 
-    def test_current_status(self):
-        self.assertEqual(self.handler.current_status, self.status)
-
-    def test_current_status_empty(self):
-        with self.assertRaises(ValueError):
-            self.basic.current_status
-
     def test_apply_status(self):
         self.basic.apply_status(self.session, self.status)
         self.assertEqual(self.basic.status, [self.status])

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -75,8 +75,8 @@ def pre_checking(
     Pre checking allows to check if there are statuses
     or other conditions that change the chosen technique.
     """
-    if monster.status.status_exists():
-        status = monster.status.current_status
+    status = monster.status.get_current_status()
+    if status:
         result_status = status.execute_status_action(
             session, combat, target, EffectPhase.PRE_CHECKING
         )

--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -52,8 +52,9 @@ class GiveEffect(CoreEffect):
             monsters = get_target_monsters(objectives, tech, user, target)
             if monsters:
                 for monster in monsters:
-                    if monster.status.status_exists():
-                        monster.status.current_status.set_combat_state(combat)
+                    current = monster.status.get_current_status()
+                    if current:
+                        current.set_combat_state(combat)
                     monster.status.apply_status(session, status)
                 combat.update_icons_for_monsters()
                 combat.animate_update_party_hud()

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -879,7 +879,8 @@ def calculate_status_modifier(item: Item, target: Monster) -> float:
     config = config_capdev.items.get(item.slug)
     status_modifier = config_capdev.status_modifier
 
-    if config is None or not target.status.status_exists():
+    status = target.status.get_current_status()
+    if config is None or status is None:
         return status_modifier
 
     logger.debug(f"Base status_modifier: {status_modifier}")

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -540,9 +540,9 @@ class Monster:
         if self.is_fainted:
             self.current_hp = 0
             self.status.apply_faint(self)
-            self.status.current_status.apply_phase_and_use(
-                session, EffectPhase.ON_FAINT
-            )
+            current = self.status.get_current_status()
+            if current:
+                current.apply_phase_and_use(session, EffectPhase.ON_FAINT)
 
 
 class SpriteLoader:
@@ -696,14 +696,13 @@ class MonsterStatusHandler:
         self.status = status if status is not None else []
 
     @property
-    def current_status(self) -> Status:
-        if not self.status:
-            raise ValueError("Monster has no status to retrieve.")
-        return self.status[0]
-
-    @property
     def is_fainted(self) -> bool:
         return self.has_status("faint")
+
+    def get_current_status(self) -> Optional[Status]:
+        if not self.status:
+            return None
+        return self.status[0]
 
     def apply_status(self, session: Session, new_status: Status) -> None:
         """
@@ -714,7 +713,8 @@ class MonsterStatusHandler:
         ensuring proper transitions between statuses based on their category and
         interaction rules.
         """
-        if not self.status:
+        current_status = self.get_current_status()
+        if current_status is None:
             self.add_status(new_status)
             new_status.nr_turn = 1
             new_status.apply_phase_and_use(session, EffectPhase.ON_START)
@@ -723,7 +723,6 @@ class MonsterStatusHandler:
         if self.has_status(new_status.slug):
             return
 
-        current_status = self.current_status
         current_status.apply_phase_and_use(session, EffectPhase.ON_END)
 
         new_status.nr_turn = 1
@@ -753,8 +752,8 @@ class MonsterStatusHandler:
 
     def clear_status(self, session: Session) -> None:
         """Clears the current status effect for monsters in combat."""
-        if self.status:
-            current_status = self.current_status
+        current_status = self.get_current_status()
+        if current_status:
             current_status.apply_phase_and_use(session, EffectPhase.ON_END)
             self.status.clear()
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -558,12 +558,15 @@ class CombatState(CombatAnimations):
 
         # Handle new entry and removed monster's status effects
         phase = EffectPhase.SWAP_MONSTER
-        if monster.status.status_exists():
-            status = monster.status.current_status
+        status = monster.status.get_current_status()
+        if status:
             status.execute_status_action(self.session, self, monster, phase)
-        if removed is not None and removed.status.status_exists():
-            status = removed.status.current_status
-            status.execute_status_action(self.session, self, removed, phase)
+        if removed is not None:
+            r_status = removed.status.get_current_status()
+            if r_status:
+                r_status.execute_status_action(
+                    self.session, self, removed, phase
+                )
 
         # Create message for combat swap
         format_params = {
@@ -803,8 +806,8 @@ class CombatState(CombatAnimations):
             params = {"name": target.name.upper()}
             message = T.format("combat_call_tuxemon", params)
         # check statuses
-        if user.status.status_exists():
-            status = user.status.current_status
+        status = user.status.get_current_status()
+        if status:
             result_status = status.execute_status_action(
                 self.session, self, user, EffectPhase.PERFORM_TECH
             )
@@ -910,8 +913,8 @@ class CombatState(CombatAnimations):
         message = T.format(item.use_item, context)
         # animation sprite
         item_sprite = self._method_cache.get(item, False)
-        if result_item.success:
-            status = target.status.current_status
+        status = target.status.get_current_status()
+        if result_item.success and status:
             status.execute_status_action(
                 self.session, self, target, EffectPhase.PERFORM_ITEM
             )
@@ -1115,8 +1118,8 @@ class CombatState(CombatAnimations):
         Parameters:
             monster: Monster that was defeated.
         """
-        if monster.status.status_exists():
-            status = monster.status.current_status
+        status = monster.status.get_current_status()
+        if status:
             result_status = status.execute_status_action(
                 self.session, self, monster, EffectPhase.CHECK_PARTY_HP
             )

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -128,10 +128,12 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         """
         run = Technique.create("menu_run")
         run.set_combat_state(self.combat)
+        status = self.monster.status.get_current_status()
+        message = status.name.lower() if status else ""
         if not run.validate_monster(self.session, self.monster):
             params = {
                 "monster": self.monster.name.upper(),
-                "status": self.monster.status.current_status.name.lower(),
+                "status": message,
             }
             msg = T.format("combat_player_run_status", params)
             tools.open_dialog(self.client, [msg])
@@ -146,10 +148,12 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             added = menuitem.game_object
             swap = Technique.create("swap")
             swap.set_combat_state(self.combat)
+            status = self.monster.status.get_current_status()
+            message = status.name.lower() if status else ""
             if not swap.validate_monster(self.session, self.monster):
                 params = {
                     "monster": self.monster.name.upper(),
-                    "status": self.monster.status.current_status.name.lower(),
+                    "status": message,
                 }
                 msg = T.format("combat_player_swap_status", params)
                 tools.open_dialog(self.client, [msg])
@@ -227,8 +231,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             target = menu_item.game_object
 
             # check target status
-            if target.status.status_exists():
-                status = target.status.current_status
+            status = target.status.get_current_status()
+            if status:
                 result_status = status.execute_status_action(
                     self.session, self.combat, target, EffectPhase.ENQUEUE_ITEM
                 )


### PR DESCRIPTION
PR replaced `@property` accessor `current_status` with an explicit `get_current_status()` method to improve clarity and control. This change helps avoid unintentional `ValueError` in edge cases where no status is present