### PR TITLE
Add sound loading/unloading support and corresponding event actions

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -127,6 +127,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.transition_teleport.TransitionTeleportAction
 .. autoscriptinfoclass:: tuxemon.event.actions.translated_dialog_choice.TranslatedDialogChoiceAction
 .. autoscriptinfoclass:: tuxemon.event.actions.translated_dialog.TranslatedDialogAction
+.. autoscriptinfoclass:: tuxemon.event.actions.unload_sound.UnloadSoundAction
 .. autoscriptinfoclass:: tuxemon.event.actions.unpause_music.UnpauseMusicAction
 .. autoscriptinfoclass:: tuxemon.event.actions.update_tile_properties.UpdateTilePropertiesAction
 .. autoscriptinfoclass:: tuxemon.event.actions.variable_math.VariableMathAction

--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -167,7 +167,10 @@ class SoundManager:
         path = Path(filename)
 
         if not path.exists():
-            logger.error(f"audio file does not exist: {filename}")
+            logger.error(f"Audio file does not exist: {filename}")
+            logger.debug(
+                f"Sound '{slug}' failed to resolve to a valid file path."
+            )
             return None
 
         return path
@@ -176,6 +179,7 @@ class SoundManager:
         self, slug: str, value: float = prepare.CONFIG.sound_volume
     ) -> SoundProtocol:
         if slug in self.sounds:
+            logger.debug(f"Sound '{slug}' loaded from cache.")
             return self.sounds[slug]
 
         filename = self.get_sound_filename(slug)
@@ -186,6 +190,7 @@ class SoundManager:
             sound = pygame.mixer.Sound(filename)
             sound.set_volume(value)
             self.sounds[slug] = SoundWrapper(sound)
+            logger.debug(f"Sound '{slug}' loaded and cached successfully.")
             return self.sounds[slug]
         except (MemoryError, pygame.error) as e:
             logger.error(f"Failed to load sound '{slug}': {e}")
@@ -196,3 +201,14 @@ class SoundManager:
     ) -> None:
         sound = self.load_sound(slug, value)
         sound.play()
+
+    def unload_sound(self, slug: str) -> None:
+        if slug in self.sounds:
+            del self.sounds[slug]
+            logger.debug(f"Unloaded sound '{slug}' from cache.")
+        else:
+            logger.debug(f"Attempted to unload non-existent sound '{slug}'.")
+
+    def unload_all_sounds(self) -> None:
+        self.sounds.clear()
+        logger.debug("All sounds unloaded from SoundManager cache.")

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -14,7 +14,7 @@ from tuxemon.session import Session
 @dataclass
 class PlaySoundAction(EventAction):
     """
-    Play a sound from "resources/sounds/".
+    Plays a short sound effect from the "resources/sounds/" folder.
 
     Script usage:
         .. code-block::
@@ -22,16 +22,17 @@ class PlaySoundAction(EventAction):
             play_sound <filename>[,volume]
 
     Script parameters:
-        filename: Sound file to load.
-        volume: Number between 0.0 and 1.0.
+        filename: The sound file to load (must exist in the sounds database).
+        volume: A float between 0.0 and 1.0 representing the relative volume level.
+            This value is multiplied by the user's configured sound volume.
 
-        Attention!
-        The volume will be based on the main value
-        in the options menu.
-        e.g. if you set volume = 0.5 here, but the
-        player has 0.5 among its options, then it'll
-        result into 0.25 (0.5*0.5)
+    Example:
+        If volume=0.5 and the player's sound setting is also 0.5,
+        the resulting effective playback volume will be 0.25.
 
+    Note:
+        This is intended for short non-looping sound effects (e.g., cues, UI feedback),
+        not for ambient or background music.
     """
 
     name = "play_sound"

--- a/tuxemon/event/actions/unload_sound.py
+++ b/tuxemon/event/actions/unload_sound.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.session import Session
+
+
+@final
+@dataclass
+class UnloadSoundAction(EventAction):
+    """
+    Unload a specific sound from memory cache, or all sounds if no filename is given.
+
+    Script usage:
+        .. code-block::
+
+            unload_sound <filename>
+            unload_sound
+
+    Script parameters:
+        filename: Name of the sound file to unload.
+            If omitted, all cached sounds will be removed from memory.
+    """
+
+    name = "unload_sound"
+    filename: Optional[str] = None
+
+    def start(self, session: Session) -> None:
+        client = session.client
+        if not self.filename:
+            client.sound_manager.unload_all_sounds()
+        else:
+            client.sound_manager.unload_sound(self.filename)


### PR DESCRIPTION
PR introduces better memory management and script-level control for short sound effects.

It includes:
- `unload_sound(slug)` method in `SoundManager`, allowing individual sound assets to be removed from memory
- `unload_all_sounds()` method to clear the entire cache of loaded sound effects, useful during scene transitions or low-memory conditions
- new `EventAction` classe: `UnloadSoundAction`: lets scripts unload a specific sound by filename and clears all cached sound effects from script commands

These changes allow scripts to manage sound memory more intentionally. For instance, if a scene loads a large one-time sound effect, like an explosion or cinematic roar, that’s never used again, there wasn’t a way to unload it.