### PR TITLE
Fix Positioning and Issues in Double Battles (2vs2, 1vs2, 2vs1)

### DIFF
--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -251,7 +251,7 @@ class CombatState(CombatAnimations):
         elif phase == CombatPhase.HOUSEKEEPING:
             # this will wait for players to fill battleground positions
             for player in self.active_players:
-                positions_available = self.update_player_positions(player)
+                positions_available = self.get_available_positions(player)
                 if positions_available:
                     return None
             return CombatPhase.DECISION
@@ -459,37 +459,22 @@ class CombatState(CombatAnimations):
         state.on_menu_selection = add  # type: ignore[assignment]
         state.escape_key_exits = False
 
-    def update_player_positions(self, player: NPC) -> int:
+    def get_max_positions(self, player: NPC) -> int:
         """
-        Updates the maximum positions for a player and returns the number of
-        available positions.
-
-        This function checks if the player has only one monster in their party,
-        and if so, sets the maximum positions to 1. If the player has more than
-        one monster in their party, it sets the maximum positions to 2 if the
-        battle is a double battle, and 1 otherwise. It also updates the feet
-        position of the monster if the battle is a double battle and the player
-        has only one monster in play.
-
-        Parameters:
-            player: The player to update the positions for.
-
-        Returns:
-            The number of available positions for the player.
+        Calculates the maximum number of positions for a player based on
+        their party size and battle mode.
         """
         if len(alive_party(player)) == 1:
-            self._max_positions[player] = 1
-            if self.is_double:
-                monster = self.field_monsters.get_monsters(player)[0]
-                new_feet = self.get_feet_position(player, monster, False)
-                self.sprite_map.update_sprite_position(monster, new_feet)
-        else:
-            if self.is_double:
-                self._max_positions[player] = 2
-            else:
-                self._max_positions[player] = 1
-        on_the_field = self.field_monsters.get_monsters(player)
-        return self._max_positions[player] - len(on_the_field)
+            return 1
+        return 2 if self.is_double else 1
+
+    def get_available_positions(self, player: NPC) -> int:
+        """
+        Returns the number of available positions for a player on the battlefield.
+        """
+        max_positions = self.get_max_positions(player)
+        on_the_field = len(self.field_monsters.get_monsters(player))
+        return max_positions - on_the_field
 
     def fill_battlefield_positions(self, ask: bool = False) -> None:
         """
@@ -503,7 +488,18 @@ class CombatState(CombatAnimations):
 
         # TODO: integrate some values for different match types
         for player in self.active_players:
-            positions_available = self.update_player_positions(player)
+
+            max_positions = self.get_max_positions(player)
+            self._max_positions[player] = max_positions
+
+            if max_positions == 1 and self.is_double:
+                on_the_field = self.field_monsters.get_monsters(player)
+                if on_the_field:
+                    monster = on_the_field[0]
+                    new_feet = self.get_feet_position(player, monster)
+                    self.sprite_map.update_sprite_position(monster, new_feet)
+
+            positions_available = self.get_available_positions(player)
             if positions_available:
                 monsters = self.field_monsters.get_monsters(player)
                 available = get_awake_monsters(player, monsters, self._turn)
@@ -547,6 +543,9 @@ class CombatState(CombatAnimations):
         sprite = self._method_cache.get(capture_device, False)
         if not sprite:
             raise ValueError(f"Sprite not found for item {capture_device}")
+
+        if removed:
+            self.position_tracker.unassign(player, removed)
 
         self.field_monsters.add_monster(player, monster)
         self.animate_monster_release(player, monster, sprite)
@@ -746,6 +745,7 @@ class CombatState(CombatAnimations):
         Parameters:
             monster: Monster whose actions will be removed.
         """
+        self.status_icons.recalculate_icon_positions()
         action_queue = self._action_queue.queue
         action_queue[:] = [
             action
@@ -1066,7 +1066,6 @@ class CombatState(CombatAnimations):
             owner = winner.get_owner()
             if owner.isplayer:
                 self.task(partial(self.animate_exp, winner), 2.5)
-                self.task(partial(self.hud_manager.delete_hud, winner), 3.2)
                 self.task(partial(self.update_hud, owner, False), 3.2)
 
     def animate_party_status(self) -> None:

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -27,6 +27,7 @@ from tuxemon.tools import scale, scale_sequence
 from .combat_ui import (
     CombatUI,
     FieldMonsters,
+    FieldPositionTracker,
     HudManager,
     MonsterSpriteMap,
     StatusIconManager,
@@ -110,6 +111,7 @@ class CombatAnimations(Menu[None], ABC):
         self.status_icons = StatusIconManager(self)
         _layout = prepare_layout(self.players)
         self.hud_manager = HudManager(_layout)
+        self.position_tracker = FieldPositionTracker()
 
     def animate_open(self) -> None:
         self.transition_none_normal()
@@ -149,7 +151,9 @@ class CombatAnimations(Menu[None], ABC):
         monster sprite moving into position, and the capture device opening animation.
         It also plays the combat call sound.
         """
-        feet = self.get_feet_position(npc, monster, self.is_double)
+        slot_index = self.position_tracker.get_open_slot(npc)
+        self.position_tracker.assign(npc, monster, slot_index, self.is_double)
+        feet = self.get_feet_position(npc, monster)
 
         # Load and scale capture device sprite
         capdev = self.load_sprite(f"gfx/items/{monster.capture_device}.png")
@@ -216,25 +220,13 @@ class CombatAnimations(Menu[None], ABC):
         # Load and play combat call sound
         self.play_sound_effect(monster.combat_call, 1.3)
 
-    def get_feet_position(
-        self, npc: NPC, monster: Monster, is_double: bool
-    ) -> tuple[int, int]:
-        """
-        Calculates the feet position of the monster.
-
-        This function determines the feet position of the monster based on its
-        index in the list of monsters in play.
-
-        Returns:
-            The x and y coordinates of the feet position.
-        """
-        monsters = self.field_monsters.get_monsters(npc)
-        if is_double and monster in monsters:
-            monster_index = str(monsters.index(monster))
-        else:
-            monster_index = ""
-        center = self.hud_manager.get_rect(npc, f"home{monster_index}").center
-        return center[0], center[1] + tools.scale(11)
+    def get_feet_position(self, npc: NPC, monster: Monster) -> tuple[int, int]:
+        """Calculates the feet position of the monster."""
+        key = self.position_tracker.get_key(npc, monster)
+        rect = self.hud_manager.get_rect(npc, key)
+        center_x, center_y = rect.center
+        feet_x, feet_y = center_x, center_y + tools.scale(11)
+        return feet_x, feet_y
 
     def animate_sprite_spin(self, sprite: Sprite) -> None:
         self.animate(
@@ -905,6 +897,8 @@ class CombatAnimations(Menu[None], ABC):
         alive_members = alive_party(character)
         if len(monsters) > 1 and len(monsters) <= len(alive_members):
             for i, monster in enumerate(monsters):
+                self.hud_manager.delete_hud(monster)
                 self.build_hud(monster, f"hud{i}", animate)
         else:
+            self.hud_manager.delete_hud(monsters[0])
             self.build_hud(monsters[0], "hud", animate)

--- a/tuxemon/states/combat/combat_ui.py
+++ b/tuxemon/states/combat/combat_ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, MutableMapping, Sequence
+from enum import Enum
 from itertools import chain
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -144,6 +145,20 @@ class FieldMonsters:
 
 
 class HudManager:
+    """
+    Handles positioning and sprite assignment for HUD elements tied to monsters
+    during battle.
+
+    This class provides a visual mapping between each NPC and their assigned
+    monster HUD components. It allows retrieval of screen rectangles for rendering
+    UI elements, and handles lifecycle management of associated HUD sprites
+    (e.g., health bars, names, status).
+
+    The layout is decoupled from any battle logic and defined per NPC via a
+    dictionary of position keys mapped to lists of Rects. This makes the system
+    flexible and reusable across single and double battles with different formations.
+    """
+
     def __init__(self, layout: dict[NPC, dict[str, list[Rect]]]) -> None:
         """Manages HUD positions and mappings for NPCs in combat."""
         self.layout = layout
@@ -180,10 +195,101 @@ class HudManager:
         return self.hud_map.get(monster)
 
 
+class Side(Enum):
+    PLAYER = "player"
+    OPPONENT = "opponent"
+
+
+class BattleFieldLayout:
+    """
+    Represents the battlefield layout by tracking which monsters appear on
+    each side and in which slot.
+
+    This class assigns each monster a tuple of (Side, index), allowing the
+    battle system to query position and orientation for rendering or logic
+    purposes.
+    """
+
+    def __init__(
+        self,
+        monsters_left: Sequence[Monster],
+        monsters_right: Sequence[Monster],
+    ):
+        self.monster_positions: dict[Monster, tuple[Side, int]] = {}
+
+        for i, monster in enumerate(monsters_left):
+            self.monster_positions[monster] = (Side.OPPONENT, i)
+        for i, monster in enumerate(monsters_right):
+            self.monster_positions[monster] = (Side.PLAYER, i)
+
+    def get_side(self, monster: Monster) -> Side:
+        """Returns the side (PLAYER or OPPONENT) that the given monster belongs to."""
+        return self.monster_positions[monster][0]
+
+    def get_index(self, monster: Monster) -> int:
+        """Returns the slot index for the given monster on its side."""
+        return self.monster_positions[monster][1]
+
+    def is_single_battle(self) -> bool:
+        """Determines whether the current layout represents a single battle (1v1)."""
+        return (
+            sum(
+                1
+                for side, _ in self.monster_positions.values()
+                if side == Side.PLAYER
+            )
+            == 1
+            and sum(
+                1
+                for side, _ in self.monster_positions.values()
+                if side == Side.OPPONENT
+            )
+            == 1
+        )
+
+
+class FieldPositionTracker:
+    """
+    Tracks field slot assignments for monsters during battle.
+
+    This class maintains a mapping between each (NPC, Monster) pair
+    and their assigned field slot (e.g. 'home', 'home0', 'home1').
+    It's useful for determining positioning during animations or swaps,
+    especially in double battles where multiple slots are active.
+    """
+
+    def __init__(self) -> None:
+        self._positions: dict[tuple[NPC, Monster], str] = {}
+
+    def assign(
+        self, npc: NPC, monster: Monster, slot_index: int, is_double: bool
+    ) -> None:
+        """Assigns a monster to a specific field slot key."""
+        key = f"home{slot_index}" if is_double else "home"
+        self._positions[(npc, monster)] = key
+
+    def unassign(self, npc: NPC, monster: Monster) -> None:
+        """Removes the field slot assignment of a monster."""
+        self._positions.pop((npc, monster), None)
+
+    def get_key(self, npc: NPC, monster: Monster) -> str:
+        return self._positions.get((npc, monster), "home")
+
+    def get_open_slot(self, npc: NPC) -> int:
+        """Returns the lowest unused slot index for this NPC (0 or 1)."""
+        used_slots = {
+            int(pos[-1])
+            for (n, _), pos in self._positions.items()
+            if n == npc and pos.startswith("home") and pos[-1].isdigit()
+        }
+        return 0 if 0 not in used_slots else 1 if 1 not in used_slots else 0
+
+
 class StatusIconManager:
     """Handles creation, caching, and updating of status icons."""
 
     def __init__(self, state: State, layer: int = 200) -> None:
+        self._layout: Optional[BattleFieldLayout] = None
         self.state = state
         self.layer = layer
         self._status_icon_cache: dict[
@@ -194,40 +300,33 @@ class StatusIconManager:
     def determine_icon_position(
         self,
         monster: Monster,
-        monsters_in_play: Sequence[Monster],
-        base_monsters: Sequence[Monster],
-    ) -> tuple[float, float]:
-        """Determine the position of the icon based on the monster's status."""
-        icon_positions = {
-            (True, 1): prepare.ICON_OPPONENT_SLOT,
-            (True, 0): prepare.ICON_OPPONENT_DEFAULT,
-            (False, 1): prepare.ICON_PLAYER_SLOT,
-            (False, 0): prepare.ICON_PLAYER_DEFAULT,
-        }
-        return icon_positions[
-            (
-                monsters_in_play == base_monsters,
-                monsters_in_play.index(monster),
-            )
-        ]
-
-    def create_icon_cache(
-        self,
-        active_monsters: Sequence[Monster],
         monsters_left: Sequence[Monster],
         monsters_right: Sequence[Monster],
-    ) -> None:
+    ) -> tuple[float, float]:
+        """Determine the position of the icon based on the monster's status."""
+        layout = BattleFieldLayout(monsters_left, monsters_right)
+        is_single = layout.is_single_battle()
+        is_opponent = layout.get_side(monster) == Side.OPPONENT
+        index = layout.get_index(monster)
+        return self.get_icon_position(is_opponent, index, is_single)
+
+    def create_icon_cache(self, active_monsters: Sequence[Monster]) -> None:
         """Create and fill the icon cache and status icons dictionaries."""
+        if not self._layout:
+            raise ValueError(
+                "Layout must be initialized before creating icons."
+            )
+        is_single = self._layout.is_single_battle()
+
         self._status_icons.clear()
         for monster in active_monsters:
             self._status_icons[monster] = []
+            is_opponent = self._layout.get_side(monster) == Side.OPPONENT
+            index = self._layout.get_index(monster)
             for status in monster.status.get_statuses():
                 if status.icon:
-                    is_left = monster in monsters_left
-                    icon_position = self.determine_icon_position(
-                        monster,
-                        monsters_left if is_left else monsters_right,
-                        monsters_left,
+                    icon_position = self.get_icon_position(
+                        is_opponent, index, is_single
                     )
                     cache_key = (status.icon, icon_position)
                     if cache_key not in self._status_icon_cache:
@@ -238,7 +337,6 @@ class StatusIconManager:
                                 center=icon_position,
                             )
                         )
-
                     self._status_icons[monster].append(
                         self._status_icon_cache[cache_key]
                     )
@@ -250,11 +348,11 @@ class StatusIconManager:
         monsters_right: Sequence[Monster],
     ) -> None:
         """Reset status icons for monsters."""
-        # Remove all status icons
+        self._layout = BattleFieldLayout(monsters_left, monsters_right)
         self.state.sprites.remove(
             *[icon for icons in self._status_icons.values() for icon in icons]
         )
-        self.create_icon_cache(active_monsters, monsters_left, monsters_right)
+        self.create_icon_cache(active_monsters)
         self.add_all_icons()
 
     def add_all_icons(self) -> None:
@@ -290,6 +388,40 @@ class StatusIconManager:
                 animate_func(icon.image, initial=0, set_alpha=255, duration=2)
             else:
                 icon.image.set_alpha(255)
+
+    def get_icon_position(
+        self, is_opponent: bool, index: int, single_battle: bool
+    ) -> tuple[float, float]:
+        if single_battle:
+            return {
+                (True, 0): prepare.ICON_OPPONENT_DEFAULT,
+                (True, 1): prepare.ICON_OPPONENT_SLOT,
+                (False, 0): prepare.ICON_PLAYER_DEFAULT,
+                (False, 1): prepare.ICON_PLAYER_SLOT,
+            }[(is_opponent, index)]
+        else:
+            return {
+                (True, 0): prepare.ICON_OPPONENT_DEFAULT,
+                (True, 1): prepare.ICON_OPPONENT_SLOT,
+                (False, 1): prepare.ICON_PLAYER_DEFAULT,
+                (False, 0): prepare.ICON_PLAYER_SLOT,
+            }[(is_opponent, index)]
+
+    def recalculate_icon_positions(self) -> None:
+        if not self._layout:
+            raise ValueError(
+                "Layout must be initialized before recalculating positions."
+            )
+        is_single = self._layout.is_single_battle()
+
+        for monster, icons in self._status_icons.items():
+            is_opponent = self._layout.get_side(monster) == Side.OPPONENT
+            index = self._layout.get_index(monster)
+            icon_position = self.get_icon_position(
+                is_opponent, index, is_single
+            )
+            for icon in icons:
+                icon.rect.center = icon_position
 
 
 class MonsterSpriteMap:


### PR DESCRIPTION
PR addresses several issues observed during double battles, especially in edge cases like 1vs2 or 2vs1 matchups.

List of issues:
1. Incorrect status icon position on initial field entry.
2. Status icon not refreshing or updating after monster swap or faint, resulting in old states persisting on the wrong HUD.
3. Monster sprite misplacement during swap:
   - When swapping *Rockitten → Nut*, Nut appears correctly in Rockitten’s original slot.
   - When swapping *Pairagrin → Nut*, Nut appears stacked over Rockitten — indicating the wrong field slot (e.g. home0/home1) was assigned.
4. Slot key assignment drift after fainting, especially in double battles, where the replacement monster is assigned to an incorrect or already-occupied key.
5. Incorrect HUD bar (e.g. HP/status) assignment post-swap, leading to sprites receiving the wrong overlay or none at all.

---

refactor of Player Position Logic in `CombatState`:
- introduced `get_max_positions` as a pure function to calculate how many monsters a player *can* have on the field
- added `get_available_positions` to compute how many positions are still open
- these methods replace the now-removed `update_player_positions`

improved Phase Transition Flow:
- updated the `determine_phase` method to use the new `get_available_positions` logic
- this simplifies state checking and avoids manual management of `_max_positions` inside phase logic
- ensures the `CombatPhase.HOUSEKEEPING` accurately pauses when more monsters need to be deployed

updated `fill_battlefield_positions`:
- handles sprite positioning for single-monster cases in double battles
- uses `get_max_positions` and `get_available_positions` to decide when to ask the player or send in the next monster
- reduces duplicated logic for checking which monsters are awake and eligible

removed: `update_player_positions`:
- this method was fully decomposed and its responsibilities relocated to smaller, more modular functions

introduced `BattleFieldLayout` for UI Positioning:
- new class that tracks which monster is on which side (player or opponent) and in which slot
- this helps simplify logic in visual systems, like icon placement, by centralizing layout metadata
- ensures position references are always correct regardless of team orientation or battle mode

refactored `StatusIconManager` to use layout object:
- replaced manual inferences of left/right side with `BattleFieldLayout` lookups
- introduced `get_icon_position` for clean mapping between battle side/slot and icon coordinates
- created a `recalculate_icon_positions` method that dynamically updates icon sprite positions when battlefield layout changes—critical during swaps or replacements in 2vs2