### PR TITLE
Fix incorrect NPC orientation during movement to target

### DIFF
--- a/tuxemon/event/actions/pathfind_to_char.py
+++ b/tuxemon/event/actions/pathfind_to_char.py
@@ -74,6 +74,10 @@ class PathfindToCharAction(EventAction):
             logger.info(
                 f"Skipped: Moving entity {self.moving_entity.slug} is already at desired destination {final_destination}."
             )
+            direction = get_direction(
+                self.moving_entity.tile_pos, final_destination
+            )
+            self.moving_entity.set_facing(direction)
             return
 
         self.moving_entity.pathfind(final_destination)


### PR DESCRIPTION
PR fixes an issue where `pathfind_to_npc` caused the moving NPC to face away from the target instead of toward them. The moving NPC (e.g. the one walking toward the player, as shown in the image) is now correctly oriented to face the target during movement. This bug was identified while working on double battle-related positioning fixes.

![Screenshot_2025-06-20_14-59-41](https://github.com/user-attachments/assets/dfebfdcf-56b7-423b-a09d-ace40b74eabe)