### PR TITLE
Refactor HUD Capture Device Logic

### DIFF
--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -513,7 +513,7 @@ class CombatAnimations(Menu[None], ABC):
 
     def animate_party_hud_in(self, player: NPC, home: Rect) -> None:
         """
-        Party HUD is the arrow thing with balls.  Yes, that one.
+        Animates the party HUD (the arrow thing with balls).
 
         Parameters:
             player: The player whose HUD is being animated.
@@ -525,75 +525,38 @@ class CombatAnimations(Menu[None], ABC):
         else:
             tray, centerx, offset = self.animate_party_hud_right(home)
 
-        # If the tray is None (wild monster)
-        if tray is None:
+        if tray is None or any(t.wild for t in player.monsters):
             return
 
-        has_wild_monster = any(t.wild for t in player.monsters)
-        positions = [
-            len(player.monsters) - i - 1 if side == "left" else i
-            for i in range(player.party_limit)
-        ]
+        positions = (
+            [len(player.monsters) - i - 1 for i in range(player.party_limit)]
+            if side == "left"
+            else list(range(player.party_limit))
+        )
 
-        for index in range(player.party_limit):
-            if has_wild_monster:
-                continue
+        scaled_top = scale(1)
 
+        for index, pos in enumerate(positions):
             monster = (
                 player.monsters[index]
                 if index < len(player.monsters)
                 else None
             )
-            pos = positions[index]
-            scaled_top = scale(1)
+            centerx_pos = centerx - (pos if monster else index) * offset
 
-            if monster:
-                if monster.status.is_fainted:
-                    sprite = self._load_sprite(
-                        self.graphics.icons.icon_faint,
-                        {
-                            "top": tray.rect.top + scaled_top,
-                            "centerx": centerx - pos * offset,
-                            "layer": hud_layer,
-                        },
-                    )
-                    status = "faint"
-                elif monster.status.status_exists():
-                    sprite = self._load_sprite(
-                        self.graphics.icons.icon_status,
-                        {
-                            "top": tray.rect.top + scaled_top,
-                            "centerx": centerx - pos * offset,
-                            "layer": hud_layer,
-                        },
-                    )
-                    status = "effected"
-                else:
-                    sprite = self._load_sprite(
-                        self.graphics.icons.icon_alive,
-                        {
-                            "top": tray.rect.top + scaled_top,
-                            "centerx": centerx - pos * offset,
-                            "layer": hud_layer,
-                        },
-                    )
-                    status = "alive"
-            else:
-                sprite = self._load_sprite(
-                    self.graphics.icons.icon_empty,
-                    {
-                        "top": tray.rect.top + scaled_top,
-                        "centerx": centerx - index * offset,
-                        "layer": hud_layer,
-                    },
-                )
-                status = "empty"
+            sprite = self._load_sprite(
+                self.graphics.icons.icon_empty,
+                {
+                    "top": tray.rect.top + scaled_top,
+                    "centerx": centerx_pos,
+                    "layer": hud_layer,
+                },
+            )
 
             capdev = CaptureDeviceSprite(
                 sprite=sprite,
                 tray=tray,
                 monster=monster,
-                state=status,
                 icon=self.graphics.icons,
             )
             self.capdevs.append(capdev)

--- a/tuxemon/surfanim.py
+++ b/tuxemon/surfanim.py
@@ -10,7 +10,7 @@ import bisect
 import itertools
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import Any, Final, Optional, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 
 # TODO: Feature idea: if the same image file is specified, re-use the Surface
 import pygame
@@ -33,9 +33,6 @@ class State(Enum):
     STOPPED = "stopped"
 
 
-dummy_image: Final = Surface((0, 0))
-
-
 class FrameManager:
     """
     The FrameManager class is designed to manage a sequence of frames, each
@@ -48,6 +45,8 @@ class FrameManager:
             duration: A float value representing the duration of the frame in
                 seconds.
     """
+
+    _dummy_image: Surface = Surface((0, 0))
 
     def __init__(
         self, frames: Sequence[tuple[Union[str, Surface], float]]
@@ -109,7 +108,7 @@ class FrameManager:
         frame number is out of range.
         """
         if frame_num >= len(self.images):
-            return dummy_image
+            return FrameManager._dummy_image
         return self.images[frame_num]
 
 


### PR DESCRIPTION
PR refactors the `animate_party_hud_in` method in `CombatAnimations` and improves the `CaptureDeviceSprite` class. The goal is to simplify status logic, reduce clutter, and push visual decisions into sprite components where they belong.

Key changes:
- moved monster status resolution logic into `CaptureDeviceSprite`: added a `resolve_status()` method to determine `"alive"`, `"faint"`, `"effected"`, or `"empty"` based on the assigned `monster` and this eliminates status condition logic from the animation layer
- `CaptureDeviceSprite` now selects and sets its own image: new `update_image()` method uses the resolved state to choose the right icon and this encapsulates image handling and makes future theming or restyling easier
- simplified `animate_party_hud_in()` in `CombatAnimations`: removed repeated if-else trees and manual icon resolution and replaced them with a clean loop that instantiates `CaptureDeviceSprite`, which handles its own setup internally
- inline `scale(1)` or stores it as `scaled_top` for clearer position logic: maintains vertical alignment logic without cluttering the HUD loop