### PR TITLE
Refactor `MenuItem` class to support positioning and improved state handling

### DIFF
--- a/tests/tuxemon/test_interface_menu_item.py
+++ b/tests/tuxemon/test_interface_menu_item.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock
+
+from pygame import Surface
+
+from tuxemon.menu.interface import MenuItem
+
+
+class TestMenuItem(unittest.TestCase):
+
+    def setUp(self):
+        self.image = Surface((10, 10))
+        self.game_object = MagicMock()
+
+    def test_init_default(self):
+        menu_item = MenuItem(
+            self.image, "Test Label", "Test Description", self.game_object
+        )
+        self.assertEqual(menu_item.label, "Test Label")
+        self.assertEqual(menu_item.description, "Test Description")
+        self.assertEqual(menu_item.enabled, True)
+
+    def test_init_custom(self):
+        menu_item = MenuItem(
+            self.image,
+            "Test Label",
+            "Test Description",
+            self.game_object,
+            enabled=False,
+            position=(100, 100),
+        )
+        self.assertEqual(menu_item.label, "Test Label")
+        self.assertEqual(menu_item.description, "Test Description")
+        self.assertEqual(menu_item.enabled, False)
+
+    def test_update_image_focus(self):
+        menu_item = MenuItem(
+            self.image, "Test Label", "Test Description", self.game_object
+        )
+        menu_item._in_focus = True
+        menu_item.update_image = MagicMock()
+        menu_item.update_image()
+
+    def test_update_image_enabled(self):
+        menu_item = MenuItem(
+            self.image, "Test Label", "Test Description", self.game_object
+        )
+        menu_item.enabled = False
+        menu_item.update_image = MagicMock()
+        menu_item.update_image()
+
+    def test_enabled_property(self):
+        menu_item = MenuItem(
+            self.image, "Test Label", "Test Description", self.game_object
+        )
+        self.assertTrue(menu_item.enabled)
+        menu_item.enabled = False
+        self.assertFalse(menu_item.enabled)
+
+    def test_in_focus_property(self):
+        menu_item = MenuItem(
+            self.image, "Test Label", "Test Description", self.game_object
+        )
+        self.assertFalse(menu_item.in_focus)
+        menu_item.in_focus = True
+        self.assertTrue(menu_item.in_focus)
+
+    def test_repr(self):
+        menu_item = MenuItem(
+            self.image, "Test Label", "Test Description", self.game_object
+        )
+        self.assertIn("Test Label", str(menu_item))
+        self.assertIn("enabled=True", str(menu_item))

--- a/tuxemon/menu/interface.py
+++ b/tuxemon/menu/interface.py
@@ -149,37 +149,74 @@ T = TypeVar("T", covariant=True)
 
 class MenuItem(Generic[T], Sprite):
     """
-    Item from a menu.
+    Represents a selectable item within a user interface menu.
+
+    A MenuItem is a visual component used to represent an option in a menu.
+    It can display an image, label, and description, and is associated with
+    a callable game object or behavior that is triggered when selected.
+
+    Inherits from:
+        Sprite: Provides rendering, animation, and position management.
+
+    Type Parameters:
+        T: The type of the game object or callable associated with this item.
 
     Parameters:
-        image: Image of the menu item.
-        label: Name of the menu item.
-        description: Description of the menu item.
-        game_object: Callable used when the menu item is selected.
-
+        image: The visual surface to represent the item.
+        label: A short label or name for the menu item.
+        description: A longer description or tooltip text.
+        game_object: A callable or linked object triggered on selection.
+        enabled: Whether the menu item is interactable. Defaults to True.
+        position: Initial (x, y) position of the item.
+            If None, position must be set later. Defaults to None.
     """
 
     def __init__(
         self,
-        image: Surface,
+        image: Optional[Surface],
         label: Optional[str],
         description: Optional[str],
         game_object: T,
         enabled: bool = True,
+        position: Optional[tuple[int, int]] = None,
     ):
-        super().__init__()
-        self.image = image
-        self.rect = image.get_rect() if image else Rect(0, 0, 0, 0)
+        super().__init__(image=image)
         self.label = label
         self.description = description
         self.game_object = game_object
-        self.enabled = enabled
-
+        self._enabled = enabled
         self._in_focus = False
 
-    def toggle_focus(self) -> None:
-        """Toggles the focus of the menu item."""
-        self._in_focus = not self._in_focus
+        if position is not None:
+            self.set_position(*position)
+
+        self.update_image()
+
+    def update_image(self) -> None:
+        """
+        Update the image of the sprite, applying focus/enabled visual changes.
+        """
+        super().update_image()
+
+        if self._image is None:
+            return
+
+        if self._in_focus:
+            # Add visual effect for focus here
+            pass
+
+        if not self._enabled:
+            # Add visual effect for not enabled here
+            pass
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        if self._enabled != value:
+            self._enabled = value
 
     @property
     def in_focus(self) -> bool:
@@ -190,20 +227,32 @@ class MenuItem(Generic[T], Sprite):
         self._in_focus = bool(value)
 
     def __repr__(self) -> str:
-        return f"MenuItem({self.label}, {self.description}, image={self.image}, enabled={self.enabled})"
+        return (
+            f"<{self.__class__.__name__} at 0x{id(self):x} "
+            f"label={self.label!r}, enabled={self.enabled}>"
+        )
 
 
 class MenuCursor(Sprite):
     """
-    Menu cursor.
+    Visual indicator for the currently selected menu item.
 
-    Typically it is an arrow that shows the currently selected menu item.
+    Typically rendered as an arrow or icon, the MenuCursor tracks the selected item
+    in a menu interface. It supports optional pixel offsets to fine-tune its position
+    relative to the target item.
+
+    Inherits from:
+        Sprite: Provides image, rect, and positioning logic.
 
     Parameters:
-        image: Image that represents the cursor.
+        image: The visual representation of the cursor.
+        x_offset: Horizontal offset from the anchor point. Defaults to 0.
+        y_offset: Vertical offset from the anchor point. Defaults to 0.
     """
 
-    def __init__(self, image: Surface) -> None:
-        super().__init__()
-        self.image = image
-        self.rect = image.get_rect()
+    def __init__(
+        self, image: Surface, x_offset: int = 0, y_offset: int = 0
+    ) -> None:
+        super().__init__(image=image)
+        self.x_offset = x_offset
+        self.y_offset = y_offset

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -671,6 +671,7 @@ class Menu(Generic[T], State):
         selected = self.get_selected_item()
         assert selected
         selected.in_focus = True
+        selected.update_image()
 
     def hide_cursor(self) -> None:
         """Hide the cursor that indicates the selected object."""
@@ -679,6 +680,7 @@ class Menu(Generic[T], State):
             selected = self.get_selected_item()
             if selected is not None:
                 selected.in_focus = False
+                selected.update_image()
 
     def refresh_layout(self) -> None:
         """Fit border to contents and hide/show cursor."""
@@ -872,12 +874,14 @@ class Menu(Generic[T], State):
         previous = self.get_selected_item()
         if previous is not None:
             previous.in_focus = False
+            previous.update_image()
         self.selected_index = index
         self.menu_select_sound.play()
         self.trigger_cursor_update(animate)
         selected = self.get_selected_item()
         assert selected
         selected.in_focus = True
+        selected.update_image()
         self.on_menu_selection_change()
 
     def search_items(self, target_object: Any) -> Optional[MenuItem[T]]:


### PR DESCRIPTION
PR refactors the `MenuItem` class to improve its UI integration.

Changes include:
- introduced a `position` parameter in the constructor, allowing direct placement of menu items during creation
- delegated image and rect handling to the parent `Sprite` class, reducing redundancy and leveraging existing logic
- centralized visual state updates in `update_image()` for better encapsulation of focus and enabled effects
- switched to internal variables (`_enabled`, `_in_focus`) with property setters for controlled state mutation
- streamlined the `enabled` setter with an early-out condition to avoid unnecessary state updates
- removed `toggle_focus()` method as it was unused and redundant with the property-based state control