### PR TITLE
Add customizable formatting for currency and quantity display in menus

### DIFF
--- a/mods/tuxemon/l18n/cs_CZ/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/cs_CZ/LC_MESSAGES/base.po
@@ -1816,4 +1816,4 @@ msgstr "STOP!"
 
 # Money notification
 msgid "player_wallet"
-msgstr "Peněženka ${{name}}: ${{currency}}${{money}}"
+msgstr "Peněženka ${{name}}: ${{money_formatted}}"

--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -2827,7 +2827,7 @@ msgid "wood_booster_description"
 msgstr "Ermöglicht die Formänderung von Holz Tuxemon."
 
 msgid "combat_victory_trainer"
-msgstr "{name} hat gewonnen und {currency}{prize} erhalten!"
+msgstr "{name} hat gewonnen und {prize} erhalten!"
 
 msgid "exhausted"
 msgstr "Erschöpft"
@@ -2852,7 +2852,7 @@ msgstr "Laden"
 
 # Money notification
 msgid "player_wallet"
-msgstr "${{name}}'s Geldbörse: ${{currency}}${{money}}"
+msgstr "${{name}}'s Geldbörse: ${{money_formatted}}"
 
 msgid "combat_forfeit"
 msgstr ""

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -897,7 +897,7 @@ msgstr "Room 31, Block 2, Omnichannel Tower, Cotton Town\n"
 # Money notification
 
 msgid "player_wallet"
-msgstr "${{name}}'s wallet: ${{currency}}${{money}}"
+msgstr "${{name}}'s wallet: ${{money_formatted}}"
 
 msgid "wallet"
 msgstr "Wallet"
@@ -1015,7 +1015,7 @@ msgid "combat_victory"
 msgstr "{name} has won!"
 
 msgid "combat_victory_trainer"
-msgstr "{name} has won and has received {currency}{prize}!"
+msgstr "{name} has won and received {prize}!"
 
 msgid "combat_defeat"
 msgstr "{name} has been defeated!"
@@ -1088,7 +1088,7 @@ msgid "combat_state_confused_tech"
 msgstr "{target} gets muddled and not {name}!"
 
 msgid "combat_state_gold"
-msgstr "{name} gets {symbol}{gold}!"
+msgstr "{name} gets {gold}!"
 
 msgid "combat_state_switch"
 msgstr "{target} is {types} type!"

--- a/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
@@ -1425,4 +1425,4 @@ msgstr "Tuxemon: Xero"
 
 # Money notification
 msgid "player_wallet"
-msgstr "${{name}}:n lompakko: ${{currency}}${{money}}"
+msgstr "${{name}}:n lompakko: ${{money_formatted}}"

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -6169,7 +6169,7 @@ msgid "combat_skip"
 msgstr "{user} saute le tour !"
 
 msgid "combat_victory_trainer"
-msgstr "{name} a gagné et a reçu {currency}{prize} !"
+msgstr "{name} a gagné et a reçu {prize} !"
 
 ## COMBAT STATE STATUSES
 msgid "combat_state_blinded_get"

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -3254,7 +3254,7 @@ msgid "combat_skip"
 msgstr "{user} salta il turno!"
 
 msgid "combat_victory_trainer"
-msgstr "{name} ha vinto e ha ottenuto {currency}{prize}!"
+msgstr "{name} ha vinto e ha ottenuto {prize}!"
 
 ## COMBAT STATE STATUSES
 msgid "combat_state_blinded_get"

--- a/mods/tuxemon/l18n/ja/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/ja/LC_MESSAGES/base.po
@@ -829,7 +829,7 @@ msgstr "{box} ({qty})"
 
 # Money notification
 msgid "player_wallet"
-msgstr "${{name}} のウォレット: ${{currency}}${{money}}"
+msgstr "${{name}} のウォレット: ${{money_formatted}}"
 
 ## MAP SIGNS ##
 msgid "welcome_location_city"

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -2605,7 +2605,7 @@ msgstr "Jest puste i pełne pajęczyn."
 
 # Money notification
 msgid "player_wallet"
-msgstr "Portfel ${{name}}: ${{currency}}${{money}}"
+msgstr "Portfel ${{name}}: ${{money_formatted}}"
 
 msgid "monster_menu_move"
 msgstr "Ruch"

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -3300,7 +3300,7 @@ msgid "combat_skip"
 msgstr "{user} pula a vez!"
 
 msgid "combat_victory_trainer"
-msgstr "{name} ganhou e recebeu {currency}{prize}!"
+msgstr "{name} ganhou e recebeu {prize}!"
 
 msgid "combat_state_chargedup_get"
 msgstr "{target} é totalmente carregado."

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -758,7 +758,7 @@ msgstr "它允许将水系精灵变形为不同的形式."
 
 # Money notification
 msgid "player_wallet"
-msgstr "${{name}}的钱包: ${{currency}}${{money}}"
+msgstr "${{name}}的钱包: ${{money_formatted}}"
 
 msgid "combat_skip"
 msgstr "{user}跳过了本回合!"
@@ -976,7 +976,7 @@ msgstr "{name}现在不能使用."
 msgid "combat_victory_trainer"
 msgstr ""
 "{name}获胜了!\n"
-" 你获得了 {currency}{prize}!"
+" 你获得了 {prize}!"
 
 msgid "combat_state_chargedup_get"
 msgstr "{target}已充满电."

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -23,6 +23,7 @@ from tuxemon.db import (
     TargetType,
 )
 from tuxemon.locale import T
+from tuxemon.menu.formatter import CurrencyFormatter
 from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
@@ -306,9 +307,10 @@ def _handle_win(
             client.execute_action("modify_money", var, True)
 
             if prize > 0:
+                formatter = CurrencyFormatter()
+                formatted_prize = formatter.format(prize)
+                info["prize"] = formatted_prize
                 set_var(session, "battle_last_prize", str(prize))
-                info["prize"] = str(prize)
-                info["currency"] = "$"
                 return T.format("combat_victory_trainer", info)
             else:
                 return T.format("combat_victory", info)

--- a/tuxemon/core/effects/money.py
+++ b/tuxemon/core/effects/money.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
 from tuxemon.locale import T
+from tuxemon.menu.formatter import CurrencyFormatter
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -41,7 +42,9 @@ class MoneyEffect(CoreEffect):
         if tech.hit:
             amount = int(damage * mult)
             _give_money(session, player, amount)
-            params = {"name": user.name.upper(), "symbol": "$", "gold": amount}
+            formatter = CurrencyFormatter()
+            formatted_amount = formatter.format(amount)
+            params = {"name": user.name.upper(), "gold": formatted_amount}
             extra = [T.format("combat_state_gold", params)]
         else:
             user.current_hp = max(0, user.current_hp - damage)

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -16,6 +16,7 @@ from babel.messages.pofile import read_po
 from tuxemon import prepare
 from tuxemon.constants import paths
 from tuxemon.formula import convert_ft, convert_km, convert_lbs, convert_mi
+from tuxemon.menu.formatter import CurrencyFormatter
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -388,17 +389,20 @@ def replace_text(session: Session, text: str) -> str:
     Examples:
         >>> replace_text(session, "${{name}} is running away!")
         'Red is running away!'
-
     """
     player = session.player
     client = session.client
     unit_measure = prepare.CONFIG.unit_measure
+    formatter = CurrencyFormatter()
 
     replacements = {
         "${{name}}": player.name,
         "${{NAME}}": player.name.upper(),
         "${{currency}}": "$",
         "${{money}}": str(player.money_controller.money_manager.get_money()),
+        "${{money_formatted}}": formatter.format(
+            player.money_controller.money_manager.get_money()
+        ),
         "${{tuxepedia_seen}}": str(player.tuxepedia.get_seen_count()),
         "${{tuxepedia_caught}}": str(player.tuxepedia.get_caught_count()),
         "${{map_name}}": client.map_manager.map_name,
@@ -532,7 +536,6 @@ def process_translate_text(
         text_slug: Text to translate.
         parameters: A sequence of parameters in the format ``"key=value"`` used
             to format the string.
-
     """
     replace_values = {}
     T.check_translation(text_slug)

--- a/tuxemon/menu/formatter.py
+++ b/tuxemon/menu/formatter.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+
+class CurrencyFormatter:
+    """Formats a monetary value with a currency symbol."""
+
+    def __init__(self, symbol: str = "$", position: str = "before") -> None:
+        self.symbol = symbol
+        self.position = position
+
+    def format(self, amount: int) -> str:
+        if self.position == "before":
+            return f"{self.symbol}{amount}"
+        else:
+            return f"{amount}{self.symbol}"
+
+
+class QuantityFormatter:
+    """Formats a quantity value with a quantity symbol."""
+
+    def __init__(self, symbol: str = "x") -> None:
+        self.symbol = symbol
+
+    def format(self, quantity: int) -> str:
+        return f"{self.symbol} {quantity}"

--- a/tuxemon/states/character/__init__.py
+++ b/tuxemon/states/character/__init__.py
@@ -10,8 +10,9 @@ from pygame_menu import locals
 
 from tuxemon import formula
 from tuxemon import prepare as pre
-from tuxemon.db import MonsterModel, OutputBattle, db
+from tuxemon.db import MonsterModel, db
 from tuxemon.locale import T
+from tuxemon.menu.formatter import CurrencyFormatter
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.npc import NPC
 from tuxemon.platform.const import buttons
@@ -128,9 +129,10 @@ class CharacterState(PygameMenuState):
         )
         lab1.translate(fix_measure(width, 0.45), fix_measure(height, 0.15))
         # money
-        money = self.char.money_controller.money_manager.get_money()
+        money = CurrencyFormatter()
+        amount = self.char.money_controller.money_manager.get_money()
         lab2: Any = menu.add.label(
-            title=f"{T.translate('wallet')}: {money}",
+            title=f"{T.translate('wallet')}: {money.format(amount)}",
             label_id="money",
             font_size=self.font_size_smaller,
             align=locals.ALIGN_LEFT,

--- a/tuxemon/states/items/shop_menu.py
+++ b/tuxemon/states/items/shop_menu.py
@@ -11,6 +11,7 @@ from pygame.rect import Rect
 from tuxemon import prepare, tools
 from tuxemon.item.item import INFINITE_ITEMS, Item
 from tuxemon.locale import T
+from tuxemon.menu.formatter import CurrencyFormatter
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
 from tuxemon.menu.quantity import QuantityAndCostMenu, QuantityAndPriceMenu
@@ -349,23 +350,26 @@ def generate_item_label(
     price: Optional[int] = None,
     seller_mode: bool = False,
 ) -> str:
+    formatter = CurrencyFormatter()
     if seller_mode:
         cost = economy.lookup_item(item.slug, "cost") or round(
             item.cost * economy.model.resale_multiplier
         )
+        cost_tag = formatter.format(cost)
         return (
-            f"${cost:3} {item.name} x {item.quantity}"
+            f"{cost_tag} {item.name} x {item.quantity}"
             if item.quantity != INFINITE_ITEMS
-            else f"${cost:3} {item.name}"
+            else f"{cost_tag} {item.name}"
         )
     else:
         qty = qty or 0
         price = price or 0
+        price_tag = formatter.format(price)
         if item.quantity != INFINITE_ITEMS:
             return (
-                f"${price:4} {item.name} x {qty}"
+                f"{price_tag} {item.name} x {qty}"
                 if qty > 0
-                else f"${price:4} {T.translate('shop_buy_soldout')}"
+                else f"{price_tag} {T.translate('shop_buy_soldout')}"
             )
         else:
-            return f"${price:4} {item.name}"
+            return f"{price_tag} {item.name}"

--- a/tuxemon/states/phone/phone_banking.py
+++ b/tuxemon/states/phone/phone_banking.py
@@ -12,6 +12,7 @@ from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
 from tuxemon.locale import T
+from tuxemon.menu.formatter import CurrencyFormatter
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.tools import open_choice_dialog, open_dialog
 
@@ -34,14 +35,17 @@ class NuPhoneBanking(PygameMenuState):
         money_manager = self.char.money_controller.money_manager
         bank_account = money_manager.get_bank_balance()
         wallet_player = money_manager.get_money()
+        formatter = CurrencyFormatter()
+        formatter_bank = formatter.format(bank_account)
+        formatter_wallet = formatter.format(wallet_player)
 
-        _wallet = f"{T.translate('wallet')}: {wallet_player}"
+        _wallet = f"{T.translate('wallet')}: {formatter_wallet}"
         menu.add.label(
             title=_wallet,
             label_id="wallet",
             font_size=self.font_size_small,
         )
-        _bank = f"{T.translate('bank')}: {bank_account}"
+        _bank = f"{T.translate('bank')}: {formatter_bank}"
         menu.add.label(
             title=_bank,
             label_id="bank",
@@ -62,7 +66,7 @@ class NuPhoneBanking(PygameMenuState):
         def choice(op: str) -> None:
             var_menu = []
             for ele in elements:
-                _ele = str(ele)
+                _ele = formatter.format(ele)
                 if op == "deposit" and ele <= wallet_player:
                     _param = (_ele, _ele, partial(deposit, ele))
                     var_menu.append(_param)
@@ -85,7 +89,7 @@ class NuPhoneBanking(PygameMenuState):
         def bill_manager(op: str, bill_name: str) -> None:
             var_menu = []
             for ele in elements:
-                _ele = str(ele)
+                _ele = formatter.format(ele)
                 if op == "pay" and ele <= wallet_player:
                     _param = (_ele, _ele, partial(pay, ele, bill_name))
                     var_menu.append(_param)


### PR DESCRIPTION
PR introduces flexible formatting support for currency and quantity values in the `QuantityMenu` and its subclasses.

Key changes:
- introduced `CurrencyFormatter` and `QuantityFormatter` helper classes, these allow easy customization of symbol placement (before or after the value) and formatting styles
- `QuantityMenu` now accepts optional `currency_formatter` and `quantity_formatter` parameters and if not provided, default formatters are used (`$` before value, `x` before quantity)
- refactored string construction logic in `initialize_items()` and `show_money()` to use the new formatters
- display logic in `QuantityAndPriceMenu` and `QuantityAndCostMenu` now benefits from consistent formatting through the formatters