### PR TITLE
Refactor `replace_text` and `paginate_translation` into Dedicated `TextFormatter` Class

### DIFF
--- a/tuxemon/event/actions/choice_item.py
+++ b/tuxemon/event/actions/choice_item.py
@@ -9,10 +9,11 @@ from functools import partial
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.locale import T, replace_text
+from tuxemon.locale import T
 from tuxemon.npc import NPC
 from tuxemon.session import Session
 from tuxemon.states.choice.choice_item import ChoiceItem
+from tuxemon.ui.text_formatter import TextFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class ChoiceItemAction(EventAction):
             session.client.pop_state()
 
         # perform text substitutions
-        choices = replace_text(session, self.choices)
+        choices = TextFormatter.replace_text(session, self.choices, T)
         player = session.player
 
         # make menu options for each string between the colons

--- a/tuxemon/event/actions/choice_monster.py
+++ b/tuxemon/event/actions/choice_monster.py
@@ -9,10 +9,11 @@ from functools import partial
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.locale import T, replace_text
+from tuxemon.locale import T
 from tuxemon.npc import NPC
 from tuxemon.session import Session
 from tuxemon.states.choice.choice_monster import ChoiceMonster
+from tuxemon.ui.text_formatter import TextFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class ChoiceMonsterAction(EventAction):
             session.client.pop_state()
 
         # perform text substitutions
-        choices = replace_text(session, self.choices)
+        choices = TextFormatter.replace_text(session, self.choices, T)
         player = session.player
 
         # make menu options for each string between the colons

--- a/tuxemon/event/actions/choice_npc.py
+++ b/tuxemon/event/actions/choice_npc.py
@@ -9,10 +9,11 @@ from functools import partial
 from typing import final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.locale import T, replace_text
+from tuxemon.locale import T
 from tuxemon.npc import NPC
 from tuxemon.session import Session
 from tuxemon.states.choice.choice_npc import ChoiceNpc
+from tuxemon.ui.text_formatter import TextFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class ChoiceNpcAction(EventAction):
             session.client.pop_state()
 
         # perform text substitutions
-        choices = replace_text(session, self.choices)
+        choices = TextFormatter.replace_text(session, self.choices, T)
         player = session.player
 
         # make menu options for each string between the colons

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -9,9 +9,10 @@ from typing import Any, Optional, final
 from tuxemon.db import DialogueModel, db
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import get_avatar, string_to_colorlike
-from tuxemon.locale import process_translate_text
+from tuxemon.locale import T
 from tuxemon.session import Session
 from tuxemon.tools import open_dialog
+from tuxemon.ui.text_formatter import TextFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,9 @@ class TranslatedDialogAction(EventAction):
     style: Optional[str] = None
 
     def start(self, session: Session) -> None:
-        key = process_translate_text(session, self.raw_parameters, [])
+        key = TextFormatter(session, T).paginate_translation(
+            self.raw_parameters
+        )
 
         avatar_sprite = None
         if self.avatar:

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -10,9 +10,10 @@ from typing import final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from tuxemon.locale import T, replace_text
+from tuxemon.locale import T
 from tuxemon.npc import NPC
 from tuxemon.session import Session
+from tuxemon.ui.text_formatter import TextFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class TranslatedDialogChoiceAction(EventAction):
             session.client.pop_state()
 
         # perform text substitutions
-        choices = replace_text(session, self.choices)
+        choices = TextFormatter.replace_text(session, self.choices, T)
         player = get_npc(session, "player")
         assert player
 

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import gettext
 import logging
-from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
+from collections.abc import Callable, Generator, Mapping
 from dataclasses import dataclass
 from gettext import GNUTranslations
 from pathlib import Path
@@ -15,9 +15,6 @@ from babel.messages.pofile import read_po
 
 from tuxemon import prepare
 from tuxemon.constants import paths
-from tuxemon.formula import convert_ft, convert_km, convert_lbs, convert_mi
-from tuxemon.menu.formatter import CurrencyFormatter
-from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -376,196 +373,6 @@ class TranslatorPo:
             return ""
         else:
             return self.translate(text)
-
-
-def replace_text(session: Session, text: str) -> str:
-    """
-    Replaces ``${{var}}`` tiled variables with their in-session value.
-
-    Parameters:
-        session: Session containing the information to fill the variables.
-        text: Text whose references to variables should be substituted.
-
-    Examples:
-        >>> replace_text(session, "${{name}} is running away!")
-        'Red is running away!'
-    """
-    player = session.player
-    client = session.client
-    unit_measure = prepare.CONFIG.unit_measure
-    formatter = CurrencyFormatter()
-
-    replacements = {
-        "${{name}}": player.name,
-        "${{NAME}}": player.name.upper(),
-        "${{currency}}": "$",
-        "${{money}}": str(player.money_controller.money_manager.get_money()),
-        "${{money_formatted}}": formatter.format(
-            player.money_controller.money_manager.get_money()
-        ),
-        "${{tuxepedia_seen}}": str(player.tuxepedia.get_seen_count()),
-        "${{tuxepedia_caught}}": str(player.tuxepedia.get_caught_count()),
-        "${{map_name}}": client.map_manager.map_name,
-        "${{map_desc}}": client.map_manager.map_desc,
-        "${{north}}": client.map_manager.map_north,
-        "${{south}}": client.map_manager.map_south,
-        "${{east}}": client.map_manager.map_east,
-        "${{west}}": client.map_manager.map_west,
-    }
-
-    # Add unit-specific replacements
-    if unit_measure == "metric":
-        replacements.update(
-            {
-                "${{length}}": prepare.U_KM,
-                "${{weight}}": prepare.U_KG,
-                "${{height}}": prepare.U_CM,
-                "${{steps}}": str(convert_km(player.steps)),
-            }
-        )
-    else:
-        replacements.update(
-            {
-                "${{length}}": prepare.U_MI,
-                "${{weight}}": prepare.U_LB,
-                "${{height}}": prepare.U_FT,
-                "${{steps}}": str(convert_mi(player.steps)),
-            }
-        )
-
-    # Add monster-specific replacements
-    for i, monster in enumerate(player.monsters):
-        monster_replacements = {
-            "${{monster_" + str(i) + "_name}}": monster.name,
-            "${{monster_" + str(i) + "_desc}}": monster.description,
-            "${{monster_"
-            + str(i)
-            + "_types}}": " - ".join(
-                T.translate(_type.name) for _type in monster.types.current
-            ),
-            "${{monster_" + str(i) + "_category}}": monster.category,
-            "${{monster_"
-            + str(i)
-            + "_shape}}": T.translate(monster.shape.slug),
-            "${{monster_" + str(i) + "_hp}}": str(monster.current_hp),
-            "${{monster_" + str(i) + "_hp_max}}": str(monster.hp),
-            "${{monster_" + str(i) + "_level}}": str(monster.level),
-            "${{monster_"
-            + str(i)
-            + "_gender}}": T.translate(f"gender_{monster.gender}"),
-            "${{monster_" + str(i) + "_bond}}": str(monster.bond),
-            "${{monster_" + str(i) + "_txmn_id}}": str(monster.txmn_id),
-            "${{monster_"
-            + str(i)
-            + "_warm}}": T.translate(f"taste_{monster.taste_warm}"),
-            "${{monster_"
-            + str(i)
-            + "_cold}}": T.translate(f"taste_{monster.taste_cold}"),
-            "${{monster_"
-            + str(i)
-            + "_moves}}": " - ".join(
-                _move.name for _move in monster.moves.get_moves()
-            ),
-        }
-
-        # Add unit-specific monster replacements
-        if unit_measure == "metric":
-            monster_replacements.update(
-                {
-                    "${{monster_"
-                    + str(i)
-                    + "_steps}}": str(convert_km(monster.steps)),
-                    "${{monster_" + str(i) + "_weight}}": str(monster.weight),
-                    "${{monster_" + str(i) + "_height}}": str(monster.height),
-                }
-            )
-        else:
-            monster_replacements.update(
-                {
-                    "${{monster_"
-                    + str(i)
-                    + "_steps}}": str(convert_mi(monster.steps)),
-                    "${{monster_"
-                    + str(i)
-                    + "_weight}}": str(convert_lbs(monster.weight)),
-                    "${{monster_"
-                    + str(i)
-                    + "_height}}": str(convert_ft(monster.height)),
-                }
-            )
-
-        monster_replacements.update(
-            {
-                "${{monster_" + str(i) + "_armour}}": str(monster.armour),
-                "${{monster_" + str(i) + "_dodge}}": str(monster.dodge),
-                "${{monster_" + str(i) + "_melee}}": str(monster.melee),
-                "${{monster_" + str(i) + "_ranged}}": str(monster.ranged),
-                "${{monster_" + str(i) + "_speed}}": str(monster.speed),
-            }
-        )
-
-        replacements.update(monster_replacements)
-
-    # Add game variable replacements
-    for key, value in player.game_variables.items():
-        replacements.update(
-            {
-                "${{var:" + str(key) + "}}": str(value),
-                "${{msgid:" + str(key) + "}}": T.translate(str(value)),
-            }
-        )
-
-    # Replace placeholders in the text
-    for placeholder, replacement in replacements.items():
-        text = text.replace(placeholder, replacement)
-
-    # Replace newline characters
-    text = text.replace(r"\n", "\n")
-
-    return text
-
-
-def process_translate_text(
-    session: Session,
-    text_slug: str,
-    parameters: Iterable[str],
-) -> Sequence[str]:
-    """
-    Translate a dialog to a sequence of pages of text.
-
-    Parameters:
-        session: Session containing the information to fill the variables.
-        text_slug: Text to translate.
-        parameters: A sequence of parameters in the format ``"key=value"`` used
-            to format the string.
-    """
-    replace_values = {}
-    T.check_translation(text_slug)
-
-    # extract INI-style params
-    for param in parameters:
-        key, value = param.split("=")
-
-        # TODO: is this code still valid? Translator class is NOT iterable
-        """
-        # Check to see if param_value is translatable
-        if value in translator:
-            value = trans(value)
-        """
-        # match special placeholders like ${{name}}
-        replace_values[key] = replace_text(session, value)
-
-    # generate translation
-    text = T.format(text_slug, replace_values)
-
-    # clear the terminal end-line symbol (multi-line translation records)
-    text = text.rstrip("\n")
-
-    # split text into pages for scrolling
-    pages = text.split("\n")
-
-    # generate scrollable text
-    return [replace_text(session, page) for page in pages]
 
 
 locale_finder = LocaleFinder(Path(prepare.fetch("l18n")))

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -30,8 +30,9 @@ from typing import (
 from tuxemon import prepare
 from tuxemon.compat.rect import ReadOnlyRect
 from tuxemon.db import Comparison
-from tuxemon.locale import T, replace_text
+from tuxemon.locale import T
 from tuxemon.math import Vector2
+from tuxemon.ui.text_formatter import TextFormatter
 
 if TYPE_CHECKING:
     from pygame.rect import Rect
@@ -377,7 +378,7 @@ def show_result_as_dialog(
     msg_type = "use_success" if result else "use_failure"
     template = getattr(entity, msg_type)
     if template:
-        message = T.translate(replace_text(session, template))
+        message = T.translate(TextFormatter.replace_text(session, template, T))
         open_dialog(session.client, [message])
 
 

--- a/tuxemon/ui/text_formatter.py
+++ b/tuxemon/ui/text_formatter.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from functools import partial
+from typing import Optional
+
+from tuxemon import prepare
+from tuxemon.formula import convert_ft, convert_km, convert_lbs, convert_mi
+from tuxemon.locale import TranslatorPo
+from tuxemon.menu.formatter import CurrencyFormatter
+from tuxemon.session import Session
+from tuxemon.ui.text_paginator import TextPaginator
+
+logger = logging.getLogger(__name__)
+
+
+class TextFormatter:
+    """
+    A class responsible for formatting text by replacing placeholders with
+    dynamic values.
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        translator: TranslatorPo,
+        paginator: Optional[TextPaginator] = None,
+    ):
+        self.session = session
+        self.translator = translator
+        self.paginator = paginator or TextPaginator()
+        self._replacements: dict[str, Callable[[], str]] = {}
+        self._register_default_replacements()
+
+    @classmethod
+    def replace_text(
+        cls,
+        session: Session,
+        text: str,
+        translator: TranslatorPo,
+        paginator: Optional[TextPaginator] = None,
+    ) -> str:
+        """
+        Convenience class method to format text without instantiating the formatter directly.
+        """
+        formatter = cls(session, translator, paginator)
+        return formatter.format_text(text)
+
+    def set_paginator(self, paginator: TextPaginator) -> None:
+        """Replaces the current paginator with a new one."""
+        self.paginator = paginator
+
+    def _register_player_client_replacements(self) -> None:
+        """Registers replacements related to the player and client."""
+        player = self.session.player
+        client = self.session.client
+        formatter = CurrencyFormatter()
+
+        player_client_map = {
+            "${{name}}": lambda: player.name,
+            "${{NAME}}": lambda: player.name.upper(),
+            "${{currency}}": lambda: "$",
+            "${{money}}": lambda: str(
+                player.money_controller.money_manager.get_money()
+            ),
+            "${{money_formatted}}": lambda: formatter.format(
+                player.money_controller.money_manager.get_money()
+            ),
+            "${{tuxepedia_seen}}": lambda: str(
+                player.tuxepedia.get_seen_count()
+            ),
+            "${{tuxepedia_caught}}": lambda: str(
+                player.tuxepedia.get_caught_count()
+            ),
+            "${{map_name}}": lambda: client.map_manager.map_name,
+            "${{map_desc}}": lambda: client.map_manager.map_desc,
+            "${{north}}": lambda: client.map_manager.map_north,
+            "${{south}}": lambda: client.map_manager.map_south,
+            "${{east}}": lambda: client.map_manager.map_east,
+            "${{west}}": lambda: client.map_manager.map_west,
+        }
+        for placeholder, callable_func in player_client_map.items():
+            self.register_replacement(placeholder, callable_func)
+
+    def _register_unit_measure_replacements(self) -> None:
+        """Registers replacements for units of measurement (metric vs. imperial)."""
+        player = self.session.player
+        unit_measure = prepare.CONFIG.unit_measure
+
+        unit_map = {}
+        if unit_measure == "metric":
+            unit_map["${{length}}"] = lambda: prepare.U_KM
+            unit_map["${{weight}}"] = lambda: prepare.U_KG
+            unit_map["${{height}}"] = lambda: prepare.U_CM
+            unit_map["${{steps}}"] = lambda: str(convert_km(player.steps))
+        else:  # Assuming "imperial" for non-metric
+            unit_map["${{length}}"] = lambda: prepare.U_MI
+            unit_map["${{weight}}"] = lambda: prepare.U_LB
+            unit_map["${{height}}"] = lambda: prepare.U_FT
+            unit_map["${{steps}}"] = lambda: str(convert_mi(player.steps))
+
+        for placeholder, callable_func in unit_map.items():
+            self.register_replacement(placeholder, callable_func)
+
+    def _register_monster_replacements(self) -> None:
+        """Registers replacements for each monster in the player's party."""
+        player = self.session.player
+        unit_measure = prepare.CONFIG.unit_measure
+
+        # Define common monster attributes and their callables
+        monster_attributes = {
+            "name": lambda m: m.name,
+            "desc": lambda m: m.description,
+            "category": lambda m: m.category,
+            "hp": lambda m: str(m.current_hp),
+            "hp_max": lambda m: str(m.hp),
+            "level": lambda m: str(m.level),
+            "bond": lambda m: str(m.bond),
+            "txmn_id": lambda m: str(m.txmn_id),
+            "armour": lambda m: str(m.armour),
+            "dodge": lambda m: str(m.dodge),
+            "melee": lambda m: str(m.melee),
+            "ranged": lambda m: str(m.ranged),
+            "speed": lambda m: str(m.speed),
+            "types": lambda m: " - ".join(
+                self.translator.translate(_type.name)
+                for _type in m.types.current
+            ),
+            "shape": lambda m: self.translator.translate(m.shape.slug),
+            "gender": lambda m: self.translator.translate(
+                f"gender_{m.gender}"
+            ),
+            "warm": lambda m: self.translator.translate(
+                f"taste_{m.taste_warm}"
+            ),
+            "cold": lambda m: self.translator.translate(
+                f"taste_{m.taste_cold}"
+            ),
+            "moves": lambda m: " - ".join(
+                _move.name for _move in m.moves.get_moves()
+            ),
+        }
+
+        # Define unit-dependent monster attributes
+        unit_dependent_monster_attributes = {
+            "metric": {
+                "steps": lambda m: str(convert_km(m.steps)),
+                "weight": lambda m: str(m.weight),
+                "height": lambda m: str(m.height),
+            },
+            "imperial": {
+                "steps": lambda m: str(convert_mi(m.steps)),
+                "weight": lambda m: str(convert_lbs(m.weight)),
+                "height": lambda m: str(convert_ft(m.height)),
+            },
+        }
+
+        for i, monster in enumerate(player.monsters):
+            # Register common attributes
+            for key, func in monster_attributes.items():
+                self.register_replacement(
+                    f"${{monster_{i}_{key}}}", partial(func, monster)
+                )
+
+            # Register unit-dependent attributes
+            unit_key = "metric" if unit_measure == "metric" else "imperial"
+            for key, func in unit_dependent_monster_attributes[
+                unit_key
+            ].items():
+                self.register_replacement(
+                    f"${{monster_{i}_{key}}}", partial(func, monster)
+                )
+
+    def _register_game_variable_replacements(self) -> None:
+        """Registers replacements for game-specific variables."""
+        player = self.session.player
+        for key, value in player.game_variables.items():
+            self.register_replacement(f"${{var:{key}}}", partial(str, value))
+            self.register_replacement(
+                f"${{msgid:{key}}}",
+                partial(self.translator.translate, str(value)),
+            )
+
+    def _register_default_replacements(self) -> None:
+        """Registers the common, built-in replacements by calling helper methods."""
+        self._register_player_client_replacements()
+        self._register_unit_measure_replacements()
+        self._register_monster_replacements()
+        self._register_game_variable_replacements()
+
+    def register_replacement(
+        self, placeholder: str, value_callable: Callable[[], str]
+    ) -> None:
+        """
+        Registers a custom replacement.
+
+        Parameters:
+            placeholder: The placeholder string (e.g., "${{custom_var}}").
+            value_callable: A callable (function or lambda) that returns the
+                string value for the placeholder. This allows for dynamic
+                retrieval of values at the time of formatting.
+        """
+        if (
+            not isinstance(placeholder, str)
+            or not placeholder.startswith("${{")
+            or not placeholder.endswith("}}")
+        ):
+            logger.warning(
+                f"Registering non-standard placeholder format: {placeholder}"
+            )
+        self._replacements[placeholder] = value_callable
+        logger.debug(f"Registered replacement: {placeholder}")
+
+    def unregister_replacement(self, placeholder: str) -> None:
+        """
+        Unregisters a replacement if it exists.
+
+        Parameters:
+            placeholder: The placeholder string to unregister.
+        """
+        if placeholder in self._replacements:
+            del self._replacements[placeholder]
+            logger.info(f"Unregistered placeholder: {placeholder}")
+        else:
+            logger.warning(
+                f"Attempted to unregister non-existent placeholder: {placeholder}"
+            )
+
+    def clear_replacements(self) -> None:
+        """
+        Clears all registered replacements.
+        """
+        self._replacements.clear()
+        logger.info("All TextFormatter replacements cleared.")
+
+    def format_text(self, text: str) -> str:
+        """
+        Replaces variables in a text string with their dynamic values.
+
+        Parameters:
+            text: Text whose references to variables should be substituted.
+
+        Returns:
+            The formatted string.
+        """
+        formatted_text = text.replace(r"\n", "\n")
+        temp_text = formatted_text
+
+        # Evaluate callables and perform replacements
+        for placeholder, value_callable in self._replacements.items():
+            if placeholder in temp_text:
+                try:
+                    replacement_value = value_callable()
+                    temp_text = temp_text.replace(
+                        placeholder, replacement_value
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Error evaluating replacement for placeholder '{placeholder}': {e}",
+                        exc_info=True,
+                    )
+                    temp_text = temp_text.replace(
+                        placeholder, f"[ERROR:{placeholder}]"
+                    )
+            formatted_text = temp_text
+
+        # Check for any remaining placeholder patterns that were not registered
+        import re
+
+        # Find all occurrences of ${{...}} pattern
+        remaining_placeholder_patterns = re.findall(
+            r"\$\{\{.*?\}\}", formatted_text
+        )
+        for placeholder in remaining_placeholder_patterns:
+            if placeholder not in self._replacements:
+                logger.warning(
+                    f"Unhandled placeholder '{placeholder}' found in text after formatting. "
+                    "Consider registering it or checking for typos."
+                )
+
+        return formatted_text
+
+    def paginate_translation(
+        self,
+        text_slug: str,
+        parameters: Optional[Mapping[str, str]] = None,
+    ) -> Sequence[str]:
+        """
+        Translates a dialog and processes it into a sequence of pages of text,
+        applying dynamic replacements.
+
+        Parameters:
+            text_slug: The translation slug for the main text.
+            parameters: A dictionary of key-value pairs for additional formatting
+                within the translated string (e.g., {"item_name": "Potion"}).
+                These parameters are applied *after* the initial dynamic replacements.
+
+        Returns:
+            A sequence of formatted text pages.
+        """
+        # Use the injected translator for checking and formatting
+        self.translator.check_translation(text_slug)
+        translated_text = self.translator.format(text_slug, parameters)
+
+        # Apply general dynamic replacements from TextFormatter
+        processed_text = self.format_text(translated_text)
+
+        # Use the injected paginator to split the text into pages
+        pages = self.paginator.paginate_text(processed_text)
+
+        # Apply format_text to each page again. This is primarily useful if:
+        # 1. Placeholders could span across the original newline characters
+        #  (which they shouldn't with ${{...}})
+        # 2. Contextual replacements might change based on the isolated page content
+        #  (unlikely for this design)
+        # For this design, if format_text on the whole string is complete, this loop
+        # might be redundant but is kept for safety or if future placeholder types
+        # could introduce newlines.
+        return [self.format_text(page) for page in pages]

--- a/tuxemon/ui/text_paginator.py
+++ b/tuxemon/ui/text_paginator.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Sequence
+from itertools import dropwhile
+from typing import Optional
+
+
+class TextPaginator:
+    """
+    A class responsible for paginating text into a sequence of pages based on
+    line length and page height constraints.
+    If no constraints are provided, it defaults to newline-based pagination.
+    """
+
+    def __init__(
+        self,
+        max_line_length: Optional[int] = None,
+        max_lines_per_page: Optional[int] = None,
+        line_break_chars: str = "\n",
+        strip_lines: bool = True,
+    ):
+        """
+        Initializes the TextPaginator with display constraints.
+
+        Parameters:
+            max_line_length: Max number of characters per line (for wrapping).
+            max_lines_per_page: Max lines per page (for pagination).
+            line_break_chars: Characters used to split input into lines.
+            strip_lines: Whether to strip whitespace from each line.
+        """
+        self.max_line_length = max_line_length
+        self.max_lines_per_page = max_lines_per_page
+        self.line_break_chars = line_break_chars
+        self.strip_lines = strip_lines
+
+    def paginate_text(self, text: str) -> Sequence[str]:
+        """
+        Splits the given text into a sequence of pages.
+
+        - If no constraints are provided, splits by newline characters.
+        - If constraints are set, applies word wrapping and page height limits.
+
+        Returns:
+            A list of page strings, each representing a chunk of text.
+        """
+        if self.max_line_length is None and self.max_lines_per_page is None:
+            # Default behavior: just split by line breaks
+            return text.rstrip("\n").split("\n")
+
+        lines = self._normalize_and_wrap_text(text)
+        lines = self._trim_blank_edges(lines)
+        return self._chunk_lines_into_pages(lines)
+
+    def _normalize_and_wrap_text(self, text: str) -> list[str]:
+        """
+        Breaks the input into lines and wraps them if line length is constrained.
+        """
+        raw_lines = text.split(self.line_break_chars)
+        wrapped_lines: list[str] = []
+
+        for line in raw_lines:
+            if self.strip_lines:
+                line = line.strip()
+
+            if self.max_line_length:
+                wrapped_lines.extend(
+                    textwrap.wrap(
+                        line,
+                        width=self.max_line_length,
+                        break_long_words=True,
+                        break_on_hyphens=False,
+                    )
+                )
+            else:
+                wrapped_lines.append(line)
+
+        return wrapped_lines
+
+    def _trim_blank_edges(self, lines: list[str]) -> list[str]:
+        """
+        Removes blank lines from the beginning and end of the input.
+        """
+        trimmed_front = list(dropwhile(lambda l: not l.strip(), lines))
+        trimmed_back = list(
+            reversed(
+                list(
+                    dropwhile(lambda l: not l.strip(), reversed(trimmed_front))
+                )
+            )
+        )
+        return trimmed_back
+
+    def _chunk_lines_into_pages(self, lines: list[str]) -> list[str]:
+        """
+        Chunks the lines into pages based on the max_lines_per_page constraint.
+        """
+        if self.max_lines_per_page is None:
+            return [self.line_break_chars.join(lines)]
+
+        pages: list[str] = []
+        current_page: list[str] = []
+
+        for line in lines:
+            if len(current_page) >= self.max_lines_per_page:
+                pages.append(self.line_break_chars.join(current_page))
+                current_page = []
+
+            current_page.append(line)
+
+        if current_page:
+            pages.append(self.line_break_chars.join(current_page))
+
+        return pages


### PR DESCRIPTION
PR introduces a cleaner and more modular approach to text formatting and pagination by encapsulating responsibilities in dedicated classes.

Key Changes:
- modular `TextFormatter` Class, all formatting logic has been extracted into its own class, improving clarity, reusability, and testability
- new `TextPaginator` utility, a flexible paginator now handles line wrapping and page splitting based on configurable constraints like line length and page height and defaults to basic newline-splitting when no constraints are given
- external placeholder registration, dynamic values (like `${{quest_giver}}`) can now be injected via `register_replacement`, decoupling internal code from specific domain values
- decoupled from Session internals, the formatter still accepts a `Session`, but no longer relies on its internal structure - minimizing future coupling
- streamlined `paginate_translation` flow, translation and formatting responsibilities are now clearly divided: `translator.format()` handles localization, and `TextFormatter` handles placeholder injection and pagination