### PR TITLE
Refactor `GraphicBox` Border Logic and Extract `TileLayout` Utility Class

### DIFF
--- a/tuxemon/ui/draw.py
+++ b/tuxemon/ui/draw.py
@@ -35,6 +35,54 @@ def create_layout(
 layout = create_layout(prepare.SCALE)
 
 
+class TileLayout:
+    """
+    Extracts a grid of tiles from a border image and assigns logical names
+    like 'nw', 'n', 'ne', etc. Assumes a 3x3 layout by default.
+    """
+
+    def __init__(self, image: Surface, grid_size: int = 3) -> None:
+        if grid_size <= 0:
+            raise ValueError("Grid size must be a positive integer")
+        self.grid_size = grid_size
+        self.tiles: dict[str, Surface] = self._extract_tiles(image)
+
+    def _extract_tiles(self, image: Surface) -> dict[str, Surface]:
+        if image.get_size() == (0, 0):
+            raise ValueError("Image cannot be empty")
+
+        iw, ih = image.get_size()
+
+        if iw % self.grid_size != 0 or ih % self.grid_size != 0:
+            raise ValueError("Image dimensions must be divisible by grid size")
+
+        tw, th = iw // self.grid_size, ih // self.grid_size
+        layout_map = {
+            (0, 0): "nw",
+            (0, 1): "n",
+            (0, 2): "ne",
+            (1, 0): "w",
+            (1, 1): "c",
+            (1, 2): "e",
+            (2, 0): "sw",
+            (2, 1): "s",
+            (2, 2): "se",
+        }
+
+        tiles: dict[str, Surface] = {}
+        for (row, col), label in layout_map.items():
+            x, y = col * tw, row * th
+            rect = Rect(x, y, tw, th)
+            tiles[label] = image.subsurface(rect)
+
+        if len(tiles) != self.grid_size**2:
+            raise ValueError(
+                f"Expected {self.grid_size ** 2} tiles, got {len(tiles)}"
+            )
+
+        return tiles
+
+
 class GraphicBox(Sprite):
     """
     Generic class for drawing graphical boxes.
@@ -70,7 +118,7 @@ class GraphicBox(Sprite):
         self._background = background
         self._color = color
         self._fill_tiles = fill_tiles
-        self._tiles: list[Surface] = []
+        self._tiles: dict[str, Surface] = {}
         self._tile_size = 0, 0
 
         if border:
@@ -95,17 +143,15 @@ class GraphicBox(Sprite):
     def _set_border(self, image: Surface) -> None:
         """
         Sets the border image and extracts the individual tiles.
+        The border graphic must contain 9 tiles laid out in a 3x3 grid.
 
         Parameters:
             image: The border image.
         """
-        iw, ih = image.get_size()
-        tw, th = iw // self.TILE_GRID_SIZE, ih // self.TILE_GRID_SIZE
-        self._tile_size = tw, th
-        self._tiles = [
-            image.subsurface((x, y, tw, th))
-            for x, y in product(range(0, iw, tw), range(0, ih, th))
-        ]
+        layout = TileLayout(image, self.TILE_GRID_SIZE)
+        self._tiles = layout.tiles
+        self._tile_size = next(iter(self._tiles.values())).get_size()
+        self._needs_update = True
 
     def update_image(self) -> None:
         """
@@ -139,51 +185,44 @@ class GraphicBox(Sprite):
 
     def _draw_tiled_fill(self, surface: Surface, inner: Rect) -> None:
         tw, th = self._tile_size
+        center_tile = self._tiles["c"]
         for x in range(inner.left, inner.right, tw):
             for y in range(inner.top, inner.bottom, th):
-                surface.blit(self._tiles[4], (x, y))
+                surface.blit(center_tile, (x, y))
 
     def _draw_border(self, surface: Surface, rect: Rect, inner: Rect) -> None:
-        (
-            tile_nw,
-            tile_w,
-            tile_sw,
-            tile_n,
-            tile_c,
-            tile_s,
-            tile_ne,
-            tile_e,
-            tile_se,
-        ) = self._tiles
+        """
+        Draws the tiled border around the inner rectangle.
+        """
         left, top = rect.topleft
         tw, th = self._tile_size
         surface_blit = surface.blit  # cache the blit method
 
-        # Draw top and bottom tiles
+        # Draw top and bottom border tiles
         for x in range(inner.left, inner.right, tw):
             area = (
                 (0, 0, tw, th)
                 if x + tw < inner.right
                 else (0, 0, tw - (x + tw - inner.right), th)
             )
-            surface_blit(tile_n, (x, top), area)
-            surface_blit(tile_s, (x, inner.bottom), area)
+            surface_blit(self._tiles["n"], (x, top), area)
+            surface_blit(self._tiles["s"], (x, inner.bottom), area)
 
-        # Draw left and right tiles
+        # Draw left and right border tiles
         for y in range(inner.top, inner.bottom, th):
             area = (
                 (0, 0, tw, th)
                 if y + th < inner.bottom
                 else (0, 0, tw, th - (y + th - inner.bottom))
             )
-            surface_blit(tile_w, (left, y), area)
-            surface_blit(tile_e, (inner.right, y), area)
+            surface_blit(self._tiles["w"], (left, y), area)
+            surface_blit(self._tiles["e"], (inner.right, y), area)
 
-        # Draw corners
-        surface_blit(tile_nw, (left, top))
-        surface_blit(tile_sw, (left, inner.bottom))
-        surface_blit(tile_ne, (inner.right, top))
-        surface_blit(tile_se, (inner.right, inner.bottom))
+        # Draw corner tiles
+        surface_blit(self._tiles["nw"], (left, top))
+        surface_blit(self._tiles["sw"], (left, inner.bottom))
+        surface_blit(self._tiles["ne"], (inner.right, top))
+        surface_blit(self._tiles["se"], (inner.right, inner.bottom))
 
 
 def guest_font_height(font: Font) -> int:


### PR DESCRIPTION
PR improves the `GraphicBox` implementation by refactoring internal tile handling and extracting a reusable `TileLayout` utility.

Key Changes:
- refactored tile storage: swapped the `_tiles` list for a dictionary with semantic keys (`"nw"`, `"n"`, `"c"`, etc.) and eliminates index confusion and makes the border logic easier to follow
- introduced `TileLayout` class: handles all image-splitting and tile-labeling logic in a dedicated utility, supports potential extension to other grid sizes in the future and makes `GraphicBox` cleaner by offloading image parsing responsibilities
- improved semantic clarity: tile roles are explicitly labeled, making the code more self-documenting and readable
- updated rendering logic: all `blit` operations now reference tile labels by name rather than position and rendering behavior remains consistent with the previous implementation
- added defensive validation: raises errors if image dimensions are not divisible by grid size and ensures the correct number of tiles is extracted
- triggered image update: added `self._needs_update = True` to signal changes when setting a new border