### PR TITLE
Refactor Monster Stats into Structured Dataclasses

### DIFF
--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -155,8 +155,8 @@ class TestCanEvolve(unittest.TestCase):
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_stats_match(self):
-        self.mon.hp = 30
-        self.mon.melee = 20
+        self.mon.base_stats.hp = 30
+        self.mon.base_stats.melee = 20
         evo = MonsterEvolutionItemModel(
             monster_slug="rockat", stats="hp:greater_or_equal:melee"
         )
@@ -164,8 +164,8 @@ class TestCanEvolve(unittest.TestCase):
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_stats_mismatch(self):
-        self.mon.speed = 5
-        self.mon.armour = 10
+        self.mon.base_stats.speed = 5
+        self.mon.base_stats.armour = 10
         evo = MonsterEvolutionItemModel(
             monster_slug="rockat", stats="speed:greater_or_equal:armour"
         )

--- a/tuxemon/core/effects/buff.py
+++ b/tuxemon/core/effects/buff.py
@@ -38,11 +38,21 @@ class BuffEffect(CoreEffect):
         amount = target.return_stat(StatType(self.statistic))
         value = int(amount * self.percentage)
 
-        target.armour += value if self.statistic == StatType.armour else 0
-        target.dodge += value if self.statistic == StatType.dodge else 0
-        target.hp += value if self.statistic == StatType.hp else 0
-        target.melee += value if self.statistic == StatType.melee else 0
-        target.speed += value if self.statistic == StatType.speed else 0
-        target.ranged += value if self.statistic == StatType.ranged else 0
+        target.base_stats.armour += (
+            value if self.statistic == StatType.armour else 0
+        )
+        target.base_stats.dodge += (
+            value if self.statistic == StatType.dodge else 0
+        )
+        target.base_stats.hp += value if self.statistic == StatType.hp else 0
+        target.base_stats.melee += (
+            value if self.statistic == StatType.melee else 0
+        )
+        target.base_stats.speed += (
+            value if self.statistic == StatType.speed else 0
+        )
+        target.base_stats.ranged += (
+            value if self.statistic == StatType.ranged else 0
+        )
 
         return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -643,7 +643,7 @@ def calculate_base_stats(
             modifier = 0
 
         final_value = base_value + modifier
-        setattr(monster, stat, final_value)
+        setattr(monster.base_stats, stat, final_value)
 
 
 def apply_stat_updates(
@@ -654,7 +654,7 @@ def apply_stat_updates(
 
     for attr in attributes:
         setattr(
-            monster,
+            monster.base_stats,
             attr,
             update_stat(attr, getattr(monster, attr), taste_cold, taste_warm),
         )

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import random
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID, uuid4
 
@@ -68,7 +68,9 @@ SIMPLE_PERSISTANCE_ATTRIBUTES = (
 
 
 @dataclass
-class ModifierStats:
+class BasicStats:
+    """The fundamental statistical attributes of a monster."""
+
     armour: int = 0
     dodge: int = 0
     hp: int = 0
@@ -76,12 +78,25 @@ class ModifierStats:
     ranged: int = 0
     speed: int = 0
 
+    def sum(self) -> int:
+        total = sum(int(getattr(self, field.name)) for field in fields(self))
+        return total
+
+
+@dataclass
+class TemporaryStatBoosts(BasicStats):
+    """Temporary additive boosts to a monster's base stats."""
+
     def to_dict(self) -> dict[str, int]:
-        return self.__dict__
+        return {
+            field.name: getattr(self, field.name) for field in fields(self)
+        }
 
     @classmethod
-    def from_dict(cls, data: dict[str, int]) -> ModifierStats:
-        return cls(**data)
+    def from_dict(cls, data: dict[str, int]) -> TemporaryStatBoosts:
+        valid_fields = {field.name for field in fields(cls)}
+        filtered_data = {k: v for k, v in data.items() if k in valid_fields}
+        return cls(**filtered_data)
 
 
 # class definition for tuxemon flairs:
@@ -108,18 +123,14 @@ class Monster:
         self.description: str = ""
         self.instance_id: UUID = uuid4()
 
-        self.armour: int = 0
-        self.dodge: int = 0
-        self.melee: int = 0
-        self.ranged: int = 0
-        self.speed: int = 0
+        self.base_stats: BasicStats = BasicStats()
         self.current_hp: int = 0
-        self.hp: int = 0
+
         self.level: int = 0
         self.steps: float = 0.0
         self.bond: int = prepare.BOND
 
-        self.modifiers = ModifierStats()
+        self.modifiers = TemporaryStatBoosts()
 
         self.moves = MonsterMovesHandler()
         self.evolutions: list[MonsterEvolutionItemModel] = []
@@ -189,6 +200,30 @@ class Monster:
         method = cls(save_data)
         method.load(slug)
         return method
+
+    @property
+    def armour(self) -> int:
+        return self.base_stats.armour
+
+    @property
+    def dodge(self) -> int:
+        return self.base_stats.dodge
+
+    @property
+    def hp(self) -> int:
+        return self.base_stats.hp
+
+    @property
+    def melee(self) -> int:
+        return self.base_stats.melee
+
+    @property
+    def ranged(self) -> int:
+        return self.base_stats.ranged
+
+    @property
+    def speed(self) -> int:
+        return self.base_stats.speed
 
     @property
     def hp_ratio(self) -> float:


### PR DESCRIPTION
PR introduces a set of improvements and refinements to how monster stats are structured and managed:
- renamed `ModifierStats` to `TemporaryStatBoosts` for clearer intent and readability
- introduced `BasicStats` as the foundational container for a monster’s core statistics (`hp`, `speed`, etc.)
- updated monsters to use `base_stats: BasicStats` for storing core values and `modifiers: TemporaryStatBoosts` for transient bonuses
- preserved inheritance between `BasicStats` and `TemporaryStatBoosts` to ensure consistent field structure
- preserved and updated `to_dict()` and `from_dict()` methods on `TemporaryStatBoosts` to support clean serialization and deserialization workflows
- moved property accessors (`armour`, `dodge`, etc.) onto the `Monster` class for simplified usage and future extensibility