### PR TITLE
Improve `add_item` and `remove_item` with Quantity Support

### DIFF
--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -119,8 +119,7 @@ def load_party_items(
             npc_item.variables, game_variables
         ):
             item = Item.create(npc_item.slug, npc_item.model_dump())
-            item.set_quantity(npc_item.quantity)
-            npc.items.add_item(item)
+            npc.items.add_item(item, npc_item.quantity)
 
 
 def check_variables(

--- a/tuxemon/states/items/shop_menu.py
+++ b/tuxemon/states/items/shop_menu.py
@@ -295,8 +295,7 @@ class TransactionManager:
             in_bag.increase_quantity(quantity)
         else:
             new_item = Item.create(item.slug)
-            new_item.set_quantity(quantity)
-            buyer.items.add_item(new_item)
+            buyer.items.add_item(new_item, quantity)
 
         price = self.economy.lookup_item_price(item.slug)
         total_cost = quantity * price
@@ -304,11 +303,7 @@ class TransactionManager:
 
     def sell_item(self, seller: NPC, item: Item, quantity: int) -> None:
         """Process selling of items."""
-        remaining_quantity = item.quantity - quantity
-        if remaining_quantity <= 0:
-            seller.items.remove_item(item)
-        else:
-            item.set_quantity(remaining_quantity)
+        seller.items.remove_item(item, quantity)
 
         cost = self.economy.lookup_item(item.slug, "cost")
         if cost is None:

--- a/tuxemon/states/pc_locker/__init__.py
+++ b/tuxemon/states/pc_locker/__init__.py
@@ -138,23 +138,21 @@ class ItemTakeState(PygameMenuState):
         def take(itm: Item, quantity: int) -> None:
             self.client.remove_state_by_name("ChoiceState")
             self.client.remove_state_by_name("ItemTakeState")
+
             diff = itm.quantity - quantity
             retrieve = self.char.items.find_item(itm.slug)
+
             if diff <= 0:
                 self.item_boxes.remove_item(itm)
-                if retrieve is not None:
-                    retrieve.increase_quantity(quantity)
-                else:
-                    self.char.items.add_item(itm)
             else:
                 itm.set_quantity(diff)
-                if retrieve is not None:
-                    retrieve.increase_quantity(quantity)
-                else:
-                    # item deposited
-                    new_item = Item.create(itm.slug)
-                    new_item.set_quantity(quantity)
-                    self.char.items.add_item(new_item)
+
+            if retrieve:
+                retrieve.increase_quantity(quantity)
+            else:
+                new_item = Item.create(itm.slug)
+                self.char.items.add_item(new_item, quantity)
+
             open_dialog(
                 self.client,
                 [
@@ -388,51 +386,33 @@ class ItemDropOff(ItemMenuState):
 
         def deposit(itm: Item, quantity: int) -> None:
             self.client.pop_state(self)
-            if not quantity:
+            if quantity <= 0:
                 return
 
-            # item deposited
-            new_item = Item.create(itm.slug)
-            diff = itm.quantity - quantity
             item_boxes = self.char.item_boxes
-
             box = item_boxes.get_items(self.box_name)
 
-            def find_monster_box(itm: Item, box: list[Item]) -> Optional[Item]:
-                for ele in box:
-                    if ele.slug == itm.slug:
-                        return ele
-                return None
+            new_item = Item.create(itm.slug)
+            new_item.set_quantity(quantity)
 
-            if box:
-                retrieve = find_monster_box(itm, box)
-                if retrieve is not None:
-                    stored = item_boxes.get_items_by_iid(retrieve.instance_id)
-                    if stored is not None:
-                        if diff <= 0:
-                            stored.increase_quantity(quantity)
-                            self.char.items.remove_item(itm)
-                        else:
-                            stored.increase_quantity(quantity)
-                            itm.set_quantity(diff)
-                else:
-                    if diff <= 0:
-                        new_item.set_quantity(quantity)
-                        item_boxes.add_item(self.box_name, new_item)
-                        self.char.items.remove_item(itm)
-                    else:
-                        itm.set_quantity(diff)
-                        new_item.set_quantity(quantity)
-                        item_boxes.add_item(self.box_name, new_item)
+            def find_item_in_box(
+                slug: str, items: list[Item]
+            ) -> Optional[Item]:
+                return next((i for i in items if i.slug == slug), None)
+
+            retrieve = find_item_in_box(itm.slug, box) if box else None
+            stored = (
+                item_boxes.get_items_by_iid(retrieve.instance_id)
+                if retrieve
+                else None
+            )
+
+            if stored:
+                stored.increase_quantity(quantity)
             else:
-                if diff <= 0:
-                    new_item.set_quantity(quantity)
-                    item_boxes.add_item(self.box_name, new_item)
-                    self.char.items.remove_item(itm)
-                else:
-                    itm.set_quantity(diff)
-                    new_item.set_quantity(quantity)
-                    item_boxes.add_item(self.box_name, new_item)
+                item_boxes.add_item(self.box_name, new_item)
+
+            self.char.items.remove_item(itm, quantity)
 
         self.client.push_state(
             QuantityMenu(

--- a/tuxemon/states/phone/phone.py
+++ b/tuxemon/states/phone/phone.py
@@ -51,15 +51,10 @@ class NuPhone(PygameMenuState):
             open_dialog(self.client, [no_signal])
 
         def _uninstall(itm: Item) -> None:
-            count = self.char.items.count_item(itm.slug)
-            if count > 1:
-                self.char.items.remove_item(itm)
-                self.client.replace_state("NuPhone", character=self.char)
-            else:
-                open_dialog(
-                    self.client,
-                    [T.translate("uninstall_app")],
-                )
+            open_dialog(
+                self.client,
+                [T.translate("uninstall_app")],
+            )
 
         menu._column_max_width = [
             fix_measure(menu._width, 0.25),


### PR DESCRIPTION
PR enhances the `add_item` and `remove_item` methods by allowing direct specification of item quantity, making inventory updates cleaner and more intuitive (split from #2914)

Changes:
- `add_item(item, quantity=1)` now supports an optional `quantity` argument
- `remove_item(item, quantity=1)` now supports partial quantity removal; when the remaining amount drops to zero or below, the item is automatically removed from the inventory
- automatically sets the item’s quantity when adding new items to the bag
- reduces the need for manual `set_quantity()` calls after item creation
- removed the deprecated `count_item` method, which only counted stack instances and not actual quantities, this caused bugs in inventory checks, now that `add_item()` properly handles quantities, the issue is fully resolved
- added `Item.test()` class method to facilitate clean test instance creation without requiring database loading or complex mocking; simplifies unit test setup and improves isolation