### PR TITLE
Fix crash on `random_encounter` Event Action + Fix crash `StatChangeEffect` + Refactor `StatChangeEffect` 

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -5136,7 +5136,7 @@ msgstr ""
 " see a GUPPHIRE believe it means they will have good luck all year."
 
 msgid "gupphire"
-msgstr "gupphire"
+msgstr "Gupphire"
 
 msgid "gupphish_description"
 msgstr ""
@@ -5144,7 +5144,7 @@ msgstr ""
 "who value teamwork."
 
 msgid "gupphish"
-msgstr "gupphish"
+msgstr "Gupphish"
 
 msgid "hampotamos_description"
 msgstr "It nibbles on RINOCEREED, clearing away dead skin, moss and weeds."

--- a/tuxemon/core/effects/photogenesis.py
+++ b/tuxemon/core/effects/photogenesis.py
@@ -36,13 +36,12 @@ class PhotogenesisEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         combat = tech.get_combat_state()
-        player = user.get_owner()
         extra: list[str] = []
         done: bool = False
 
         tech.hit = tech.accuracy >= combat.get_tech_hit(user)
 
-        hour = int(player.game_variables.get("hour", 0))
+        hour = int(session.player.game_variables.get("hour", 0))
         hp = user.shape.attributes.hp
         max_multiplier = hp / 2
 

--- a/tuxemon/core/effects/run.py
+++ b/tuxemon/core/effects/run.py
@@ -29,10 +29,9 @@ class RunEffect(CoreEffect):
         extra: list[str] = []
         ran: bool = False
         combat = tech.get_combat_state()
-        self.player = user.get_owner()
         self.session = session
 
-        game_variables = self.player.game_variables
+        game_variables = session.player.game_variables
         attempts = game_variables.get("run_attempts", 0)
 
         method = self._determine_escape_method(combat, user, game_variables)

--- a/tuxemon/core/effects/statchange.py
+++ b/tuxemon/core/effects/statchange.py
@@ -2,12 +2,13 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, StatusEffectResult
-from tuxemon.db import EffectPhase
+from tuxemon.db import EffectPhase, StatType
 from tuxemon.tools import ops_dict
 
 if TYPE_CHECKING:
@@ -15,22 +16,47 @@ if TYPE_CHECKING:
     from tuxemon.session import Session
     from tuxemon.status.status import Status
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class StatChangeEffect(CoreEffect):
     """
-    Change combat stats.
+    Applies a stat-altering effect to a target monster during combat.
 
-    JSON SYNTAX:
-        value: The number to change the stat by, default is add, use
-            negative to subtract.
-        dividing: Set this to True to divide instead of adding or
-            subtracting the value.
-        overridetofull: In most cases you won't need this. If ``True`` it
-            will set the stat to its original value rather than the
-            specified value, but due to the way the
-            game is coded, it currently only works on hp.
+    This effect modifies one or more combat-relevant stats on a monster, either
+    through addition, subtraction, or division, depending on configuration. The affected
+    stats are pulled from the status's stat components (e.g. `status.statmelee`, etc.),
+    and can impact either permanent base stats or temporary health values.
 
+    This class supports optional randomness via `max_deviation`, and HP overrides using
+    `overridetofull` which resets current HP to the max HP.
+
+    Effect Trigger:
+        - Only applies if the status has phase `PERFORM_STATUS`.
+
+    JSON SYNTAX (per stat object inside Status):
+        {
+            "value": int,               # Amount to apply to the stat (positive or negative)
+            "max_deviation": int,       # Optional random deviation applied to value
+            "operation": str,           # Operation: "add", "subtract", "divide" (from ops_dict)
+            "overridetofull": bool      # Special case for HP: resets current HP to max HP if True
+        }
+
+    Stats Supported:
+        - speed
+        - armour
+        - melee
+        - ranged
+        - dodge
+        - hp         > modifies base_stats.hp
+        - current_hp > modifies runtime health
+
+    Attributes:
+        name: Effect name, used for identification and serialization.
+
+    Returns:
+        StatusEffectResult: Indicates if the stat change was successful and references the status name.
     """
 
     name = "statchange"
@@ -48,32 +74,59 @@ class StatChangeEffect(CoreEffect):
         ]
         statslugs = [
             "speed",
-            "current_hp",
+            "current_hp",  # special case
             "armour",
             "melee",
             "ranged",
             "dodge",
         ]
         newstatvalue = 0
+
         if status.has_phase(EffectPhase.PERFORM_STATUS):
-            for stat, slugdata in zip(statsmaster, statslugs):
+            for stat, slug in zip(statsmaster, statslugs):
                 if not stat:
                     continue
-                value = stat.value
-                max_deviation = stat.max_deviation
-                operation = stat.operation
-                override = stat.overridetofull
-                basestatvalue = getattr(target, slugdata)
-                min_value = value - max_deviation
-                max_value = value + max_deviation
-                if max_deviation:
-                    value = random.randint(int(min_value), int(max_value))
 
-                if value > 0 and not override:
-                    newstatvalue = ops_dict[operation](basestatvalue, value)
-                if slugdata == "current_hp" and override:
+                value = stat.value
+                max_dev = stat.max_deviation
+                override = stat.overridetofull
+                operation = stat.operation
+
+                # Apply deviation properly for positive or negative values
+                if max_dev:
+                    min_val = value - max_dev
+                    max_val = value + max_dev
+                    value = random.randint(int(min_val), int(max_val))
+
+                # Handle HP override explicitly
+                if slug == "current_hp" and override:
                     target.current_hp = target.hp
+                    logger.info(
+                        f"[{status.name}] Overriding current HP > {target.name}: {target.hp}"
+                    )
+                    continue
+
+                base_value = (
+                    getattr(target, slug)
+                    if slug == "current_hp"
+                    else getattr(target.base_stats, slug, None)
+                )
+                if base_value is None:
+                    continue
+
+                newstatvalue = ops_dict[operation](base_value, value)
+
                 if newstatvalue <= 0:
-                    newstatvalue = 1
-                setattr(target, slugdata, newstatvalue)
+                    newstatvalue = 1  # avoid death via stat drop
+
+                # Assign value
+                if slug == "current_hp":
+                    setattr(target, slug, newstatvalue)
+                elif slug in StatType.__members__:
+                    setattr(target.base_stats, slug, newstatvalue)
+
+                logger.debug(
+                    f"[{status.name}] {slug} changed on {target.name}: {base_value} > {newstatvalue}"
+                )
+
         return StatusEffectResult(name=status.name, success=bool(newstatvalue))

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -17,7 +17,6 @@ from tuxemon.graphics import ColorLike, string_to_colorlike
 from tuxemon.item.item import Item
 from tuxemon.monster import Monster
 from tuxemon.session import Session
-from tuxemon.states.world.worldstate import WorldState
 
 logger = logging.getLogger(__name__)
 
@@ -121,9 +120,8 @@ class RandomEncounterAction(EventAction):
             battle_mode="single",
         )
 
-        self.world = session.client.get_state_by_name(WorldState)
-        self.world.movement.lock_controls(player)
-        self.world.movement.stop_char(player)
+        session.client.movement_manager.lock_controls(player)
+        session.client.movement_manager.stop_char(player)
 
         rgb: ColorLike = prepare.WHITE_COLOR
         if self.rgb:

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -553,7 +553,7 @@ class CombatState(CombatAnimations):
 
         self.field_monsters.add_monster(player, monster)
         self.animate_monster_release(player, monster, sprite)
-        self.update_hud(player)
+        self.update_hud(player, True, True)
 
         # Remove "bond" status from all active monsters
         for mon in self.active_monsters:
@@ -678,7 +678,7 @@ class CombatState(CombatAnimations):
         while recharging moves and triggering AI actions for NPCs.
         """
         for player in list(self.active_players):
-            self.update_hud(player, False)
+            self.update_hud(player, False, False)
             monsters = self.field_monsters.get_monsters(player)
             for monster in monsters:
                 if player in self.human_players:
@@ -1073,7 +1073,7 @@ class CombatState(CombatAnimations):
             owner = winner.get_owner()
             if owner.isplayer:
                 self.task(partial(self.animate_exp, winner), 2.5)
-                self.task(partial(self.update_hud, owner, False), 3.2)
+                self.task(partial(self.update_hud, owner, False, True), 3.2)
 
     def animate_party_status(self) -> None:
         """

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -596,7 +596,7 @@ class CombatAnimations(Menu[None], ABC):
             enemy.rect.centerx = back_island.rect.centerx
             self.sprite_map.add_sprite(opp_mon, enemy)
             self.field_monsters.add_monster(opponent, opp_mon)
-            self.update_hud(opponent)
+            self.update_hud(opponent, True, True)
 
         self.sprites.add(enemy)
 
@@ -828,23 +828,41 @@ class CombatAnimations(Menu[None], ABC):
             blink_monster(breakout_delay)
             show_failure(breakout_delay)
 
-    def update_hud(self, character: NPC, animate: bool = True) -> None:
+    def update_hud(self, character: NPC, animate: bool, delete: bool) -> None:
         """
-        Updates hud (where it appears name, level, etc.).
+        Updates the Heads-Up Display (HUD) for monsters belonging to the given character.
 
         Parameters:
-            character: The character whose HUD needs to be updated.
-            animate: Whether to animate the HUD update. Defaults to True.
+            character: The character whose monsters' HUDs should be refreshed.
+            animate: Whether to animate HUD transitions.
+            delete: Whether to delete existing HUDs before updating.
         """
         monsters = self.field_monsters.get_monsters(character)
         if not monsters:
             return
 
+        if delete:
+            self._delete_monster_huds(monsters)
+
         alive_members = alive_party(character)
         if len(monsters) > 1 and len(monsters) <= len(alive_members):
-            for i, monster in enumerate(monsters):
-                self.hud_manager.delete_hud(monster)
-                self.build_hud(monster, f"hud{i}", animate)
+            self._update_multiple_huds(monsters, animate)
         else:
-            self.hud_manager.delete_hud(monsters[0])
-            self.build_hud(monsters[0], "hud", animate)
+            self._update_single_hud(monsters[0], animate)
+
+    def _delete_monster_huds(self, monsters: list[Monster]) -> None:
+        """Deletes the HUDs of all given monsters."""
+        for monster in monsters:
+            self.hud_manager.delete_hud(monster)
+
+    def _update_multiple_huds(
+        self, monsters: list[Monster], animate: bool
+    ) -> None:
+        """Updates HUDs for multiple monsters with indexed HUD positions."""
+        for i, monster in enumerate(monsters):
+            hud_id = f"hud{i}"
+            self.build_hud(monster, hud_id, animate)
+
+    def _update_single_hud(self, monster: Monster, animate: bool) -> None:
+        """Updates the HUD for a single monster using a default HUD ID."""
+        self.build_hud(monster, "hud", animate)

--- a/tuxemon/states/combat/combat_menus_park.py
+++ b/tuxemon/states/combat/combat_menus_park.py
@@ -68,7 +68,7 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
 
     def initialize_items(self) -> Generator[MenuItem[MenuGameObj], None, None]:
         self.combat.hud_manager.delete_hud(self.monster)
-        self.combat.update_hud(self.player, False)
+        self.combat.update_hud(self.player, False, True)
 
         menu_items_map = (
             (ParkMenuKeys.BALL, "menu_ball", self.throw_tuxeball),


### PR DESCRIPTION
PR addresses a crash occurring during the `random_encounter` event. The fix adapts the implementation to use the `movement_manager` passed through the client (before the world).

Refactored `StatChangeEffect` to fix a crash caused by improper `setattr` usage - it was trying to assign to `dodge` directly instead of `base_stats.dodge`. Took the opportunity to fully rewrite the effect for clarity. The new version ensures `current_hp` override is clean, handles both positive and negative deviations properly, and includes logging to help trace stat changes during battle.

Refactored the `update_hud` method to prevent unnecessary reloading of HP and EXP bars at the end of each turn. Previously, HUD elements were deleted and rebuilt regardless of context, which led to jarring UI refreshes - particularly noticeable when no significant changes (like level-ups or monster swaps) occurred.

`Photogenesis` kept failing for the opponent because they tried to access the `hour` variable from the NPC. Since that variable didn’t exist, it defaulted to `0`, which corresponds to midnight. I’ve since resolved the issue by ensuring the correct time reference is provided, allowing `Photogenesis` to function as intended.