### PR TITLE
Introduce Activation Lifecycle for `ParkSession` with Runtime Validation

### DIFF
--- a/mods/tuxemon/maps/spyder_park.yaml
+++ b/mods/tuxemon/maps/spyder_park.yaml
@@ -1,7 +1,7 @@
 events:
   Alert 100:
     actions:
-    - translated_dialog spyder_park_steps100
+    - translated_dialog spyder_park_steps100,,center,center
     conditions:
     - is step_tracker player,steps_park,100
     type: event
@@ -289,7 +289,6 @@ events:
     - transition_teleport spyder_park_entrance.tmx,5,4,0.3
     - char_face player,up
     - add_item tuxeball_park,-25
-    - clear_variable park_out
     - park_experience stop
     - remove_step_tracker player,steps_park
     conditions:
@@ -407,7 +406,6 @@ events:
     actions:
     - transition_teleport spyder_park_entrance.tmx,5,4,0.3
     - char_face player,up
-    - clear_variable park_out
     - park_experience stop
     conditions:
     - not has_item player,tuxeball_park

--- a/mods/tuxemon/maps/spyder_park_cave.yaml
+++ b/mods/tuxemon/maps/spyder_park_cave.yaml
@@ -1,7 +1,7 @@
 events:
   Alert 100:
     actions:
-    - translated_dialog spyder_park_steps100
+    - translated_dialog spyder_park_steps100,,center,center
     conditions:
     - is step_tracker player,steps_park,100
     type: event
@@ -29,7 +29,6 @@ events:
     - transition_teleport spyder_park_entrance.tmx,5,4,0.3
     - char_face player,up
     - add_item tuxeball_park,-25
-    - clear_variable park_out
     - park_experience stop
     - remove_step_tracker player,steps_park
     conditions:
@@ -75,7 +74,6 @@ events:
     actions:
     - transition_teleport spyder_park_entrance.tmx,5,4,0.3
     - char_face player,up
-    - clear_variable park_out
     - park_experience stop
     conditions:
     - not has_item player,tuxeball_park

--- a/mods/tuxemon/maps/spyder_park_south.yaml
+++ b/mods/tuxemon/maps/spyder_park_south.yaml
@@ -1,7 +1,7 @@
 events:
   Alert 100:
     actions:
-    - translated_dialog spyder_park_steps100
+    - translated_dialog spyder_park_steps100,,center,center
     conditions:
     - is step_tracker player,steps_park,100
     type: event
@@ -182,7 +182,6 @@ events:
     - transition_teleport spyder_park_entrance.tmx,5,4,0.3
     - char_face player,up
     - add_item tuxeball_park,-25
-    - clear_variable park_out
     - park_experience stop
     - remove_step_tracker player,steps_park
     conditions:
@@ -252,7 +251,6 @@ events:
     actions:
     - transition_teleport spyder_park_entrance.tmx,5,4,0.3
     - char_face player,up
-    - clear_variable park_out
     - park_experience stop
     conditions:
     - not has_item player,tuxeball_park

--- a/tuxemon/event/actions/park_experience.py
+++ b/tuxemon/event/actions/park_experience.py
@@ -32,29 +32,28 @@ class ParkExperienceAction(EventAction):
 
     def start(self, session: Session) -> None:
         if self.option == "start":
-            pass
+            session.client.park_session.activate_session()
         elif self.option == "stop":
+            session.client.park_session.deactivate_session()
             self._handle_stop(session)
         else:
             raise ValueError(f"{self.option} must be 'start' or 'stop'")
 
     def _handle_stop(self, session: Session) -> None:
         self.client = session.client
+        session.player.game_variables.pop("park_out", None)
 
         if self.client.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
-        if self.client.current_state.name == "ParkState":
-            logger.error(
-                f"The state 'ParkState' is already active. No action taken."
-            )
-            return
-
         self.client.push_state("ParkState", session=session)
 
     def update(self, session: Session) -> None:
-        try:
-            session.client.get_state_by_name("ParkState")
-        except ValueError:
-            session.client.park_session.reset_session()
+        if self.option == "stop":
+            try:
+                session.client.get_state_by_name("ParkState")
+            except ValueError:
+                session.client.park_session.reset_session()
+                self.stop()
+        else:
             self.stop()

--- a/tuxemon/park_tracker.py
+++ b/tuxemon/park_tracker.py
@@ -88,11 +88,37 @@ class ParkSession:
         self.tracker = ParkTracker()
         self.encounters: dict[str, ParkEncounter] = {}
         self.encounter_history: dict[str, list[ParkEncounter]] = {}
+        self._is_active: bool = False
+
+    @property
+    def is_active(self) -> bool:
+        """
+        Returns True if the park session is currently active, False otherwise.
+        """
+        return self._is_active
+
+    def activate_session(self) -> None:
+        """Activates the park session."""
+        if not self._is_active:
+            self._is_active = True
+            logger.info("Park session activated.")
+        else:
+            logger.debug("Park session is already active.")
+
+    def deactivate_session(self) -> None:
+        """Deactivates the park session."""
+        if self._is_active:
+            self._is_active = False
+            logger.info("Park session deactivated.")
+        else:
+            logger.debug("Park session is already inactive.")
 
     def reset_session(self) -> None:
         self.tracker.clear_all()
         self.encounters.clear()
         self.encounter_history.clear()
+        self._is_active = False
+        logger.info("Park session reset and deactivated.")
 
     def record_capture(self) -> None:
         self.tracker.record_successful_capture()

--- a/tuxemon/states/combat/combat_menus_park.py
+++ b/tuxemon/states/combat/combat_menus_park.py
@@ -50,6 +50,10 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
         self.enemy = cmb.players[1]  # ai
         self.monster = monster
         self.opponents = cmb.field_monsters.get_monsters(self.enemy)
+        if not self.client.park_session.is_active:
+            raise ValueError(
+                "Use the event action 'park_experience start' to enable the Park Session"
+            )
         self.encounter = session.client.park_session.start_encounter(
             self.opponents[0]
         )


### PR DESCRIPTION
PR enhances the `ParkSession` class by introducing lifecycle management through an activation flag and supporting methods.

Key changes:
- added `_is_active` flag with a corresponding `is_active` property to track session state
- implemented `activate_session()` and `deactivate_session()` methods for controlled session management
- sessions are now initiated via the `park_experience start` event action and terminated via `park_experience stop`
- if a session is accessed or an encounter is triggered without activation (`start` not invoked), a `ValueError` will be raised to prevent undefined behavior during the first meeting