### PR TITLE
Refactor `PCState` Menu Creation with `PCMenuBuilder` and Modular `MenuProvider` System

### DIFF
--- a/tuxemon/event/actions/access_pc.py
+++ b/tuxemon/event/actions/access_pc.py
@@ -9,6 +9,7 @@ from typing import final
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
+from tuxemon.states.pc import PCMenuBuilder
 
 logger = logging.getLogger()
 
@@ -54,7 +55,12 @@ class AccessPCAction(EventAction):
             )
             return
 
-        self.client.push_state("PCState", character=character)
+        menu_builder = PCMenuBuilder(
+            client=self.client, character=character, menu_providers=None
+        )
+        self.client.push_state(
+            "PCState", character=character, menu_builder=menu_builder
+        )
 
     def update(self, session: Session) -> None:
         try:

--- a/tuxemon/states/pc/__init__.py
+++ b/tuxemon/states/pc/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import pygame_menu
 
@@ -16,6 +16,7 @@ from tuxemon.state import State
 from tuxemon.tools import open_dialog
 
 if TYPE_CHECKING:
+    from tuxemon.client import LocalPygameClient
     from tuxemon.npc import NPC
 
 MenuGameObj = Callable[[], object]
@@ -30,10 +31,101 @@ def add_menu_items(
         menu.add.button(label, callback)
 
 
+class MenuProvider:
+    def get_menu_items(
+        self, client: LocalPygameClient, character: NPC
+    ) -> list[tuple[str, MenuGameObj]]:
+        raise NotImplementedError
+
+
+class PCMenuBuilder:
+    """Builds the menu items for the PCState."""
+
+    def __init__(
+        self,
+        client: LocalPygameClient,
+        character: NPC,
+        menu_providers: Optional[list[MenuProvider]] = None,
+    ) -> None:
+        self.client = client
+        self.character = character
+        self.menu_providers = (
+            menu_providers if menu_providers is not None else []
+        )
+
+    def _change_state(self, state: str, **kwargs: Any) -> partial[State]:
+        return partial(self.client.replace_state, state, **kwargs)
+
+    def _not_implemented_dialog(self) -> None:
+        open_dialog(self.client, [T.translate("not_implemented")])
+
+    def build_menu_items(self) -> list[tuple[str, MenuGameObj]]:
+        char = self.character
+        menu: list[tuple[str, MenuGameObj]] = []
+
+        # Monster box logic
+        if len(char.monsters) == prepare.PARTY_LIMIT:
+            monster_storage_callback = partial(
+                open_dialog,
+                self.client,
+                [T.translate("menu_storage_monsters_full")],
+            )
+        else:
+            monster_storage_callback = self._change_state(
+                "MonsterStorageState", character=char
+            )
+
+        if char.monster_boxes.get_all_monsters_visible():
+            menu.append(("menu_storage", monster_storage_callback))
+
+        if len(char.monsters) > 1:
+            menu.append(
+                (
+                    "menu_dropoff",
+                    self._change_state("MonsterDropOffState", character=char),
+                )
+            )
+
+        # Item box logic
+        if len(char.items.get_items()) == prepare.MAX_LOCKER:
+            item_storage_callback = partial(
+                open_dialog,
+                self.client,
+                [T.translate("menu_storage_items_full")],
+            )
+        else:
+            item_storage_callback = self._change_state(
+                "ItemStorageState", character=char
+            )
+
+        if char.item_boxes.get_all_items_visible():
+            menu.append(("menu_item_storage", item_storage_callback))
+
+        if len(char.items.get_items()) > 1:
+            menu.append(
+                (
+                    "menu_item_dropoff",
+                    self._change_state("ItemDropOffState", character=char),
+                )
+            )
+
+        # Other menu items
+        menu.append(("menu_multiplayer", self._not_implemented_dialog))
+        menu.append(("log_off", self.client.pop_state))
+
+        # Collect items from all injected providers
+        for provider in self.menu_providers:
+            menu.extend(provider.get_menu_items(self.client, self.character))
+
+        return menu
+
+
 class PCState(PygameMenuState):
     """The PC State: deposit monster, deposit item, etc."""
 
-    def __init__(self, character: NPC) -> None:
+    def __init__(
+        self, character: NPC, menu_builder: Optional[PCMenuBuilder] = None
+    ) -> None:
         super().__init__()
         kennel = prepare.KENNEL
         locker = prepare.LOCKER
@@ -45,55 +137,13 @@ class PCState(PygameMenuState):
         if not char.item_boxes.has_box(locker, "item"):
             char.item_boxes.create_box(locker, "item")
 
-        def change_state(state: str, **kwargs: Any) -> partial[State]:
-            return partial(self.client.replace_state, state, **kwargs)
-
-        # monster boxes
-        if len(char.monsters) == prepare.PARTY_LIMIT:
-            storage = partial(
-                open_dialog,
-                self.client,
-                [T.translate("menu_storage_monsters_full")],
-            )
+        if menu_builder is None:
+            self.menu_builder = PCMenuBuilder(self.client, char)
         else:
-            storage = change_state("MonsterStorageState", character=char)
+            self.menu_builder = menu_builder
 
-        dropoff = change_state("MonsterDropOffState", character=char)
-
-        # item boxes
-        if len(char.items.get_items()) == prepare.MAX_LOCKER:
-            storage = partial(
-                open_dialog,
-                self.client,
-                [T.translate("menu_storage_items_full")],
-            )
-        else:
-            item_storage = change_state("ItemStorageState", character=char)
-
-        item_dropoff = change_state("ItemDropOffState", character=char)
-
-        def not_implemented_dialog() -> None:
-            open_dialog(self.client, [T.translate("not_implemented")])
-
-        multiplayer = change_state("MultiplayerMenu")
-
-        nr_monsters = len(char.monster_boxes.get_all_monsters_visible())
-        nr_items = len(char.item_boxes.get_all_items_visible())
-
-        menu: list[tuple[str, MenuGameObj]] = []
-        if nr_monsters > 0:
-            menu.append(("menu_storage", storage))
-        if len(char.monsters) > 1:
-            menu.append(("menu_dropoff", dropoff))
-        if nr_items > 0:
-            menu.append(("menu_item_storage", item_storage))
-        if len(char.items.get_items()) > 1:
-            menu.append(("menu_item_dropoff", item_dropoff))
-        # replace multiplayer when fixed
-        menu.append(("menu_multiplayer", not_implemented_dialog))
-        menu.append(("log_off", self.client.pop_state))
-
-        add_menu_items(self.menu, menu)
+        menu_items = self.menu_builder.build_menu_items()
+        add_menu_items(self.menu, menu_items)
 
     def update_animation_size(self) -> None:
         widgets_size = self.menu.get_size(widget=True)
@@ -103,16 +153,8 @@ class PCState(PygameMenuState):
         )
 
     def animate_open(self) -> Animation:
-        """
-        Animate the menu popping in.
-
-        Returns:
-            Popping in animation.
-
-        """
+        """Animate the menu popping in."""
         self.animation_size = 0.0
-
         ani = self.animate(self, animation_size=1.0, duration=0.2)
         ani.schedule(self.update_animation_size, ScheduleType.ON_UPDATE)
-
         return ani


### PR DESCRIPTION
PR introduces structural improvements to the `PCState` class by refactoring its menu creation logic into a new, reusable `PCMenuBuilder` class and adding a flexible `MenuProvider` interface for injecting custom menu items.

Key Changes:
- added `PCMenuBuilder`: encapsulates the logic for constructing PC menu items based on inventory and monster box state, replacing inline logic from `PCState`
- simplified `PCState`: delegates menu generation to `PCMenuBuilder`, resulting in a cleaner and more readable constructor
- introduced `MenuProvider`: a pluggable interface that allows external components to inject specific menu options dynamically
- supports dependency injection: `PCMenuBuilder` can accept a list of providers via `menu_providers`, making it extensible without modifying core logic
- modular design: default menu options (e.g. monster storage, item drop-off) remain inside the builder, while specialized logic can be outsourced to providers