### PR TITLE
Fix Wild Monster HUD Position in Single Battles

### DIFF
--- a/mods/combat_layouts.yaml
+++ b/mods/combat_layouts.yaml
@@ -21,10 +21,10 @@ LAYOUT_COORDINATES:
     hud: [145, 45, 110, 50] # fixed HUD for single monster
     # HUD position for the first monster in a 2 vs 2 setup
     hud0: [145, 25, 110, 50] # shifted upward for first HUD
-    status_icon0: [164, 61, 9, 9] # status icon aligned with hud0
+    monster_status_icon_slot_0: [164, 61, 9, 9] # status icon aligned with hud0
     # HUD position for the second monster in a 2 vs 2 setup
     hud1: [145, 45, 110, 50] # same as hud (fallback for 2nd monster)
-    status_icon1: [164, 81, 9, 9] # status icon aligned with hud
+    monster_status_icon_slot_1: [164, 81, 9, 9] # status icon aligned with hud
     # Tuxeball icon strip (left side, shows number of available monsters)
     party: [145, 57, 110, 50] # placed just below the HUD region
     # Monster box image position for single monster
@@ -47,9 +47,9 @@ LAYOUT_COORDINATES:
     home1: [155, 18, 95, 70]
     hud: [18, 0, 85, 30]
     hud0: [18, 0, 85, 30]
-    status_icon0: [15, 17, 9, 9]
+    monster_status_icon_slot_0: [15, 17, 9, 9]
     hud1: [18, 20, 85, 30]
-    status_icon1: [15, 37, 9, 9]
+    monster_status_icon_slot_1: [15, 37, 9, 9]
     party: [18, 12, 85, 30]
     monster_box_home: [187, 64, 1, 1]
     monster_box_home0: [172, 64, 1, 1]
@@ -63,9 +63,9 @@ LAYOUT_COORDINATES:
     home1: [55, 40, 95, 70]
     hud: [80, 20, 110, 50]
     hud0: [80, 5, 110, 50]
-    status_icon0: [99, 41, 9, 9]
+    monster_status_icon_slot_0: [99, 41, 9, 9]
     hud1: [80, 35, 110, 50]
-    status_icon1: [99, 71, 9, 9]
+    monster_status_icon_slot_1: [99, 71, 9, 9]
     party: [80, 50, 110, 50]
     monster_box_home: [117, 86, 1, 1]
     monster_box_home0: [102, 86, 1, 1]

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -123,7 +123,9 @@ class CombatAnimations(Menu[None], ABC):
         monster sprite moving into position, and the capture device opening animation.
         It also plays the combat call sound.
         """
-        self.hud_manager.assign(npc, monster, self.is_double)
+        self.hud_manager.assign(
+            len(self.players), npc, monster, self.is_double
+        )
         feet = self.hud_manager.get_feet_position(npc, monster)
 
         # Load and scale capture device sprite
@@ -512,6 +514,9 @@ class CombatAnimations(Menu[None], ABC):
         # Get player and opponent
         player, opponent = self.players
         opp_mon = opponent.monsters[0]
+        self.hud_manager.assign(
+            len(self.players), opponent, opp_mon, self.is_double
+        )
         player_home = self.hud_manager.get_rect(player, "home")
         opp_home = self.hud_manager.get_rect(opponent, "home")
 

--- a/tuxemon/ui/combat_hud.py
+++ b/tuxemon/ui/combat_hud.py
@@ -52,12 +52,20 @@ class CombatLayoutManager:
     def hud_map(self) -> dict[Monster, Sprite]:
         return self._hud_sprites
 
-    def assign(self, npc: NPC, monster: Monster, is_double: bool) -> None:
+    def assign(
+        self, nr_players: int, npc: NPC, monster: Monster, is_double: bool
+    ) -> None:
+        if monster in self._monster_ui:
+            logger.debug(f"{monster.name} already assigned, skipping.")
+            return
         side = Side.PLAYER if npc.isplayer else Side.OPPONENT
         slot_index = self.get_open_slot(npc)
 
-        if not is_double and side == Side.PLAYER:
+        if not is_double and nr_players == 2 and side == Side.PLAYER:
             slot_index = 1
+
+        if not is_double and nr_players == 2 and side == Side.OPPONENT:
+            slot_index = 0
 
         key = f"home{slot_index}" if is_double else "home"
         feet = self.get_feet_position(npc, monster)

--- a/tuxemon/ui/combat_status.py
+++ b/tuxemon/ui/combat_status.py
@@ -118,7 +118,7 @@ class StatusIconManager:
     ) -> tuple[float, float]:
         owner = monster.get_owner()
         layout_data = self._layouts.get(owner, {})
-        rects = layout_data.get(f"status_icon{index}", [])
+        rects = layout_data.get(f"monster_status_icon_slot_{index}", [])
         return rects[0].topleft if rects else (0, 0)
 
     def recalculate_icon_positions(self) -> None:


### PR DESCRIPTION
PR updates the `assign()` method in `CombatLayoutManager` to correctly position the HUD icon of wild monsters during single (non-double) battles. The fix ensures wild monsters are consistently assigned to slot index `0`, resolving layout misalignment issues. Target monsters were unaffected.