### PR TITLE
Clean up redundant test case in step tracker tests

### DIFF
--- a/tests/tuxemon/test_step_tracker.py
+++ b/tests/tuxemon/test_step_tracker.py
@@ -50,11 +50,6 @@ class TestStepTracker(unittest.TestCase):
         self.tracker.trigger_milestone_event(100)
         self.assertTrue(self.tracker.has_triggered_milestone(100))
 
-    def test_milestone_dialogue_shown(self):
-        self.tracker.trigger_milestone_event(100)
-        self.tracker.show_milestone_dialogue(100)
-        self.assertTrue(self.tracker.has_shown_milestone(100))
-
 
 class TestStepTrackerManager(unittest.TestCase):
 


### PR DESCRIPTION
## PR Summary
This small PR removes a duplicated test case `test_milestone_dialogue_shown` from `test_step_tracker.py`. The test was declared twice with the same logic, which could lead to unnecessary maintenance and confusion in future.