### PR TITLE
Improve Encounter Scaling and Filtering Mechanics

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4122,6 +4122,9 @@ msgstr "To The Bottom"
 msgid "menu_party_level_lowest"
 msgstr "Lowest Level"
 
+msgid "menu_party_alignment"
+msgstr "Alignment"
+
 msgid "menu_party_level_highest"
 msgstr "Highest Level"
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1418,13 +1418,32 @@ class EnvironmentModel(BaseModel, BaseLookupModel):
         raise ValueError(f"the music {v} doesn't exist in the db")
 
 
+class HeldItemProbability(BaseModel):
+    item_slug: str = Field(
+        ..., description="Slug of the item that can be held."
+    )
+    probability: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Probability (0.0-1.0) of this item being held.",
+    )
+
+    @field_validator("item_slug")
+    def item_exists(cls, v: str) -> str:
+        if not has.db_entry("item", v):
+            raise ValueError(f"the item '{v}' doesn't exist in the db")
+        return v
+
+
 class EncounterItemModel(BaseModel):
     monster: str = Field(..., description="Monster slug for this encounter")
     encounter_rate: float = Field(
         ..., description="Probability of encountering this monster."
     )
-    held_items: Sequence[str] = Field(
-        ..., description="A list of items that will be held."
+    held_items: Sequence[HeldItemProbability] = Field(
+        [],
+        description="A list of items that will be held with their probabilities.",
     )
     level_range: Sequence[int] = Field(
         ...,
@@ -1440,24 +1459,40 @@ class EncounterItemModel(BaseModel):
         description="Modifier for the experience points required to defeat this wild monster.",
         gt=0.0,
     )
+    level_offset: Optional[int] = Field(
+        None,
+        description="Offset (+/- levels) to apply to the monster's level.",
+    )
+    level_offset_range: Optional[tuple[int, int]] = Field(
+        None,
+        description="Range of offset (+/- levels) to apply randomly to base level.",
+    )
+    min_player_level: Optional[int] = Field(
+        None,
+        description="Minimum average level of player's party for this encounter.",
+    )
+    max_player_level: Optional[int] = Field(
+        None,
+        description="Maximum average level of player's party for this encounter.",
+    )
+    scaling_enabled: bool = Field(
+        False,
+        description="If true, scales the monster level based on player's party level average.",
+    )
+    override_level_range: bool = Field(
+        False,
+        description="If true, allows scaling to override a monster's declared level_range and match party average directly.",
+    )
+    scaling_offset_range: Optional[tuple[int, int]] = Field(
+        None,
+        description="Range used for random offset when scaling level overrides are applied (e.g. [-3, +4])",
+    )
 
     @field_validator("monster")
     def monster_exists(cls: EncounterItemModel, v: str) -> str:
         if has.db_entry("monster", v):
             return v
         raise ValueError(f"the monster {v} doesn't exist in the db")
-
-    @field_validator("held_items")
-    def item_exists(
-        cls: EncounterItemModel, v: Sequence[str]
-    ) -> Sequence[str]:
-        if v:
-            for item in v:
-                if not has.db_entry("item", item):
-                    raise ValueError(
-                        f"the item '{item}' doesn't exist in the db"
-                    )
-        return v
 
 
 class EncounterModel(BaseModel, BaseLookupModel):
@@ -1467,6 +1502,22 @@ class EncounterModel(BaseModel, BaseLookupModel):
     )
     monsters: Sequence[EncounterItemModel] = Field(
         [], description="Monsters encounterable"
+    )
+    scaling_zone: bool = Field(
+        False,
+        description="If true, this zone applies level scaling to all monsters",
+    )
+    scale_offset_range: Optional[tuple[int, int]] = Field(
+        None,
+        description="Custom offset range applied when scaling override is active (e.g. -3 to +5)",
+    )
+    scale_multiplier: float = Field(
+        1.0,
+        description="Multiplier applied to party average to define base scaled level",
+    )
+    override_level_range: bool = Field(
+        False,
+        description="If true, allows scaling to override a monster's declared level_range and match party average directly.",
     )
 
     @classmethod

--- a/tuxemon/encounter.py
+++ b/tuxemon/encounter.py
@@ -19,12 +19,12 @@ logger = logging.getLogger(__name__)
 class EncounterData:
     def __init__(self, slug: str) -> None:
         self.slug = slug
-        self.encounters = self.load_encounters(slug)
-
-    def load_encounters(self, slug: str) -> Sequence[EncounterItemModel]:
-        """Loads encounter data from the db."""
-        results = EncounterModel.lookup(slug, db)
-        return results.monsters
+        self.encounter_model = EncounterModel.lookup(slug, db)
+        self.encounters = self.encounter_model.monsters
+        self.scaling_zone = self.encounter_model.scaling_zone
+        self.override_level_range = self.encounter_model.override_level_range
+        self.scale_offset_range = self.encounter_model.scale_offset_range
+        self.scale_multiplier = self.encounter_model.scale_multiplier
 
     def get_encounters(self) -> Sequence[EncounterItemModel]:
         """Returns the loaded encounter data."""
@@ -32,65 +32,195 @@ class EncounterData:
 
 
 class Encounter:
-    def __init__(self, encounter_data: EncounterData) -> None:
-        self.encounter_cache: dict[str, Sequence[EncounterItemModel]] = {}
-        self.encounter_data = encounter_data
+    def __init__(self, zone: EncounterData) -> None:
+        self.zone_cache: dict[str, Sequence[EncounterItemModel]] = {}
+        self.zone = zone
+
+    def is_scaling_zone(self) -> bool:
+        return self.zone.scaling_zone
 
     def get_valid_encounters(self, character: NPC) -> list[EncounterItemModel]:
-        """Returns a list of valid encounters for the given character."""
-        if self.encounter_data.slug not in self.encounter_cache:
-            encounters = self.encounter_data.get_encounters()
-            self.encounter_cache[self.encounter_data.slug] = encounters
+        """
+        Returns a list of valid encounters for the given character,
+        considering variables, time of day, weather, and player level.
+        """
+        if self.zone.slug not in self.zone_cache:
+            encounters = self.zone.get_encounters()
+            self.zone_cache[self.zone.slug] = encounters
 
-        return [
-            _enc
-            for _enc in self.encounter_cache[self.encounter_data.slug]
-            if not _enc.variables
-            or all(
-                all(
-                    character.game_variables.get(key) == value
-                    for key, value in variable.items()
+        player_avg_level = character.party.level_average
+        if player_avg_level is None:
+            return []
+
+        valid_encs = []
+        for _enc in self.zone_cache[self.zone.slug]:
+            is_variable_match = True
+            if _enc.variables:
+                for variable in _enc.variables:
+                    for key, value in variable.items():
+                        if character.game_variables.get(key) != value:
+                            is_variable_match = False
+                            break
+                    if not is_variable_match:
+                        break
+            if not is_variable_match:
+                continue
+
+            # Player Level check
+            if not is_variable_match:
+                logger.debug(
+                    f"[Filter] Encounter '{_enc.monster}' excluded due to variable mismatch"
                 )
-                for variable in _enc.variables
-            )
-        ]
+                continue
+
+            if (
+                _enc.min_player_level is not None
+                and player_avg_level < _enc.min_player_level
+            ):
+                logger.debug(
+                    f"[Filter] '{_enc.monster}' excluded (player level too low)"
+                )
+                continue
+
+            valid_encs.append(_enc)
+        logger.debug(f"[Valid] Encounter '{_enc.monster}' is valid")
+        return valid_encs
 
     def choose_encounter(
         self,
         encounters: list[EncounterItemModel],
         total_prob: Optional[float],
     ) -> Optional[EncounterItemModel]:
-        """Chooses a random encounter based on encounter rates."""
+        """Chooses a random encounter based on encounter rates and dynamic modifiers."""
         if not encounters:
             return None
 
         total_prob = total_prob or 1.0
-        encounter_rate = prepare.CONFIG.encounter_rate_modifier
-        scale = float(total_prob) / sum(
-            encounter.encounter_rate for encounter in encounters
-        )
-        scale *= encounter_rate
+        encounter_rate_modifier = prepare.CONFIG.encounter_rate_modifier
+
+        sum_rates = sum(enc.encounter_rate for enc in encounters)
+        if sum_rates == 0:
+            return None
+
+        scale = (total_prob / sum_rates) * encounter_rate_modifier
 
         total = 0.0
         roll = random.random() * 100
         for encounter in encounters:
-            total += encounter.encounter_rate * scale
+            rate = encounter.encounter_rate * scale
+            logger.debug(
+                f"[Rate] Monster '{encounter.monster}' weighted rate: {rate:.2f}"
+            )
+            total += rate
             if total >= roll:
+                logger.debug(
+                    f"[Chosen] Rolled {roll:.2f}, selected '{encounter.monster}'"
+                )
                 return encounter
 
         return None
 
     def get_level(self, encounter: EncounterItemModel) -> int:
-        """Returns a random level for the encounter."""
-        if len(encounter.level_range) > 1:
-            return random.randint(
+        """Returns a random level for the encounter, applying the level offset."""
+        base = (
+            random.randint(
                 encounter.level_range[0], encounter.level_range[1] - 1
             )
-        else:
-            return encounter.level_range[0]
+            if len(encounter.level_range) > 1
+            else encounter.level_range[0]
+        )
+
+        offset = (
+            random.randint(*encounter.level_offset_range)
+            if encounter.level_offset_range
+            else (encounter.level_offset or 0)
+        )
+
+        return max(1, base + offset)
 
     def get_held_item(self, encounter: EncounterItemModel) -> Optional[str]:
-        """Returns a random held item for the encounter."""
+        """Returns a random held item for the encounter based on probabilities."""
         if not encounter.held_items:
+            logger.debug(
+                f"[HeldItem] No held items for monster '{encounter.monster}'"
+            )
             return None
-        return random.choice(encounter.held_items)
+
+        total_prob = sum(item.probability for item in encounter.held_items)
+        if total_prob == 0:
+            logger.debug(
+                f"[HeldItem] Held items exist but total probability is zero for '{encounter.monster}'"
+            )
+            return None
+
+        roll = random.uniform(0, total_prob)
+        logger.debug(
+            f"[HeldItem] Rolled {roll:.2f} (range 0-{total_prob:.2f}) for monster '{encounter.monster}'"
+        )
+
+        current_prob_sum = 0.0
+        for item_data in encounter.held_items:
+            current_prob_sum += item_data.probability
+            logger.debug(
+                f"[HeldItem] Checking item '{item_data.item_slug}' with threshold {current_prob_sum:.2f}"
+            )
+            if roll <= current_prob_sum:
+                logger.debug(
+                    f"[HeldItem] Selected item: '{item_data.item_slug}'"
+                )
+                return item_data.item_slug
+
+        logger.debug(f"[HeldItem] No item selected — fallback to None")
+        return None
+
+    def get_scaled_level(
+        self, character: NPC, encounter: EncounterItemModel
+    ) -> int:
+        level_avg = character.party.level_average or 1
+        override = (
+            self.zone.override_level_range or encounter.override_level_range
+        )
+        zone = self.zone
+
+        if (self.is_scaling_zone() or encounter.scaling_enabled) and override:
+            base = int(level_avg * (zone.scale_multiplier or 1.0))
+            if zone.scale_offset_range:
+                offset = random.randint(*zone.scale_offset_range)
+            else:
+                offset = random.randint(-2, +2)
+            level = max(1, base + offset)
+            logger.debug(
+                f"[ScalingOverride] Base: {base}, Offset: {offset}, Final: {level}"
+            )
+            return level
+        else:
+            # Standard scaling within level_range
+            base_min, base_max = encounter.level_range
+            base = max(base_min, min(level_avg, base_max - 1))
+            offset_range = (
+                encounter.scaling_offset_range
+                or self.zone.scale_offset_range
+                or (-2, 2)
+            )
+            offset = random.randint(*offset_range)
+            level = max(1, level_avg + offset)
+            logger.debug(
+                f"[Scaling] Standard scaling — level clamped to range: {level}"
+            )
+            return level
+
+    def determine_level(
+        self, character: NPC, encounter: EncounterItemModel
+    ) -> int:
+        if encounter.scaling_enabled or self.is_scaling_zone():
+            level = self.get_scaled_level(character, encounter)
+            logger.debug(
+                f"[Scaling] Encounter '{encounter.monster}' scaled to level {level} "
+                f"(Party avg: {character.party.level_average})"
+            )
+        else:
+            level = self.get_level(encounter)
+            logger.debug(
+                f"[Static] Encounter '{encounter.monster}' using static level {level}"
+            )
+        return level

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon import prepare
 from tuxemon.combat import check_battle_legal
-from tuxemon.db import EncounterItemModel, EnvironmentModel, db
+from tuxemon.db import EnvironmentModel, db
 from tuxemon.encounter import Encounter, EncounterData
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -20,8 +19,6 @@ from tuxemon.session import Session
 from tuxemon.states.combat.combat_context import CombatContext
 
 logger = logging.getLogger(__name__)
-
-encounter_cache: dict[str, Sequence[EncounterItemModel]] = {}
 
 
 @final
@@ -61,8 +58,8 @@ class RandomEncounterAction(EventAction):
             logger.error("Battle is not legal, won't start")
             return
 
-        encounter_data = EncounterData(self.encounter_slug)
-        encounter = Encounter(encounter_data)
+        zone = EncounterData(self.encounter_slug)
+        encounter = Encounter(zone)
         results = encounter.get_valid_encounters(player)
 
         if not results:
@@ -76,7 +73,7 @@ class RandomEncounterAction(EventAction):
             return
 
         held_item = encounter.get_held_item(eligible)
-        level = encounter.get_level(eligible)
+        level = encounter.determine_level(player, eligible)
 
         logger.info("Starting random encounter!")
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from math import hypot
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
@@ -670,6 +671,28 @@ class PartyHandler:
         """Returns the maximum number of monsters allowed in the party."""
         return self._party_limit
 
+    @property
+    def level_lowest(self) -> Optional[int]:
+        """Returns the lowest level among monsters in the party, or None if empty."""
+        if not self._monsters:
+            return None
+        return min(mon.level for mon in self._monsters)
+
+    @property
+    def level_highest(self) -> Optional[int]:
+        """Returns the highest level among monsters in the party, or None if empty."""
+        if not self._monsters:
+            return None
+        return max(mon.level for mon in self._monsters)
+
+    @property
+    def level_average(self) -> Optional[int]:
+        """Returns the average level of monsters in the party, or None if empty."""
+        if not self._monsters:
+            return None
+        total = sum(mon.level for mon in self._monsters)
+        return round(total / len(self._monsters))
+
     def add_monster(
         self,
         monster: Monster,
@@ -833,6 +856,27 @@ class PartyHandler:
             for monster in self._monsters:
                 monster.owner = None
         self._monsters.clear()
+
+    def get_alignment(self) -> Optional[str]:
+        """
+        Returns the dominant elemental type in the party,
+        based on the most frequently occurring type among monsters.
+        If no types are found, returns None.
+        """
+        type_counter: Counter[str] = Counter()
+
+        for monster in self._monsters:
+            try:
+                type_slugs = monster.types.get_type_slugs()
+                type_counter.update(type_slugs)
+            except Exception:
+                continue  # Skip if the monster has no types
+
+        if not type_counter:
+            return None
+
+        dominant_type, _ = type_counter.most_common(1)[0]
+        return dominant_type
 
     def encode_party(self) -> Sequence[Mapping[str, Any]]:
         return encode_monsters(self._monsters)

--- a/tuxemon/states/party/__init__.py
+++ b/tuxemon/states/party/__init__.py
@@ -65,14 +65,14 @@ class PartyState(PygameMenuState):
         )
         lab1.translate(fxw(0.05), fxh(0.15))
         # levels
-        levels = [monster.level for monster in self.char.monsters]
-        level_lowest = min(levels)
-        level_highest = max(levels)
-        level_average = round(sum(levels) / len(levels))
+        level_lowest = self.char.party.level_lowest
+        level_highest = self.char.party.level_highest
+        level_average = self.char.party.level_average
+        party_alignment = self.char.party.get_alignment()
         # highest
         highest = T.translate("menu_party_level_highest")
         lab2: Any = menu.add.label(
-            title=f"{highest}: {level_highest}",
+            title=f"{highest}: {level_highest or 0}",
             font_size=self.font_type.smaller,
             align=locals.ALIGN_LEFT,
             float=True,
@@ -81,7 +81,7 @@ class PartyState(PygameMenuState):
         # average
         average = T.translate("menu_party_level_average")
         lab3: Any = menu.add.label(
-            title=f"{average}: {level_average}",
+            title=f"{average}: {level_average or 0}",
             font_size=self.font_type.smaller,
             align=locals.ALIGN_LEFT,
             float=True,
@@ -90,12 +90,22 @@ class PartyState(PygameMenuState):
         # lowest
         lowest = T.translate("menu_party_level_lowest")
         lab4: Any = menu.add.label(
-            title=f"{lowest}: {level_lowest}",
+            title=f"{lowest}: {level_lowest or 0}",
             font_size=self.font_type.smaller,
             align=locals.ALIGN_LEFT,
             float=True,
         )
         lab4.translate(fxw(0.05), fxh(0.35))
+        # alignment
+        if party_alignment:
+            alignment = T.translate("menu_party_alignment")
+            lab7: Any = menu.add.label(
+                title=f"{alignment}: {T.translate(party_alignment)}",
+                font_size=self.font_type.smaller,
+                align=locals.ALIGN_LEFT,
+                float=True,
+            )
+            lab7.translate(fxw(0.05), fxh(0.40))
 
         total = sum(monster.steps for monster in monsters)
         # bond


### PR DESCRIPTION
PR introduces the following changes:
- added support for **scaling encounters based on party average level**, with override logic to optionally ignore monster `level_range` when scaling is enabled
- introduced new `override_level_range` flag at both **zone-level** and **monster-level** to control whether scaling bypasses defined level constraints
- implemented `scaling_offset_range` per monster allowing more granular control over level variability
- enhanced encounter filtering logic with cleaner variable matching using nested `all()` comprehensions
- refactored `get_scaled_level()` to support zone-wide and monster-specific scaling behaviors, with fallback to traditional level selection if scaling is inactive
- modernized encounter cache usage and removed redundant logging and logic from the older implementation
- added docstrings and improved readability in key methods like `choose_encounter`, `get_level`, and `get_valid_encounters`
- deprecated older `get_level()` behavior in favor of the new scaling-aware `determine_level()` mechanism


```
{
  // Encounter zone identifier
  "slug": "whatever",

  // Enables scaling mechanics across the zone
  "scaling_zone": true,

  // Allows scaled levels to exceed the monster's level_range
  "override_level_range": true,

  // Applies a multiplier to party average level for scaling (e.g. 1.0 = exact average)
  "scale_multiplier": 1.15,

  // Optional default offset range if monster doesn't define its own
  "scale_offset_range": [-3, 4],

  // List of monster encounters in this zone
  "monsters": [
    {
      // Monster identifier slug
      "monster": "cataspike",

      // Chance of appearing relative to other monsters (higher = more likely)
      "encounter_rate": 3.5,

      // Items this monster may hold when encountered, with spawn chances
      "held_items": [
        {
          "item_slug": "item_1",
          "probability": 0.25
        },
        {
          "item_slug": "item_1",
          "probability": 0.10
        }
      ],

      // Base level range — ignored if override_level_range is true
      "level_range": [8, 12],

      // Optional experience modifier for defeating the monster
      "exp_req_mod": 2.0,

      // Static offset to apply to level (if no range is given)
      "level_offset": 1,

      // Dynamic range to randomly offset the monster’s level
      "level_offset_range": [-2, 3],

      // Minimum party average level required for this encounter to be valid
      "min_player_level": 5,

      // Maximum party average level allowed for this encounter
      "max_player_level": 25,

      // Enables scaling logic for this specific monster
      "scaling_enabled": true,

      // If true, this monster can ignore level_range and scale freely
      "override_level_range": true,

      // Optional offset range used during scaling override
      "scaling_offset_range": [-2, 2],

      ]
    }
  ]
}
```
