### PR TITLE
Improve Status Application Flow with Held Item Immunity

### DIFF
--- a/mods/tuxemon/db/item/antidote_grapes.json
+++ b/mods/tuxemon/db/item/antidote_grapes.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["poison"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/cure_festering.json
+++ b/mods/tuxemon/db/item/cure_festering.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["festering"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/die.json
+++ b/mods/tuxemon/db/item/die.json
@@ -1,5 +1,12 @@
 {
-  "effects": [],
+  "effects": [
+    {
+      "type": "die",
+      "parameters": [
+        "sniping:enraged"
+      ]
+    }
+  ],
   "slug": "die",
   "sort": "utility",
   "sprite": "gfx/items/die.png",

--- a/mods/tuxemon/db/item/feather.json
+++ b/mods/tuxemon/db/item/feather.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["grabbed"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/flute.json
+++ b/mods/tuxemon/db/item/flute.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["noddingoff"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/horseshoe.json
+++ b/mods/tuxemon/db/item/horseshoe.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["all"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/marble.json
+++ b/mods/tuxemon/db/item/marble.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["stuck"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/refreshing_slice.json
+++ b/mods/tuxemon/db/item/refreshing_slice.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["exhausted"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/toy_bear.json
+++ b/mods/tuxemon/db/item/toy_bear.json
@@ -12,6 +12,7 @@
     "consumable": false,
     "holdable": true
   },
+  "immunity_to_status": ["lifeleech"],
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1804,6 +1804,9 @@ msgstr "{target} is turning ranged attacks back on the attacker."
 msgid "combat_state_immune"
 msgstr "{target} is immune to {method}"
 
+msgid "combat_state_immune_multiple"
+msgstr "{target} are immune to {method}"
+
 # Generic notifications
 msgid "empty_slot"
 msgstr "Empty Slot"

--- a/tests/tuxemon/test_monster_status_handler.py
+++ b/tests/tuxemon/test_monster_status_handler.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from tuxemon.db import CategoryStatus, ResponseStatus
-from tuxemon.monster import MonsterStatusHandler
+from tuxemon.monster import Monster, MonsterItemHandler, MonsterStatusHandler
 
 
 class TestMonsterStatusHandler(unittest.TestCase):
@@ -12,8 +12,12 @@ class TestMonsterStatusHandler(unittest.TestCase):
     def setUp(self):
         self.status = MagicMock(slug="test")
         self.session = MagicMock()
+        self.monster = MagicMock(spec=Monster)
+        self.monster.name = "Rockitten"
         self.basic = MonsterStatusHandler()
         self.handler = MonsterStatusHandler([self.status])
+        self.mock_item = MagicMock()
+        self.mock_item.is_immune.return_value = False
 
     def test_init(self):
         self.assertEqual(self.basic.status, [])
@@ -22,7 +26,9 @@ class TestMonsterStatusHandler(unittest.TestCase):
         self.assertEqual(self.handler.status, [self.status])
 
     def test_apply_status(self):
-        self.basic.apply_status(self.session, self.status)
+        self.monster.held_item = MagicMock(spec=MonsterItemHandler)
+        self.monster.held_item.get_item.return_value = self.mock_item
+        self.basic.apply_status(self.session, self.status, self.monster)
         self.assertEqual(self.basic.status, [self.status])
 
     def test_apply_status_replace(self):
@@ -31,16 +37,20 @@ class TestMonsterStatusHandler(unittest.TestCase):
             on_positive_status=ResponseStatus.replaced,
         )
         status2 = MagicMock(on_positive_status=ResponseStatus.replaced)
+        self.monster.held_item = MagicMock(spec=MonsterItemHandler)
+        self.monster.held_item.get_item.return_value = self.mock_item
         handler = MonsterStatusHandler([status1])
-        handler.apply_status(self.session, status2)
+        handler.apply_status(self.session, status2, self.monster)
         self.assertEqual(len(handler.status), 1)
         self.assertNotEqual(handler.status[0], status1)
 
     def test_apply_status_remove(self):
         status1 = MagicMock(category=CategoryStatus.positive)
         status2 = MagicMock(on_positive_status=ResponseStatus.removed)
+        self.monster.held_item = MagicMock(spec=MonsterItemHandler)
+        self.monster.held_item.get_item.return_value = self.mock_item
         handler = MonsterStatusHandler([status1])
-        handler.apply_status(self.session, status2)
+        handler.apply_status(self.session, status2, self.monster)
         self.assertEqual(handler.status, [])
 
     def test_clear_status(self):

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -515,7 +515,7 @@ class AI:
         """
         Send action tech.
         """
-        self.character.game_variables["action_tech"] = technique.slug
+        self.combat._combat_variables["action_tech"] = technique.slug
         technique = pre_checking(
             self.session, self.monster, technique, target, self.combat
         )

--- a/tuxemon/core/effects/die.py
+++ b/tuxemon/core/effects/die.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
+from tuxemon.monster import Monster
+from tuxemon.status.status import Status
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.session import Session
+
+
+@dataclass
+@dataclass
+class DieEffect(CoreEffect):
+    """
+    This effect applies one random status from a list to the target monster.
+
+    Typically used by held items like "Die", which grant a random condition
+    (e.g. Enraged or Sniping) when combat begins.
+
+    Parameters:
+        statuses: A colon-separated string of status slugs
+            (e.g. "enraged:sniping").
+    """
+
+    name = "die"
+    statuses: str
+
+    def apply_item_target(
+        self, session: Session, item: Item, target: Monster
+    ) -> ItemEffectResult:
+        combat = item.get_combat_state()
+        if combat._turn == 1:
+            statuses = self.statuses.split(":")
+            status_slug = random.choice(statuses)
+            status = Status.create(status_slug, target)
+            target.status.apply_status(session, status, target)
+            combat.update_icons_for_monsters()
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon.combat import get_target_monsters
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.locale import T
 from tuxemon.status.status import Status
 
 if TYPE_CHECKING:
@@ -36,7 +37,6 @@ class GiveEffect(CoreEffect):
     def apply_tech_target(
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
-        monsters: list[Monster] = []
         combat = tech.get_combat_state()
         player = user.get_owner()
 
@@ -45,18 +45,33 @@ class GiveEffect(CoreEffect):
         value = combat.get_tech_hit(user)
         success = tech.potency >= potency and tech.accuracy >= value
 
+        status = Status.create(self.condition, user, player.steps)
         if success:
-            status = Status.create(self.condition, user, player.steps)
             status.set_combat_state(combat)
 
-            monsters = get_target_monsters(objectives, tech, user, target)
-            if monsters:
-                for monster in monsters:
-                    current = monster.status.get_current_status()
-                    if current:
-                        current.set_combat_state(combat)
-                    monster.status.apply_status(session, status)
-                combat.update_icons_for_monsters()
-                combat.animate_update_party_hud()
+        immune_info = []
+        successful_targets = []
+        extras = []
+        monsters = get_target_monsters(objectives, tech, user, target)
 
-        return TechEffectResult(name=tech.name, success=bool(monsters))
+        for monster in monsters:
+            result = monster.status.apply_status(session, status, monster)
+            if result.applied:
+                successful_targets.append(monster)
+            elif result.blocked_by:
+                immune_info.append(f"{monster.name} ({result.blocked_by})")
+
+        if immune_info:
+            immune_names = ", ".join(immune_info)
+            key = (
+                "combat_state_immune"
+                if len(immune_info) == 1
+                else "combat_state_immune_multiple"
+            )
+            params = {"target": immune_names, "method": status.name}
+            extract_text = T.format(key, params)
+            extras = [extract_text]
+
+        return TechEffectResult(
+            name=tech.name, success=bool(monsters), extras=extras
+        )

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -167,6 +167,7 @@ class EffectPhase(Enum):
     ON_END = "on_end"
     ON_FAINT = "on_faint"
     ON_START = "on_start"
+    ON_DECISION = "on_decision"
     PERFORM_ITEM = "perform_item"
     PERFORM_STATUS = "perform_status"
     PERFORM_TECH = "perform_tech"
@@ -334,6 +335,9 @@ class ItemModel(BaseModel, BaseLookupModel):
         le=1.0,
     )
     modifiers: list[Modifier] = Field(..., description="Various modifiers")
+    immunity_to_status: Sequence[str] = Field(
+        [], description="Statuses this item grants immunity to"
+    )
 
     @classmethod
     def lookup(cls, slug: str, db: ModData) -> ItemModel:
@@ -373,6 +377,16 @@ class ItemModel(BaseModel, BaseLookupModel):
         ):
             return v
         raise ValueError(f"the animation {v} doesn't exist in the db")
+
+    @field_validator("immunity_to_status")
+    def status_exists(cls: ItemModel, v: Sequence[str]) -> Sequence[str]:
+        if v:
+            for status in v:
+                if status != "all" and not has.db_entry("status", status):
+                    raise ValueError(
+                        f"A status {status} doesn't exist in the db"
+                    )
+        return v
 
 
 class AttributesModel(BaseModel):

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -63,6 +63,7 @@ class Item:
         self.use_success: str = ""
         self.use_failure: str = ""
         self.usable_in: Sequence[State] = []
+        self.immunity_to_status: Sequence[str] = []
         self.cost: int = 0
         self.wear: int = 0
         self.max_wear: int = 0
@@ -135,6 +136,7 @@ class Item:
         self.max_wear = results.max_wear
         self.break_chance = results.break_chance
         self.sort = results.sort
+        self.immunity_to_status = results.immunity_to_status
         self.category = results.category
         self.sprite = results.sprite
         self.usable_in = results.usable_in
@@ -158,6 +160,12 @@ class Item:
         if not self.combat_state:
             raise ValueError("No CombatState.")
         return self.combat_state
+
+    def is_immune(self, status: str) -> bool:
+        return (
+            "all" in self.immunity_to_status
+            or status in self.immunity_to_status
+        )
 
     def set_combat_state(self, combat_state: Optional[CombatState]) -> None:
         """Sets the CombatState."""

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -737,6 +737,12 @@ class MonsterSpriteHandler:
         }
 
 
+@dataclass
+class StatusApplyResult:
+    applied: bool
+    blocked_by: Optional[str] = None
+
+
 class MonsterStatusHandler:
     def __init__(self, status: Optional[list[Status]] = None):
         self.status = status if status is not None else []
@@ -750,7 +756,19 @@ class MonsterStatusHandler:
             return None
         return self.status[0]
 
-    def apply_status(self, session: Session, new_status: Status) -> None:
+    def is_blocked(self, monster: Monster, status_slug: str) -> Optional[str]:
+        """Check if the monster's held item grants immunity to the given status."""
+        item = monster.held_item.get_item()
+        if item and item.is_immune(status_slug):
+            logger.debug(
+                f"Item '{item.name}' blocks status '{status_slug}' for monster '{monster.name}'."
+            )
+            return item.name
+        return None
+
+    def apply_status(
+        self, session: Session, new_status: Status, monster: Monster
+    ) -> StatusApplyResult:
         """
         Apply a status effect to a monster during combat by replacing or removing
         the previous status effect.
@@ -759,33 +777,76 @@ class MonsterStatusHandler:
         ensuring proper transitions between statuses based on their category and
         interaction rules.
         """
+        logger.debug(
+            f"Trying to apply status '{new_status.slug}' to monster '{monster.name}'."
+        )
+
+        blocked_by = self.is_blocked(monster, new_status.slug)
+        if blocked_by:
+            logger.debug(
+                f"Status '{new_status.slug}' blocked by '{blocked_by}'."
+            )
+            return StatusApplyResult(applied=False, blocked_by=blocked_by)
+
         current_status = self.get_current_status()
         if current_status is None:
+            logger.debug("No current status, applying new status directly.")
             self.add_status(new_status)
             new_status.nr_turn = 1
             new_status.apply_phase_and_use(session, EffectPhase.ON_START)
-            return
+            return StatusApplyResult(applied=True)
 
         if self.has_status(new_status.slug):
-            return
+            logger.debug(
+                f"Monster already has status '{new_status.slug}', skipping."
+            )
+            current_status.stack_level = min(
+                current_status.stack_level + 1, Status.MAX_STACKS
+            )
+            logger.debug(
+                f"Stacking status '{new_status.slug}': now at {current_status.stack_level}/{Status.MAX_STACKS}."
+            )
+            return StatusApplyResult(
+                applied=False, blocked_by=current_status.name
+            )
 
+        logger.debug(
+            f"Ending current status '{current_status.slug}' with ON_END phase."
+        )
         current_status.apply_phase_and_use(session, EffectPhase.ON_END)
 
         new_status.nr_turn = 1
+        logger.debug(
+            f"Starting new status '{new_status.slug}' with ON_START phase."
+        )
         new_status.apply_phase_and_use(session, EffectPhase.ON_START)
 
         if current_status.category == CategoryStatus.positive:
+            logger.debug(
+                f"Current status is positive. Transition rule: {new_status.on_positive_status}"
+            )
             if new_status.on_positive_status == ResponseStatus.replaced:
                 self.add_status(new_status)
             elif new_status.on_positive_status == ResponseStatus.removed:
                 self.remove_status()
         elif current_status.category == CategoryStatus.negative:
+            logger.debug(
+                f"Current status is negative. Transition rule: {new_status.on_negative_status}"
+            )
             if new_status.on_negative_status == ResponseStatus.replaced:
                 self.add_status(new_status)
             elif new_status.on_positive_status == ResponseStatus.removed:
                 self.remove_status()
         else:
+            logger.debug(
+                "Current status has no category. Applying new status."
+            )
             self.add_status(new_status)
+
+        logger.debug(
+            f"Status '{new_status.slug}' successfully applied to monster '{monster.name}'."
+        )
+        return StatusApplyResult(applied=True)
 
     def add_status(self, status: Status) -> None:
         if self.has_status(status.slug):

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -339,6 +339,7 @@ class CombatState(CombatAnimations):
         elif phase == CombatPhase.DECISION:
             self.update_icons_for_monsters()
             self.animate_update_party_hud()
+            self.check_decisions()
             if not self._decision_queue:
                 self.initialize_hit_chances()
                 self.process_player_decisions()
@@ -684,6 +685,21 @@ class CombatState(CombatAnimations):
                     monster.moves.recharge_moves()
                     self.ai_manager.process_ai_turn(monster, player)
 
+    def check_decisions(self) -> None:
+        for player in list(self.active_players):
+            monsters = self.field_monsters.get_monsters(player)
+            for monster in monsters:
+                held_item = monster.held_item.get_item()
+                if held_item:
+                    held_item.execute_item_action(
+                        self.session, self, player, monster
+                    )
+                status = monster.status.get_current_status()
+                if status:
+                    status.execute_status_action(
+                        self.session, self, monster, EffectPhase.ON_DECISION
+                    )
+
     def apply_statuses(self) -> None:
         """
         Applies and updates status effects for all active monsters.
@@ -822,7 +838,7 @@ class CombatState(CombatAnimations):
                 message += "\n" + template
             if result_status.statuses:
                 status = random.choice(result_status.statuses)
-                user.status.apply_status(self.session, status)
+                user.status.apply_status(self.session, status, user)
 
         if result_tech.success and method.use_success:
             template = getattr(method, "use_success")

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -43,6 +43,8 @@ class Status:
     Particular status that tuxemon monsters can be affected.
     """
 
+    MAX_STACKS: int = 5
+
     effect_manager: Optional[EffectManager] = None
     condition_manager: Optional[ConditionManager] = None
 
@@ -72,6 +74,7 @@ class Status:
         self.duration: int = 0
         self.phase: EffectPhase = EffectPhase.DEFAULT
         self.range: Range = Range.melee
+        self.stack_level: int = 1
         self.on_positive_status: Optional[ResponseStatus] = None
         self.on_negative_status: Optional[ResponseStatus] = None
         self.on_tech_use: Optional[str] = None


### PR DESCRIPTION
PR introduces several refinements across the status effect system.

Key changes:
- refactors item immunity logic into a dedicated method `is_blocked_by_item()` within `MonsterStatusHandler`
- integrates this item immunity method into the `apply_status()` function, streamlining the flow and enabling earlier rejection of blocked statuses
- adds strategic `logger.debug()` statements in `apply_status()` to trace application decisions, including: when a monster resists a status, held item behavior, the ransitioning from existing statuses, and the final outcome of status application
- updates the `GiveEffect` core logic to utilize enhanced result handling via `StatusApplyResult` dataclass
- ensures consistent messaging and localization support depending on single or multiple immunity targets, using `combat_state_immune` vs. `combat_state_immune_multiple`
- introduces a new `stack_level` attribute in the `Status` class along with the constant `MAX_STACK = 5`, enabling better management and logging of status stacking behavior

the held items were added back in PR #2715, but weren’t integrated into the combat engine, now most of them are functioning properly: 
- `Antidote Grapes`: immune to **Poison**
- `Cure Festering`: immune to **Festering**
- `Feather`: immune to **Grabbed**
- `Flute`: immune to **Nodding Off**
- `Horseshoe`: immune to **all statuses** (acts as a full restore safeguard)
- `Marble`: immune to **Stuck**
- `Refreshing Slice`: immune to **Exhausted**
- `Toy Bear`: immune to **Lifeleech**
- `Die`: at the beginning of combat, grants either **Enraged** or **Sniping** randomly (specific effect for the item)

This item still requires implementation work (planned):
- `Open Hand`: prevents attacks from reducing enemy HP below 1.


https://github.com/user-attachments/assets/98c6da3a-bf2d-4798-a391-d55c66e47256

