### PR TITLE
Add `parse_flag` utility for consistent boolean parsing in event actions

### DIFF
--- a/tuxemon/event/actions/add_tracker.py
+++ b/tuxemon/event/actions/add_tracker.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import TYPE_CHECKING, Optional, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
-from tuxemon.session import Session
+from tuxemon.tools import parse_flag
 from tuxemon.tracker import TrackingPoint
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +32,15 @@ class AddTrackerAction(EventAction):
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple").
         location: location name (e.g. "paper_town").
-        visited: if it has been visited or not (true or false), default True
+        visited: Optional string flag indicating if the location was visited.
+            Accepts "true", "1", "yes" for True (case-insensitive).
+            Defaults to True if omitted.
     """
 
     name = "add_tracker"
     character: str
     location: str
-    visited: Optional[bool] = None
+    visited: Optional[str] = None
 
     def start(self, session: Session) -> None:
         character = get_npc(session, self.character)
@@ -47,6 +52,6 @@ class AddTrackerAction(EventAction):
             logger.error(f"Add msgid '{self.location}' in the 'en_US' base.po")
             return
 
-        visited = True if self.visited is None else self.visited
+        visited = True if self.visited is None else parse_flag(self.visited)
         tracking_point = TrackingPoint(visited)
         character.tracker.add_location(self.location, tracking_point)

--- a/tuxemon/event/actions/input_variable.py
+++ b/tuxemon/event/actions/input_variable.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import TYPE_CHECKING, Optional, final
 
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
-from tuxemon.session import Session
+from tuxemon.tools import parse_flag
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
 
 
 @final
@@ -24,11 +27,12 @@ class InputVariableAction(EventAction):
 
     Script parameters:
         question: The question the player needs to reply (eg. "access_code")
-                  then you create the msgid "access_code" inside the PO file:
-                  msgid "access_code"
-                  msgstr "Here the actual question?"
+            then you create the msgid "access_code" inside the PO file:
+                msgid "access_code"
+                msgstr "Here the actual question?"
         variable: Name of the variable where to store the output.
-        escape: Whether the input can be closed or not. Default False.
+        escape: Optional string flag ("true", "1", "yes" for True),
+            defaults to False when omitted
 
     eg. "input_variable access_code,response_question"
     eg. "input_variable access_code,response_question,escape"
@@ -49,7 +53,7 @@ class InputVariableAction(EventAction):
 
     def start(self, session: Session) -> None:
         self.client = session.client
-        _escape = True if self.escape else False
+        _escape = parse_flag(self.escape)
         session.client.push_state(
             "InputMenu",
             prompt=T.translate(self.question),

--- a/tuxemon/event/actions/set_kennel_visible.py
+++ b/tuxemon/event/actions/set_kennel_visible.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import final
+from typing import TYPE_CHECKING, Optional, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.prepare import KENNEL
-from tuxemon.session import Session
 from tuxemon.states.pc_kennel import HIDDEN_LIST
+from tuxemon.tools import parse_flag
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +22,13 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SetKennelVisibleAction(EventAction):
     """
-    Set the kennel visible or hidden.
+    Set a kennel's visibility state for a character.
 
     From hidden to visible:
-    set_kennel_visible player,name_kennel,true
+        set_kennel_visible player,name_kennel,true
 
     From visible to hidden:
-    set_kennel_visible player,name_kennel,false
+        set_kennel_visible player,name_kennel,false
 
     Script usage:
         .. code-block::
@@ -33,16 +36,17 @@ class SetKennelVisibleAction(EventAction):
             set_kennel_visible <character>,<kennel>,<visible>
 
     Script parameters:
-        character: Either "player" or npc slug name (e.g. "npc_maple").
+        character: Either "player" or NPC slug name (e.g. "npc_maple").
         kennel: Name of the kennel.
-        visible: true/false.
-
+        visible: Optional string flag to set visibility.
+            Accepts "true", "1", "yes" for visible (case-insensitive).
+            Defaults to False when omitted or invalid.
     """
 
     name = "set_kennel_visible"
     npc_slug: str
     kennel: str
-    visible: str
+    visible: Optional[str] = None
 
     def start(self, session: Session) -> None:
         character = get_npc(session, self.npc_slug)
@@ -51,27 +55,14 @@ class SetKennelVisibleAction(EventAction):
             return
 
         kennel = self.kennel
-        visible = self.visible
+        is_visible = parse_flag(self.visible)
 
         if kennel == KENNEL:
-            raise ValueError(
-                f"{kennel} cannot be made invisible.",
-            )
+            raise ValueError(f"{kennel} cannot be made invisible.")
+        if not character.monster_boxes.has_box(kennel, "monster"):
+            return
+
+        if is_visible:
+            HIDDEN_LIST.remove(kennel)
         else:
-            if character.monster_boxes.has_box(kennel, "monster"):
-                if visible == "true":
-                    if kennel in HIDDEN_LIST:
-                        HIDDEN_LIST.remove(kennel)
-                    else:
-                        return
-                elif visible == "false":
-                    if kennel in HIDDEN_LIST:
-                        return
-                    else:
-                        HIDDEN_LIST.append(kennel)
-                else:
-                    raise ValueError(
-                        f"{visible} is invalid, must be true or false",
-                    )
-            else:
-                return
+            HIDDEN_LIST.append(kennel) if kennel not in HIDDEN_LIST else None

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -454,3 +454,13 @@ def compare(
         return bool(ne(value1, value2))
     else:
         raise ValueError(f"{key} isn't among {list(Comparison)}")
+
+
+def parse_flag(value: Optional[str]) -> bool:
+    """
+    Convert a string flag to a boolean.
+
+    Accepted truthy values: "true", "1", "yes" (case-insensitive).
+    All other values (including None) return False.
+    """
+    return str(value or "").strip().lower() in {"true", "1", "yes"}


### PR DESCRIPTION
PR introduces a new helper function called `parse_flag()` to simplify and standardize string-to-boolean conversions across event actions. It recognizes `"true"`, `"1"`, and `"yes"` (case-insensitive) as truthy values, defaulting to `False` for everything else. I’ve updated relevant actions to use `parse_flag()` instead of manual string comparisons. This helps reduce repetition, avoids inconsistent flag handling, and improves overall code readability.