### PR TITLE
Fix World Menu Activation Bug + Refactor Menu Visibility Logic: Remove NPC Menu Flags and Introduce `MenuFlags` System

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -268,6 +268,7 @@ class WorldMenuEntry(BaseModel):
     position: int
     label_key: str
     state: str
+    enabled: bool = True
 
 
 class ItemModel(BaseModel, BaseLookupModel):

--- a/tuxemon/event/actions/menu.py
+++ b/tuxemon/event/actions/menu.py
@@ -3,32 +3,36 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import TYPE_CHECKING, Optional, final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.session import Session
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
 
 
 @final
 @dataclass
 class MenuAction(EventAction):
     """
-    Enable/disable one or more menu.
+    Toggle visibility of one or more world menu entries, or apply a preset.
 
     Script usage:
         .. code-block::
 
-            menu <act>[,menu]
+            menu <flag>[,menu_1:menu_2:...]   # toggles specific menus
+            menu <preset>                     # applies preset config
 
-    Script parameters:
-        act: enable or disable
-        menu: specific menu (menu_monster, menu_bag, menu_player,
-            exit, menu_options, menu_save, menu_load)
-            without specification, everything disabled
+    Parameters:
+        flag: "enable" or "disable", applied to specified menus (or all)
+        preset: one of defined presets ("minimal", etc.)
 
-    eg. menu disable,menu_bag
-    eg. menu enable,menu_player
-
+    Examples:
+        menu reset                         > clears all menu flags
+        menu enable                        > enables all menus
+        menu disable,menu_bag:menu_player  > disables specified menus
+        menu enable,all                    > enables all menus
+        menu minimal                       > applies "minimal" preset
     """
 
     name = "menu"
@@ -36,28 +40,32 @@ class MenuAction(EventAction):
     menu: Optional[str] = None
 
     def start(self, session: Session) -> None:
-        player = session.player
-        result = True if self.act == "enable" else False
+        flags = session.world.menu_manager.menu_flags
+        valid_keys = flags.DEFAULT_PRESETS["full"].keys()
+        presets = flags.DEFAULT_PRESETS.keys()
 
-        if self.menu is None:
-            player.menu_bag = result
-            player.menu_load = result
-            player.menu_monsters = result
-            player.menu_save = result
-            player.menu_player = result
-            player.menu_missions = result
+        if self.act == "reset":
+            flags.reset_flags()
+            flags.apply_preset("raw")
+            session.world.menu_manager.update_menu_display()
+            return
+
+        if self.act in presets:
+            flags.apply_preset(self.act)
         else:
-            if self.menu == "menu_bag":
-                player.menu_bag = result
-            elif self.menu == "menu_load":
-                player.menu_load = result
-            elif self.menu == "menu_monsters":
-                player.menu_monsters = result
-            elif self.menu == "menu_save":
-                player.menu_save = result
-            elif self.menu == "menu_player":
-                player.menu_player = result
-            elif self.menu == "menu_missions":
-                player.menu_missions = result
+            if self.act not in ("enable", "disable"):
+                raise ValueError(
+                    f"Invalid menu action: '{self.act}' must be 'enable', 'disable', or a preset name."
+                )
+
+            result = self.act == "enable"
+
+            if self.menu is None or self.menu.strip() == "all":
+                for key in valid_keys:
+                    flags.set_enabled(key, result)
             else:
-                raise ValueError(f"{self.menu} isn't valid.")
+                keys = [k.strip() for k in self.menu.split(":")]
+                for key in keys:
+                    flags.set_enabled(key, result)
+
+        session.world.menu_manager.update_menu_display()

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -110,13 +110,6 @@ class NPC(Entity[NPCState]):
         self.money_controller = MoneyController(self)
         # list of ways player can interact with the Npc
         self.interactions: Sequence[str] = []
-        # menu labels (world menu)
-        self.menu_save: bool = True
-        self.menu_load: bool = True
-        self.menu_player: bool = True
-        self.menu_monsters: bool = True
-        self.menu_bag: bool = True
-        self.menu_missions: bool = True
         self.mission_controller = MissionController(self)
         self.economy: Optional[Economy] = None
         self.shop_inventory: Optional[ShopInventory] = None

--- a/tuxemon/states/world/world_menu_flags.py
+++ b/tuxemon/states/world/world_menu_flags.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MenuFlags:
+    """
+    Stores and manages visibility states of world menu entries.
+    Supports dynamic toggling, preset configurations, and export/import.
+    """
+
+    DEFAULT_PRESETS: dict[str, dict[str, bool]] = {
+        "full": {
+            "menu_bag": True,
+            "menu_load": True,
+            "menu_monster": True,
+            "menu_save": True,
+            "menu_player": True,
+            "menu_missions": True,
+        },
+        "minimal": {
+            "menu_bag": True,
+            "menu_load": False,
+            "menu_monster": True,
+            "menu_save": False,
+            "menu_player": True,
+            "menu_missions": False,
+        },
+        "raw": {
+            "menu_bag": False,
+            "menu_load": True,
+            "menu_monster": False,
+            "menu_save": True,
+            "menu_player": False,
+            "menu_missions": False,
+        },
+    }
+
+    def __init__(self, preset: str = "full") -> None:
+        if preset not in self.DEFAULT_PRESETS:
+            raise ValueError(f"Unknown preset: '{preset}'")
+        self._flags: dict[str, bool] = self.DEFAULT_PRESETS[preset].copy()
+        logger.debug(
+            f"MenuFlags initialized with preset '{preset}' > {self._flags}"
+        )
+
+    def is_enabled(self, key: str) -> bool:
+        result = self._flags.get(key, False)
+        logger.debug(f"is_enabled('{key}') > {result}")
+        return result
+
+    def set_enabled(self, key: str, value: bool) -> None:
+        if key not in self._flags:
+            logger.debug(f"MenuFlags: auto-registering new menu key '{key}'")
+        else:
+            logger.debug(f"MenuFlags: updating '{key}' → {value}")
+        self._flags[key] = value
+
+    def reset_flags(self) -> None:
+        for key in self._flags:
+            self._flags[key] = False
+        logger.debug("Resetting all menu flags: all visibility disabled")
+
+    def enable(self, key: str) -> None:
+        logger.debug(f"enable('{key}')")
+        self.set_enabled(key, True)
+
+    def disable(self, key: str) -> None:
+        logger.debug(f"disable('{key}')")
+        self.set_enabled(key, False)
+
+    def apply_preset(self, preset: str) -> None:
+        if preset not in self.DEFAULT_PRESETS:
+            raise ValueError(f"Unknown preset: '{preset}'")
+        logger.debug(f"apply_preset('{preset}')")
+        self._flags = self.DEFAULT_PRESETS[preset].copy()
+
+    def export(self) -> dict[str, bool]:
+        logger.debug("export() called")
+        return self._flags.copy()
+
+    def import_flags(self, flags: dict[str, bool]) -> None:
+        logger.debug(f"import_flags({flags})")
+        for k in self._flags:
+            if k in flags:
+                self._flags[k] = bool(flags[k])
+                logger.debug(f"> Imported '{k}' = {self._flags[k]}")

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -14,7 +14,10 @@ from tuxemon import prepare
 from tuxemon.animation import ScheduleType
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
+from tuxemon.platform.const import buttons
+from tuxemon.platform.events import PlayerInput
 from tuxemon.states.monster import MonsterMenuHandler
+from tuxemon.states.world.world_menu_flags import MenuFlags
 
 if TYPE_CHECKING:
     from tuxemon.animation import Animation
@@ -69,13 +72,14 @@ class WorldMenuManager:
     """Manages persistent menu items and builds the dynamic world menu."""
 
     def __init__(self, client: LocalPygameClient) -> None:
+        self.menu_flags = MenuFlags()
         self.menu_items: list[MenuItem] = []
-        self.menu_state: Optional[WorldMenuState] = None
+        self.menu_renderer: Optional[WorldMenuState] = None
         self.client = client
 
-    def set_menu_state(self, menu_state: WorldMenuState) -> None:
+    def set_menu_renderer(self, menu_renderer: WorldMenuState) -> None:
         """Links the menu manager to a WorldMenuState instance."""
-        self.menu_state = menu_state
+        self.menu_renderer = menu_renderer
 
     def set_item_enabled(self, key: str, enabled: bool) -> None:
         """Enables or disables a menu item by its key, if it exists."""
@@ -137,7 +141,9 @@ class WorldMenuManager:
         self.update_menu_display()
 
     def remove_item(self, key: str) -> None:
-        """Removes a menu item by its label key from the manager's persistent list."""
+        """
+        Removes a menu item by its label key from the manager's persistent list.
+        """
         label = T.translate(key).upper()
         initial_len = len(self.menu_items)
 
@@ -150,8 +156,8 @@ class WorldMenuManager:
 
     def update_menu_display(self) -> None:
         """Notifies the linked WorldMenuState to refresh its display."""
-        if self.menu_state:
-            self.menu_state.update_menu_from_manager()
+        if self.menu_renderer:
+            self.menu_renderer.update_menu_from_manager()
 
     def _get_change_state_callback(
         self, state: str, **kwargs: Any
@@ -171,15 +177,24 @@ class WorldMenuManager:
     def _insert_item_specific_entries_in_menu(
         self, player: NPC, current_menu: list[MenuItem]
     ) -> None:
-        """Inserts item-specific menu entries into the current_menu at their defined positions."""
+        """
+        Inserts item-specific menu entries into the current_menu at their
+        defined positions.
+        """
         entries: list[tuple[int, MenuItem]] = []
 
         for itm in player.items.get_items():
-            wm = getattr(itm, "world_menu", None)
+            wm = itm.world_menu
             if wm and all(
                 hasattr(wm, attr)
-                for attr in ["position", "label_key", "state"]
+                for attr in ["position", "label_key", "state", "enabled"]
             ):
+                if wm.enabled and wm.label_key not in self.menu_flags._flags:
+                    self.menu_flags.set_enabled(wm.label_key, True)
+
+                if not self.menu_flags.is_enabled(wm.label_key):
+                    continue
+
                 if not self.item_exists(wm.label_key, current_menu):
                     label = T.translate(wm.label_key).upper()
                     callback = self._get_change_state_callback(
@@ -198,7 +213,9 @@ class WorldMenuManager:
     def _merge_persistent_items(
         self, current_menu: list[MenuItem]
     ) -> list[MenuItem]:
-        """Appends persistent menu items, ensuring no duplicate labels are added."""
+        """
+        Appends persistent menu items, ensuring no duplicate labels are added.
+        """
         return [
             item
             for item in self.menu_items
@@ -210,25 +227,25 @@ class WorldMenuManager:
         Builds the complete list of menu items based on the player's state
         and any globally managed items.
         """
-        if self.menu_state is None:
+        if self.menu_renderer is None:
             logger.error(
-                "WorldMenuManager: menu_state is not set. Returning empty menu."
+                "WorldMenuManager: menu_renderer is not set. Returning empty menu."
             )
             return []
 
         param = {"character": player}
         current_menu: list[MenuItem] = []
 
-        if player.monsters and player.menu_monsters:
+        if player.monsters and self.menu_flags.is_enabled("menu_monster"):
             current_menu.append(
                 MenuItem(
                     "menu_monster",
                     T.translate("menu_monster").upper(),
-                    self.menu_state.open_monster_menu,
+                    self.menu_renderer.open_monster_menu,
                 )
             )
 
-        if player.items.get_items() and player.menu_bag:
+        if player.items.get_items() and self.menu_flags.is_enabled("menu_bag"):
             current_menu.append(
                 self._menu_item(
                     "menu_bag",
@@ -238,7 +255,7 @@ class WorldMenuManager:
                 )
             )
 
-        if player.menu_player:
+        if self.menu_flags.is_enabled("menu_player"):
             current_menu.append(
                 self._menu_item("menu_player", "CharacterState", kwargs=param)
             )
@@ -248,10 +265,10 @@ class WorldMenuManager:
                 self._menu_item("menu_missions", "MissionState", kwargs=param)
             )
 
-        if player.menu_save:
+        if self.menu_flags.is_enabled("menu_save"):
             current_menu.append(self._menu_item("menu_save", "SaveMenuState"))
 
-        if player.menu_load:
+        if self.menu_flags.is_enabled("menu_load"):
             current_menu.append(self._menu_item("menu_load", "LoadMenuState"))
 
         current_menu.append(self._menu_item("menu_options", "ControlState"))
@@ -277,7 +294,7 @@ class WorldMenuState(PygameMenuState):
         self.char = character
         super().__init__(height=prepare.SCREEN_SIZE[1])
         self.menu_manager = menu_manager
-        self.menu_manager.set_menu_state(self)
+        self.menu_manager.set_menu_renderer(self)
         self.update_menu_from_manager()
         self.handler = MonsterMenuHandler(self.client, self.char)
 
@@ -303,3 +320,9 @@ class WorldMenuState(PygameMenuState):
         ani = self.animate(self, animation_offset=0, duration=0.50)
         ani.schedule(self.update_animation_position, ScheduleType.ON_UPDATE)
         return ani
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        if event.button in (buttons.START, buttons.BACK) and event.pressed:
+            self.client.pop_state()
+            return None
+        return None

--- a/tuxemon/states/world/worldstate.py
+++ b/tuxemon/states/world/worldstate.py
@@ -43,7 +43,7 @@ direction_map: Mapping[int, Direction] = {
 
 
 class WorldSave(TypedDict, total=False):
-    pass
+    menu_flags: dict[str, bool]
 
 
 class WorldState(State):
@@ -73,10 +73,14 @@ class WorldState(State):
     def get_state(self, session: Session) -> WorldSave:
         """Returns a dictionary of the World to be saved."""
         state: WorldSave = {}
+        state["menu_flags"] = self.menu_manager.menu_flags.export()
         return state
 
     def set_state(self, session: Session, save_data: WorldSave) -> None:
         """Recreates the World from the provided saved data."""
+        self.menu_manager.menu_flags.import_flags(
+            save_data.get("menu_flags", {})
+        )
 
     def resume(self) -> None:
         """Called after returning focus to this state"""


### PR DESCRIPTION
PR key changes:
- removes hardcoded menu visibility flags (`menu_save`, `menu_load`, `menu_player`, etc.) from the `NPC` class to reduce UI coupling and keep entity logic clean  
- introduces a new `MenuFlags` class to manage menu visibility centrally. This class provides: preset configurations (`full`, `minimal`), individual flag toggling via `set_enabled()`, `enable()`, `disable()`, support for saving/loading via `export()` and `import_flags()`  
- integrates `MenuFlags` into `WorldMenuManager`, replacing previous flag reads from `NPC`, menu visibility is now fully managed outside the player object
- extends the world save/load system to include `menu_flags`: flags are exported via `get_state()` and restored with `set_state()` and this ensures menu visibility persists across gameplay sessions
- updates `MenuAction` event action to work with the new system: allows script toggling of specific flags, supports `all` keyword (e.g. `menu disable:all`) and supports presets (e.g. `menu minimal`)
- fxes bug where pressing ESC or BACK repeatedly would stack multiple `WorldMenuState` instances: adds input handling to `WorldMenuState` that prevents re-triggering while the menu is active and allows clean menu closure