### PR TITLE
Fix Game Start Failure Due to TranslatorManager Compilation Oversight in PR #2944

### DIFF
--- a/tuxemon/core/effects/button_lock.py
+++ b/tuxemon/core/effects/button_lock.py
@@ -31,8 +31,7 @@ class ButtonLockEffect(CoreEffect):
     def apply_tech_target(
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
-        combat = tech.combat_state
-        assert combat
+        combat = tech.get_combat_state()
         visible = self.visible.lower() == "true"
         combat._menu_visibility.update_visibility(self.menu, visible)
         return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/park.py
+++ b/tuxemon/core/effects/park.py
@@ -80,18 +80,18 @@ class ParkEffect(CoreEffect):
             "menu_park_playful",
             "menu_park_alert",
         ]
-        assert item.combat_state
+        combat_state = item.get_combat_state()
         empty = Technique.create("empty")
         empty.use_tech = random.choice(labels)
-        item.combat_state._action_queue.rewrite(target, empty)
+        combat_state._action_queue.rewrite(target, empty)
         self.session.client.park_session.record_failure()
 
     def _apply_capture_effects(self, item: Item, target: Monster) -> None:
         formula.on_capture_success(item, target, self.session.player)
-        assert item.combat_state
+        combat_state = item.get_combat_state()
 
         if self.session.player.tuxepedia.is_seen(target.slug):
-            item.combat_state._new_tuxepedia = True
+            combat_state._new_tuxepedia = True
         self.session.player.tuxepedia.add_entry(target.slug, SeenStatus.caught)
         target.capture_device = item.slug
         target.wild = False

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -311,7 +311,7 @@ def pygame_init() -> None:
     # Configure databases and locale
     from tuxemon.locale import T
 
-    T.initialize_translations()
+    T.initialize_translations(recompile=CONFIG.recompile_translations)
     from tuxemon.db import db
 
     db.load()
@@ -357,7 +357,7 @@ def headless_init() -> None:
     """Initializes game components for a headless environment."""
     from tuxemon.locale import T
 
-    T.initialize_translations()
+    T.initialize_translations(recompile=CONFIG.recompile_translations)
     from tuxemon.db import db
 
     db.load()


### PR DESCRIPTION
PR resolves a critical issue preventing the game from starting. The root cause was a failure to recompile the `TranslatorManager`, stemming from a missing update in the previous pull request (#2944). This fix ensures that the necessary changes are applied, allowing the game to launch correctly.