### PR TITLE
Drop setup.py - complete migration to pyproject.toml

### DIFF
--- a/buildconfig/build_deb.sh
+++ b/buildconfig/build_deb.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
 export PYBUILD_DISABLE=test
-python setup.py sdist --keep-temp
+python3 -m build --sdist
+cd dist
+tar -xf tuxemon-*.tar.gz
 cd tuxemon-*
-cp ../dist/* ..
+cp ../tuxemon-*.tar.gz ..
 debmake -b':py3'
 echo "./mods usr/share/tuxemon/" > debian/install
 dpkg-buildpackage -us -uc -b
 cd ..
-mv tuxemon*.deb build/tuxemon-$TRAVIS_DIST-$TRAVIS_BRANCH.deb
+version=$(python3 -c "import tuxemon; print(tuxemon.__version__)")
+branch=$(git rev-parse --abbrev-ref HEAD)
+date=$(date +%Y%m%d)
+mkdir -p build
+mv tuxemon*.deb build/tuxemon-${version}-${branch}-${date}.deb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tuxemon"
-version = "0.4.35"
 description = "Open source monster-fighting RPG"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -26,7 +25,7 @@ classifiers = [
         "Topic :: Games/Entertainment :: Role-Playing"
 ]
 requires-python = ">=3.9"
-dynamic = ["dependencies"]
+dynamic = ["version", "dependencies"]
 
 [project.urls]
 homepage = "https://www.tuxemon.org"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,11 +1,13 @@
-Tools to get/manipulate game files or config should go here.
+## Tools & Scripts Directory
 
-* Scripts should have documentation at the top of the file
-* Do not add script dependencies to requirements.txt or setup.py
-* New python scripts should be written for python 3.9+
-* Scripts do not require unit testing
-* Do not modify project if your script requires another language/runtime
+This folder contains optional utilities for manipulating game files and configurations related to Tuxemon. These are **not required** to run or play the game.
 
-If you are writing a script which is a requirement to play the game,
-then do not write a script.  The game should be playable without the use
-of scripts.
+### General Guidelines
+- **Documentation:** All scripts should include a description and usage instructions at the top of the file.
+- **Language:** New scripts must be written in Python **3.9+**.
+- **Dependencies:** Do **not** add script-specific dependencies to `requirements.txt`.
+- **Testing:** Unit tests are **not required** for scripts in this folder.
+- **External Runtimes:** Scripts should not depend on other languages or runtimes. If they do, they must remain isolated and not alter the project itself.
+
+### Gameplay Rule
+If you're creating functionality that is required to **play** the game, it should be built into the game—not left as a separate script.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-# SPDX-License-Identifier: GPL-3.0
-# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from setuptools import setup
-
-# Configure setuptools
-setup()

--- a/tuxemon/__init__.py
+++ b/tuxemon/__init__.py
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from tuxemon.version import __version__


### PR DESCRIPTION
PR removes the legacy `setup.py` file, which was the last remaining piece of the old packaging setup. The project now fully uses `pyproject.toml` for build configuration and metadata, following modern Python packaging standards.  
All essential details (project info, dependencies, versioning via setuptools-scm, and entry points) are now defined in TOML.