### PR TITLE
Add Final HP-Affecting Tastes: Savory (+5%) & Bland (-5%)

### DIFF
--- a/mods/tuxemon/db/taste/taste.json
+++ b/mods/tuxemon/db/taste/taste.json
@@ -148,5 +148,35 @@
     "rarity_score": 1.0,
     "slug": "refined",
     "taste_type": "warm"
+  },
+  {
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "multiplier": 1.05,
+        "values": [
+          "hp"
+        ]
+      }
+    ],
+    "name": "taste_savory",
+    "rarity_score": 0.4,
+    "slug": "savory",
+    "taste_type": "warm"
+  },
+  {
+    "modifiers": [
+      {
+        "attribute": "stat",
+        "multiplier": 0.95,
+        "values": [
+          "hp"
+        ]
+      }
+    ],
+    "name": "taste_bland",
+    "rarity_score": 0.4,
+    "slug": "bland",
+    "taste_type": "cold"
   }
 ]

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -8590,6 +8590,18 @@ msgstr "Dry"
 msgid "taste_dry_description"
 msgstr "A parched, dusty flavor, like stale crackers that dull your senses."
 
+msgid "taste_savory"
+msgstr "Savory"
+
+msgid "taste_savory_description"
+msgstr "A rich, slow-roasted flavor, like smoky mushrooms and caramelized onions that settle warmly in your core."
+
+msgid "taste_bland"
+msgstr "Bland"
+
+msgid "taste_bland_description"
+msgstr "A vague, chalky taste, like powdered mashed potatoes made with a sigh instead of water."
+
 # Terrains
 msgid "terrain_freshwater"
 msgstr "Freshwater"

--- a/tuxemon/core/effects/food_preference.py
+++ b/tuxemon/core/effects/food_preference.py
@@ -27,6 +27,8 @@ OPPOSITE_TASTES = {
     "taste_flakey": "taste_zesty",
     "taste_refined": "taste_dry",
     "taste_dry": "taste_refined",
+    "taste_savory": "taste_bland",
+    "taste_bland": "taste_savory",
 }
 
 


### PR DESCRIPTION
PR finalizes the taste mechanic by adding the last two missing flavor types, both affecting the HP stat:
- **Savory** warmer-tasting flavor that increases HP by **+5%**
- **Bland** cooler-tasting flavor that reduces HP by **–5%**

These additions complete the taste effect spectrum, ensuring full coverage of stat-impacting flavors.