### PR TITLE
Fix Immediate Sound Volume Update When Slider Is Changed

### DIFF
--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import pygame_menu
 from pygame.surface import Surface
-from pygame_menu import locals, sound
+from pygame_menu.locals import ALIGN_LEFT, SCROLLAREA_POSITION_NONE
+from pygame_menu.sound import SOUND_TYPE_WIDGET_SELECTION
 from pygame_menu.widgets.core.selection import Selection
 from pygame_menu.widgets.core.widget import Widget
 from pygame_menu.widgets.widget.menubar import MENUBAR_STYLE_ADAPTIVE
@@ -85,11 +86,11 @@ def get_theme() -> pygame_menu.Theme:
 
     theme = pygame_menu.Theme(
         background_color=tuxemon_background,
-        widget_alignment=locals.ALIGN_LEFT,
+        widget_alignment=ALIGN_LEFT,
         title=False,
         widget_selection_effect=TuxemonArrowSelection(),
         border_color=tuxemon_border,
-        scrollarea_position=locals.SCROLLAREA_POSITION_NONE,
+        scrollarea_position=SCROLLAREA_POSITION_NONE,
         widget_padding=(10, 20),
         title_close_button=False,
         title_bar_style=MENUBAR_STYLE_ADAPTIVE,
@@ -125,13 +126,13 @@ def get_sound_engine(
 
     if _sound_engine is not None:
         _sound_engine.set_sound_volume(
-            sound_type=sound.SOUND_TYPE_WIDGET_SELECTION, volume=volume
+            sound_type=SOUND_TYPE_WIDGET_SELECTION, volume=volume
         )
         return _sound_engine
 
     sound_engine = pygame_menu.Sound()
     sound_engine.set_sound(
-        sound_type=sound.SOUND_TYPE_WIDGET_SELECTION,
+        sound_type=SOUND_TYPE_WIDGET_SELECTION,
         sound_file=filename,
         volume=float(volume),
     )

--- a/tuxemon/states/control/control_state.py
+++ b/tuxemon/states/control/control_state.py
@@ -7,7 +7,8 @@ from functools import partial
 from typing import Any, Optional, Union
 
 import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.sound import SOUND_TYPE_WIDGET_SELECTION
 
 from tuxemon import prepare
 from tuxemon.animation import Animation, ScheduleType
@@ -26,8 +27,8 @@ class ControlState(PygameMenuState):
     def __init__(self, **kwargs: Any) -> None:
         """Used when initializing the state."""
         theme = get_theme()
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         self.main_menu = "main_menu" in kwargs and kwargs["main_menu"]
         kwargs.pop("main_menu", None)
         super().__init__(**kwargs)
@@ -161,6 +162,8 @@ class ControlState(PygameMenuState):
                 self.client.config.update_attribute(
                     "gameplay", "sound_volume", str(volume)
                 )
+                sound = self.menu.get_sound()
+                sound.set_sound_volume(SOUND_TYPE_WIDGET_SELECTION, volume)
 
             music.set_onchange(on_change_music)
             sound.set_onchange(on_change_sound)


### PR DESCRIPTION
PR fixes #2962 where changes to the "Sound volume" slider do not immediately affect the actual volume during menu interactions. Specifically: previously, sound volume adjustments would not take effect until exiting the settings menu and this behavior was inconsistent with "Music volume," which updates instantly, leading to user confusion.