### PR TITLE
Fix Navigation Bug in World Menu

### DIFF
--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -322,7 +322,10 @@ class WorldMenuState(PygameMenuState):
         return ani
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        if event.button in (buttons.START, buttons.BACK) and event.pressed:
+        if (
+            event.button in (buttons.START, buttons.B, buttons.BACK)
+            and event.pressed
+        ):
             self.client.pop_state()
             return None
-        return None
+        return super().process_event(event)


### PR DESCRIPTION
PR resolves an issue in the world menu where vertical navigation (up/down) was broken. The bug occurred due to a missing line in the previous pull request (#2946), which has now been restored.