### PR TITLE
Enhance CraftingStation EventAction with `file_yaml` Attribute Support

### DIFF
--- a/mods/tuxemon/db/item/trace_bio_sample.json
+++ b/mods/tuxemon/db/item/trace_bio_sample.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_dusty_datalog.json
+++ b/mods/tuxemon/db/item/trace_dusty_datalog.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_echo_core.json
+++ b/mods/tuxemon/db/item/trace_echo_core.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_encoded_chip.json
+++ b/mods/tuxemon/db/item/trace_encoded_chip.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_encrypted_fragment.json
+++ b/mods/tuxemon/db/item/trace_encrypted_fragment.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_flickering_drive.json
+++ b/mods/tuxemon/db/item/trace_flickering_drive.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_latent_relic.json
+++ b/mods/tuxemon/db/item/trace_latent_relic.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_mysterious_data_slate.json
+++ b/mods/tuxemon/db/item/trace_mysterious_data_slate.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_prismatic_crystal.json
+++ b/mods/tuxemon/db/item/trace_prismatic_crystal.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/trace_signal_node.json
+++ b/mods/tuxemon/db/item/trace_signal_node.json
@@ -8,7 +8,9 @@
     ""
   ],
   "modifiers": [],
-  "behaviors": {},
+  "behaviors": {
+    "consumable": true
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/tuxemon/event/actions/crafting_station.py
+++ b/tuxemon/event/actions/crafting_station.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import final
+from typing import Optional, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
@@ -22,19 +22,21 @@ class CraftingStationAction(EventAction):
     Script usage:
         .. code-block::
 
-            crafting_station <state_name>[,optional]
+            crafting_station <character_slug>,<method>[,file_yaml]
 
     Script parameters:
         character_slug: The slug of the character (NPC).
         method: Suggests how the recipe is executed, e.g., cooking, forging.
+        file_yaml: The YAML file (like `recipe.yaml`) that contains the recipe
+            definitions to load into the system (mods folder).
     """
 
     name = "crafting_station"
     character_slug: str
     method: str
+    file_yaml: Optional[str] = None
 
     def start(self, session: Session) -> None:
-        self.session = session
         self.client = session.client
 
         if self.client.current_state is None:
@@ -53,8 +55,12 @@ class CraftingStationAction(EventAction):
             )
             return
 
+        file_yaml = self.file_yaml or "recipes.yaml"
         self.client.push_state(
-            "CraftMenuState", character=character, method=self.method
+            "CraftMenuState",
+            character=character,
+            file_yaml=file_yaml,
+            method=self.method,
         )
 
     def update(self, session: Session) -> None:

--- a/tuxemon/states/items/craft_menu.py
+++ b/tuxemon/states/items/craft_menu.py
@@ -25,8 +25,11 @@ class CraftMenuState(PygameMenuState):
     This state is responsible for the craft menu.
     """
 
-    def __init__(self, character: NPC, method: Optional[str] = None) -> None:
+    def __init__(
+        self, character: NPC, file_yaml: str, method: Optional[str] = None
+    ) -> None:
         self.character = character
+        self.file_yaml = file_yaml
         self.method = method
         width, height = prepare.SCREEN_SIZE
 
@@ -46,7 +49,7 @@ class CraftMenuState(PygameMenuState):
         def up() -> None:
             menu._scrollarea._scrollbars[0].bump_to_top()
 
-        yaml_path = (paths.mods_folder / "recipes.yaml").resolve()
+        yaml_path = (paths.mods_folder / self.file_yaml).resolve()
         if not yaml_path.exists():
             raise FileNotFoundError(f"Recipe file not found: {yaml_path}")
 
@@ -97,7 +100,7 @@ class CraftMenuState(PygameMenuState):
             )
 
     def add_tool_label(self, menu: pygame_menu.Menu, recipe: Recipe) -> None:
-        for tool in getattr(recipe, "required_tools", []):
+        for tool in recipe.required_tools:
             tool_name = T.translate(tool.get("slug", ""))
             consumed_text = (
                 T.translate("menu_tool_consumed")


### PR DESCRIPTION
PR introduces a new attribute, `file_yaml`, to the `crafting_station` EventAction. The attribute allows for specifying the name of a YAML recipe file to be passed into the relevant crafting station state. When triggered, this enables the state to dynamically load and display the appropriate crafting menu based on contextual recipe data.

As soon as #2928 lands, a new PR’s on its way