### PR TITLE
Fix monster storage persistence

### DIFF
--- a/tuxemon/boxes.py
+++ b/tuxemon/boxes.py
@@ -2,8 +2,10 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 import uuid
-from typing import TYPE_CHECKING, Optional
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional
 
 from tuxemon import prepare
 from tuxemon.item.item import decode_items, encode_items
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC, NPCState
+
+logger = logging.getLogger(__name__)
 
 
 class BoxCollection:
@@ -328,42 +332,6 @@ class BoxCollection:
                 f"{source_box_id} doesn't exist or {monster.slug} isn't in the {source_box_id} box"
             )
 
-    def save(self, state: NPCState) -> None:
-        """
-        Saves the current state of the box collection.
-
-        Parameters:
-            state: The state to save the box collection to.
-        """
-        state["item_boxes"] = {}
-        state["monster_boxes"] = {}
-        for box_id, items in self.item_boxes.items():
-            state["item_boxes"][box_id] = encode_items(items)
-        for box_id, monsters in self.monster_boxes.items():
-            state["monster_boxes"][box_id] = encode_monsters(monsters)
-
-    def load(self, char: NPC, save_data: NPCState) -> None:
-        """
-        Loads the box collection from a saved state.
-
-        Parameters:
-            save_data: The saved state to load the box collection from.
-        """
-        self.item_boxes = {
-            box_id: decode_items(items)
-            for box_id, items in save_data.get("item_boxes", {}).items()
-        }
-
-        self.monster_boxes = {}
-
-        for box_id, encoded_monsters in save_data.get(
-            "monster_boxes", {}
-        ).items():
-            monsters = decode_monsters(encoded_monsters)
-            for monster in monsters:
-                monster.set_owner(char)
-            self.monster_boxes[box_id] = monsters
-
 
 class ItemBoxes(BoxCollection):
     def __init__(self) -> None:
@@ -372,23 +340,28 @@ class ItemBoxes(BoxCollection):
         """
         super().__init__()
 
-    def save(self, state: NPCState) -> None:
+    def get_state(self) -> dict[str, Sequence[Mapping[str, Any]]]:
         """
         Saves the current state of the item boxes.
-
-        Parameters:
-            state: The state to save the item boxes to.
         """
-        super().save(state)
+        return {
+            box_id: encode_items(items)
+            for box_id, items in self.item_boxes.items()
+        }
 
-    def load(self, char: NPC, save_data: NPCState) -> None:
+    def load(self, save_data: NPCState) -> None:
         """
         Loads the item boxes from a saved state.
-
-        Parameters:
-            save_data: The saved state to load the item boxes from.
         """
-        super().load(char, save_data)
+        self.item_boxes = {
+            box_id: decode_items(items)
+            for box_id, items in save_data.get("item_boxes", {}).items()
+        }
+
+        for box_id, items in self.item_boxes.items():
+            item_count = len(items)
+            if item_count == 0:
+                logger.debug(f"Warning: loaded box '{box_id}' is empty")
 
 
 class MonsterBoxes(BoxCollection):
@@ -542,20 +515,35 @@ class MonsterBoxes(BoxCollection):
         else:
             raise ValueError("Monster not found in box.")
 
-    def save(self, state: NPCState) -> None:
+    def get_state(self) -> dict[str, Sequence[Mapping[str, Any]]]:
         """
         Saves the current state of the monster boxes.
-
-        Parameters:
-            state: The state to save the monster boxes to.
         """
-        super().save(state)
+        return {
+            box_id: encode_monsters(monsters)
+            for box_id, monsters in self.monster_boxes.items()
+        }
 
     def load(self, char: NPC, save_data: NPCState) -> None:
         """
         Loads the monster boxes from a saved state.
-
-        Parameters:
-            save_data: The saved state to load the monster boxes from.
         """
-        super().load(char, save_data)
+        self.monster_boxes = {}
+
+        for box_id, encoded_monsters in save_data.get(
+            "monster_boxes", {}
+        ).items():
+            monsters = decode_monsters(encoded_monsters)
+            monster_count = len(monsters)
+            logger.debug(
+                f"Loaded box '{box_id}' with {monster_count} monsters."
+            )
+            if monster_count == 0:
+                logger.debug(
+                    f"Warning: loaded monster box '{box_id}' is empty"
+                )
+            for monster in monsters:
+                monster.set_owner(char)
+            self.monster_boxes[box_id] = monsters
+
+        logger.debug(f"Loaded {len(self.monster_boxes)} monster boxes.")

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -172,8 +172,8 @@ class NPC(Entity[NPCState]):
             "monsters": self.party.encode_party(),
             "player_name": self.name,
             "player_steps": self.steps,
-            "monster_boxes": dict(),
-            "item_boxes": dict(),
+            "monster_boxes": self.monster_boxes.get_state(),
+            "item_boxes": self.item_boxes.get_state(),
             "tile_pos": self.tile_pos,
             "teleport_faint": self.teleport_faint.to_tuple(),
             "tracker": encode_tracking(self.tracker),
@@ -181,8 +181,6 @@ class NPC(Entity[NPCState]):
             "unlocked_letters": encode_cipher(self.unlocked_letters),
         }
 
-        self.monster_boxes.save(state)
-        self.item_boxes.save(state)
         state["money"] = self.money_controller.save()
 
         return state
@@ -208,7 +206,7 @@ class NPC(Entity[NPCState]):
         self.money_controller.load(save_data)
         self.unlocked_letters = decode_cipher(save_data)
         self.monster_boxes.load(self, save_data)
-        self.item_boxes.load(self, save_data)
+        self.item_boxes.load(save_data)
 
         self.teleport_faint = TeleportFaint.from_tuple(
             save_data["teleport_faint"]


### PR DESCRIPTION
PR fixes #2972 a bug where Tuxemon dropped into the computer's monster storage would disappear after restarting the game. After depositing a Tuxemon and saving the game, the monster storage appeared empty on reload. The issue was in the **saving logic**, not loading. `get_state()` methods returned improperly structured data, causing the game to fail serializing monster and item box contents correctly.

Key changes:
- updated `get_state()` methods in `MonsterBoxes` and `ItemBoxes` to match `NPCState` expectations
- confirmed `NPC.get_state()` assigns properly structured `monster_boxes` and `item_boxes` values