### PR TITLE
Refactor Acquisition Timestamp MsgIDs for Granular Localization

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4080,17 +4080,53 @@ msgstr "Evolution"
 msgid "yes_evolutions"
 msgstr "Evolutions"
 
-msgid "tuxepedia_capture_today"
+msgid "tuxepedia_acquisition_unknown_today"
+msgstr "Acquired today"
+
+msgid "tuxepedia_acquisition_unknown_days_ago"
+msgstr "Acquired {doc} days ago"
+
+msgid "tuxepedia_acquisition_captured_today"
 msgstr "Captured today"
 
-msgid "tuxepedia_trade_today"
-msgstr "Traded today"
-
-msgid "tuxepedia_capture"
+msgid "tuxepedia_acquisition_captured_days_ago"
 msgstr "Captured {doc} days ago"
 
-msgid "tuxepedia_trade"
+msgid "tuxepedia_acquisition_traded_today"
+msgstr "Traded today"
+
+msgid "tuxepedia_acquisition_traded_days_ago"
 msgstr "Traded {doc} days ago"
+
+msgid "tuxepedia_acquisition_bred_today"
+msgstr "Bred today"
+
+msgid "tuxepedia_acquisition_bred_days_ago"
+msgstr "Bred {doc} days ago"
+
+msgid "tuxepedia_acquisition_gifted_today"
+msgstr "Gifted today"
+
+msgid "tuxepedia_acquisition_gifted_days_ago"
+msgstr "Gifted {doc} days ago"
+
+msgid "tuxepedia_acquisition_purchased_today"
+msgstr "Purchased today"
+
+msgid "tuxepedia_acquisition_purchased_days_ago"
+msgstr "Purchased {doc} days ago"
+
+msgid "tuxepedia_acquisition_rescued_today"
+msgstr "Rescued today"
+
+msgid "tuxepedia_acquisition_rescued_days_ago"
+msgstr "Rescued {doc} days ago"
+
+msgid "tuxepedia_acquisition_created_today"
+msgstr "Created today"
+
+msgid "tuxepedia_acquisition_created_days_ago"
+msgstr "Created {doc} days ago"
 
 msgid "tuxepedia_exp"
 msgstr "{exp_lv}xp to Lv {lv}"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -6920,9 +6920,6 @@ msgstr "有进化型"
 msgid "yes_evolutions"
 msgstr "进化型"
 
-msgid "tuxepedia_capture"
-msgstr "捕获了{doc}天"
-
 msgid "tuxepedia_exp"
 msgstr "需要{exp_lv}经验到等级{lv}"
 

--- a/tuxemon/states/monster_info/__init__.py
+++ b/tuxemon/states/monster_info/__init__.py
@@ -164,21 +164,9 @@ class MonsterInfoState(PygameMenuState):
         )
         lab9.translate(fxw(0.50), fxh(0.45))
         # capture
-        doc = today_ordinal() - monster.capture
-        if doc >= 1:
-            ref = (
-                T.format("tuxepedia_trade", {"doc": doc})
-                if monster.has_acquisition(Acquisition.TRADED)
-                else T.format("tuxepedia_capture", {"doc": doc})
-            )
-        else:
-            ref = (
-                T.translate("tuxepedia_trade_today")
-                if monster.has_acquisition(Acquisition.TRADED)
-                else T.translate("tuxepedia_capture_today")
-            )
+        reference = get_acquisition_reference(monster)
         lab10: Any = menu.add.label(
-            title=ref,
+            title=reference,
             label_id="capture",
             font_size=self.font_type.smaller,
             align=locals.ALIGN_LEFT,
@@ -345,6 +333,14 @@ class MonsterInfoState(PygameMenuState):
             client.remove_state_by_name("MonsterInfoState")
 
         return None
+
+
+def get_acquisition_reference(monster: Monster) -> str:
+    acq_type = monster.acquisition
+    doc = today_ordinal() - monster.capture
+    time_key = "today" if doc < 1 else "days_ago"
+    msgid = f"tuxepedia_acquisition_{acq_type.value}_{time_key}"
+    return T.translate(msgid) if doc < 1 else T.format(msgid, {"doc": doc})
 
 
 def _get_monsters(monster: Monster, source: str) -> list[Monster]:


### PR DESCRIPTION
PR improves localization for acquisition timestamp messages by introducing explicit message IDs (`msgid`) per acquisition type and replacing the previous generic entries. This simplifies translator workflows and improves end-user clarity.

Key changes:
- added new `msgid`/`msgstr` entries for each `Acquisition` enum variant: `captured`, `traded`, `bred`, `gifted`, `purchased`, `rescued`, `created`, and `unknown`, each type now has messages for both “today” and “{doc} days ago”
- replaced legacy generic keys: `tuxepedia_acquisition_today` now replaced by specific variants, e.g. `tuxepedia_acquisition_captured_today` and `tuxepedia_acquisition_days_ago` now replaced by specific variants, e.g. `tuxepedia_acquisition_gifted_days_ago`
- ensured backwards compatibility by removing reliance on fallback display logic
- improved translator context and reduced ambiguity