### PR TITLE
Fix for Grabbed and Stuck Status Not Reverting Technique Stats After Removal

### DIFF
--- a/tuxemon/core/effects/grabbed.py
+++ b/tuxemon/core/effects/grabbed.py
@@ -34,14 +34,20 @@ class GrabbedEffect(CoreEffect):
     def apply_status_target(
         self, session: Session, status: Status, target: Monster
     ) -> StatusEffectResult:
+        if self.divisor == 0:
+            raise ValueError("StuckEffect divisor must be non-zero.")
+
         done: bool = False
         ranges = self.ranges.split(":")
         moves = [
             tech for tech in target.moves.get_moves() if tech.range in ranges
         ]
+
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             done = True
-        # applies effect on techniques
+        elif status.has_phase(EffectPhase.ON_END):
+            target.moves.set_stats()
+
         if done and moves:
             for move in moves:
                 move.potency = move.default_potency / self.divisor

--- a/tuxemon/core/effects/stuck.py
+++ b/tuxemon/core/effects/stuck.py
@@ -34,14 +34,20 @@ class StuckEffect(CoreEffect):
     def apply_status_target(
         self, session: Session, status: Status, target: Monster
     ) -> StatusEffectResult:
+        if self.divisor == 0:
+            raise ValueError("StuckEffect divisor must be non-zero.")
+
         done: bool = False
         ranges = self.ranges.split(":")
         moves = [
             tech for tech in target.moves.get_moves() if tech.range in ranges
         ]
+
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             done = True
-        # applies effect on techniques
+        elif status.has_phase(EffectPhase.ON_END):
+            target.moves.set_stats()
+
         if done and moves:
             for move in moves:
                 move.potency = move.default_potency / self.divisor


### PR DESCRIPTION
PR fixes #2976 a bug where a monster affected by the *Grabbed* condition experiences reduced power for its Melee and Reach techniques, but that reduction was not properly reversed after the status was removed. To fix this, I’ve added logic under the `ON_END` phase to reapply default stats to the monster’s techniques when the status expires or is cleared. This ensures that the technique potency and power values return to normal. I’ve also applied the same fix to the *Stuck* status effect, which shared the exact same issue and behavior. Finally, regarding stat modifiers from status effects, I’ll be adding the relevant lines under PR #2948, since that one already modifies `StatChangeEffect`.