### PR TITLE
Support pre/post battle dialogue in `NpcModel` + Beautifier NPC folder JSON

### DIFF
--- a/mods/tuxemon/db/npc/37707_female.json
+++ b/mods/tuxemon/db/npc/37707_female.json
@@ -1,10 +1,8 @@
 {
   "slug": "37707_female",
-  "template": 
-    {
-      "sprite_name": "37707_female",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "37707_female",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/37707_female_missing.json
+++ b/mods/tuxemon/db/npc/37707_female_missing.json
@@ -1,10 +1,8 @@
 {
   "slug": "37707_female_missing",
-  "template": 
-    {
-      "sprite_name": "37707_female_missing",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "37707_female_missing",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/37707_male.json
+++ b/mods/tuxemon/db/npc/37707_male.json
@@ -1,10 +1,8 @@
 {
   "slug": "37707_male",
-  "template": 
-    {
-      "sprite_name": "37707_male",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "37707_male",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/37707_male_missing.json
+++ b/mods/tuxemon/db/npc/37707_male_missing.json
@@ -1,10 +1,8 @@
 {
   "slug": "37707_male_missing",
-  "template": 
-    {
-      "sprite_name": "37707_male_missing",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "37707_male_missing",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/aeble.json
+++ b/mods/tuxemon/db/npc/aeble.json
@@ -1,10 +1,8 @@
 {
   "slug": "aeble",
-  "template": 
-    {
-      "sprite_name": "ceo",
-      "combat_front": "adventurer",
-      "slug": "ceo"
-    }
-
+  "template": {
+    "sprite_name": "ceo",
+    "combat_front": "adventurer",
+    "slug": "ceo"
+  }
 }

--- a/mods/tuxemon/db/npc/allie.json
+++ b/mods/tuxemon/db/npc/allie.json
@@ -1,10 +1,8 @@
 {
   "slug": "allie",
-  "template": 
-    {
-      "sprite_name": "omnichannelallie",
-      "combat_front": "goth_rose",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "omnichannelallie",
+    "combat_front": "goth_rose",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/azure_npcs.json
+++ b/mods/tuxemon/db/npc/azure_npcs.json
@@ -1,42 +1,34 @@
 [
   {
     "slug": "unknownwitch",
-    "template": 
-      {
-        "sprite_name": "witch",
-        "combat_front": "witch",
-        "slug": "heroine"
-      }
-  
+    "template": {
+      "sprite_name": "witch",
+      "combat_front": "witch",
+      "slug": "heroine"
+    }
   },
   {
     "slug": "azure_enforcer",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "azure_enforcer2",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "enforcer_rookie",
-        "slug": "enforcer_rookie"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "enforcer_rookie",
+      "slug": "enforcer_rookie"
+    }
   },
   {
     "slug": "azure_knight",
-    "template": 
-      {
-        "sprite_name": "knight",
-        "combat_front": "knight",
-        "slug": "knight"
-      }
-  
+    "template": {
+      "sprite_name": "knight",
+      "combat_front": "knight",
+      "slug": "knight"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/bob.json
+++ b/mods/tuxemon/db/npc/bob.json
@@ -1,10 +1,8 @@
 {
   "slug": "bob",
-  "template": 
-    {
-      "sprite_name": "bob",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "bob",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/christie.json
+++ b/mods/tuxemon/db/npc/christie.json
@@ -1,10 +1,8 @@
 {
   "slug": "christie",
-  "template": 
-    {
-      "sprite_name": "christie",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "christie",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/conworker1.json
+++ b/mods/tuxemon/db/npc/conworker1.json
@@ -1,10 +1,8 @@
 {
   "slug": "conworker1",
-  "template": 
-    {
-      "sprite_name": "bob",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "bob",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/conworker2.json
+++ b/mods/tuxemon/db/npc/conworker2.json
@@ -1,10 +1,8 @@
 {
   "slug": "conworker2",
-  "template": 
-    {
-      "sprite_name": "bob",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "bob",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/conworker3.json
+++ b/mods/tuxemon/db/npc/conworker3.json
@@ -1,10 +1,8 @@
 {
   "slug": "conworker3",
-  "template": 
-    {
-      "sprite_name": "bob",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "bob",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/cotton_breeder.json
+++ b/mods/tuxemon/db/npc/cotton_breeder.json
@@ -1,10 +1,8 @@
 {
   "slug": "cotton_breeder",
-  "template": 
-    {
-      "sprite_name": "bob",
-      "combat_front": "adventurer",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "bob",
+    "combat_front": "adventurer",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/cotton_misa_bro.json
+++ b/mods/tuxemon/db/npc/cotton_misa_bro.json
@@ -1,10 +1,8 @@
 {
   "slug": "cotton_misa_bro",
-  "template": 
-    {
-      "sprite_name": "childactor_fiery",
-      "combat_front": "yellowbelt",
-      "slug": "childactor"
-    }
-
+  "template": {
+    "sprite_name": "childactor_fiery",
+    "combat_front": "yellowbelt",
+    "slug": "childactor"
+  }
 }

--- a/mods/tuxemon/db/npc/cotton_misa_gramps.json
+++ b/mods/tuxemon/db/npc/cotton_misa_gramps.json
@@ -1,10 +1,8 @@
 {
   "slug": "cotton_misa_gramps",
-  "template": 
-    {
-      "sprite_name": "granny",
-      "combat_front": "heroine",
-      "slug": "granny"
-    }
-
+  "template": {
+    "sprite_name": "granny",
+    "combat_front": "heroine",
+    "slug": "granny"
+  }
 }

--- a/mods/tuxemon/db/npc/grace.json
+++ b/mods/tuxemon/db/npc/grace.json
@@ -1,10 +1,8 @@
 {
   "slug": "grace",
-  "template": 
-    {
-      "sprite_name": "heroine",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "heroine",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/happy_guy.json
+++ b/mods/tuxemon/db/npc/happy_guy.json
@@ -1,10 +1,8 @@
 {
   "slug": "happy_guy",
-  "template": 
-    {
-      "sprite_name": "ceo",
-      "combat_front": "adventurer",
-      "slug": "ceo"
-    }
-
+  "template": {
+    "sprite_name": "ceo",
+    "combat_front": "adventurer",
+    "slug": "ceo"
+  }
 }

--- a/mods/tuxemon/db/npc/knight1.json
+++ b/mods/tuxemon/db/npc/knight1.json
@@ -1,10 +1,8 @@
 {
   "slug": "knight1",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/knight2.json
+++ b/mods/tuxemon/db/npc/knight2.json
@@ -1,10 +1,8 @@
 {
   "slug": "knight2",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/knight3.json
+++ b/mods/tuxemon/db/npc/knight3.json
@@ -1,10 +1,8 @@
 {
   "slug": "knight3",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/knight4.json
+++ b/mods/tuxemon/db/npc/knight4.json
@@ -1,10 +1,8 @@
 {
   "slug": "knight4",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/kyle.json
+++ b/mods/tuxemon/db/npc/kyle.json
@@ -1,10 +1,8 @@
 {
   "slug": "kyle",
-  "template": 
-    {
-      "sprite_name": "cooldude",
-      "combat_front": "cooldude",
-      "slug": "cooldude"
-    }
-
+  "template": {
+    "sprite_name": "cooldude",
+    "combat_front": "cooldude",
+    "slug": "cooldude"
+  }
 }

--- a/mods/tuxemon/db/npc/liela.json
+++ b/mods/tuxemon/db/npc/liela.json
@@ -1,10 +1,8 @@
 {
   "slug": "liela",
-  "template": 
-    {
-      "sprite_name": "heroine",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "heroine",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/maple.json
+++ b/mods/tuxemon/db/npc/maple.json
@@ -1,10 +1,8 @@
 {
   "slug": "maple_girl",
-  "template": 
-    {
-      "sprite_name": "fashionista_fiery",
-      "combat_front": "fashionista",
-      "slug": "fashionista"
-    }
-
+  "template": {
+    "sprite_name": "fashionista_fiery",
+    "combat_front": "fashionista",
+    "slug": "fashionista"
+  }
 }

--- a/mods/tuxemon/db/npc/marissa.json
+++ b/mods/tuxemon/db/npc/marissa.json
@@ -1,10 +1,8 @@
 {
   "slug": "marissa",
-  "template": 
-    {
-      "sprite_name": "girl1",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "girl1",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/misa.json
+++ b/mods/tuxemon/db/npc/misa.json
@@ -1,10 +1,8 @@
 {
   "slug": "misa",
-  "template": 
-    {
-      "sprite_name": "fashionista",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "fashionista",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/npc_mom.json
+++ b/mods/tuxemon/db/npc/npc_mom.json
@@ -1,10 +1,8 @@
 {
   "slug": "npc_mom",
-  "template": 
-    {
-      "sprite_name": "girl1",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "girl1",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/npc_test.json
+++ b/mods/tuxemon/db/npc/npc_test.json
@@ -1,11 +1,10 @@
 {
   "slug": "npc_test",
-  "template": 
-    {
-      "sprite_name": "adventurer",
-      "combat_front": "adventurer",
-      "slug": "adventurer"
-    },
+  "template": {
+    "sprite_name": "adventurer",
+    "combat_front": "adventurer",
+    "slug": "adventurer"
+  },
   "monsters": [
     {
       "name": "Snowball",

--- a/mods/tuxemon/db/npc/npc_wife.json
+++ b/mods/tuxemon/db/npc/npc_wife.json
@@ -1,10 +1,8 @@
 {
   "slug": "npc_wife",
-  "template": 
-    {
-      "sprite_name": "girl1",
-      "combat_front": "heroine",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "girl1",
+    "combat_front": "heroine",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/nurse1.json
+++ b/mods/tuxemon/db/npc/nurse1.json
@@ -1,10 +1,8 @@
 {
   "slug": "nurse1",
-  "template": 
-    {
-      "sprite_name": "nurse",
-      "combat_front": "nurse",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "nurse",
+    "combat_front": "nurse",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/nurse2.json
+++ b/mods/tuxemon/db/npc/nurse2.json
@@ -1,10 +1,8 @@
 {
   "slug": "nurse2",
-  "template": 
-    {
-      "sprite_name": "nurse",
-      "combat_front": "nurse",
-      "slug": "heroine"
-    }
-
+  "template": {
+    "sprite_name": "nurse",
+    "combat_front": "nurse",
+    "slug": "heroine"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt.json
+++ b/mods/tuxemon/db/npc/omnigrunt.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt10.json
+++ b/mods/tuxemon/db/npc/omnigrunt10.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt10",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt2.json
+++ b/mods/tuxemon/db/npc/omnigrunt2.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt2",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt3.json
+++ b/mods/tuxemon/db/npc/omnigrunt3.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt3",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt4.json
+++ b/mods/tuxemon/db/npc/omnigrunt4.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt4",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt5.json
+++ b/mods/tuxemon/db/npc/omnigrunt5.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt5",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt6.json
+++ b/mods/tuxemon/db/npc/omnigrunt6.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt6",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt7.json
+++ b/mods/tuxemon/db/npc/omnigrunt7.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt7",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt8.json
+++ b/mods/tuxemon/db/npc/omnigrunt8.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt8",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt9.json
+++ b/mods/tuxemon/db/npc/omnigrunt9.json
@@ -1,10 +1,8 @@
 {
   "slug": "omnigrunt9",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/omnigrunt_zeke.json
+++ b/mods/tuxemon/db/npc/omnigrunt_zeke.json
@@ -1,10 +1,8 @@
 {
   "slug": "zeke",
-  "template": 
-    {
-      "sprite_name": "knight",
-      "combat_front": "knight",
-      "slug": "knight"
-    }
-
+  "template": {
+    "sprite_name": "knight",
+    "combat_front": "knight",
+    "slug": "knight"
+  }
 }

--- a/mods/tuxemon/db/npc/penguin.json
+++ b/mods/tuxemon/db/npc/penguin.json
@@ -1,10 +1,8 @@
 {
   "slug": "penguin",
-  "template": 
-    {
-      "sprite_name": "penguin",
-      "combat_front": "penguin",
-      "slug": "noclass"
-    }
-
+  "template": {
+    "sprite_name": "penguin",
+    "combat_front": "penguin",
+    "slug": "noclass"
+  }
 }

--- a/mods/tuxemon/db/npc/postboy.json
+++ b/mods/tuxemon/db/npc/postboy.json
@@ -1,10 +1,8 @@
 {
   "slug": "postboy",
-  "template": 
-    {
-      "sprite_name": "postboy",
-      "combat_front": "adventurer",
-      "slug": "postboy"
-    }
-
+  "template": {
+    "sprite_name": "postboy",
+    "combat_front": "adventurer",
+    "slug": "postboy"
+  }
 }

--- a/mods/tuxemon/db/npc/professor.json
+++ b/mods/tuxemon/db/npc/professor.json
@@ -1,10 +1,8 @@
 {
   "slug": "professor",
-  "template": 
-    {
-      "sprite_name": "professor",
-      "combat_front": "professor",
-      "slug": "professor"
-    }
-
+  "template": {
+    "sprite_name": "professor",
+    "combat_front": "professor",
+    "slug": "professor"
+  }
 }

--- a/mods/tuxemon/db/npc/red.json
+++ b/mods/tuxemon/db/npc/red.json
@@ -1,10 +1,8 @@
 {
   "slug": "npc_red",
-  "template": 
-    {
-      "sprite_name": "adventurer",
-      "combat_front": "adventurer",
-      "slug": "adventurer"
-    }
-
+  "template": {
+    "sprite_name": "adventurer",
+    "combat_front": "adventurer",
+    "slug": "adventurer"
+  }
 }

--- a/mods/tuxemon/db/npc/rock.json
+++ b/mods/tuxemon/db/npc/rock.json
@@ -1,10 +1,8 @@
 {
   "slug": "rock",
-  "template": 
-    {
-      "sprite_name": "boulder",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "boulder",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/shady_guy.json
+++ b/mods/tuxemon/db/npc/shady_guy.json
@@ -1,10 +1,8 @@
 {
   "slug": "shady_guy",
-  "template": 
-    {
-      "sprite_name": "ninja",
-      "combat_front": "ninja",
-      "slug": "ninja"
-    }
-
+  "template": {
+    "sprite_name": "ninja",
+    "combat_front": "ninja",
+    "slug": "ninja"
+  }
 }

--- a/mods/tuxemon/db/npc/speck.json
+++ b/mods/tuxemon/db/npc/speck.json
@@ -1,10 +1,8 @@
 {
   "slug": "speck",
-  "template": 
-    {
-      "sprite_name": "beachcomber",
-      "combat_front": "beachgoer",
-      "slug": "beachgoer"
-    }
-
+  "template": {
+    "sprite_name": "beachcomber",
+    "combat_front": "beachgoer",
+    "slug": "beachgoer"
+  }
 }

--- a/mods/tuxemon/db/npc/spyder_citypark_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_citypark_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_citypark_bobette",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_citypark_bobette1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_citypark_bobette2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "catgirl_green",
       "combat_front": "catgirl",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_citypark_edith",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_citypark_edith1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_citypark_edith2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -25,6 +45,16 @@
   },
   {
     "slug": "spyder_citypark_frances",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_citypark_frances1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_citypark_frances2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_black",
       "combat_front": "florist",

--- a/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
@@ -49,6 +49,16 @@
   },
   {
     "slug": "spyder_cottoncafe_cayden",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": null,
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lostfight",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -217,6 +227,16 @@
   },
   {
     "slug": "spyder_cottontunnel_carlos",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_cottontunnel_carlos1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_cottontunnel_carlos2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -225,6 +245,16 @@
   },
   {
     "slug": "spyder_confusedperson",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": null,
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_confused2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "childactor_fiery",
       "combat_front": "tennisplayer_fiery",

--- a/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_datacenter_fermi",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_datacenter_fermi1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_datacenter_fermi2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_datacenter_onnes",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_datacenter_onnes1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_datacenter_onnes2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_datacenter_bayliss",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_datacenter_bayliss1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_datacenter_bayliss2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_datacenter_chomsky",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_datacenter_chomsky1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_datacenter_chomsky2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_datacenter_lagrange",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_datacenter_lagrange1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_datacenter_lagrange2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/spyder_dojo_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dojo_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_dojo_ares",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_ares1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_ares2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -33,6 +43,16 @@
   },
   {
     "slug": "spyder_dojo_kataro",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_kataro1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_kataro2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -41,6 +61,16 @@
   },
   {
     "slug": "spyder_dojo_iroh",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_iroh1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_iroh2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -49,6 +79,16 @@
   },
   {
     "slug": "spyder_dojo_hermes",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_hermes1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_hermes2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -57,6 +97,16 @@
   },
   {
     "slug": "spyder_dojo_hephastus",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_hephastus1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_hephastus2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -65,6 +115,16 @@
   },
   {
     "slug": "spyder_dojo_orion",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_orion1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_orion2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",
@@ -73,6 +133,16 @@
   },
   {
     "slug": "spyder_dojo_saturn",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_saturn1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_saturn2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -81,6 +151,16 @@
   },
   {
     "slug": "spyder_dojo_sokka",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_sokka1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_sokka2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",
@@ -97,6 +177,16 @@
   },
   {
     "slug": "spyder_dojo_toph",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_toph1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_toph2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -129,6 +219,16 @@
   },
   {
     "slug": "spyder_dojo_yangchen",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dojo_yangchen1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dojo_yangchen2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",

--- a/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
@@ -9,6 +9,16 @@
   },
   {
     "slug": "spyder_dragonscave_benden",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_benden1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_benden2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -17,6 +27,16 @@
   },
   {
     "slug": "spyder_dragonscave_cailin",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_cailin1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_cailin2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_blue",
       "combat_front": "dragonrider",
@@ -33,6 +53,16 @@
   },
   {
     "slug": "spyder_dragonscave_daenny",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_daenny1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_daenny2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider",
       "combat_front": "dragonrider",
@@ -41,6 +71,16 @@
   },
   {
     "slug": "spyder_dragonscave_griffin",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_griffin1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_griffin2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_fiery",
       "combat_front": "dragonrider",
@@ -57,6 +97,16 @@
   },
   {
     "slug": "spyder_dragonscave_lessa",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_lessa1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_lessa2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -65,6 +115,16 @@
   },
   {
     "slug": "spyder_dragonscave_lucille",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_lucille1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_lucille2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -73,6 +133,16 @@
   },
   {
     "slug": "spyder_dragonscave_mal",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_mal1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_mal2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderboss_fiery",
       "combat_front": "spyder_boss",
@@ -81,6 +151,16 @@
   },
   {
     "slug": "spyder_dragonscave_ray",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_ray1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_ray2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -89,6 +169,16 @@
   },
   {
     "slug": "spyder_dragonscave_tomas",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_tomas1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_tomas2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_green",
       "combat_front": "dragonrider",
@@ -97,6 +187,16 @@
   },
   {
     "slug": "spyder_dragonscave_tru",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dragonscave_tru1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dragonscave_tru2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "knightlord",

--- a/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_dryadsgrove_aquemini",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dryadsgrove_aquemini1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dryadsgrove_aquemini2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "waternymph",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_dryadsgrove_ferris",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dryadsgrove_ferris1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dryadsgrove_ferris2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "metalnymph",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_dryadsgrove_ignatia",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dryadsgrove_ignatia1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dryadsgrove_ignatia2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "firenymph",
       "combat_front": "firenymph",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_dryadsgrove_petra",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dryadsgrove_petra1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dryadsgrove_petra2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "earthnymph",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_dryadsgrove_sylvia",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_dryadsgrove_sylvia1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_dryadsgrove_sylvia2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "woodnymph",

--- a/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_greenwash_aissa",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_aissa1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_aissa2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_greenwash_alex",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_alex1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_alex2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_greenwash_broer",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_broer1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_broer2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_greenwash_chip",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_chip1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_chip2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_greenwash_clarence",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_clarence1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_clarence2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "aviator",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_greenwash_dempsey",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_dempsey1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_dempsey1",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_greenwash_dippel",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_dippel1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_dippel2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_greenwash_gluck",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_gluck1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_gluck2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_greenwash_gregor",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_gregor1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_gregor2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -81,6 +171,16 @@
   },
   {
     "slug": "spyder_greenwash_heidenstam",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_heidenstam1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_heidenstam2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "postboy_red",
       "combat_front": "cooldude",
@@ -89,6 +189,16 @@
   },
   {
     "slug": "spyder_greenwash_hunt",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_hunt1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_hunt2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -97,6 +207,16 @@
   },
   {
     "slug": "spyder_greenwash_lewie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_lewie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_lewie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -105,6 +225,16 @@
   },
   {
     "slug": "spyder_greenwash_lewis",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_lewis1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_lewis2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -113,6 +243,16 @@
   },
   {
     "slug": "spyder_greenwash_looten",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_looten1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_looten2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -121,6 +261,16 @@
   },
   {
     "slug": "spyder_greenwash_louis",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_louis1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_louis2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -129,6 +279,16 @@
   },
   {
     "slug": "spyder_greenwash_moreau",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_moreau1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_moreau2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -137,6 +297,16 @@
   },
   {
     "slug": "spyder_greenwash_morehouse",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_greenwash_morehouse1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_greenwash_morehouse2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/spyder_hospital_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_hospital_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_hospital1_aurora",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_aurora1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_aurora2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderboss_blonde",
       "combat_front": "spyder_boss",
@@ -17,6 +27,16 @@
   },
   {
     "slug": "spyder_hospital1_luzia",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_luzia1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_luzia2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderboss_fiery",
       "combat_front": "spyder_boss",
@@ -25,6 +45,16 @@
   },
   {
     "slug": "spyder_hospital1_liane",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_liane1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_liane2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderboss_green",
       "combat_front": "spyder_boss",
@@ -33,6 +63,16 @@
   },
   {
     "slug": "spyder_hospital1_fring",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_fring1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_fring2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -41,6 +81,16 @@
   },
   {
     "slug": "spyder_hospital1_felu",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_felu1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_felu2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -49,6 +99,16 @@
   },
   {
     "slug": "spyder_hospital1_eleni",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_eleni1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_eleni2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderboss_lapi",
       "combat_front": "spyder_boss",
@@ -57,6 +117,16 @@
   },
   {
     "slug": "spyder_hospital1_rakez",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_rakez1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_rakez2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -73,6 +143,16 @@
   },
   {
     "slug": "spyder_hospital1_zekar",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_zekar1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_zekar2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -81,6 +161,16 @@
   },
   {
     "slug": "spyder_hospital1_walt",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_walt1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_walt2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -89,6 +179,16 @@
   },
   {
     "slug": "spyder_hospital1_rhizome",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_hospital1_rhizome1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_hospital1_rhizome2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/spyder_lion_mountain_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_lion_mountain_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_lionmountain_jacques",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_jacques1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_jacques2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_lionmountain_adam",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_adam1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_adam2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_lionmountain_arlene",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_arlene1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_arlene2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_lionmountain_david",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_david1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_david2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_lionmountain_alexander",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_alexander1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_alexander2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_lionmountain_chhurim",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_chhurim1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_chhurim2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_lionmountain_emilio",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_emilio1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_emilio2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_lionmountain_tom",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_tom1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_tom2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_lionmountain_conrad",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_conrad1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_conrad2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -73,6 +163,16 @@
   },
   {
     "slug": "spyder_lionmountain_kurt",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_lionmountain_kurt1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_lionmountain_kurt2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",

--- a/mods/tuxemon/db/npc/spyder_mansion_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_mansion_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_top_jackson",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_top_jackson1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_top_jackson2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_top_mickey",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_top_mickey1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_top_mickey2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_top_ricardo",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_top_ricardo1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_top_ricardo2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "rogue_red",
       "combat_front": "rogue",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_top_russell",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_top_russell1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_top_russell2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "mage",
@@ -73,6 +113,16 @@
   },
   {
     "slug": "spyder_mansion_lyle",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_mansion_pirate1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_mansion_pirate2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "pirate",
@@ -81,6 +131,16 @@
   },
   {
     "slug": "spyder_mansion_lucy",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_mansion_lucy1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_mansion_lucy2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -89,6 +149,16 @@
   },
   {
     "slug": "spyder_mansion_gillette",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_mansion_gillette1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_mansion_gillette2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "magician_brown",
       "combat_front": "magician",
@@ -145,6 +215,16 @@
   },
   {
     "slug": "spyder_basement_bobby",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_basement_bobby1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_basement_bobby2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "postboy",
       "combat_front": "rocker",
@@ -153,6 +233,16 @@
   },
   {
     "slug": "spyder_basement_catholi",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_basement_catholi1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_basement_catholi2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "disciple",
       "combat_front": "healer",
@@ -161,6 +251,16 @@
   },
   {
     "slug": "spyder_basement_coralli",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_basement_coralli1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_basement_coralli2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "dancer",
@@ -177,6 +277,16 @@
   },
   {
     "slug": "spyder_basement_roger",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_basement_roger1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_basement_roger2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer_lapi",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_nimrod_zircon",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_zircon1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_zircon2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist_brown",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_nimrod_xeon",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_xeon1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_xeon2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "robot",
       "combat_front": "xeon",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_nimrod_tru",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_tru1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_tru2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "knightlord",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_nimrod_thatcher",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_thatcher1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_thatcher2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_nimrod_rebel",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_rebel1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_rebel2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "aviator",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_nimrod_maverick",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_maverick1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_maverick2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_nimrod_mace",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_mace1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_mace2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_nimrod_justice",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_justice1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_justice2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_nimrod_honour",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_honour1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_honour2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -73,6 +163,16 @@
   },
   {
     "slug": "spyder_nimrod_chromerobo",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_chromerobo1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_chromerobo2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "robot",
       "combat_front": "chrome_robo",
@@ -81,6 +181,16 @@
   },
   {
     "slug": "spyder_nimrod_antimony",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_antimony1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_antimony2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -89,6 +199,16 @@
   },
   {
     "slug": "spyder_nimrod_bowie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_bowie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_bowie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_boss",
@@ -97,6 +217,16 @@
   },
   {
     "slug": "spyder_nimrod_archer",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_archer1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_archer2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -105,6 +235,16 @@
   },
   {
     "slug": "spyder_nimrod_argon",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_nimrod_argon1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_nimrod_argon2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist_black",

--- a/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
@@ -9,6 +9,16 @@
   },
   {
     "slug": "spyder_omnichannel_schwartz",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_schwartz1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_schwartz2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "rogue",
       "combat_front": "rogue",
@@ -17,6 +27,16 @@
   },
   {
     "slug": "spyder_omnichannel_strauss",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_strauss1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_strauss2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "warrior",
       "combat_front": "warrior",
@@ -25,6 +45,16 @@
   },
   {
     "slug": "spyder_omnichannel_william",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_william1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_william2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_black",
       "combat_front": "yellowbelt",
@@ -33,6 +63,16 @@
   },
   {
     "slug": "spyder_omnichannel_tohei",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_tohei1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_tohei2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -65,6 +105,16 @@
   },
   {
     "slug": "spyder_omnichannel_dempsey",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_dempsey1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_dempsey2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderboss",
       "combat_front": "spyder_boss",
@@ -73,6 +123,16 @@
   },
   {
     "slug": "spyder_omnichannel_crane",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_crane1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_crane2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -81,6 +141,16 @@
   },
   {
     "slug": "spyder_omnichannel_carnegie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_carnegie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_carnegie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -89,6 +159,16 @@
   },
   {
     "slug": "spyder_omnichannel_byrne",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_byrne1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_byrne2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -97,6 +177,16 @@
   },
   {
     "slug": "spyder_omnichannel_bettger",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_omnichannel_bettger1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_omnichannel_bettger2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",

--- a/mods/tuxemon/db/npc/spyder_route2_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route2_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_route2_marion",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route2_marion1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route2_marion2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_route2_graf",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route2_graf1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route2_graf2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "tennisplayer",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_route2_roddick",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route2_roddick1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route2_roddick2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer_fiery",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/spyder_route3_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route3_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_route3_qqq",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_qqq1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_qqq2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_route3_zoolander",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_zoolander1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_zoolander2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "overseer",
       "combat_front": "overseer",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_route3_weaver",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_weaver1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_weaver2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "knight",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_route3_wanda",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_wanda1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_wanda2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "fisher",
       "combat_front": "fisher",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_route3_twig",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_twig1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_twig2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_route3_surat",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_surat1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_surat2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_route3_roxby",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_roxby1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_roxby2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_route3_novak",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_novak1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_novak2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_route3_curie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_curie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_curie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -73,6 +163,16 @@
   },
   {
     "slug": "spyder_route3_connor",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route3_connor1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route3_connor2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/spyder_route4_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route4_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_route4_beck",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route4_beck1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route4_beck2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "yellowbelt",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_route4_marshall",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route4_marshall1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route4_marshall2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_route4_rincewind",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route4_rincewind1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route4_rincewind2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_blue",
       "combat_front": "yellowbelt",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_route4_roger",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route4_roger1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route4_roger2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_route4_wulf",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route4_wulf1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route4_wulf2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "maniac",
       "combat_front": "alchemist",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_route4_rosamund",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route4_rosamund1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route4_rosamund2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",

--- a/mods/tuxemon/db/npc/spyder_route5_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route5_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_route5_cleo",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route5_cleo1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route5_cleo2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "catgirl_blonde",
       "combat_front": "catgirl",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_route5_edith",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route5_edith1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route5_edith2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_route5_hunter",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route5_hunter1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route5_hunter2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_route5_goliath",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route5_goliath1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route5_goliath2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_route5_sara",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route5_sara1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route5_sara2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_route5_tryphaena",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route5_tryphaena1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route5_tryphaena2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",

--- a/mods/tuxemon/db/npc/spyder_route6_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route6_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_route6_frances",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_frances1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_frances2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_brown",
       "combat_front": "florist",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_route6_orion",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_orion1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_orion2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_route6_ping",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_ping1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_ping2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_route6_rigel",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_rigel1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_rigel2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_route6_richard",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_richard1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_richard2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_route6_blair",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_blair1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_blair2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_route6_gunner",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_gunner1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_gunner2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_route6_mungo",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_mungo1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_mungo2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_route6_maxwell",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route6_maxwell1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route6_maxwell2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor_blue",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/spyder_route7_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route7_npcs.json
@@ -25,6 +25,16 @@
   },
   {
     "slug": "spyder_route7_statius",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_statius1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_statius2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -33,6 +43,16 @@
   },
   {
     "slug": "spyder_route7_jacopo",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_jacopo1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_jacopo2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "magician_blonde",
       "combat_front": "magician",
@@ -41,6 +61,16 @@
   },
   {
     "slug": "spyder_route7_pia",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_pia1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_pia2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -49,6 +79,16 @@
   },
   {
     "slug": "spyder_route7_penitent",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_penitent1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_penitent2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "baller",
@@ -57,6 +97,16 @@
   },
   {
     "slug": "spyder_route7_nino",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_nino1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_nino2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor_lapi",
       "combat_front": "professor",
@@ -65,6 +115,16 @@
   },
   {
     "slug": "spyder_route7_hugh",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_hugh1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_hugh2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "cooldude_black",
       "combat_front": "rocker",
@@ -73,6 +133,16 @@
   },
   {
     "slug": "spyder_route7_arnaut",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_arnaut1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_arnaut2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "winger",
@@ -81,6 +151,16 @@
   },
   {
     "slug": "spyder_route7_conrad",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_conrad1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_conrad2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -89,6 +169,16 @@
   },
   {
     "slug": "spyder_route7_manfred",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_manfred1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_manfred2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "postboy_green",
       "combat_front": "cooldude",
@@ -97,6 +187,16 @@
   },
   {
     "slug": "spyder_route7_sordello",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_route7_sordello1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_route7_sordello2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "coach",

--- a/mods/tuxemon/db/npc/spyder_routea_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routea_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_routea_connie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_connie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_connie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_routea_dagger",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_dagger1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_dagger2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "rocker",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_routea_doris",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_doris1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_doris2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_routea_joe",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_joe1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_joe2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_routea_koan",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_koan1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_koan2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "boss_red",
       "combat_front": "rocker",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_routea_lexi",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_lexi1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_lexi2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "catgirl_violet",
       "combat_front": "catgirl",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_routea_lotu",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_lotu1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_lotu2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_routea_rosy",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_rosy1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_rosy2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_routea_vince",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routea_vince1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routea_vince2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",

--- a/mods/tuxemon/db/npc/spyder_routeb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routeb_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_routeb_electra",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routeb_electra1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routeb_electra2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_agent",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_routeb_cytherea",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routeb_cytherea1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routeb_cytherea2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_routeb_nephthys",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routeb_nephthys1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routeb_nephthys2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_agent",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_routeb_sedna",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routeb_sedna1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routeb_sedna2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_rookie",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_routeb_calypso",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routeb_calypso1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routeb_calypso2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight_yellow",
       "combat_front": "enforcer_boss",

--- a/mods/tuxemon/db/npc/spyder_routee_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routee_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_routee_calliope",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routee_calliope1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routee_calliope2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_agent",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_routee_aiolos",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_routee_aiolos1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_routee_aiolos2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_rookie",

--- a/mods/tuxemon/db/npc/spyder_scoop_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_scoop_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_scoop_alyssa",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_alyssa1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_alyssa2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_scoop_paine",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_paine1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_paine2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_scoop_orba",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_orba1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_orba2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_scoop_rubid",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_rubid1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_rubid2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_scoop_weaver",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_weaver1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_weaver2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_scoop_turner",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_turner1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_turner2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_scoop_taggart",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_taggart1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_taggart2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -65,6 +135,16 @@
   },
   {
     "slug": "spyder_scoop_berys",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_berys1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_berys2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor_black",
       "combat_front": "professor",
@@ -97,6 +177,16 @@
   },
   {
     "slug": "spyder_scoop_donald",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_donald1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_donald2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "cooldude_fiery",
       "combat_front": "cooldude",
@@ -113,6 +203,16 @@
   },
   {
     "slug": "spyder_scoop_lanth",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_scoop_lanth1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_scoop_lanth2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
@@ -9,6 +9,16 @@
   },
   {
     "slug": "spyder_searoutec_river",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_river1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_river2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "swimmer_orange",
       "combat_front": "swimmer",
@@ -17,6 +27,16 @@
   },
   {
     "slug": "spyder_searoutec_nigel",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_nigel1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_nigel2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "dragonrider_blue",
       "combat_front": "dragonrider",
@@ -25,6 +45,16 @@
   },
   {
     "slug": "spyder_searoutec_more",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_more1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_more2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "swimmer_green",
       "combat_front": "swimmer",
@@ -33,6 +63,16 @@
   },
   {
     "slug": "spyder_searoutec_rutherford",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_rutherford1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_rutherford2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -41,6 +81,16 @@
   },
   {
     "slug": "spyder_searoutec_sandy",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_sandy1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_sandy2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "fisher",
       "combat_front": "fisher",
@@ -49,6 +99,16 @@
   },
   {
     "slug": "spyder_searoutec_maurice",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_maurice1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_maurice2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "fisher_fiery",
       "combat_front": "fisher",
@@ -57,6 +117,16 @@
   },
   {
     "slug": "spyder_searoutec_leek",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_leek1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_leek2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "swimmer",
       "combat_front": "swimmer",
@@ -65,6 +135,16 @@
   },
   {
     "slug": "spyder_searoutec_wade",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_wade1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_wade2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "swimmer_blue",
       "combat_front": "swimmer",
@@ -73,6 +153,16 @@
   },
   {
     "slug": "spyder_searoutec_stafford",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_stafford1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_stafford2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "yellowbelt",
@@ -81,6 +171,16 @@
   },
   {
     "slug": "spyder_searoutec_gil",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_gil1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_gil2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "swimmer_blue",
       "combat_front": "swimmer",
@@ -89,6 +189,16 @@
   },
   {
     "slug": "spyder_searoutec_carstair",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_carstair1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_carstair2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_blue",
       "combat_front": "yellowbelt",
@@ -97,6 +207,16 @@
   },
   {
     "slug": "spyder_searoutec_beech",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_searoutec_beech1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_searoutec_beech2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "swimmer_red",
       "combat_front": "swimmer",

--- a/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_tunnelb_beryll",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_tunnelb_beryll1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_tunnelb_beryll2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_tunnelb_greta",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_tunnelb_greta1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_tunnelb_greta2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_tunnelb_iris",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_tunnelb_iris1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_tunnelb_iris2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "florist_brown",
       "combat_front": "florist",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_tunnelb_meitner",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_tunnelb_meitner1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_tunnelb_meitner2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_tunnelb_lute",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_tunnelb_lute1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_tunnelb_lute2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_tunnelb_tommy",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_tunnelb_tommy1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_tunnelb_tommy2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_gray",
       "combat_front": "yellowbelt",

--- a/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_walled_crassus",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_crassus1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_crassus2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_walled_alexander",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_alexander1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_alexander2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_walled_rufus",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_rufus1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_rufus2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_walled_vanderbilt",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_vanderbilt1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_vanderbilt2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_walled_astor",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_astor1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_astor2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_walled_ford",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_ford1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_ford2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_walled_girard",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_girard1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_girard2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_walled_augustus",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_augustus1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_augustus2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_walled_fugger",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_fugger1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_fugger2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -73,6 +163,16 @@
   },
   {
     "slug": "spyder_walled_carnegie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_carnegie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_carnegie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -81,6 +181,16 @@
   },
   {
     "slug": "spyder_walled_osman",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_osman1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_osman2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -89,6 +199,16 @@
   },
   {
     "slug": "spyder_walled_musa",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_musa1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_musa2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -97,6 +217,16 @@
   },
   {
     "slug": "spyder_walled_midas",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_walled_midas1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_walled_midas2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",

--- a/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
@@ -1,6 +1,16 @@
 [
   {
     "slug": "spyder_wayfarer1_bismuth",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_bismuth1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_bismuth2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -9,6 +19,16 @@
   },
   {
     "slug": "spyder_wayfarer1_victor",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_victor1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_victor2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -17,6 +37,16 @@
   },
   {
     "slug": "spyder_wayfarer1_ratcher",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_ratcher1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_ratcher2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -25,6 +55,16 @@
   },
   {
     "slug": "spyder_wayfarer1_nightshade",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_nightshade1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_nightshade2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",
@@ -33,6 +73,16 @@
   },
   {
     "slug": "spyder_wayfarer1_morton",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_morton1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_morton2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -41,6 +91,16 @@
   },
   {
     "slug": "spyder_wayfarer1_jessie",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_jessie1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_jessie2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -49,6 +109,16 @@
   },
   {
     "slug": "spyder_wayfarer1_morningstar",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_morningstar1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_morningstar2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -57,6 +127,16 @@
   },
   {
     "slug": "spyder_wayfarer1_james",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_james1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_james2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -65,6 +145,16 @@
   },
   {
     "slug": "spyder_wayfarer1_bravo",
+    "dialogue": {
+      "dialogue": {
+        "default": {
+          "pre_battle": "spyder_wayfarer1_bravo1",
+          "post_battle_win": null,
+          "post_battle_lose": "spyder_wayfarer1_bravo2",
+          "post_battle_draw": null
+        }
+      }
+    },
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",

--- a/mods/tuxemon/db/npc/taba_acolyte_1.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_1.json
@@ -1,11 +1,8 @@
 {
-    "slug": "acolyte",
-    "template": 
-      {
-        "sprite_name": "disciple",
-        "combat_front": "disciple",
-        "slug": "disciple"
-      }
-  
+  "slug": "acolyte",
+  "template": {
+    "sprite_name": "disciple",
+    "combat_front": "disciple",
+    "slug": "disciple"
   }
-  
+}

--- a/mods/tuxemon/db/npc/taba_acolyte_2.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_2.json
@@ -1,11 +1,8 @@
 {
-    "slug": "garth",
-    "template": 
-      {
-        "sprite_name": "disciple",
-        "combat_front": "disciple",
-        "slug": "disciple"
-      }
-  
+  "slug": "garth",
+  "template": {
+    "sprite_name": "disciple",
+    "combat_front": "disciple",
+    "slug": "disciple"
   }
-  
+}

--- a/mods/tuxemon/db/npc/taba_acolyte_3.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_3.json
@@ -1,11 +1,8 @@
 {
-    "slug": "acolyte3",
-    "template": 
-      {
-        "sprite_name": "disciple",
-        "combat_front": "disciple",
-        "slug": "disciple"
-      }
-  
+  "slug": "acolyte3",
+  "template": {
+    "sprite_name": "disciple",
+    "combat_front": "disciple",
+    "slug": "disciple"
   }
-  
+}

--- a/mods/tuxemon/db/npc/taba_acolyte_4.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_4.json
@@ -1,10 +1,8 @@
 {
-    "slug": "loch",
-    "template":
-      {
-        "sprite_name": "disciple",
-        "combat_front": "disciple",
-        "slug": "disciple"
-      }
+  "slug": "loch",
+  "template": {
+    "sprite_name": "disciple",
+    "combat_front": "disciple",
+    "slug": "disciple"
   }
-  
+}

--- a/mods/tuxemon/db/npc/taba_acolyte_cam.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_cam.json
@@ -1,11 +1,8 @@
 {
-    "slug": "cam",
-    "template": 
-      {
-        "sprite_name": "disciple",
-        "combat_front": "disciple",
-        "slug": "disciple"
-      }
-  
+  "slug": "cam",
+  "template": {
+    "sprite_name": "disciple",
+    "combat_front": "disciple",
+    "slug": "disciple"
   }
-  
+}

--- a/mods/tuxemon/db/npc/taba_greeter.json
+++ b/mods/tuxemon/db/npc/taba_greeter.json
@@ -1,10 +1,8 @@
 {
   "slug": "taba_greeter",
-  "template": 
-    {
-      "sprite_name": "shopassistant",
-      "combat_front": "adventurer",
-      "slug": "shopassistant"
-    }
-
+  "template": {
+    "sprite_name": "shopassistant",
+    "combat_front": "adventurer",
+    "slug": "shopassistant"
+  }
 }

--- a/mods/tuxemon/db/npc/taba_houses.json
+++ b/mods/tuxemon/db/npc/taba_houses.json
@@ -1,123 +1,98 @@
 [
-{
-  "slug": "taba_house1_husband",
-  "template": 
-    {
+  {
+    "slug": "taba_house1_husband",
+    "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
       "slug": "maniac"
     }
-
-},
-{
-  "slug": "taba_house1_wife",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house1_wife",
+    "template": {
       "sprite_name": "granny",
       "combat_front": "heroine",
       "slug": "heroine"
     }
-
-},
-{
-  "slug": "taba_house2_owner",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house2_owner",
+    "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
       "slug": "heroine"
     }
-
-},
-{
-  "slug": "taba_house2_reader1",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house2_reader1",
+    "template": {
       "sprite_name": "heroine_brown",
       "combat_front": "heroine",
       "slug": "heroine"
     }
-
-},
-{
-  "slug": "taba_house2_reader2",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house2_reader2",
+    "template": {
       "sprite_name": "heroine_red",
       "combat_front": "heroine",
       "slug": "heroine"
     }
-
-},
-{
-  "slug": "taba_house3_owner",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house3_owner",
+    "template": {
       "sprite_name": "homemaker_black",
       "combat_front": "heroine",
       "slug": "heroine"
     }
-
-},
-{
-  "slug": "taba_house3_client1",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house3_client1",
+    "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
       "slug": "florist"
     }
-
-},
-{
-  "slug": "taba_house3_client2",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house3_client2",
+    "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
       "slug": "homemaker"
     }
-
-},
-{
-  "slug": "taba_house4_client1",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house4_client1",
+    "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
       "slug": "professor"
     }
-
-},
-{
-  "slug": "taba_house4_waiter",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house4_waiter",
+    "template": {
       "sprite_name": "shopassistant_grey",
       "combat_front": "adventurer",
       "slug": "shopassistant"
     }
-
-},
-{
-  "slug": "taba_house4_client2",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house4_client2",
+    "template": {
       "sprite_name": "shopassistant_red",
       "combat_front": "adventurer",
       "slug": "shopassistant"
     }
-
-},
-{
-  "slug": "taba_house4_owner",
-  "template": 
-    {
+  },
+  {
+    "slug": "taba_house4_owner",
+    "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
       "slug": "florist"
     }
-
-}
-
+  }
 ]

--- a/mods/tuxemon/db/npc/tabanurse.json
+++ b/mods/tuxemon/db/npc/tabanurse.json
@@ -1,10 +1,8 @@
 {
   "slug": "tabanurse",
-  "template": 
-    {
-      "sprite_name": "nurse",
-      "combat_front": "nurse",
-      "slug": "nurse"
-    }
-
+  "template": {
+    "sprite_name": "nurse",
+    "combat_front": "nurse",
+    "slug": "nurse"
+  }
 }

--- a/mods/tuxemon/db/npc/tallon.json
+++ b/mods/tuxemon/db/npc/tallon.json
@@ -1,10 +1,8 @@
 {
   "slug": "tallon",
-  "template": 
-    {
-      "sprite_name": "ninja",
-      "combat_front": "ninja",
-      "slug": "ninja"
-    }
-
+  "template": {
+    "sprite_name": "ninja",
+    "combat_front": "ninja",
+    "slug": "ninja"
+  }
 }

--- a/mods/tuxemon/db/npc/test_npcs.json
+++ b/mods/tuxemon/db/npc/test_npcs.json
@@ -1,5002 +1,4002 @@
 [
   {
     "slug": "test_npc001",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc002",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc003",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc004",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc005",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc006",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc007",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc008",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc009",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc010",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc011",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc012",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc013",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc014",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc015",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc016",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc017",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc018",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc019",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc020",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc021",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc022",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc023",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc024",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc025",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc026",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc027",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc028",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc029",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc030",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc031",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc032",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc033",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc034",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc035",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc036",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc037",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc038",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc039",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc040",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc041",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc042",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc043",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc044",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc045",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc046",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc047",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc048",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc049",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc050",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc051",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc052",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc053",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc054",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc055",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc056",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc057",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc058",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc059",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc060",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc061",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc062",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc063",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc064",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc065",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc066",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc067",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc068",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc069",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc070",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc071",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc072",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc073",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc074",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc075",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc076",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc077",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc078",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc079",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc080",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc081",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc082",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc083",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc084",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc085",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc086",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc087",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc088",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc089",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc090",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc091",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc092",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc093",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc094",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc095",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc096",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc097",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc098",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc099",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc100",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc101",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc102",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc103",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc104",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc105",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc106",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc107",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc108",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc109",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc110",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc111",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc112",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc113",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc114",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc115",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc116",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc117",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc118",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc119",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc120",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc121",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc122",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc123",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc124",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc125",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc126",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc127",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc128",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc129",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc130",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc131",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc132",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc133",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc134",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc135",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc136",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc137",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc138",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc139",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc140",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc141",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc142",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc143",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc144",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc145",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc146",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc147",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc148",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc149",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc150",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc151",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc152",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc153",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc154",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc155",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc156",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc157",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc158",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc159",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc160",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc161",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc162",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc163",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc164",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc165",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc166",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc167",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc168",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc169",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc170",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc171",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc172",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc173",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc174",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc175",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc176",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc177",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc178",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc179",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc180",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc181",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc182",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc183",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc184",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc185",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc186",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc187",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc188",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc189",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc190",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc191",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc192",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc193",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc194",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc195",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc196",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc197",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc198",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc199",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc200",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc201",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc202",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc203",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc204",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc205",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc206",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc207",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc208",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc209",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc210",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc211",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc212",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc213",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc214",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc215",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc216",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc217",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc218",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc219",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc220",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc221",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc222",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc223",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc224",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc225",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc226",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc227",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc228",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc229",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc230",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc231",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc232",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc233",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc234",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc235",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc236",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc237",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc238",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc239",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc240",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc241",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc242",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc243",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc244",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc245",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc246",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc247",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc248",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc249",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc250",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc251",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc252",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc253",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc254",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc255",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc256",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc257",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc258",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc259",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc260",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc261",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc262",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc263",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc264",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc265",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc266",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc267",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc268",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc269",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc270",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc271",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc272",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc273",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc274",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc275",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc276",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc277",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc278",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc279",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc280",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc281",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc282",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc283",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc284",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc285",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc286",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc287",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc288",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc289",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc290",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc291",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc292",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc293",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc294",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc295",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc296",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc297",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc298",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc299",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc300",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc301",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc302",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc303",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc304",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc305",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc306",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc307",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc308",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc309",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc310",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc311",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc312",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc313",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc314",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc315",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc316",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc317",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc318",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc319",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc320",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc321",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc322",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc323",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc324",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc325",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc326",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc327",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc328",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc329",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc330",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc331",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc332",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc333",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc334",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc335",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc336",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc337",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc338",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc339",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc340",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc341",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc342",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc343",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc344",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc345",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc346",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc347",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc348",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc349",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc350",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc351",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc352",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc353",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc354",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc355",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc356",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc357",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc358",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc359",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc360",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc361",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc362",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc363",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc364",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc365",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc366",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc367",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc368",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc369",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc370",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc371",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc372",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc373",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc374",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc375",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc376",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc377",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc378",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc379",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc380",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc381",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc382",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc383",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc384",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc385",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc386",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc387",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc388",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc389",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc390",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc391",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc392",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc393",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc394",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc395",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc396",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc397",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc398",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc399",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc400",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc401",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc402",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc403",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc404",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc405",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc406",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc407",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc408",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc409",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc410",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc411",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc412",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc413",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc414",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc415",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc416",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc417",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc418",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc419",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc420",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc421",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc422",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc423",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc424",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc425",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc426",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc427",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc428",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc429",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc430",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc431",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc432",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc433",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc434",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc435",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc436",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc437",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc438",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc439",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc440",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc441",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc442",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc443",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc444",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc445",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc446",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc447",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc448",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc449",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc450",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc451",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc452",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc453",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc454",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc455",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc456",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc457",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc458",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc459",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc460",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc461",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc462",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc463",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc464",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc465",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc466",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc467",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc468",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc469",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc470",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc471",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc472",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc473",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc474",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc475",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc476",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc477",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc478",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc479",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc480",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc481",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc482",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc483",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc484",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc485",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc486",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc487",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc488",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc489",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc490",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc491",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc492",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc493",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc494",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc495",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc496",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc497",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc498",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc499",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   },
   {
     "slug": "test_npc500",
-    "template": 
-      {
-        "sprite_name": "professor",
-        "combat_front": "professor",
-        "slug": "professor"
-      }
-  
+    "template": {
+      "sprite_name": "professor",
+      "combat_front": "professor",
+      "slug": "professor"
+    }
   }
 ]

--- a/mods/tuxemon/db/npc/timmy.json
+++ b/mods/tuxemon/db/npc/timmy.json
@@ -1,11 +1,9 @@
 {
-    "slug": "timmy",
-    "gender": "male",
-    "template": 
-        {
-          "sprite_name": "childactor",
-          "combat_front": "heroine",
-          "slug": "childactor"
-        }
-    
+  "slug": "timmy",
+  "gender": "male",
+  "template": {
+    "sprite_name": "childactor",
+    "combat_front": "heroine",
+    "slug": "childactor"
+  }
 }

--- a/mods/tuxemon/db/npc/tuxeball.json
+++ b/mods/tuxemon/db/npc/tuxeball.json
@@ -1,10 +1,8 @@
 {
   "slug": "tuxeball",
-  "template": 
-    {
-      "sprite_name": "tuxeball",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "tuxeball",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/tuxeball_green.json
+++ b/mods/tuxemon/db/npc/tuxeball_green.json
@@ -1,10 +1,8 @@
 {
   "slug": "tuxeball_green",
-  "template": 
-    {
-      "sprite_name": "tuxeball_green",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "tuxeball_green",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/tuxeball_red.json
+++ b/mods/tuxemon/db/npc/tuxeball_red.json
@@ -1,10 +1,8 @@
 {
   "slug": "tuxeball_red",
-  "template": 
-    {
-      "sprite_name": "tuxeball_red",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "tuxeball_red",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/tuxeball_violet.json
+++ b/mods/tuxemon/db/npc/tuxeball_violet.json
@@ -1,10 +1,8 @@
 {
   "slug": "tuxeball_violet",
-  "template": 
-    {
-      "sprite_name": "tuxeball_violet",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "tuxeball_violet",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/tuxeball_yellow.json
+++ b/mods/tuxemon/db/npc/tuxeball_yellow.json
@@ -1,10 +1,8 @@
 {
   "slug": "tuxeball_yellow",
-  "template": 
-    {
-      "sprite_name": "tuxeball_yellow",
-      "combat_front": "noclass",
-      "slug": "interactive_obj"
-    }
-
+  "template": {
+    "sprite_name": "tuxeball_yellow",
+    "combat_front": "noclass",
+    "slug": "interactive_obj"
+  }
 }

--- a/mods/tuxemon/db/npc/tuxemart.json
+++ b/mods/tuxemon/db/npc/tuxemart.json
@@ -1,10 +1,8 @@
 {
   "slug": "tuxemart_keeper",
-  "template": 
-    {
-      "sprite_name": "shopassistant",
-      "combat_front": "adventurer",
-      "slug": "shopassistant"
-    }
-
+  "template": {
+    "sprite_name": "shopassistant",
+    "combat_front": "adventurer",
+    "slug": "shopassistant"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrund1.json
+++ b/mods/tuxemon/db/npc/xerogrund1.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrund1",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrund2.json
+++ b/mods/tuxemon/db/npc/xerogrund2.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrund2",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt1.json
+++ b/mods/tuxemon/db/npc/xerogrunt1.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt1",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt10.json
+++ b/mods/tuxemon/db/npc/xerogrunt10.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt10",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt2.json
+++ b/mods/tuxemon/db/npc/xerogrunt2.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt2",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt3.json
+++ b/mods/tuxemon/db/npc/xerogrunt3.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt3",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt4.json
+++ b/mods/tuxemon/db/npc/xerogrunt4.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt4",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt5.json
+++ b/mods/tuxemon/db/npc/xerogrunt5.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt5",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt6.json
+++ b/mods/tuxemon/db/npc/xerogrunt6.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt6",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt7.json
+++ b/mods/tuxemon/db/npc/xerogrunt7.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt7",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt8.json
+++ b/mods/tuxemon/db/npc/xerogrunt8.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt8",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/mods/tuxemon/db/npc/xerogrunt9.json
+++ b/mods/tuxemon/db/npc/xerogrunt9.json
@@ -1,10 +1,8 @@
 {
   "slug": "xerogrunt9",
-  "template": 
-    {
-      "sprite_name": "xerogrunt",
-      "combat_front": "adventurer",
-      "slug": "xerogrunt"
-    }
-
+  "template": {
+    "sprite_name": "xerogrunt",
+    "combat_front": "adventurer",
+    "slug": "xerogrunt"
+  }
 }

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1278,6 +1278,69 @@ class NpcTemplateModel(BaseModel):
         raise ValueError(f"the template {v} doesn't exist in the db")
 
 
+class DialogueContent(BaseModel):
+    # This model holds all dialogue types
+    greeting: Optional[Union[str, list[str]]] = Field(
+        None, description="Greeting dialogue"
+    )
+    idle: Optional[Union[str, list[str]]] = Field(
+        None, description="Idle chatter"
+    )
+    farewell: Optional[Union[str, list[str]]] = Field(
+        None, description="Dialogue when saying goodbye"
+    )
+    pre_battle: Optional[Union[str, list[str]]] = Field(
+        None, description="Dialogue before a battle"
+    )
+    post_battle_win: Optional[Union[str, list[str]]] = Field(
+        None, description="Dialogue if NPC wins"
+    )
+    post_battle_lose: Optional[Union[str, list[str]]] = Field(
+        None, description="Dialogue if NPC loses"
+    )
+    post_battle_draw: Optional[Union[str, list[str]]] = Field(
+        None, description="Dialogue if battle is a draw"
+    )
+
+    @field_validator("*")
+    def translation_exists(
+        cls, v: Optional[Union[str, list[str]]]
+    ) -> Optional[Union[str, list[str]]]:
+        if not v:
+            return v
+
+        if isinstance(v, str):
+            if not has.translation(v):
+                raise ValueError(f"No translation exists with msgid: {v}")
+        elif isinstance(v, list):
+            for msgid in v:
+                if not has.translation(msgid):
+                    raise ValueError(
+                        f"No translation exists with msgid: {msgid}"
+                    )
+        return v
+
+
+class DialogueProfile(BaseModel):
+    default: DialogueContent = Field(
+        ..., description="The default dialogue for the NPC"
+    )
+    location_based: dict[str, DialogueContent] = Field(
+        default_factory=dict,
+        description="Overrides for dialogue based on location (map.tmx)",
+    )
+
+    def get_dialogue_for_location(self, location: str) -> DialogueContent:
+        """Returns location-specific dialogue if available, otherwise default."""
+        return self.location_based.get(location, self.default)
+
+
+class NpcSpeech(BaseModel):
+    profile: DialogueProfile = Field(
+        ..., description="All dialogue for the NPC"
+    )
+
+
 class NpcModel(BaseModel, BaseLookupModel):
     table_name: ClassVar[str] = "npc"
     slug: str = Field(..., description="Slug of the name of the NPC")
@@ -1288,6 +1351,9 @@ class NpcModel(BaseModel, BaseLookupModel):
     )
     items: Sequence[BagItemModel] = Field(
         [], description="List of items in the NPCs bag"
+    )
+    speech: Optional[NpcSpeech] = Field(
+        None, description="Dialogue for this NPC"
     )
 
     @classmethod

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -7,7 +7,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, final
 
-from tuxemon.db import NpcModel, db
+from tuxemon.db import (
+    DialogueContent,
+    DialogueProfile,
+    NpcModel,
+    db,
+)
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import Item
 from tuxemon.monster import Monster
@@ -67,6 +72,8 @@ class CreateNpcAction(EventAction):
         if npc_details.items:
             load_party_items(npc, npc_details, game_variables)
         npc.sprite_controller.load_sprites(npc.template)
+        if npc_details.speech:
+            npc.dialogue = merge_dialogue(npc_details.speech.profile, None)
 
 
 lookup_cache: dict[str, NpcModel] = {}
@@ -125,4 +132,74 @@ def check_variables(
             for key, value in variable.items()
         )
         for variable in npc_vars
+    )
+
+
+def merge_dialogue(
+    source: Optional[DialogueProfile],
+    fallback: Optional[DialogueProfile] = None,
+) -> DialogueProfile:
+    """
+    Merges a source DialogueProfile with a fallback.
+
+    Dialogue fields from the source take precedence.
+    Location-based overrides from both models are merged.
+    """
+    source = source or DialogueProfile(
+        default=DialogueContent(
+            greeting=None,
+            idle=None,
+            farewell=None,
+            pre_battle=None,
+            post_battle_win=None,
+            post_battle_lose=None,
+            post_battle_draw=None,
+        )
+    )
+    fallback = fallback or DialogueProfile(
+        default=DialogueContent(
+            greeting=None,
+            idle=None,
+            farewell=None,
+            pre_battle=None,
+            post_battle_win=None,
+            post_battle_lose=None,
+            post_battle_draw=None,
+        )
+    )
+
+    # Create the merged default DialogueContent
+    merged_default_content_dict = fallback.default.model_dump(
+        exclude_none=True
+    )
+    merged_default_content_dict.update(
+        source.default.model_dump(exclude_none=True)
+    )
+    merged_default = DialogueContent.model_validate(
+        merged_default_content_dict
+    )
+
+    # Merge the location-based overrides
+    merged_location_based = {
+        **fallback.location_based,
+        **source.location_based,
+    }
+
+    # For any shared locations, we need to perform a deeper merge
+    for location, source_content in source.location_based.items():
+        if location in fallback.location_based:
+            fallback_content = fallback.location_based[location]
+            merged_content_dict = fallback_content.model_dump(
+                exclude_none=True
+            )
+            merged_content_dict.update(
+                source_content.model_dump(exclude_none=True)
+            )
+            merged_location_based[location] = DialogueContent.model_validate(
+                merged_content_dict
+            )
+
+    return DialogueProfile(
+        default=merged_default,
+        location_based=merged_location_based,
     )

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 from tuxemon import prepare
 from tuxemon.battle import BattlesHandler
 from tuxemon.boxes import ItemBoxes, MonsterBoxes
-from tuxemon.db import Direction, NpcModel, db
+from tuxemon.db import DialogueProfile, Direction, NpcModel, db
 from tuxemon.entity import Entity
 from tuxemon.item.item import Item, decode_items, encode_items
 from tuxemon.locale import T
@@ -127,6 +127,7 @@ class NPC(Entity[NPCState]):
         self.items = NPCBagHandler(item_boxes=self.item_boxes)
         self.pending_evolutions: list[tuple[Monster, Monster]] = []
         self.steps: float = 0.0
+        self.dialogue: Optional[DialogueProfile] = None
 
         # pathfinding and waypoint related
         self.pathfinding: Optional[tuple[int, int]] = None


### PR DESCRIPTION
PR introduces new dialogue fields to the `NpcModel`:
- `pre_battle`: Slug for dialogue shown before battle initiation  
- `post_battle_win`: Slug for dialogue shown after the NPC wins  
- `post_battle_lose`: Slug for dialogue shown after the NPC loses  
- `post_battle_draw`: Slug for dialogue shown after a draw
- `greeting`: Dialogue shown when first interacting with the NPC  
- `idle`: Ambient or filler dialogue used during repeated interactions  
- `farewell`: Dialogue shown when ending an interaction  

This change is part of a broader effort to reduce the number of hardcoded or map-bound strings, particularly in battle-related events. By centralizing NPC dialogue into the model, we gain:
- dialogue logic is now decoupled from map triggers  
- dialogue can be managed and localized directly from NPC JSON  
- helps prevent unintended dialogue triggers during auto-teleport events (notably in the Spyder campaign), where translated strings are often invoked prematurely (if set_variable isn't used)

This is the first step toward resolving issue #2981, by moving dialogue into the NPC model, we lay the groundwork for more robust and predictable event handling.