### PR TITLE
Fix: Flinching Condition Not Removed After Trigger

### DIFF
--- a/tuxemon/core/effects/flinching.py
+++ b/tuxemon/core/effects/flinching.py
@@ -24,7 +24,6 @@ class FlinchingEffect(CoreEffect):
 
     Parameters:
         chance: The chance.
-
     """
 
     name = "flinching"
@@ -38,12 +37,11 @@ class FlinchingEffect(CoreEffect):
             status.has_phase(EffectPhase.PRE_CHECKING)
             and random.random() > self.chance
         ):
-            user = status.get_host()
             empty = status.on_tech_use
             assert empty
             skip = Technique.create(empty)
             tech = [skip]
-            user.status.clear_status(session)
+            target.status.clear_status(session)
         return StatusEffectResult(
             name=status.name, success=True, techniques=tech
         )


### PR DESCRIPTION
PR fixes #2984 the flinching condition was not being removed after it triggered and caused the monster to lose its turn. The code intended to clear the flinching status was incorrectly targeting `user`, which refers to the monster that applied the condition, rather than `target`, which is the monster affected by it.
```python
# Previous (incorrect)
user.status.clear_status(session)

# Updated (correct)
target.status.clear_status(session)
```
Now, when a monster flinches and loses its turn, the flinching condition is properly cleared as expected.