### PR TITLE
XP formula divides total XP by number of hits

### DIFF
--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -83,12 +83,11 @@ class TestRewardSystem(unittest.TestCase):
         self.assertEqual(money, expected_money)
 
     def test_calculate_experience_default_method(self):
-        hits, _ = self.damage_tracker.count_hits(self.loser, self.winner)
         experience = calculate_experience(
             self.loser, self.winner, self.damage_tracker
         )
         expected_experience = int(
-            (self.loser.total_experience // (self.loser.level * hits))
+            (self.loser.total_experience // (self.loser.level))
             * self.loser.experience_modifier
         )
         self.assertEqual(experience[0], expected_experience)
@@ -117,7 +116,6 @@ class TestRewardSystem(unittest.TestCase):
         total_exp = calculate_experience_base(
             self.loser.total_experience,
             self.loser.level,
-            self.damage_tracker.count_hits(self.loser, self.winner)[0],
             self.loser.experience_modifier,
         )
         participants = self.damage_tracker.get_attackers(self.loser)
@@ -130,11 +128,10 @@ class TestRewardSystem(unittest.TestCase):
         experience = calculate_experience_base(
             self.loser.total_experience,
             self.loser.level,
-            hits,
             self.loser.experience_modifier,
         )
         expected_experience = int(
-            (self.loser.total_experience // (self.loser.level * hits))
+            (self.loser.total_experience // (self.loser.level))
             * self.loser.experience_modifier
         )
         self.assertEqual(experience, expected_experience)

--- a/tuxemon/states/combat/reward_system.py
+++ b/tuxemon/states/combat/reward_system.py
@@ -164,7 +164,6 @@ def calculate_experience(
         exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         )
         return exp, 0
@@ -173,7 +172,6 @@ def calculate_experience(
         exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         ) * round(monster_hits / total_hits)
         return exp, 0
@@ -182,7 +180,6 @@ def calculate_experience(
         total_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         )
 
@@ -204,7 +201,6 @@ def calculate_experience(
         total_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         )
 
@@ -245,9 +241,9 @@ def calculate_experience(
 
 
 def calculate_experience_base(
-    total_experience: float, level: int, hits: int, experience_modifier: float
+    total_experience: float, level: int, experience_modifier: float
 ) -> int:
     """
-    Base formula for experience calculation.
+    Base formula for experience calculation without hits.
     """
-    return int((total_experience // (level * hits)) * experience_modifier)
+    return int((total_experience // level) * experience_modifier)


### PR DESCRIPTION
This should correct an error in the XP formula, a hold over from when XP used to be apportioned based on how many hits each participant did.

It was dividing XP based on number of hits the knocked-out monster had taken, meaning that a monster knocked out in two hits gave half as much XP as one knocked out in one. 