### PR TITLE
Multiplier Adjustments in the Xero Campaign

### DIFF
--- a/mods/tuxemon/db/encounter/taba_ba_passageway_1.json
+++ b/mods/tuxemon/db/encounter/taba_ba_passageway_1.json
@@ -2,7 +2,7 @@
   "monsters": [
     {
       "encounter_rate": 3.5,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         2,
@@ -13,7 +13,7 @@
     },
     {
       "encounter_rate": 3.5,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         3,
@@ -24,7 +24,7 @@
     },
     {
       "encounter_rate": 0.2,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         4,

--- a/mods/tuxemon/db/encounter/taba_ba_passageway_2.json
+++ b/mods/tuxemon/db/encounter/taba_ba_passageway_2.json
@@ -2,7 +2,7 @@
   "monsters": [
     {
       "encounter_rate": 3,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         4,
@@ -13,7 +13,7 @@
     },
     {
       "encounter_rate": 3,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         4,
@@ -24,7 +24,7 @@
     },
     {
       "encounter_rate": 1.6,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         5,

--- a/mods/tuxemon/db/encounter/taba_ba_passageway_3.json
+++ b/mods/tuxemon/db/encounter/taba_ba_passageway_3.json
@@ -2,7 +2,7 @@
   "monsters": [
     {
       "encounter_rate": 3,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         5,
@@ -13,7 +13,7 @@
     },
     {
       "encounter_rate": 3,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         5,
@@ -24,7 +24,7 @@
     },
     {
       "encounter_rate": 0.8,
-      "exp_req_mod": 15,
+      "exp_req_mod": 3,
       "held_items": [],
       "level_range": [
         6,

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -215,7 +215,7 @@
     <property name="act32" value="set_variable rockittenball:yes"/>
     <property name="act40" value="pathfind professor,10,9"/>
     <property name="act41" value="char_face professor,up"/>
-    <property name="act42" value="add_monster cardiling,3,professor,27,40"/>
+    <property name="act42" value="add_monster cardiling,3,professor,20,40"/>
     <property name="act43" value="remove_npc tuxeball_red"/>
     <property name="act44" value="set_variable cardilingball:yes"/>
     <property name="act45" value="set_variable prof_choice:cardiling"/>
@@ -260,7 +260,7 @@
     <property name="act32" value="set_variable cardilingball:yes"/>
     <property name="act40" value="pathfind professor,11,9"/>
     <property name="act41" value="char_face professor,up"/>
-    <property name="act42" value="add_monster tweesher,3,professor,27,40"/>
+    <property name="act42" value="add_monster tweesher,3,professor,20,40"/>
     <property name="act43" value="remove_npc tuxeball_yellow"/>
     <property name="act44" value="set_variable tweesherball:yes"/>
     <property name="act45" value="set_variable prof_choice:tweesher"/>
@@ -289,7 +289,7 @@
     <property name="act32" value="set_variable tweesherball:yes"/>
     <property name="act40" value="pathfind professor,9,9"/>
     <property name="act50" value="char_face professor,up"/>
-    <property name="act51" value="add_monster rockitten,3,professor,27,40"/>
+    <property name="act51" value="add_monster rockitten,3,professor,20,40"/>
     <property name="act53" value="remove_npc tuxeball_green"/>
     <property name="act54" value="set_variable rockittenball:yes"/>
     <property name="act55" value="set_variable prof_choice:rockitten"/>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -376,7 +376,7 @@
    <properties>
     <property name="act10" value="lock_controls"/>
     <property name="act11" value="translated_dialog nobodygetsthrough"/>
-    <property name="act12" value="add_monster aardorn,2,omnigrunt,80,10"/>
+    <property name="act12" value="add_monster aardorn,2,omnigrunt,40,10"/>
     <property name="act20" value="start_battle player,omnigrunt"/>
     <property name="act21" value="wait 1.5"/>
     <property name="act30" value="set_variable whoartthou:done"/>

--- a/mods/tuxemon/maps/taba_ba_br_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_1.tmx
@@ -164,7 +164,7 @@
     <property name="act42" value="wait 0.4"/>
     <property name="act43" value="translated_dialog challenger6"/>
     <property name="act50" value="translated_dialog challenger7"/>
-    <property name="act55" value="add_monster chloragon,3,acolyte,80,100"/>
+    <property name="act55" value="add_monster chloragon,3,acolyte,40,100"/>
     <property name="act60" value="start_battle player,acolyte"/>
     <property name="act99" value="set_variable battledone:yes"/>
     <property name="cond1" value="is variable_set battledone:start"/>
@@ -221,7 +221,7 @@
     <property name="act12" value="pathfind player,9,7"/>
     <property name="act13" value="char_face player,left"/>
     <property name="act20" value="translated_dialog acolyte1redo"/>
-    <property name="act30" value="add_monster chloragon,3,acolyte,80,100"/>
+    <property name="act30" value="add_monster chloragon,3,acolyte,40,100"/>
     <property name="act40" value="start_battle player,acolyte"/>
     <property name="act98" value="set_variable redo:finished"/>
     <property name="act99" value="set_variable battledone:yes"/>

--- a/mods/tuxemon/maps/taba_ba_br_2.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_2.tmx
@@ -104,7 +104,7 @@
     <property name="act45" value="char_face garth,up"/>
     <property name="act46" value="wait 0.3"/>
     <property name="act47" value="translated_dialog acolyte2challenger9"/>
-    <property name="act50" value="add_monster mystikapi,5,garth,80,100"/>
+    <property name="act50" value="add_monster mystikapi,5,garth,70,100"/>
     <property name="act51" value="start_battle player,garth"/>
     <property name="act52" value="set_variable talkedonce:yes"/>
     <property name="cond1" value="is char_at player"/>
@@ -140,7 +140,7 @@
    <properties>
     <property name="act1" value="create_npc garth,7,9,stand"/>
     <property name="act2" value="char_face garth,up"/>
-    <property name="act3" value="add_monster mystikapi,5,garth,80,100"/>
+    <property name="act3" value="add_monster mystikapi,5,garth,70,100"/>
     <property name="cond1" value="not char_exists garth"/>
     <property name="cond2" value="is variable_set talkedonce:yes"/>
    </properties>

--- a/mods/tuxemon/maps/taba_ba_br_4.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_4.tmx
@@ -67,7 +67,7 @@
     <property name="act19" value="char_face player,right"/>
     <property name="act20" value="translated_dialog tabaacolyte4talk2"/>
     <property name="act21" value="unlock_controls"/>
-    <property name="act22" value="add_monster chloragon,5,loch,80,100"/>
+    <property name="act22" value="add_monster chloragon,5,loch,70,100"/>
     <property name="act23" value="start_battle player,loch"/>
     <property name="act24" value="set_variable 1stbattle:done"/>
     <property name="cond1" value="is char_at player"/>
@@ -103,7 +103,7 @@
    <properties>
     <property name="act10" value="clear_variable 1stbattle"/>
     <property name="act11" value="translated_dialog tabaacolyte4talk3"/>
-    <property name="act12" value="add_monster mystikapi,5,loch,80,100"/>
+    <property name="act12" value="add_monster mystikapi,5,loch,70,100"/>
     <property name="act13" value="set_monster_status"/>
     <property name="act14" value="start_battle player,loch"/>
     <property name="act17" value="set_variable 2ndbattle:done"/>
@@ -115,7 +115,7 @@
    <properties>
     <property name="act10" value="clear_variable 2ndbattle"/>
     <property name="act11" value="translated_dialog tabaacolyte4talk4"/>
-    <property name="act12" value="add_monster lambert,8,loch,80,100"/>
+    <property name="act12" value="add_monster lambert,8,loch,115,100"/>
     <property name="act13" value="set_monster_status"/>
     <property name="act14" value="start_battle player,loch"/>
     <property name="act17" value="set_variable 3rdbattle:done"/>


### PR DESCRIPTION
The upcoming PR #2989 introduces a change to the formula used for calculating base experience. As a result, the multipliers in the Xero campaign will be updated to reflect this new system. If the existing multipliers aren't adjusted (see discussion in the PR), it could lead to massively inflated XP gains, which would throw off game balance. This PR ensures the experience curve stays consistent and fair under the new formula.