### PR TITLE
Fix Reward Move List Overwritten + Equal Method (after #2989)

### DIFF
--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -83,12 +83,11 @@ class TestRewardSystem(unittest.TestCase):
         self.assertEqual(money, expected_money)
 
     def test_calculate_experience_default_method(self):
-        hits, _ = self.damage_tracker.count_hits(self.loser, self.winner)
         experience = calculate_experience(
             self.loser, self.winner, self.damage_tracker
         )
         expected_experience = int(
-            (self.loser.total_experience // (self.loser.level * hits))
+            (self.loser.total_experience // (self.loser.level))
             * self.loser.experience_modifier
         )
         self.assertEqual(experience[0], expected_experience)
@@ -117,7 +116,6 @@ class TestRewardSystem(unittest.TestCase):
         total_exp = calculate_experience_base(
             self.loser.total_experience,
             self.loser.level,
-            self.damage_tracker.count_hits(self.loser, self.winner)[0],
             self.loser.experience_modifier,
         )
         participants = self.damage_tracker.get_attackers(self.loser)
@@ -126,15 +124,13 @@ class TestRewardSystem(unittest.TestCase):
         self.assertEqual(experience[0], participant_exp)
 
     def test_calculate_experience_base(self):
-        hits, _ = self.damage_tracker.count_hits(self.loser, self.winner)
         experience = calculate_experience_base(
             self.loser.total_experience,
             self.loser.level,
-            hits,
             self.loser.experience_modifier,
         )
         expected_experience = int(
-            (self.loser.total_experience // (self.loser.level * hits))
+            (self.loser.total_experience // (self.loser.level))
             * self.loser.experience_modifier
         )
         self.assertEqual(experience, expected_experience)
@@ -174,3 +170,66 @@ class TestRewardSystem(unittest.TestCase):
 
         for monster in mock_monsters:
             monster.give_experience.assert_called()
+
+    def test_award_rewards_no_winners(self):
+        empty_tracker = DamageTracker()
+        reward_system = RewardSystem(empty_tracker, is_trainer_battle=True)
+        rewards = reward_system.award_rewards(self.loser)
+
+        self.assertEqual(len(rewards.winners), 0)
+        self.assertEqual(rewards.prize, 0)
+        self.assertFalse(rewards.update)
+        self.assertEqual(rewards.moves, [])
+        self.assertEqual(rewards.messages, [])
+
+    def test_award_rewards_no_new_moves(self):
+        self.winner.moves.update_moves.return_value = []
+        reward_system = RewardSystem(
+            self.damage_tracker, is_trainer_battle=True
+        )
+        rewards = reward_system.award_rewards(self.loser)
+
+        self.assertEqual(rewards.moves, [])
+
+    def test_award_rewards_multiple_move_updates(self):
+        self.winner.moves.update_moves.return_value = ["Fireball"]
+        second_winner = MagicMock(spec=Monster)
+        second_winner.name = "rockitten"
+        second_winner.level = 5
+        second_winner.moves = MagicMock()
+        second_winner.moves.update_moves.return_value = ["Ram"]
+        second_winner.owner = self.winner.owner
+        second_winner.status = MagicMock(spec=MonsterStatusHandler)
+        second_winner.current_hp = 50
+        second_winner.held_item = MagicMock(slug="default")
+
+        self.damage_tracker.log_damage(second_winner, self.loser, 5, 1)
+
+        reward_system = RewardSystem(
+            self.damage_tracker, is_trainer_battle=True
+        )
+        rewards = reward_system.award_rewards(self.loser)
+
+        self.assertIn("Fireball", rewards.moves)
+        self.assertIn("Ram", rewards.moves)
+        self.assertEqual(len(rewards.moves), 2)
+
+    def test_award_rewards_with_held_item_modifier(self):
+        self.winner.held_item.get_item.return_value.slug = "xp_booster"
+        reward_system = RewardSystem(
+            self.damage_tracker, is_trainer_battle=True
+        )
+        rewards = reward_system.award_rewards(self.loser)
+
+        self.assertGreater(rewards.winners[0].experience, 0)
+
+    def test_award_rewards_non_player_monster(self):
+        self.winner.owner.isplayer = False
+        reward_system = RewardSystem(
+            self.damage_tracker, is_trainer_battle=True
+        )
+        rewards = reward_system.award_rewards(self.loser)
+
+        self.assertEqual(rewards.prize, 0)
+        self.assertEqual(rewards.messages, [])
+        self.assertFalse(rewards.update)

--- a/tuxemon/states/combat/reward_system.py
+++ b/tuxemon/states/combat/reward_system.py
@@ -115,9 +115,9 @@ class RewardSystem:
                 # Grant experience and update moves
                 if winner.owner and winner.owner.isplayer:
                     levels = winner.give_experience(awarded_exp)
-                    rewards_data.moves = winner.moves.update_moves(
-                        winner.level, levels
-                    )
+                    new_moves = winner.moves.update_moves(winner.level, levels)
+                    if new_moves:
+                        rewards_data.moves.extend(new_moves)
                     rewards_data.messages.append(
                         T.format(
                             "combat_gain_exp",
@@ -164,25 +164,23 @@ def calculate_experience(
         exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         )
         return exp, 0
 
     def equal_method() -> tuple[int, int]:
-        exp = calculate_experience_base(
+        total_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
-        ) * round(monster_hits / total_hits)
-        return exp, 0
+        )
+        proportional_exp = int(total_exp * (monster_hits / total_hits))
+        return proportional_exp, 0
 
     def feeder_method() -> tuple[int, int]:
         total_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         )
 
@@ -204,7 +202,6 @@ def calculate_experience(
         total_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
-            total_hits,
             loser.experience_modifier,
         )
 
@@ -245,9 +242,9 @@ def calculate_experience(
 
 
 def calculate_experience_base(
-    total_experience: float, level: int, hits: int, experience_modifier: float
+    total_experience: float, level: int, experience_modifier: float
 ) -> int:
     """
-    Base formula for experience calculation.
+    Base formula for experience calculation without hits.
     """
-    return int((total_experience // (level * hits)) * experience_modifier)
+    return int((total_experience // level) * experience_modifier)


### PR DESCRIPTION
waiting
- [x] #2989 

PR refactors the `award_rewards` method in `RewardSystem` to address a bug.

Bug Fix: previously, `rewards_data.moves` was overwritten each time a monster learned new moves and this caused only the **last monster's** learned moves to be retained.
  ```python
  rewards_data.moves = winner.moves.update_moves(...)
  ```
fixed by using `.extend(...)` to accumulate all learned moves:
  ```python
  new_moves = winner.moves.update_moves(...)
  if new_moves:
      rewards_data.moves.extend(new_moves)
  ```
Example: If Monster A learns `["Fireball"]` and Monster B learns `["Ram"]`, only `["Ram"]` was preserved. Now both are included: `["Fireball", "Ram"]`.

Bug Fix: the expression `round(monster_hits / total_hits)` is not a proportional distribution. For example, if a winner dealt 30 hits out of a total of 100, the result would be `round(0.3)`, which is **0**. The winner would get no experience. This revised code calculates the proportion of damage dealt by the winner `(monster_hits / total_hits)` and multiplies it by the base experience, ensuring that each participant receives a fair share based on their contribution.