### PR TITLE
Fix evolution transition bug causing black screen on premature input

### DIFF
--- a/tuxemon/states/evolution/__init__.py
+++ b/tuxemon/states/evolution/__init__.py
@@ -139,13 +139,13 @@ class EvolutionTransition(State):
 
     def draw(self, surface: Surface) -> None:
         surface.fill(prepare.BLACK_COLOR)
-        if self.phase == 3:
-            sprite = self._get_phase_3_sprite()
-        else:
-            sprite = self.phase_sprites[self.phase]
+        sprite = self.phase_sprites.get(self.phase, self.evolved_sprite)
         sprite_image = sprite.image
-        if sprite_image is None:
-            return
+
+        if sprite_image is None or sprite_image.get_alpha() == 0:
+            sprite_image = (
+                self.evolved_sprite_copy
+            )  # fallback to visible image
 
         surface.blit(sprite_image, (self.x, self.y))
 
@@ -170,6 +170,13 @@ class EvolutionTransition(State):
         return sprite
 
     def on_animation_complete(self) -> None:
+        if self.original_sprite.image:
+            self.original_sprite.image.set_alpha(255)
+        self.original_sprite.image = None
+
+        self.evolved_sprite.image = self.evolved_sprite_copy
+        self.evolved_sprite.image.set_alpha(255)
+
         param = {
             "name": T.format(self.original),
             "evolve": T.format(self.evolved),


### PR DESCRIPTION
PR fixes evolution transition. 

During the evolution transition, if the player pressed a button (A, B, or BACK) while the animation was in Phase 3, the flickering phase, the screen could end up completely black. This occurred because both the original and evolved sprites were alternating between fully transparent white images. If the animation was forcefully completed during one of those transparent frames, the `draw()` method would attempt to render a sprite with zero visibility, resulting in a black screen.

Key changes:
- added fallback logic in `draw()`, if the current sprite image is `None` or fully transparent (`alpha == 0`), it now falls back to `self.evolved_sprite_copy`, ensuring a visible image is always drawn
- reset sprite visibility in `on_animation_complete()`, explicitly sets `self.evolved_sprite.image` to a clean copy and restores full opacity (`alpha = 255`), also clears the original sprite to avoid residual rendering