### PR TITLE
Fix crash caused by oversized menu text in certain languages

### DIFF
--- a/tuxemon/states/control/set_key_state.py
+++ b/tuxemon/states/control/set_key_state.py
@@ -28,7 +28,10 @@ class SetKeyState(PygameMenuState):
         theme.scrollarea_position = locals.POSITION_EAST
         theme.widget_alignment = locals.ALIGN_CENTER
         super().__init__(**kwargs)
-        self.menu.add.label(T.translate("options_new_input_key0").upper())
+        self.menu.add.label(
+            T.translate("options_new_input_key0").upper(),
+            font_size=self.font_type.small,
+        )
         self.value = value
         self.reset_theme()
 
@@ -77,13 +80,7 @@ class SetKeyState(PygameMenuState):
         )
 
     def animate_open(self) -> Animation:
-        """
-        Animate the menu popping in.
-
-        Returns:
-            Popping in animation.
-
-        """
+        """Animate the menu popping in."""
         self.animation_size = 0.0
         ani = self.animate(self, animation_size=1.0, duration=0.2)
         ani.schedule(self.update_animation_size, ScheduleType.ON_UPDATE)


### PR DESCRIPTION
Some translations contained longer sentences that exceeded the available menu width. This caused `pygame-menu` to throw an exception due to the menu size exceeding the window dimensions (see generic issue #2996)
  
To resolve the issue, I reduced the font size used in the menu. This allowed the longer text to fit within the window boundaries, preventing the crash.

I'm considering implementing a more robust solution such as: dynamic font scaling based on text length

This fix ensures stability for now, especially for languages with verbose translations.