### PR TITLE
Strengthen YAML File Validation and Expand Collision Test Coverage

### DIFF
--- a/tests/tuxemon/test_folder_maps_yaml.py
+++ b/tests/tuxemon/test_folder_maps_yaml.py
@@ -13,6 +13,7 @@ from tuxemon.script.parser import parse_action_string
 EXPECTED_SCENARIOS = ["spyder", "xero", "tobedefined"]
 FOLDER = "maps"
 EVENTS_KEY = "events"
+COLLISION_KEY = "collisions"
 MAX_LENGTH_NAME = 50
 YAML_ATTR = [
     "actions",
@@ -32,18 +33,17 @@ def expand_expected_scenarios() -> None:
         EXPECTED_SCENARIOS.append(f"{prepare.STARTING_MAP}{mod}")
 
 
-def get_yaml_files(folder_path: str) -> Generator[str, Any, None]:
-    folder = Path(folder_path)
-    for file in folder.iterdir():
+def get_yaml_files(folder_path: Path) -> Generator[Path, Any, None]:
+    for file in folder_path.iterdir():
         if file.suffix == ".yaml" and file.is_file():
-            yield file.as_posix()
+            yield file
 
 
-def load_yaml_files(folder_path: str) -> dict[str, dict]:
+def load_yaml_files(folder_path: str) -> dict[Path, dict]:
     loaded_data = {}
-    for file_path in get_yaml_files(folder_path):
+    for file_path in get_yaml_files(Path(folder_path)):
         try:
-            with open(file_path, "r") as f:
+            with file_path.open("r") as f:
                 loaded_data[file_path] = yaml.safe_load(f)
         except yaml.YAMLError as e:
             raise ValueError(f"Failed to load YAML file: {file_path}") from e
@@ -59,114 +59,179 @@ class TestYAMLFiles(unittest.TestCase):
 
     def test_yaml_event_name_length(self):
         for path, data in self.loaded_data.items():
-            for event_name in data[EVENTS_KEY].keys():
-                self.assertLessEqual(
-                    len(event_name),
-                    MAX_LENGTH_NAME,
-                    f"Event name {event_name} exceeds {MAX_LENGTH_NAME} characters: {Path(path).name}",
-                )
+            with self.subTest(file=path.name):
+                for event_name in data[EVENTS_KEY].keys():
+                    with self.subTest(event_name=event_name):
+                        self.assertLessEqual(
+                            len(event_name),
+                            MAX_LENGTH_NAME,
+                            f"Event name exceeds {MAX_LENGTH_NAME} characters.",
+                        )
 
     def test_yaml_event_labels(self):
         for path, data in self.loaded_data.items():
-            for _, event_data in data[EVENTS_KEY].items():
-                for name in event_data.keys():
-                    self.assertIn(
-                        name,
-                        YAML_ATTR,
-                        f"Event name {name} isn't among {YAML_ATTR}: {Path(path).name}",
-                    )
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    for name in event_data.keys():
+                        with self.subTest(attribute_name=name):
+                            self.assertIn(
+                                name,
+                                YAML_ATTR,
+                                f"Attribute '{name}' is not in the list of allowed attributes.",
+                            )
 
     def test_yaml_event_type(self):
         for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                self.assertIn(
-                    event_data["type"],
-                    YAML_TYPES,
-                    f"Event type {event_data['type']} isn't among {YAML_TYPES}: {Path(path).name}",
-                )
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    with self.subTest(event_data=event_data):
+                        self.assertIn(
+                            event_data["type"],
+                            YAML_TYPES,
+                            f"Event type '{event_data['type']}' is not in the list of allowed types.",
+                        )
 
-    def test_yaml_event_x_coordinate(self):
+    def test_yaml_event_coordinates_and_dimensions(self):
         for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "x" in event_data:
-                    self.assertIsInstance(
-                        event_data["x"],
-                        int,
-                        f"Value of 'x' should be an integer: {Path(path).name}",
-                    )
-
-    def test_yaml_event_y_coordinate(self):
-        for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "y" in event_data:
-                    self.assertIsInstance(
-                        event_data["y"],
-                        int,
-                        f"Value of 'y' should be an integer: {Path(path).name}",
-                    )
-
-    def test_yaml_event_width(self):
-        for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "width" in event_data:
-                    self.assertIsInstance(
-                        event_data["width"],
-                        int,
-                        f"Value of 'width' should be an integer: {Path(path).name}",
-                    )
-
-    def test_yaml_event_height(self):
-        for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "height" in event_data:
-                    self.assertIsInstance(
-                        event_data["height"],
-                        int,
-                        f"Value of 'height' should be an integer: {Path(path).name}",
-                    )
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    with self.subTest(event_data=event_data):
+                        # Test 'x'
+                        if "x" in event_data:
+                            self.assertIsInstance(
+                                event_data["x"],
+                                int,
+                                "Value of 'x' should be an integer.",
+                            )
+                        # Test 'y'
+                        if "y" in event_data:
+                            self.assertIsInstance(
+                                event_data["y"],
+                                int,
+                                "Value of 'y' should be an integer.",
+                            )
+                        # Test 'width'
+                        if "width" in event_data:
+                            self.assertIsInstance(
+                                event_data["width"],
+                                int,
+                                "Value of 'width' should be an integer.",
+                            )
+                        # Test 'height'
+                        if "height" in event_data:
+                            self.assertIsInstance(
+                                event_data["height"],
+                                int,
+                                "Value of 'height' should be an integer.",
+                            )
 
     def test_actions_structure(self):
         for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "actions" in event_data:
-                    for action in event_data["actions"]:
-                        self.assertIsInstance(
-                            action,
-                            str,
-                            f"Action in event should be a string: {Path(path).name}",
-                        )
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    if "actions" in event_data:
+                        for action in event_data["actions"]:
+                            with self.subTest(action=action):
+                                self.assertIsInstance(
+                                    action,
+                                    str,
+                                    "Action in event should be a string.",
+                                )
 
     def test_actions_teleport(self):
         for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "actions" in event_data:
-                    for action in event_data["actions"]:
-                        command, params = parse_action_string(action)
-                        if command == "transition_teleport":
-                            try:
-                                prepare.fetch(FOLDER, params[0])
-                            except OSError:
-                                self.fail(
-                                    f"Map '{params[0]}' does not exist in object {action} at {Path(path).name}"
-                                )
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    if "actions" in event_data:
+                        for action in event_data["actions"]:
+                            command, params = parse_action_string(action)
+                            if command == "transition_teleport":
+                                with self.subTest(action=action):
+                                    try:
+                                        prepare.fetch(FOLDER, params[0])
+                                    except OSError:
+                                        self.fail(
+                                            f"Map '{params[0]}' does not exist."
+                                        )
 
     def test_conditions_structure(self):
         for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "conditions" in event_data:
-                    for condition in event_data["conditions"]:
-                        self.assertIsInstance(
-                            condition,
-                            str,
-                            f"Condition in event should be a string: {Path(path).name}",
-                        )
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    if "conditions" in event_data:
+                        for condition in event_data["conditions"]:
+                            with self.subTest(condition=condition):
+                                self.assertIsInstance(
+                                    condition,
+                                    str,
+                                    "Condition in event should be a string.",
+                                )
 
     def test_conditions_operator(self):
         for path, data in self.loaded_data.items():
-            for event_data in data[EVENTS_KEY].values():
-                if "conditions" in event_data:
-                    for condition in event_data["conditions"]:
-                        self.assertTrue(
-                            condition.lower().startswith(("is ", "not ")),
-                            f"Condition '{condition}' should start with 'is' or 'not': {Path(path).name}",
+            with self.subTest(file=path.name):
+                for event_data in data[EVENTS_KEY].values():
+                    if "conditions" in event_data:
+                        for condition in event_data["conditions"]:
+                            with self.subTest(condition=condition):
+                                self.assertTrue(
+                                    condition.lower().startswith(
+                                        ("is ", "not ")
+                                    ),
+                                    "Condition should start with 'is ' or 'not '.",
+                                )
+
+    def test_collision_attributes(self):
+        for path, data in self.loaded_data.items():
+            if COLLISION_KEY in data:
+                with self.subTest(file=path.name):
+                    for collision in data[COLLISION_KEY]:
+                        self.assertIsInstance(
+                            collision,
+                            dict,
+                            "Collision entry must be a dictionary.",
+                        )
+                        required_attrs = ["height", "type", "width", "x", "y"]
+                        for attr in required_attrs:
+                            self.assertIn(
+                                attr,
+                                collision,
+                                f"Collision object is missing required attribute '{attr}'.",
+                            )
+
+    def test_collision_attribute_values(self):
+        for path, data in self.loaded_data.items():
+            if COLLISION_KEY in data:
+                with self.subTest(file=path.name):
+                    for collision in data[COLLISION_KEY]:
+                        # Check type
+                        self.assertEqual(
+                            collision.get("type"),
+                            "collision",
+                            "The 'type' for a collision object must be 'collision'.",
+                        )
+                        # Check integer attributes
+                        integer_attrs = ["height", "width", "x", "y"]
+                        for attr in integer_attrs:
+                            if attr in collision:
+                                self.assertIsInstance(
+                                    collision[attr],
+                                    int,
+                                    f"The value for '{attr}' must be an integer.",
+                                )
+
+    def test_collision_no_event_data(self):
+        for path, data in self.loaded_data.items():
+            if COLLISION_KEY in data:
+                with self.subTest(file=path.name):
+                    for collision in data[COLLISION_KEY]:
+                        self.assertNotIn(
+                            "actions",
+                            collision,
+                            "Collision object should not have an 'actions' key.",
+                        )
+                        self.assertNotIn(
+                            "conditions",
+                            collision,
+                            "Collision object should not have a 'conditions' key.",
                         )


### PR DESCRIPTION
PR reinforces the validation of YAML files by improving the organization and readability of the test suite, and by expanding coverage to include collision object checks.

Here's a summary of the changes:

- subtests: `subTest` context manager from the `unittest` module is used to provide more detailed feedback on which specific test cases are failing
- type hints: updated type hints for the `get_yaml_files` function to indicate it yields `Path` objects
- test method refactoring: `test_yaml_event_coordinates_and_dimensions`, was added to group related tests together, improving clarity and structure
- collision tests: 3 new test methods were introduced to validate collision object behavior:
  - `test_collision_attributes`: Verifies that collision objects include the required attributes
  - `test_collision_attribute_values`: Checks that collision objects have the correct attribute values
  - `test_collision_no_event_data`: Ensures that collision objects do not contain event-related keys such as `"actions"` and `"conditions"`
- consistent error messages: Assertion messages have been standardized to improve readability and debugging