### PR TITLE
Fix Cotton Cafe crash due to wrong tsx direction

### DIFF
--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -11,7 +11,6 @@
  <tileset firstgid="1551" source="../gfx/tilesets/core_outdoor.tsx"/>
  <tileset firstgid="4326" source="../gfx/tilesets/core_indoor_floors.tsx"/>
  <tileset firstgid="8190" source="../gfx/tilesets/core_indoor_walls.tsx"/>
- <tileset firstgid="12054" source="../../../../../../Tuxemon/mods/tuxemon/gfx/tilesets/core_set pieces.tsx"/>
  <layer id="1" name="Tile Layer 1" width="12" height="12">
   <data encoding="base64" compression="zlib">
    eJzbr8zAsJ8E/JZELK1CGhYRHMVDCQMArcop6Q==
@@ -19,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 5" width="12" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYCAduLMQz/4MxF+gYu/1GRjymHGba8jLwCDEyMAgzAjh8xkwMPTiUR/Giym2Bo96EDjBDMEngfgUEJ9GU3+BCYJhwB+NRgaXgOo2AOmNQHyRCYsCNPNA6s+DxHCoJ8Y8dPX4zKM2KAXaUQbE5VC7dgDDDgDWNh2K
+   eJxjYCAduLMQz/4MxF+gYreAOI8Zt7mGvAwMQowMDMKMEP5PIO7Foz6MF1NsDR71IHCCGYJPAvEpID6Npv4CEwTDgD8ajQwuAdVtANIbgfgiExYFaOaB1J8HieFQT4x56OrxmUdtUAq0owyIy6F27QCGHQCNIB4B
   </data>
  </layer>
  <layer id="3" name="Tile Layer 4" width="12" height="12">


### PR DESCRIPTION
Fixing Cotton cafe crash as per #3002

I introduced a second tileset when I was editing the Cotton Cafe map file -- this should fix that up.

Fixes #3002 