### PR TITLE
Fix State Removal Logic and Improve Stack Consistency

### DIFF
--- a/tests/tuxemon/test_state_queue.py
+++ b/tests/tuxemon/test_state_queue.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
+from collections import deque
 from unittest.mock import MagicMock
 
 from tuxemon.state.queue import StateQueue
@@ -16,14 +17,15 @@ class TestStateQueue(unittest.TestCase):
         self.assertEqual(
             self.state_queue_manager._state_manager_ref, self.state_manager_ref
         )
-        self.assertEqual(self.state_queue_manager._state_queue, [])
+        self.assertEqual(self.state_queue_manager._state_queue, deque([]))
 
     def test_queue_state(self):
         state_name = "test_state"
         kwargs = {"arg1": "value1", "arg2": "value2"}
         self.state_queue_manager.queue_state(state_name, **kwargs)
         self.assertEqual(
-            self.state_queue_manager._state_queue, [(state_name, kwargs)]
+            self.state_queue_manager._state_queue,
+            deque([(state_name, kwargs)]),
         )
 
     def test_handle_next_queued_state(self):
@@ -89,7 +91,7 @@ class TestStateQueue(unittest.TestCase):
         state_name = "simple_state"
         self.state_queue_manager.queue_state(state_name)
         self.assertEqual(
-            self.state_queue_manager._state_queue, [(state_name, {})]
+            self.state_queue_manager._state_queue, deque([(state_name, {})])
         )
 
     def test_clear(self):

--- a/tests/tuxemon/test_state_stack.py
+++ b/tests/tuxemon/test_state_stack.py
@@ -14,19 +14,19 @@ class TestStateStack(unittest.TestCase):
         self.state = Mock(spec=State)
 
     def test_init(self):
-        self.assertEqual(self.stack._stack, [])
+        self.assertEqual(list(self.stack._stack), [])
         self.assertEqual(self.stack._resume_set, set())
 
     def test_push(self):
         self.stack.push(self.state)
-        self.assertEqual(self.stack._stack, [self.state])
+        self.assertEqual(list(self.stack._stack), [self.state])
         self.assertIn(self.state, self.stack._resume_set)
 
     def test_pop(self):
         self.stack.push(self.state)
         popped_state = self.stack.pop()
         self.assertEqual(popped_state, self.state)
-        self.assertEqual(self.stack._stack, [])
+        self.assertEqual(list(self.stack._stack), [])
 
     def test_pop_with_state(self):
         state1 = Mock(spec=State)
@@ -35,7 +35,7 @@ class TestStateStack(unittest.TestCase):
         self.stack.push(state2)
         popped_state = self.stack.pop(state1)
         self.assertEqual(popped_state, state1)
-        self.assertEqual(self.stack._stack, [state2])
+        self.assertEqual(list(self.stack._stack), [state2])
 
     def test_pop_empty_stack(self):
         with self.assertRaises(RuntimeError):
@@ -54,7 +54,7 @@ class TestStateStack(unittest.TestCase):
         self.stack.push(state1)
         replaced_state = self.stack.replace(state2)
         self.assertEqual(replaced_state, state1)
-        self.assertEqual(self.stack._stack, [state2])
+        self.assertEqual(list(self.stack._stack), [state2])
 
     def test_replace_empty_stack(self):
         with self.assertRaises(RuntimeError):
@@ -76,7 +76,7 @@ class TestStateStack(unittest.TestCase):
     def test_remove(self):
         self.stack.push(self.state)
         self.stack.remove(self.state)
-        self.assertEqual(self.stack._stack, [])
+        self.assertEqual(list(self.stack._stack), [])
 
     def test_remove_state_not_found(self):
         with self.assertRaises(RuntimeError):
@@ -96,7 +96,7 @@ class TestStateStack(unittest.TestCase):
         self.stack.push(state2)
         self.assertEqual(self.stack.all(), [state2, state1])
 
-    def test_get_state_by_name(self):
+    def test_get_states_by_name(self):
 
         class StateImpl(State):
             def __init__(self, name: str) -> None:
@@ -108,11 +108,11 @@ class TestStateStack(unittest.TestCase):
 
         state = StateImpl("test_state")
         self.stack.push(state)
-        self.assertEqual(self.stack.get_state_by_name("test_state"), state)
+        self.assertEqual(self.stack.get_states_by_name("test_state")[0], state)
 
-    def test_get_state_by_name_not_found(self):
+    def test_get_states_by_name_not_found(self):
         with self.assertRaises(ValueError):
-            self.stack.get_state_by_name("test_state")
+            self.stack.get_states_by_name("test_state")
 
     def test_push_duplicate_state(self):
         self.stack.push(self.state)
@@ -150,7 +150,7 @@ class TestStateStack(unittest.TestCase):
         self.stack.remove(self.state)
         self.assertFalse(self.stack.should_resume(self.state))
 
-    def test_get_state_by_name_multiple_matches(self):
+    def test_get_states_by_name_multiple_matches(self):
         class NamedState(State):
             def __init__(self, name):
                 self._name = name
@@ -163,5 +163,5 @@ class TestStateStack(unittest.TestCase):
         state2 = NamedState("duplicate")
         self.stack.push(state2)
         self.stack.push(state1)
-        found = self.stack.get_state_by_name("duplicate")
-        self.assertEqual(found, state1)
+        found = self.stack.get_states_by_name("duplicate")
+        self.assertEqual(found[0], state1)

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -206,10 +206,15 @@ class StateManager:
             state_name: The name of the state to remove.
         """
         try:
-            state = self.state_stack.get_state_by_name(state_name)
-            self.pop_state(state)
-        except StopIteration:
-            raise ValueError(f"State with name '{state_name}' not found")
+            matches = self.state_stack.get_states_by_name(state_name)
+        except ValueError:
+            logger.warning(f"No states found with name '{state_name}'")
+            return
+
+        for state in matches:
+            logger.debug(f"Removing state: {state.name}")
+            self.state_stack.remove(state)
+            state.shutdown()
 
     @overload
     def push_state(

--- a/tuxemon/state/queue.py
+++ b/tuxemon/state/queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -26,7 +27,7 @@ class StateQueue:
                                that will activate the queued states.
         """
         self._state_manager_ref = state_manager_ref
-        self._state_queue: list[tuple[str, Mapping[str, Any]]] = []
+        self._state_queue: deque[tuple[str, Mapping[str, Any]]] = deque()
 
     def queue_state(self, state_name: str, **kwargs: Any) -> None:
         """
@@ -50,7 +51,7 @@ class StateQueue:
             True if a state was processed and activated, False otherwise.
         """
         if self._state_queue:
-            state_name, kwargs = self._state_queue.pop(0)
+            state_name, kwargs = self._state_queue.popleft()
             logger.debug(
                 f"Handling queued state: {state_name} (replacing current)"
             )
@@ -140,4 +141,4 @@ class StateQueue:
         Returns:
             List of queued states.
         """
-        return self._state_queue[:]
+        return list(self._state_queue)

--- a/tuxemon/state/stack.py
+++ b/tuxemon/state/stack.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional
 
@@ -18,13 +19,13 @@ class StateStack:
     """
 
     def __init__(self) -> None:
-        self._stack: list[State] = []
+        self._stack: deque[State] = deque()
         self._resume_set: set[State] = set()
 
     def push(self, state: State) -> None:
         """Push a new state onto the stack and mark it for resume."""
         self._resume_set.add(state)
-        self._stack.insert(0, state)
+        self._stack.appendleft(state)
 
     def pop(self, state: Optional[State] = None) -> State:
         """Pop a state from the stack."""
@@ -33,11 +34,11 @@ class StateStack:
 
         state = state or self._stack[0]
         try:
-            index = self._stack.index(state)
+            self._stack.remove(state)
         except ValueError:
             raise RuntimeError("State not found in stack")
 
-        return self._stack.pop(index)
+        return state
 
     def replace(self, new_state: State) -> State:
         """Replace the current state with a new one."""
@@ -46,7 +47,7 @@ class StateStack:
                 "Attempted to replace state when stack is empty"
             )
 
-        old_state = self._stack.pop(0)
+        old_state = self._stack.popleft()
         self.push(new_state)
         return old_state
 
@@ -76,11 +77,11 @@ class StateStack:
 
     def all(self) -> Sequence[State]:
         """Return all states in the stack."""
-        return self._stack[:]
+        return list(self._stack)
 
-    def get_state_by_name(self, name: str) -> State:
+    def get_states_by_name(self, name: str) -> list[State]:
         """Find a state in the stack by its name."""
-        for state in self._stack:
-            if state.name == name:
-                return state
-        raise ValueError(f"State with name '{name}' not found")
+        matches = [state for state in self._stack if state.name == name]
+        if not matches:
+            raise ValueError(f"State with name '{name}' not found")
+        return matches

--- a/tuxemon/ui/combat_notifier.py
+++ b/tuxemon/ui/combat_notifier.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Deque, Optional
 from tuxemon.formula import config_combat
 
 if TYPE_CHECKING:
-    from tuxemon.state import State
+    from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PR fixes #3001, even though the original report was cryptic and clue-starved.

The error logs pointed to `WorldMenuState` mysteriously vanishing mid-combat, and after peeling back the layers of the state stack logic, the culprit was clear: `pop_state(state)` was quietly ignoring its argument when queued transitions were present, leading to states not being removed and lifecycle methods not being called.

Key changes:
- refactored `remove_state_by_name` to ensure precise, queue-free state removal with proper lifecycle handling
- replaced `get_state_by_name(name)` with `get_states_by_name(name)`: handles multiple states with the same name and prevents silent failures and improves stack inspection
- replaced the internal `_stack` implementation in `StateStack` from a `list` to a `deque` to optimize performance for front-end operations
- replaced the internal `_state_queue` implementation in `StateQueue` from a `list` to a `deque` to optimize performance for front-end operations

Impact:
- resolves the misleading "crash" reported in #3001, where `WorldMenuState` was not found during menu event processing, technically just a terminal error
- all related tests now pass, including those checking lifecycle method call counts