### PR TITLE
Fix incorrect immunity feedback and refactor monster handlers

### DIFF
--- a/tests/tuxemon/test_capture.py
+++ b/tests/tuxemon/test_capture.py
@@ -9,7 +9,8 @@ from tuxemon.formula import (
     capture,
     shake_check,
 )
-from tuxemon.monster import Monster, MonsterStatusHandler
+from tuxemon.monster import Monster
+from tuxemon.monster_dir.status import MonsterStatusHandler
 
 
 class TestShakeCheck(unittest.TestCase):

--- a/tests/tuxemon/test_monster_item_handler.py
+++ b/tests/tuxemon/test_monster_item_handler.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from tuxemon.monster import MonsterItemHandler
+from tuxemon.monster_dir.held_item import MonsterItemHandler
 
 
 class TestMonsterItemHandler(unittest.TestCase):

--- a/tests/tuxemon/test_monster_sprite_handler.py
+++ b/tests/tuxemon/test_monster_sprite_handler.py
@@ -7,7 +7,7 @@ from pygame import SRCALPHA
 from pygame.surface import Surface
 
 from tuxemon import prepare
-from tuxemon.monster import MonsterSpriteHandler
+from tuxemon.monster_dir.sprite import MonsterSpriteHandler
 
 
 class TestMonsterSpriteHandler(unittest.TestCase):

--- a/tests/tuxemon/test_monster_status_handler.py
+++ b/tests/tuxemon/test_monster_status_handler.py
@@ -4,7 +4,9 @@ import unittest
 from unittest.mock import MagicMock
 
 from tuxemon.db import CategoryStatus, ResponseStatus
-from tuxemon.monster import Monster, MonsterItemHandler, MonsterStatusHandler
+from tuxemon.monster import Monster
+from tuxemon.monster_dir.held_item import MonsterItemHandler
+from tuxemon.monster_dir.status import MonsterStatusHandler
 
 
 class TestMonsterStatusHandler(unittest.TestCase):

--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -3,7 +3,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tuxemon.monster import Monster, MonsterStatusHandler
+from tuxemon.monster import Monster
+from tuxemon.monster_dir.status import MonsterStatusHandler
 from tuxemon.npc import NPC
 from tuxemon.states.combat.combat_classes import DamageTracker
 from tuxemon.states.combat.reward_system import (

--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from tuxemon.combat import get_target_monsters
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
 from tuxemon.locale import T
+from tuxemon.monster_dir.status import BlockedReason
 from tuxemon.status.status import Status
 
 if TYPE_CHECKING:
@@ -58,7 +59,7 @@ class GiveEffect(CoreEffect):
             result = monster.status.apply_status(session, status, monster)
             if result.applied:
                 successful_targets.append(monster)
-            elif result.blocked_by:
+            elif result.blocked_reason == BlockedReason.IMMUNE_BY_ITEM:
                 immune_info.append(f"{monster.name} ({result.blocked_by})")
 
         if immune_info:

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
-from tuxemon.monster import Flair
+from tuxemon.monster_dir.sprite import Flair
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -9,38 +9,41 @@ from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID, uuid4
 
-from tuxemon import formula, graphics, prepare, tools
+from tuxemon import formula, prepare
 from tuxemon.db import (
     Acquisition,
-    CategoryStatus,
     EffectPhase,
     EvolutionStage,
     GenderType,
     MonsterEvolutionItemModel,
-    MonsterFlairItemModel,
     MonsterHistoryItemModel,
     MonsterModel,
     MonsterMovesetItemModel,
     MonsterSpritesModel,
     PlagueType,
-    ResponseStatus,
     StatType,
     db,
 )
 from tuxemon.element import ElementTypesHandler
 from tuxemon.evolution import Evolution
 from tuxemon.fusion import Body
-from tuxemon.item.item import Item
 from tuxemon.locale import T
+from tuxemon.monster_dir.held_item import MonsterItemHandler
+from tuxemon.monster_dir.sprite import (
+    Flair,
+    FlairApplier,
+    MonsterSpriteHandler,
+    SpriteLoader,
+)
+from tuxemon.monster_dir.status import MonsterStatusHandler
 from tuxemon.shape import ShapeHandler
 from tuxemon.sprite import Sprite
-from tuxemon.status.status import Status, decode_status, encode_status
 from tuxemon.taste import Taste
 from tuxemon.technique.technique import Technique, decode_moves, encode_moves
 from tuxemon.time_handler import today_ordinal
 
 if TYPE_CHECKING:
-    from pygame.surface import Surface
+    pass
 
     from tuxemon.npc import NPC
     from tuxemon.session import Session
@@ -96,13 +99,6 @@ class TemporaryStatBoosts(BasicStats):
         valid_fields = {field.name for field in fields(cls)}
         filtered_data = {k: v for k, v in data.items() if k in valid_fields}
         return cls(**filtered_data)
-
-
-# class definition for tuxemon flairs:
-class Flair:
-    def __init__(self, category: str, name: str) -> None:
-        self.category = category
-        self.name = name
 
 
 class Monster:
@@ -589,334 +585,6 @@ class Monster:
             current = self.status.get_current_status()
             if current:
                 current.apply_phase_and_use(session, EffectPhase.ON_FAINT)
-
-
-class SpriteLoader:
-    def __init__(self) -> None:
-        self.sprite_cache: dict[str, Surface] = {}
-        self.animated_sprite_cache: dict[str, Sprite] = {}
-
-    def resolve_path(self, sprite: str) -> str:
-        try:
-            path = f"{sprite}.png" if not sprite.endswith(".png") else sprite
-            full_path = tools.transform_resource_filename(path)
-            if full_path:
-                return full_path
-        except OSError:
-            pass
-        logger.error(f"Could not find sprite {sprite}")
-        return prepare.MISSING_IMAGE
-
-    def load(self, path: str, **kwargs: Any) -> Surface:
-        """Loads the monster's sprite images as Pygame surfaces."""
-        if path not in self.sprite_cache:
-            self.sprite_cache[path] = graphics.load_sprite(
-                path, **kwargs
-            ).image
-        return self.sprite_cache[path]
-
-    def load_animated(
-        self, paths: list[str], frame_duration: float, scale: float
-    ) -> Sprite:
-        resolved = [self.resolve_path(p) for p in paths]
-        key = f"{'-'.join(resolved)}:{frame_duration}"
-        if key not in self.animated_sprite_cache:
-            sprite = graphics.load_animated_sprite(
-                resolved, frame_duration, scale
-            )
-            self.animated_sprite_cache[key] = sprite
-        return self.animated_sprite_cache[key]
-
-    def load_and_scale(self, path: str, scale: float) -> Surface:
-        cache_key = f"{path}:scale:{scale}"
-        if cache_key not in self.sprite_cache:
-            base_image = graphics.load_and_scale(path, scale)
-            self.sprite_cache[cache_key] = base_image
-        return self.sprite_cache[cache_key]
-
-
-class FlairApplier:
-    @staticmethod
-    def create(flairs: Sequence[MonsterFlairItemModel]) -> dict[str, Flair]:
-        _flairs: dict[str, Flair] = {}
-        for flair in flairs:
-            if flair.names:
-                new_flair = Flair(category=flair.category, name=flair.names[0])
-                _flairs[new_flair.category] = new_flair
-        return _flairs
-
-    @staticmethod
-    def apply(
-        image: Surface,
-        flairs: dict[str, Flair],
-        slug: str,
-        sprite_type: str,
-        loader: SpriteLoader,
-        **kwargs: Any,
-    ) -> Surface:
-        for flair in flairs.values():
-            path = loader.resolve_path(
-                f"gfx/sprites/battle/{slug}-{sprite_type}-{flair.name}"
-            )
-            if path != prepare.MISSING_IMAGE:
-                flair_surface = loader.load(path, **kwargs)
-                image.blit(flair_surface, (0, 0))
-        return image
-
-
-class MonsterSpriteHandler:
-    """Manages the loading, caching, and retrieval of monster sprites."""
-
-    def __init__(
-        self,
-        slug: str = "",
-        front_path: str = "",
-        back_path: str = "",
-        menu1_path: str = "",
-        menu2_path: str = "",
-        flairs: Optional[dict[str, Flair]] = None,
-    ):
-        self.loader = SpriteLoader()
-        self.slug = slug
-        self.front_path = front_path
-        self.back_path = back_path
-        self.menu1_path = menu1_path
-        self.menu2_path = menu2_path
-        self.flairs = flairs.copy() if flairs else {}
-
-    def get_sprite(
-        self,
-        sprite_type: str,
-        frame_duration: float = 0.25,
-        scale: float = prepare.SCALE,
-        **kwargs: Any,
-    ) -> Sprite:
-        """Returns a Sprite object, applying flairs if necessary."""
-        if sprite_type == "front":
-            sprite_path = self.front_path
-        elif sprite_type == "back":
-            sprite_path = self.back_path
-        elif sprite_type == "menu01":
-            sprite_path = self.menu1_path
-        elif sprite_type == "menu02":
-            sprite_path = self.menu2_path
-        elif sprite_type == "menu":
-            return self.loader.load_animated(
-                [self.menu1_path, self.menu2_path], frame_duration, scale
-            )
-        else:
-            raise ValueError(f"Cannot find sprite for: {sprite_type}")
-
-        image = self.loader.load(sprite_path, **kwargs)
-
-        if self.flairs:
-            image = FlairApplier.apply(
-                image,
-                self.flairs,
-                self.slug,
-                sprite_type,
-                self.loader,
-                **kwargs,
-            )
-
-        return Sprite(image=image)
-
-    def load_sprites(self, scale: float = prepare.SCALE) -> dict[str, Surface]:
-        """Loads all monster sprites and caches them."""
-        sprite_paths = {
-            "front": self.front_path,
-            "back": self.back_path,
-            "menu01": self.menu1_path,
-            "menu02": self.menu2_path,
-        }
-
-        return {
-            key: self.loader.load_and_scale(path, scale)
-            for key, path in sprite_paths.items()
-            if path
-        }
-
-
-@dataclass
-class StatusApplyResult:
-    applied: bool
-    blocked_by: Optional[str] = None
-
-
-class MonsterStatusHandler:
-    def __init__(self, status: Optional[list[Status]] = None):
-        self.status = status if status is not None else []
-
-    @property
-    def is_fainted(self) -> bool:
-        return self.has_status("faint")
-
-    def get_current_status(self) -> Optional[Status]:
-        if not self.status:
-            return None
-        return self.status[0]
-
-    def is_blocked(self, monster: Monster, status_slug: str) -> Optional[str]:
-        """Check if the monster's held item grants immunity to the given status."""
-        item = monster.held_item.get_item()
-        if item and item.is_immune(status_slug):
-            logger.debug(
-                f"Item '{item.name}' blocks status '{status_slug}' for monster '{monster.name}'."
-            )
-            return item.name
-        return None
-
-    def apply_status(
-        self, session: Session, new_status: Status, monster: Monster
-    ) -> StatusApplyResult:
-        """
-        Apply a status effect to a monster during combat by replacing or removing
-        the previous status effect.
-
-        This function manages status effects dynamically within a combat encounter,
-        ensuring proper transitions between statuses based on their category and
-        interaction rules.
-        """
-        logger.debug(
-            f"Trying to apply status '{new_status.slug}' to monster '{monster.name}'."
-        )
-
-        blocked_by = self.is_blocked(monster, new_status.slug)
-        if blocked_by:
-            logger.debug(
-                f"Status '{new_status.slug}' blocked by '{blocked_by}'."
-            )
-            return StatusApplyResult(applied=False, blocked_by=blocked_by)
-
-        current_status = self.get_current_status()
-        if current_status is None:
-            logger.debug("No current status, applying new status directly.")
-            self.add_status(new_status)
-            new_status.nr_turn = 1
-            new_status.apply_phase_and_use(session, EffectPhase.ON_START)
-            return StatusApplyResult(applied=True)
-
-        if self.has_status(new_status.slug):
-            logger.debug(
-                f"Monster already has status '{new_status.slug}', skipping."
-            )
-            current_status.stack_level = min(
-                current_status.stack_level + 1, Status.MAX_STACKS
-            )
-            logger.debug(
-                f"Stacking status '{new_status.slug}': now at {current_status.stack_level}/{Status.MAX_STACKS}."
-            )
-            return StatusApplyResult(
-                applied=False, blocked_by=current_status.name
-            )
-
-        logger.debug(
-            f"Ending current status '{current_status.slug}' with ON_END phase."
-        )
-        current_status.apply_phase_and_use(session, EffectPhase.ON_END)
-
-        new_status.nr_turn = 1
-        logger.debug(
-            f"Starting new status '{new_status.slug}' with ON_START phase."
-        )
-        new_status.apply_phase_and_use(session, EffectPhase.ON_START)
-
-        if current_status.category == CategoryStatus.positive:
-            logger.debug(
-                f"Current status is positive. Transition rule: {new_status.on_positive_status}"
-            )
-            if new_status.on_positive_status == ResponseStatus.replaced:
-                self.add_status(new_status)
-            elif new_status.on_positive_status == ResponseStatus.removed:
-                self.remove_status()
-        elif current_status.category == CategoryStatus.negative:
-            logger.debug(
-                f"Current status is negative. Transition rule: {new_status.on_negative_status}"
-            )
-            if new_status.on_negative_status == ResponseStatus.replaced:
-                self.add_status(new_status)
-            elif new_status.on_positive_status == ResponseStatus.removed:
-                self.remove_status()
-        else:
-            logger.debug(
-                "Current status has no category. Applying new status."
-            )
-            self.add_status(new_status)
-
-        logger.debug(
-            f"Status '{new_status.slug}' successfully applied to monster '{monster.name}'."
-        )
-        return StatusApplyResult(applied=True)
-
-    def add_status(self, status: Status) -> None:
-        if self.has_status(status.slug):
-            return
-        self.status = [status]
-
-    def remove_status(self) -> None:
-        if self.status:
-            self.status.clear()
-
-    def clear_status(self, session: Session) -> None:
-        """Clears the current status effect for monsters in combat."""
-        current_status = self.get_current_status()
-        if current_status:
-            current_status.apply_phase_and_use(session, EffectPhase.ON_END)
-            self.status.clear()
-
-    def apply_faint(self, monster: Monster) -> None:
-        self.add_status(Status.create("faint", monster))
-
-    def get_statuses(self) -> list[Status]:
-        return self.status
-
-    def has_status(self, status_slug: str) -> bool:
-        return any(status_slug == status.slug for status in self.status)
-
-    def status_exists(self) -> bool:
-        return bool(self.status)
-
-    def remove_bonded_statuses(self) -> None:
-        self.status = [sta for sta in self.get_statuses() if not sta.bond]
-
-    def encode_status(self) -> Sequence[Mapping[str, Any]]:
-        return encode_status(self.status)
-
-    def decode_status(
-        self, json_data: Optional[Mapping[str, Any]], monster: Monster
-    ) -> None:
-        if json_data and "status" in json_data:
-            self.status = [
-                cond for cond in decode_status(json_data["status"], monster)
-            ]
-
-
-class MonsterItemHandler:
-    def __init__(self, item: Optional[Item] = None):
-        self.item = item
-
-    def set_item(self, item: Item) -> None:
-        if item.behaviors.holdable:
-            self.item = item
-        else:
-            logger.error(f"{item.name} can't be held")
-
-    def get_item(self) -> Optional[Item]:
-        return self.item
-
-    def has_item(self) -> bool:
-        return self.item is not None
-
-    def clear_item(self) -> None:
-        self.item = None
-
-    def encode_item(self) -> Mapping[str, Any]:
-        return self.item.get_state() if self.item is not None else {}
-
-    def decode_item(
-        self, json_data: Optional[Mapping[str, Any]]
-    ) -> Optional[Item]:
-        return Item(save_data=json_data) if json_data is not None else None
 
 
 class MonsterMovesHandler:

--- a/tuxemon/monster_dir/held_item.py
+++ b/tuxemon/monster_dir/held_item.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from tuxemon.item.item import Item
+
+logger = logging.getLogger(__name__)
+
+
+class MonsterItemHandler:
+    def __init__(self, item: Optional[Item] = None):
+        self.item = item
+
+    def set_item(self, item: Item) -> None:
+        if item.behaviors.holdable:
+            self.item = item
+        else:
+            logger.error(f"{item.name} can't be held")
+
+    def get_item(self) -> Optional[Item]:
+        return self.item
+
+    def has_item(self) -> bool:
+        return self.item is not None
+
+    def clear_item(self) -> None:
+        self.item = None
+
+    def encode_item(self) -> Mapping[str, Any]:
+        return self.item.get_state() if self.item is not None else {}
+
+    def decode_item(
+        self, json_data: Optional[Mapping[str, Any]]
+    ) -> Optional[Item]:
+        return Item(save_data=json_data) if json_data is not None else None

--- a/tuxemon/monster_dir/sprite.py
+++ b/tuxemon/monster_dir/sprite.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Optional
+
+from tuxemon import graphics, prepare, tools
+from tuxemon.db import (
+    MonsterFlairItemModel,
+)
+from tuxemon.sprite import Sprite
+
+if TYPE_CHECKING:
+    from pygame.surface import Surface
+
+
+logger = logging.getLogger(__name__)
+
+
+class SpriteLoader:
+    def __init__(self) -> None:
+        self.sprite_cache: dict[str, Surface] = {}
+        self.animated_sprite_cache: dict[str, Sprite] = {}
+
+    def resolve_path(self, sprite: str) -> str:
+        try:
+            path = f"{sprite}.png" if not sprite.endswith(".png") else sprite
+            full_path = tools.transform_resource_filename(path)
+            if full_path:
+                return full_path
+        except OSError:
+            pass
+        logger.error(f"Could not find sprite {sprite}")
+        return prepare.MISSING_IMAGE
+
+    def load(self, path: str, **kwargs: Any) -> Surface:
+        """Loads the monster's sprite images as Pygame surfaces."""
+        if path not in self.sprite_cache:
+            self.sprite_cache[path] = graphics.load_sprite(
+                path, **kwargs
+            ).image
+        return self.sprite_cache[path]
+
+    def load_animated(
+        self, paths: list[str], frame_duration: float, scale: float
+    ) -> Sprite:
+        resolved = [self.resolve_path(p) for p in paths]
+        key = f"{'-'.join(resolved)}:{frame_duration}"
+        if key not in self.animated_sprite_cache:
+            sprite = graphics.load_animated_sprite(
+                resolved, frame_duration, scale
+            )
+            self.animated_sprite_cache[key] = sprite
+        return self.animated_sprite_cache[key]
+
+    def load_and_scale(self, path: str, scale: float) -> Surface:
+        cache_key = f"{path}:scale:{scale}"
+        if cache_key not in self.sprite_cache:
+            base_image = graphics.load_and_scale(path, scale)
+            self.sprite_cache[cache_key] = base_image
+        return self.sprite_cache[cache_key]
+
+
+class Flair:
+    def __init__(self, category: str, name: str) -> None:
+        self.category = category
+        self.name = name
+
+
+class FlairApplier:
+    @staticmethod
+    def create(flairs: Sequence[MonsterFlairItemModel]) -> dict[str, Flair]:
+        _flairs: dict[str, Flair] = {}
+        for flair in flairs:
+            if flair.names:
+                new_flair = Flair(category=flair.category, name=flair.names[0])
+                _flairs[new_flair.category] = new_flair
+        return _flairs
+
+    @staticmethod
+    def apply(
+        image: Surface,
+        flairs: dict[str, Flair],
+        slug: str,
+        sprite_type: str,
+        loader: SpriteLoader,
+        **kwargs: Any,
+    ) -> Surface:
+        for flair in flairs.values():
+            path = loader.resolve_path(
+                f"gfx/sprites/battle/{slug}-{sprite_type}-{flair.name}"
+            )
+            if path != prepare.MISSING_IMAGE:
+                flair_surface = loader.load(path, **kwargs)
+                image.blit(flair_surface, (0, 0))
+        return image
+
+
+class MonsterSpriteHandler:
+    """Manages the loading, caching, and retrieval of monster sprites."""
+
+    def __init__(
+        self,
+        slug: str = "",
+        front_path: str = "",
+        back_path: str = "",
+        menu1_path: str = "",
+        menu2_path: str = "",
+        flairs: Optional[dict[str, Flair]] = None,
+    ):
+        self.loader = SpriteLoader()
+        self.slug = slug
+        self.front_path = front_path
+        self.back_path = back_path
+        self.menu1_path = menu1_path
+        self.menu2_path = menu2_path
+        self.flairs = flairs.copy() if flairs else {}
+
+    def get_sprite(
+        self,
+        sprite_type: str,
+        frame_duration: float = 0.25,
+        scale: float = prepare.SCALE,
+        **kwargs: Any,
+    ) -> Sprite:
+        """Returns a Sprite object, applying flairs if necessary."""
+        if sprite_type == "front":
+            sprite_path = self.front_path
+        elif sprite_type == "back":
+            sprite_path = self.back_path
+        elif sprite_type == "menu01":
+            sprite_path = self.menu1_path
+        elif sprite_type == "menu02":
+            sprite_path = self.menu2_path
+        elif sprite_type == "menu":
+            return self.loader.load_animated(
+                [self.menu1_path, self.menu2_path], frame_duration, scale
+            )
+        else:
+            raise ValueError(f"Cannot find sprite for: {sprite_type}")
+
+        image = self.loader.load(sprite_path, **kwargs)
+
+        if self.flairs:
+            image = FlairApplier.apply(
+                image,
+                self.flairs,
+                self.slug,
+                sprite_type,
+                self.loader,
+                **kwargs,
+            )
+
+        return Sprite(image=image)
+
+    def load_sprites(self, scale: float = prepare.SCALE) -> dict[str, Surface]:
+        """Loads all monster sprites and caches them."""
+        sprite_paths = {
+            "front": self.front_path,
+            "back": self.back_path,
+            "menu01": self.menu1_path,
+            "menu02": self.menu2_path,
+        }
+
+        return {
+            key: self.loader.load_and_scale(path, scale)
+            for key, path in sprite_paths.items()
+            if path
+        }

--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional
+
+from tuxemon.db import (
+    CategoryStatus,
+    EffectPhase,
+    ResponseStatus,
+)
+from tuxemon.status.status import Status, decode_status, encode_status
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
+
+
+logger = logging.getLogger(__name__)
+
+
+class BlockedReason(Enum):
+    IMMUNE_BY_ITEM = "immune_by_item"
+    ALREADY_PRESENT = "already_present"
+
+
+@dataclass
+class StatusApplyResult:
+    applied: bool
+    blocked_by: Optional[str] = None
+    blocked_reason: Optional[BlockedReason] = None
+
+
+class MonsterStatusHandler:
+    def __init__(self, status: Optional[list[Status]] = None):
+        self.status = status if status is not None else []
+
+    @property
+    def is_fainted(self) -> bool:
+        return self.has_status("faint")
+
+    def get_current_status(self) -> Optional[Status]:
+        if not self.status:
+            return None
+        return self.status[0]
+
+    def is_blocked(self, monster: Monster, status_slug: str) -> Optional[str]:
+        """Check if the monster's held item grants immunity to the given status."""
+        item = monster.held_item.get_item()
+        if item and item.is_immune(status_slug):
+            logger.debug(
+                f"Item '{item.name}' blocks status '{status_slug}' for monster '{monster.name}'."
+            )
+            return item.name
+        return None
+
+    def apply_status(
+        self, session: Session, new_status: Status, monster: Monster
+    ) -> StatusApplyResult:
+        """
+        Apply a status effect to a monster during combat by replacing or removing
+        the previous status effect.
+
+        This function manages status effects dynamically within a combat encounter,
+        ensuring proper transitions between statuses based on their category and
+        interaction rules.
+        """
+        logger.debug(
+            f"Trying to apply status '{new_status.slug}' to monster '{monster.name}'."
+        )
+
+        blocked_by = self.is_blocked(monster, new_status.slug)
+        if blocked_by:
+            logger.debug(
+                f"Status '{new_status.slug}' blocked by '{blocked_by}'."
+            )
+            return StatusApplyResult(
+                applied=False,
+                blocked_by=blocked_by,
+                blocked_reason=BlockedReason.IMMUNE_BY_ITEM,
+            )
+
+        current_status = self.get_current_status()
+        if current_status is None:
+            logger.debug("No current status, applying new status directly.")
+            self.add_status(new_status)
+            new_status.nr_turn = 1
+            new_status.apply_phase_and_use(session, EffectPhase.ON_START)
+            return StatusApplyResult(applied=True)
+
+        if self.has_status(new_status.slug):
+            logger.debug(
+                f"Monster already has status '{new_status.slug}', skipping."
+            )
+            current_status.stack_level = min(
+                current_status.stack_level + 1, Status.MAX_STACKS
+            )
+            logger.debug(
+                f"Stacking status '{new_status.slug}': now at {current_status.stack_level}/{Status.MAX_STACKS}."
+            )
+            return StatusApplyResult(
+                applied=False,
+                blocked_by=current_status.name,
+                blocked_reason=BlockedReason.ALREADY_PRESENT,
+            )
+
+        logger.debug(
+            f"Ending current status '{current_status.slug}' with ON_END phase."
+        )
+        current_status.apply_phase_and_use(session, EffectPhase.ON_END)
+
+        new_status.nr_turn = 1
+        logger.debug(
+            f"Starting new status '{new_status.slug}' with ON_START phase."
+        )
+        new_status.apply_phase_and_use(session, EffectPhase.ON_START)
+
+        if current_status.category == CategoryStatus.positive:
+            logger.debug(
+                f"Current status is positive. Transition rule: {new_status.on_positive_status}"
+            )
+            if new_status.on_positive_status == ResponseStatus.replaced:
+                self.add_status(new_status)
+            elif new_status.on_positive_status == ResponseStatus.removed:
+                self.remove_status()
+        elif current_status.category == CategoryStatus.negative:
+            logger.debug(
+                f"Current status is negative. Transition rule: {new_status.on_negative_status}"
+            )
+            if new_status.on_negative_status == ResponseStatus.replaced:
+                self.add_status(new_status)
+            elif new_status.on_positive_status == ResponseStatus.removed:
+                self.remove_status()
+        else:
+            logger.debug(
+                "Current status has no category. Applying new status."
+            )
+            self.add_status(new_status)
+
+        logger.debug(
+            f"Status '{new_status.slug}' successfully applied to monster '{monster.name}'."
+        )
+        return StatusApplyResult(applied=True)
+
+    def add_status(self, status: Status) -> None:
+        if self.has_status(status.slug):
+            return
+        self.status = [status]
+
+    def remove_status(self) -> None:
+        if self.status:
+            self.status.clear()
+
+    def clear_status(self, session: Session) -> None:
+        """Clears the current status effect for monsters in combat."""
+        current_status = self.get_current_status()
+        if current_status:
+            current_status.apply_phase_and_use(session, EffectPhase.ON_END)
+            self.status.clear()
+
+    def apply_faint(self, monster: Monster) -> None:
+        self.add_status(Status.create("faint", monster))
+
+    def get_statuses(self) -> list[Status]:
+        return self.status
+
+    def has_status(self, status_slug: str) -> bool:
+        return any(status_slug == status.slug for status in self.status)
+
+    def status_exists(self) -> bool:
+        return bool(self.status)
+
+    def remove_bonded_statuses(self) -> None:
+        self.status = [sta for sta in self.get_statuses() if not sta.bond]
+
+    def encode_status(self) -> Sequence[Mapping[str, Any]]:
+        return encode_status(self.status)
+
+    def decode_status(
+        self, json_data: Optional[Mapping[str, Any]], monster: Monster
+    ) -> None:
+        if json_data and "status" in json_data:
+            self.status = [
+                cond for cond in decode_status(json_data["status"], monster)
+            ]


### PR DESCRIPTION
The indication from issue #3001 led me to investigate the behavior of the Brillio technique (also known as Sudden Glow in English). During testing, I noticed that the immunity feedback was being triggered even when the monster's held item did not grant immunity to the status effect being applied. This was especially evident when the status was already present on the target monster, causing the system to treat it as "blocked" and report it as immune, despite no item-based immunity being involved.

Upon reviewing the `apply_status` method, I found that the `StatusApplyResult` class was returning a `blocked_by` value not only when an item blocked the status, but also when the status was already present and being stacked. Since the calling code only checked for the presence of `blocked_by`, it incorrectly assumed all blocks were due to item immunity.

To resolve this, I introduced a new `BlockedReason` enum to the `StatusApplyResult` dataclass. This enum distinguishes between different reasons a status might not be applied:
- `IMMUNE_BY_ITEM`: the monster's held item blocks the status
- `ALREADY_PRESENT`: the status is already active and stacking occurs

With this change, the calling code now checks `blocked_reason` explicitly before adding a monster to the `immune_info` list. This ensures that only true item-based immunities are reported as such, and other cases like stacking can be handled separately if needed.

In addition to this fix, I also refactored the codebase by moving the `SpriteHandler`, `StatusHandler` and `ItemHandler` logic out of the main `Monster` class. These components now reside in a separate file inside a newly created `monster_dir` folder. This modularization improves code clarity and separation of concerns. The folder is temporarily named `monster_dir` to avoid naming conflicts with the existing `tuxemon.monster` module and will be renamed in a future cleanup once the transition is complete. #2936 will move `MovesHandler` and  `PlagueHandler`