### PR TITLE
Remove redundant `remove_state()` wrapper

### DIFF
--- a/tests/tuxemon/test_state_manager.py
+++ b/tests/tuxemon/test_state_manager.py
@@ -151,7 +151,7 @@ class RemoveWhenCurrent(StateManagerTestBase):
         self.state_a = self.sm.push_state("a")
         self.state_b = self.sm.push_state("b")
         # remove the current state
-        self.sm.remove_state(self.state_b)
+        self.sm.pop_state(self.state_b)
         self.sm.update(0)
 
     def test_current_state(self):
@@ -173,6 +173,13 @@ class RemoveWhenCurrent(StateManagerTestBase):
         self.assertEqual(1, self.state_a.pause.call_count)
         self.assertEqual(0, self.state_a.shutdown.call_count)
 
+    def test_remove_middle_state(self):
+        self.create_and_register_state("c")
+        state_c = self.sm.push_state("c")
+        self.sm.pop_state(self.state_a)  # Remove middle state
+        self.assertNotIn(self.state_a, self.sm.active_states)
+        self.assertEqual(1, self.state_a.shutdown.call_count)
+
 
 class RemoveWhenNotCurrent(StateManagerTestBase):
     def setUp(self):
@@ -182,7 +189,7 @@ class RemoveWhenNotCurrent(StateManagerTestBase):
         self.state_a = self.sm.push_state("a")
         self.state_b = self.sm.push_state("b")
         # remove a state that is not current
-        self.sm.remove_state(self.state_a)
+        self.sm.pop_state(self.state_a)
         self.sm.update(0)
 
     def test_current_state(self):

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -356,10 +356,6 @@ class LocalPygameClient:
         """Pop current state, or another"""
         self.state_manager.pop_state(state)
 
-    def remove_state(self, state: State) -> None:
-        """Remove a state"""
-        self.state_manager.remove_state(state)
-
     def remove_state_by_name(self, state: str) -> None:
         """Remove a state by name"""
         self.state_manager.remove_state_by_name(state)

--- a/tuxemon/event/actions/unlock_controls.py
+++ b/tuxemon/event/actions/unlock_controls.py
@@ -31,4 +31,4 @@ class UnlockControlsAction(
         sink_state = session.client.get_state_by_name(SinkState)
 
         if sink_state:
-            session.client.remove_state(sink_state)
+            session.client.pop_state(sink_state)

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -250,10 +250,6 @@ class HeadlessClient:
         """Pop current state, or another"""
         self.state_manager.pop_state(state)
 
-    def remove_state(self, state: State) -> None:
-        """Remove a state"""
-        self.state_manager.remove_state(state)
-
     def remove_state_by_name(self, state: str) -> None:
         """Remove a state by name"""
         self.state_manager.remove_state_by_name(state)

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -194,10 +194,6 @@ class StateManager:
             logger.critical("Attempted to remove a state not in the stack")
             raise RuntimeError
 
-    def remove_state(self, state: State) -> None:
-        """Remove a state from the stack by reference."""
-        self.pop_state(state)
-
     def remove_state_by_name(self, state_name: str) -> None:
         """
         Remove a state from the stack by its name.
@@ -309,7 +305,7 @@ class StateManager:
         previous = self.state_stack.current()
         instance = self.push_state(state_name, **kwargs)
         if previous is not None:
-            self.remove_state(previous)
+            self.pop_state(previous)
         return instance
 
     def push_state_with_timeout(


### PR DESCRIPTION
PR removes the `remove_state()` method from `StateManager`, which was a simple wrapper around `pop_state(state)`.

While working on PR #3007, I noticed that `remove_state()` added no additional logic, lifecycle handling, or error management. It simply forwarded the call to `pop_state(state)` without modification:

```python
def remove_state(self, state: State) -> None:
    self.pop_state(state)
```

This kind of indirection increases surface area without improving clarity or functionality. By removing it, we simplify the `StateManager` API and reduce potential confusion about whether `remove_state()` behaves differently than `pop_state()`.

Summary of changes:
- deleted `remove_state()` from `StateManager`
- replaced all internal calls to `remove_state(state)` with `pop_state(state)`