### PR TITLE
Config Enhancement: Move UI Asset Paths to `tuxemon.yaml`

### DIFF
--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -118,6 +118,13 @@ class TuxemonConfig:
             "combat_click_to_continue"
         ]
 
+        # [graphics]
+        graphics = self.config["graphics"]
+        self.dialog_box_style: str = graphics["dialog_box_style"]
+        self.menu_border: str = graphics["menu_border"]
+        self.menu_cursor: str = graphics["menu_cursor"]
+        self.menu_sound: str = graphics["menu_sound"]
+
         # [player]
         player = self.config["player"]
         self.player_animation_speed: float = player["animation_speed"]
@@ -318,6 +325,12 @@ def generate_default_config() -> dict[str, Any]:
             "sound_volume": 0.2,
             "music_volume": 0.5,
             "combat_click_to_continue": False,
+        },
+        "graphics": {
+            "dialog_box_style": "default",
+            "menu_border": "gfx/borders/borders.png",
+            "menu_cursor": "gfx/arrow.png",
+            "menu_sound": "sound_menu_select",
         },
         "player": {
             "animation_speed": 0.15,

--- a/tuxemon/event/actions/cipher_dialog.py
+++ b/tuxemon/event/actions/cipher_dialog.py
@@ -80,7 +80,7 @@ class CipherDialogAction(EventAction):
             get_avatar(session, self.avatar) if self.avatar else None
         )
 
-        dialogue = self.style or "default"
+        dialogue = self.style or session.client.config.dialog_box_style
         style = _get_style(dialogue)
         h_alignment = safe_enum_value(
             HorizontalAlignment, self.h_alignment, HorizontalAlignment.LEFT

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -74,7 +74,7 @@ class TranslatedDialogAction(EventAction):
             get_avatar(session, self.avatar) if self.avatar else None
         )
 
-        dialogue = self.style or "default"
+        dialogue = self.style or session.client.config.dialog_box_style
         style = style_cache.get(dialogue)
         h_alignment = safe_enum_value(
             HorizontalAlignment, self.h_alignment, HorizontalAlignment.LEFT

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -114,7 +114,7 @@ class PygameMenuState(State):
 
         if sound_engine is None:
             sound_file = self.client.sound_manager.get_sound_filename(
-                "sound_menu_select"
+                prepare.CONFIG.menu_sound
             )
             sound_volume = self.client.config.sound_volume
             sound_engine = get_sound_engine(sound_volume, sound_file)
@@ -335,10 +335,10 @@ class Menu(Generic[T], State):
     unavailable_color_shop: ColorLike = prepare.UNAVAILABLE_COLOR_SHOP
     # File to load for image background
     background_filename: Optional[str] = None
-    menu_select_sound_filename = "sound_menu_select"
+    menu_select_sound_filename = prepare.CONFIG.menu_sound
     font_filename = prepare.CONFIG.locale.font_file
-    borders_filename = "gfx/borders/borders.png"
-    cursor_filename = "gfx/arrow.png"
+    borders_filename = prepare.CONFIG.menu_border
+    cursor_filename = prepare.CONFIG.menu_cursor
     cursor_move_duration = 0.20
     default_character_delay = 0.05
     shrink_to_items = False  # fit the border to contents

--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -31,7 +31,7 @@ class TuxemonArrowSelection(Selection):
         #
 
         arrow = pygame_menu.BaseImage(
-            image_path=transform_resource_filename("gfx/arrow.png"),
+            image_path=transform_resource_filename(prepare.CONFIG.menu_cursor),
         ).scale(5, 5, smooth=False)
 
         super().__init__(
@@ -70,7 +70,7 @@ def get_theme() -> pygame_menu.Theme:
         return _theme
 
     tuxemon_border = pygame_menu.BaseImage(
-        image_path=transform_resource_filename("gfx/borders/borders.png"),
+        image_path=transform_resource_filename(prepare.CONFIG.menu_border),
     ).scale(5, 5, smooth=False)
 
     tuxemon_background_center_rect = tuxemon_border.get_rect()


### PR DESCRIPTION
PR extracts several hardcoded UI-related strings from the Python source files and relocates them into a new `graphics` section within the main `tuxemon.yaml` configuration file:

```yaml
graphics:
  dialog_box_style: default
  menu_border: gfx/borders/borders.png
  menu_cursor: gfx/arrow.png
  menu_sound: sound_menu_select
```

This change improves flexibility by allowing users to customize visual and audio elements without modifying the codebase directly, making it easier to experiment with different styles or assets while keeping the Python files clean and consistent.