### PR TITLE
Fix: Party HUD Icons Not Updating for Opponent's Fainted Monsters

### DIFF
--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -362,7 +362,7 @@ class CaptureDeviceSprite(Sprite):
     def resolve_status(self) -> str:
         if self.monster is None:
             return "empty"
-        if self.monster.status.is_fainted:
+        if self.monster.is_fainted:
             return "faint"
         if self.monster.status.status_exists():
             return "effected"


### PR DESCRIPTION
PR fixes a bug where the capture device icons (the small tuxeballs in the HUD) weren’t updating correctly for opponent monsters during trainer battles. Specifically, when one of the opponent’s monsters fainted, the corresponding tuxeball didn’t change color to reflect the fainted state, although it did update correctly when the monster was affected by a status condition.

The issue was caused by referencing the `Status` object directly instead of the actual `Monster` instance when checking for fainting. As a result, the `is_fainted` check didn’t behave as expected. This fix ensures the HUD correctly reflects fainted monsters by linking the icon logic to the `Monster` itself.