### PR TITLE
Refactor AI Monster Replacement Logic and Separate Filtering from Decision-Making

### DIFF
--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -14,6 +14,7 @@ import yaml
 from tuxemon import prepare
 from tuxemon.combat import pre_checking
 from tuxemon.constants import paths
+from tuxemon.db import StatType
 from tuxemon.formula import simple_damage_multiplier
 from tuxemon.technique.technique import Technique
 
@@ -460,6 +461,68 @@ class AIManager:
         """Removes all tracked AI instances from the manager."""
         logger.debug("Clearing all AI instances.")
         self.active_ais.clear()
+
+    def choose_replacement_monster(self, character: NPC) -> Optional[Monster]:
+        """
+        AI logic to select a replacement monster to send out.
+
+        This method uses the available monsters and applies AI strategy.
+        """
+        available_monsters = self.combat.get_bench(character)
+
+        if not available_monsters:
+            logger.debug(f"No available monsters for {character.name}")
+            return None
+
+        if len(available_monsters) == 1:
+            logger.debug(
+                f"Only one monster available for {character.name}: {available_monsters[0].name}"
+            )
+            return available_monsters[0]
+
+        strategy = getattr(character, "strategy", None)
+        logger.debug(f"{character.name} strategy: {strategy}")
+
+        # If no strategy, pick the next available monster in order
+        if strategy is None:
+            logger.debug(
+                f"No strategy defined. Selecting first available monster: {available_monsters[0].name}"
+            )
+            return available_monsters[0]
+
+        methods = {
+            "lv_highest": ("level", max),
+            "lv_lowest": ("level", min),
+            "healthiest": ("current_hp", max),
+            "weakest": ("current_hp", min),
+            "oldest": ("steps", max),
+            "newest": ("steps", min),
+        }
+
+        methods.update(
+            {f"{stat.value}_max": (stat.value, max) for stat in StatType}
+        )
+        methods.update(
+            {f"{stat.value}_min": (stat.value, min) for stat in StatType}
+        )
+
+        if strategy == "random":
+            chosen = random.choice(available_monsters)
+            logger.debug(f"Random strategy selected: {chosen.name}")
+            return chosen
+
+        if strategy in methods:
+            attr, func = methods[strategy]
+            chosen = func(available_monsters, key=lambda m: getattr(m, attr))
+            logger.debug(
+                f"Strategy '{strategy}' selected monster: {chosen.name} (based on {attr})"
+            )
+            return chosen
+
+        logger.debug(
+            f"Unrecognized strategy '{strategy}'. Defaulting to first available: {available_monsters[0].name}"
+        )
+        return available_monsters[0]
 
 
 class AI:

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 
 import logging
 import random
-from collections.abc import Generator, Sequence
-from typing import TYPE_CHECKING, Optional
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from tuxemon.db import (
     EffectPhase,
     GenderType,
     OutputBattle,
-    StatType,
     TargetType,
 )
 from tuxemon.locale import T
@@ -133,40 +132,6 @@ def has_effect_param(
         ele.name == effect_name and getattr(ele, attribute, None) == name
         for ele in tech.effects
     )
-
-
-def get_awake_monsters(
-    character: NPC,
-    monsters: list[Monster],
-    turn: int,
-    method: Optional[str] = None,
-) -> Generator[Monster, None, None]:
-    """
-    Iterate all non-fainted monsters in party.
-
-    Parameters:
-        character: The character.
-        monsters: List of monsters on the battlefield.
-        turn: Current turn of the battle.
-        method: Method to use when selecting a monster (default: None).
-
-    Yields:
-        Non-fainted monsters.
-    """
-    awake_monsters = [
-        monster
-        for monster in character.monsters
-        if not monster.is_fainted and monster not in monsters
-    ]
-
-    if awake_monsters:
-        if len(awake_monsters) == 1:
-            yield awake_monsters[0]
-        else:
-            if turn == 1 or method is None:
-                yield from awake_monsters
-            else:
-                yield retrieve_from_party(awake_monsters, method)
 
 
 def alive_party(character: NPC) -> list[Monster]:
@@ -457,44 +422,3 @@ def build_hud_text(
         symbol = "◉"
 
     return f"{monster.name}{icon} Lv.{monster.level}{symbol}"
-
-
-def retrieve_from_party(party: list[Monster], method: str) -> Monster:
-    """
-    Retrieves a monster from the party based on the specified method.
-
-    Parameters:
-        party: List of monsters in the party.
-        method: Method to use when selecting a monster
-            (e.g., 'lv_highest', 'healthiest', etc.).
-
-    Returns:
-        Monster: The selected monster.
-
-    Notes:
-        If the method is not recognized, a random monster from
-        the party will be returned.
-    """
-    methods = {
-        "lv_highest": ("level", max),
-        "lv_lowest": ("level", min),
-        "healthiest": ("current_hp", max),
-        "weakest": ("current_hp", min),
-        "oldest": ("steps", max),
-        "newest": ("steps", min),
-    }
-
-    # eg. speed_max, armour_max, etc.
-    methods.update(
-        {f"{stat.value}_max": (stat.value, max) for stat in StatType}
-    )
-    # eg. speed_min, armour_min, etc.
-    methods.update(
-        {f"{stat.value}_min": (stat.value, min) for stat in StatType}
-    )
-
-    if method not in methods:
-        return random.choice(party)
-
-    attr, func = methods[method]
-    return func(party, key=lambda m: getattr(m, attr))

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -50,7 +50,6 @@ from tuxemon.combat import (
     alive_party,
     battlefield,
     defeated,
-    get_awake_monsters,
     set_var,
     track_battles,
 )
@@ -489,9 +488,6 @@ class CombatState(CombatAnimations):
         Parameters:
             ask: If True, then open dialog for human players.
         """
-        # TODO: let work for trainer battles
-        humans = list(self.human_players)
-
         # TODO: integrate some values for different match types
         for player in self.active_players:
 
@@ -509,15 +505,15 @@ class CombatState(CombatAnimations):
 
             positions_available = self.get_available_positions(player)
             if positions_available:
-                monsters = self.field_monsters.get_monsters(player)
-                available = get_awake_monsters(player, monsters, self._turn)
-                for _ in range(positions_available):
-                    if player in humans and ask:
-                        self.ask_player_for_monster(player)
-                    else:
-                        monster = next(available)
-                        self.add_monster_into_play(player, monster)
-                        self.update_tuxepedia(player, monster)
+                if player in self.human_players and ask:
+                    self.ask_player_for_monster(player)
+                else:
+                    replacement = self.ai_manager.choose_replacement_monster(
+                        player
+                    )
+                    if replacement:
+                        self.add_monster_into_play(player, replacement)
+                        self.update_tuxepedia(player, replacement)
 
     def update_tuxepedia(self, player: NPC, monster: Monster) -> None:
         """
@@ -662,15 +658,21 @@ class CombatState(CombatAnimations):
         Updates HUD and assigns monsters to the decision queue for players,
         while recharging moves and triggering AI actions for NPCs.
         """
-        for player in list(self.active_players):
-            self.update_hud(player, False, False)
-            monsters = self.field_monsters.get_monsters(player)
-            for monster in monsters:
-                if player in self.human_players:
-                    self._decision_queue.append(monster)
-                else:
-                    monster.moves.recharge_moves()
-                    self.ai_manager.process_ai_turn(monster, player)
+        self._decision_queue = []
+
+        for monster in self.active_monsters:
+            char = self.field_monsters.get_npc_for_monster(monster)
+            monster.moves.recharge_moves()
+            if char in self.human_players:
+                # Still add to queue for menu interaction
+                self._decision_queue.append(monster)
+            else:
+                # Ask AIManager to handle the decision for this monster
+                self.ai_manager.process_ai_turn(monster, char)
+
+        # Start the menu flow for human players
+        if self._decision_queue:
+            self.show_monster_action_menu(self._decision_queue.pop(0))
 
     def check_decisions(self) -> None:
         for player in list(self.active_players):

--- a/tuxemon/ui/combat_monsters.py
+++ b/tuxemon/ui/combat_monsters.py
@@ -50,6 +50,13 @@ class FieldMonsters:
         """Returns a dictionary containing all NPCs and their active monsters."""
         return self.monsters_in_play
 
+    def get_npc_for_monster(self, monster: Monster) -> NPC:
+        """Returns the NPC that controls the given monster, or Raise if not found."""
+        for npc, monsters in self.monsters_in_play.items():
+            if monster in monsters:
+                return npc
+        raise ValueError(f"Monster '{monster}' not found in any NPC's roster.")
+
     def clear_all(self) -> None:
         """Removes all NPCs and their monsters from play."""
         self.monsters_in_play.clear()


### PR DESCRIPTION
PR refactors the logic for selecting replacement monsters for AI-controlled characters during combat. The goal is to separate the responsibilities of filtering available monsters and making strategic decisions, improving clarity and maintainability.

Previously, the `get_awake_monsters` function combined filtering with decision logic, including turn-based rules and hardcoded strategy strings. This design was difficult to extend and violated separation of concerns.

The new approach uses `get_bench`, which returns all non-fainted, off-field monsters for a given player. This function is now used in the AIManager to retrieve candidates for replacement.

The decision-making logic has been moved entirely into `AIManager.choose_replacement_monster`, which applies strategy-based selection. Supported strategies include level-based, HP-based, and stat-based options, as well as a random fallback. If no strategy is defined or recognized, the AI defaults to selecting the next available monster in party order.

The final version of `choose_replacement_monster` includes light debug logging to trace decisions without cluttering output. This makes AI behavior more transparent during development and testing.

This refactor improves modularity, makes the AI logic easier to test and extend, and simplifies the role of `CombatState`, which now delegates all AI decisions to the AIManager.

To support more personalized AI behavior, a new attribute called `strategy` (or more specifically, `replacement_strategy`) will be added to the `NPC` class and its corresponding JSON definitions.

This allows each trainer to have their own style of choosing replacement monsters. For example, if a trainer has five monsters - A, B, C, D, and E - and uses the `"random"` strategy, then when A faints, the next monster will be randomly selected from the remaining ones. Another trainer might prefer `"lv_highest"` or `"healthiest"`, making their AI feel more deliberate or tactical. This opens the door to more diverse and character-driven AI behavior across the game (separate PR when #2982 is merged).