### PR TITLE
Fix music restart on teleport; restrict music stop to scenario loading

### DIFF
--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -79,6 +79,7 @@ class LoadGameAction(EventAction):
 
             # teleport the player to the correct position using an event
             # engine action
+            client.current_music.stop()
             tele_x, tele_y = save_data["npc_state"]["tile_pos"]
             params = [
                 "player",

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -47,8 +47,6 @@ class TeleportAction(EventAction):
             logger.error(f"{self.character} not found")
             return
 
-        session.client.current_music.stop()
-
         # Check to see if we're also performing a transition. If we are, wait
         # to perform the teleport at the apex of the transition
         if world.transition_manager.in_transition:

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -50,8 +50,6 @@ class TransitionTeleportAction(EventAction):
             self.stop()
             return
 
-        session.client.current_music.stop()
-
         # Start the screen transition
         _time = TRANS_TIME if self.trans_time is None else self.trans_time
         rgb: ColorLike = BLACK_COLOR


### PR DESCRIPTION
PR fixed #3017 which is related to an old workaround that was causing music to restart unnecessarily when teleporting between rooms within the same scenario (e.g. Spyder campaign).

Origin: years ago, I added a `stop current_music` call during teleport events to prevent music from "spilling" between scenarios. This was meant to solve cases where a map with music (like Spyder) would impose its soundtrack on a silent map (like Xero) when loading a new scenario. It worked, but it was too aggressive.

Issue: the music stop was being triggered even during simple teleports, such as moving from the bedroom to the ground floor. Since both areas use the same track (`music_home`), the song would restart instead of continuing smoothly.

Fix:  
- removed `stop current_music` from teleport events
- moved the music stop logic to scenario loading only

Result:
- music now continues seamlessly when teleporting within the same scenario
- music is still properly stopped when loading a new save or scenario, preventing unwanted carryover, especially into silent maps