### PR TITLE
Mission Requirements (Items & Monsters) to Support Quantities and Levels

### DIFF
--- a/mods/tuxemon/db/mission/spyder.json
+++ b/mods/tuxemon/db/mission/spyder.json
@@ -9,8 +9,8 @@
     ],
     "failure_conditions": [],
     "connected_missions": [],
-    "required_items": [],
-    "required_monsters": [],
+    "required_items": {},
+    "required_monsters": {},
     "required_missions": [],
     "repeatable": false,
     "steps": {

--- a/tests/tuxemon/test_mission.py
+++ b/tests/tuxemon/test_mission.py
@@ -71,12 +71,15 @@ class TestMissionManager(TestCase):
         self.assertFalse(self.mission_controller.check_all_prerequisites())
 
     def test_check_required_items(self):
-        self.mission.required_items = ["potion", "lotion"]
+        self.mission.required_items = {"potion": None, "lotion": 2}
 
         item1 = MagicMock()
         item1.slug = "potion"
+        item1.quantity = 1
+
         item2 = MagicMock()
         item2.slug = "lotion"
+        item2.quantity = 2
 
         self.character.items = MagicMock(spec=NPCBagHandler)
         self.character.items.find_item.side_effect = lambda slug: (
@@ -85,18 +88,24 @@ class TestMissionManager(TestCase):
 
         self.assertTrue(self.mission.check_required_items(self.character))
 
+        item2.quantity = 1
+        self.assertFalse(self.mission.check_required_items(self.character))
+
         self.character.items.find_item.side_effect = lambda slug: (
             item1 if slug == "potion" else None
         )
         self.assertFalse(self.mission.check_required_items(self.character))
 
     def test_check_required_monsters(self):
-        self.mission.required_monsters = ["monster1", "monster2"]
+        self.mission.required_monsters = {"monster1": None, "monster2": 5}
 
         monster1 = MagicMock()
         monster1.slug = "monster1"
+        monster1.level = 3
+
         monster2 = MagicMock()
         monster2.slug = "monster2"
+        monster2.level = 5
 
         self.character.party = MagicMock(spec=PartyHandler)
         self.character.party.find_monster.side_effect = lambda slug: (
@@ -106,6 +115,9 @@ class TestMissionManager(TestCase):
         )
 
         self.assertTrue(self.mission.check_required_monsters(self.character))
+
+        monster2.level = 4
+        self.assertFalse(self.mission.check_required_monsters(self.character))
 
         self.character.party.find_monster.side_effect = lambda slug: (
             monster1 if slug == "monster1" else None

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1754,12 +1754,13 @@ class MissionModel(BaseModel, BaseLookupModel):
         default_factory=list,
         description="List of missions that this one unlocks",
     )
-    required_items: Sequence[str] = Field(
-        default_factory=list, description="Items required to begin the mission"
+    required_items: dict[str, Optional[int]] = Field(
+        default_factory=dict,
+        description="Items required to begin the mission with optional quantity. None means at least one.",
     )
-    required_monsters: Sequence[str] = Field(
-        default_factory=list,
-        description="Monsters required to begin the mission",
+    required_monsters: dict[str, Optional[int]] = Field(
+        default_factory=dict,
+        description="Monsters required to begin the mission with optional minimum level. None means any level.",
     )
     required_missions: Sequence[str] = Field(
         default_factory=list,
@@ -1798,8 +1799,10 @@ class MissionModel(BaseModel, BaseLookupModel):
         raise ValueError(f"no translation exists with msgid: {v}")
 
     @field_validator("required_items")
-    def item_exists(cls: MissionModel, v: Sequence[str]) -> Sequence[str]:
-        for item_slug in v:
+    def item_exists(
+        cls: MissionModel, v: dict[str, Optional[int]]
+    ) -> dict[str, Optional[int]]:
+        for item_slug in v.keys():
             if not has.db_entry("item", item_slug):
                 raise ValueError(
                     f"The item '{item_slug}' doesn't exist in the db"
@@ -1807,8 +1810,10 @@ class MissionModel(BaseModel, BaseLookupModel):
         return v
 
     @field_validator("required_monsters")
-    def monster_exists(cls: MissionModel, v: Sequence[str]) -> Sequence[str]:
-        for monster_slug in v:
+    def monster_exists(
+        cls: MissionModel, v: dict[str, Optional[int]]
+    ) -> dict[str, Optional[int]]:
+        for monster_slug in v.keys():
             if not has.db_entry("monster", monster_slug):
                 raise ValueError(
                     f"The monster '{monster_slug}' doesn't exist in the db"

--- a/tuxemon/mission/mission.py
+++ b/tuxemon/mission/mission.py
@@ -31,8 +31,8 @@ class Mission:
         self.prerequisites: Sequence[dict[str, Any]] = []
         self.connected_missions: Sequence[dict[str, Any]] = []
         self.failure_conditions: Sequence[dict[str, Any]] = []
-        self.required_items: Sequence[str] = []
-        self.required_monsters: Sequence[str] = []
+        self.required_items: dict[str, Optional[int]] = {}
+        self.required_monsters: dict[str, Optional[int]] = {}
         self.required_missions: Sequence[str] = []
         self.steps: dict[str, MissionStepModel] = {}
         self.completed_steps: set[str] = set()
@@ -119,15 +119,25 @@ class Mission:
             self.completed_steps.add(slug)
 
     def check_required_items(self, character: NPC) -> bool:
-        return all(
-            character.items.find_item(item) for item in self.required_items
-        )
+        for item_slug, required_quantity in self.required_items.items():
+            item = character.items.find_item(item_slug)
+            if not item:
+                return False
+            if (
+                required_quantity is not None
+                and item.quantity < required_quantity
+            ):
+                return False
+        return True
 
     def check_required_monsters(self, character: NPC) -> bool:
-        return all(
-            character.party.find_monster(monster)
-            for monster in self.required_monsters
-        )
+        for monster_slug, min_level in self.required_monsters.items():
+            monster = character.party.find_monster(monster_slug)
+            if not monster:
+                return False
+            if min_level is not None and monster.level < min_level:
+                return False
+        return True
 
     def get_slug_missions(self, character: NPC) -> list[str]:
         return [


### PR DESCRIPTION
PR introduces a refactor to how mission requirements are defined and validated. Instead of using simple lists of item and monster slugs, missions can now specify required quantities for items and minimum levels for monsters.

Key changes:
- changed `required_items` from `Sequence[str]` to `dict[str, Optional[int]]`: allows specifying item quantities (e.g. `"Potion": 3`) and `None` means at least one item is required
- changed `required_monsters` from `Sequence[str]` to `dict[str, Optional[int]]`: allows specifying minimum monster levels (e.g. `"Dragon": 10`) and `None` means any level is acceptable
- updated field validators to check existence of item/monster slugs in the database
- updated mission logic to validate quantities and levels