### PR TITLE
Expand `BillEntry` Attributes

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -7,6 +7,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.add_step_tracker.AddStepTrackerAction
 .. autoscriptinfoclass:: tuxemon.event.actions.add_tech.AddTechAction
 .. autoscriptinfoclass:: tuxemon.event.actions.add_tracker.AddTrackerAction
+.. autoscriptinfoclass:: tuxemon.event.actions.adjust_bill_penalty.AdjustBillPenaltyAction
 .. autoscriptinfoclass:: tuxemon.event.actions.breeding.BreedingAction
 .. autoscriptinfoclass:: tuxemon.event.actions.call_event.CallEventAction
 .. autoscriptinfoclass:: tuxemon.event.actions.camera_follow.CameraFollowAction

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -41,7 +41,7 @@ events:
     type: event
   Cathedral:
     actions:
-    - set_bill player,bill_cathedral
+    - set_bill player,bill_cathedral,0,0.1,100,0.5
     - set_variable cathedral_share:0.5
     - format_variable cathedral_share,float
     - set_variable cathedral_interest:0.1
@@ -53,20 +53,6 @@ events:
     - not variable_set cathedral_interest
     - not variable_set cathedral_fee
     - not variable_set scoop_coeff
-    type: event
-  Cathedral Share:
-    actions:
-    - variable_math battle_last_prize,*,cathedral_share
-    - format_variable battle_last_prize,int
-    - modify_bill player,bill_cathedral,,battle_last_prize
-    - format_variable battle_last_prize,-int
-    - modify_money player,,battle_last_prize
-    - set_variable battle_last_prize:0
-    conditions:
-    - is variable_set battle_last_result:won
-    - is variable_set battle_last_winner:player
-    - is bill_is player,bill_cathedral,greater_than,0
-    - is variable_is battle_last_prize,greater_than,0
     type: event
   Cheat Code ApexPlayer:
     actions:

--- a/tests/tuxemon/test_money.py
+++ b/tests/tuxemon/test_money.py
@@ -14,33 +14,32 @@ from tuxemon.money import (
 
 class TestMoneyManager(TestCase):
 
+    def setUp(self):
+        self.money_manager = MoneyManager()
+
     def test_init(self):
-        money_manager = MoneyManager()
-        self.assertEqual(money_manager.money, 0)
-        self.assertEqual(money_manager.bank_account, 0)
-        self.assertEqual(money_manager.bills, {})
+        self.assertEqual(self.money_manager.money, 0)
+        self.assertEqual(self.money_manager.bank_account, 0)
+        self.assertEqual(self.money_manager.bills, {})
 
     def test_add_money(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        self.assertEqual(money_manager.money, 100)
-        money_manager.add_money(-50)
-        self.assertEqual(money_manager.money, 50)
-        money_manager.add_money(-100)
-        self.assertEqual(money_manager.money, 0)
+        self.money_manager.add_money(100)
+        self.assertEqual(self.money_manager.money, 100)
+        self.money_manager.add_money(-50)
+        self.assertEqual(self.money_manager.money, 50)
+        self.money_manager.add_money(-100)
+        self.assertEqual(self.money_manager.money, 0)
 
     def test_remove_money(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        money_manager.remove_money(50)
-        self.assertEqual(money_manager.money, 50)
-        money_manager.remove_money(100)
-        self.assertEqual(money_manager.money, 0)
+        self.money_manager.add_money(100)
+        self.money_manager.remove_money(50)
+        self.assertEqual(self.money_manager.money, 50)
+        self.money_manager.remove_money(100)
+        self.assertEqual(self.money_manager.money, 0)
 
     def test_get_money(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        self.assertEqual(money_manager.get_money(), 100)
+        self.money_manager.add_money(100)
+        self.assertEqual(self.money_manager.get_money(), 100)
 
     def test_transfer_money_to(self):
         npc1 = MagicMock()
@@ -69,94 +68,93 @@ class TestMoneyManager(TestCase):
         self.assertEqual(npc2.money_controller.money_manager.bank_account, 50)
 
     def test_deposit_to_bank(self):
-        money_manager = MoneyManager()
-        money_manager.deposit_to_bank(100)
-        self.assertEqual(money_manager.bank_account, 100)
+        self.money_manager.deposit_to_bank(100)
+        self.assertEqual(self.money_manager.bank_account, 100)
 
     def test_withdraw_from_bank(self):
-        money_manager = MoneyManager()
-        money_manager.deposit_to_bank(100)
-        money_manager.withdraw_from_bank(50)
-        self.assertEqual(money_manager.bank_account, 50)
+        self.money_manager.deposit_to_bank(100)
+        self.money_manager.withdraw_from_bank(50)
+        self.assertEqual(self.money_manager.bank_account, 50)
         with self.assertRaises(ValueError):
-            money_manager.withdraw_from_bank(100)
+            self.money_manager.withdraw_from_bank(100)
 
     def test_get_bank_balance(self):
-        money_manager = MoneyManager()
-        money_manager.deposit_to_bank(100)
-        self.assertEqual(money_manager.get_bank_balance(), 100)
+        self.money_manager.deposit_to_bank(100)
+        self.assertEqual(self.money_manager.get_bank_balance(), 100)
 
     def test_add_bill(self):
-        money_manager = MoneyManager()
-        money_manager.add_bill("bill1", 100)
-        self.assertEqual(money_manager.bills, {"bill1": BillEntry(amount=100)})
-        money_manager.add_bill("bill1", 50)
-        self.assertEqual(money_manager.bills, {"bill1": BillEntry(amount=150)})
+        self.money_manager.set_bill("bill1", 100)
+        self.assertEqual(
+            self.money_manager.bills, {"bill1": BillEntry(amount=100)}
+        )
+        self.money_manager.add_bill("bill1", 50)
+        self.assertEqual(
+            self.money_manager.bills, {"bill1": BillEntry(amount=150)}
+        )
 
     def test_remove_bill(self):
-        money_manager = MoneyManager()
-        money_manager.add_bill("bill1", 100)
-        money_manager.remove_bill("bill1", -50)
-        self.assertEqual(money_manager.bills, {"bill1": BillEntry(amount=50)})
-        money_manager.remove_bill("bill1", -50)
-        self.assertEqual(money_manager.bills, {"bill1": BillEntry(amount=0)})
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.remove_bill("bill1", -50)
+        self.assertEqual(
+            self.money_manager.bills, {"bill1": BillEntry(amount=50)}
+        )
+        self.money_manager.remove_bill("bill1", -50)
+        self.assertEqual(
+            self.money_manager.bills, {"bill1": BillEntry(amount=0)}
+        )
 
     def test_pay_bill_with_money(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        money_manager.add_bill("bill1", 50)
-        money_manager.pay_bill_with_money("bill1", 50)
-        self.assertEqual(money_manager.money, 50)
-        self.assertEqual(money_manager.bills, {"bill1": BillEntry(amount=0)})
+        self.money_manager.add_money(100)
+        self.money_manager.set_bill("bill1", 50)
+        self.money_manager.pay_bill_with_money("bill1", 50)
+        self.assertEqual(self.money_manager.money, 50)
+        self.assertEqual(
+            self.money_manager.bills, {"bill1": BillEntry(amount=0)}
+        )
 
     def test_pay_bill_with_deposit(self):
-        money_manager = MoneyManager()
-        money_manager.deposit_to_bank(100)
-        money_manager.add_bill("bill1", 50)
-        money_manager.pay_bill_with_deposit("bill1", 50)
-        self.assertEqual(money_manager.bank_account, 50)
-        self.assertEqual(money_manager.bills, {"bill1": BillEntry(amount=0)})
+        self.money_manager.deposit_to_bank(100)
+        self.money_manager.set_bill("bill1", 50)
+        self.money_manager.pay_bill_with_deposit("bill1", 50)
+        self.assertEqual(self.money_manager.bank_account, 50)
+        self.assertEqual(
+            self.money_manager.bills, {"bill1": BillEntry(amount=0)}
+        )
 
     def test_get_bills(self):
-        money_manager = MoneyManager()
-        money_manager.add_bill("bill1", 100)
-        money_manager.add_bill("bill2", 50)
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.set_bill("bill2", 50)
         self.assertEqual(
-            money_manager.get_bills(),
+            self.money_manager.get_bills(),
             {"bill1": BillEntry(amount=100), "bill2": BillEntry(amount=50)},
         )
 
     def test_get_bill(self):
-        money_manager = MoneyManager()
-        money_manager.add_bill("bill1", 100)
-        self.assertEqual(money_manager.get_bill("bill1").amount, 100)
-        self.assertEqual(money_manager.get_bill("bill2").amount, 0)
+        self.money_manager.set_bill("bill1", 100)
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 100)
+        self.assertEqual(self.money_manager.get_bill("bill2").amount, 0)
 
     def test_get_total_bills(self):
-        money_manager = MoneyManager()
-        money_manager.add_bill("bill1", 100)
-        money_manager.add_bill("bill2", 50)
-        self.assertEqual(money_manager.get_total_bills(), 150)
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.set_bill("bill2", 50)
+        self.assertEqual(self.money_manager.get_total_bills(), 150)
 
     def test_get_total_wealth(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        money_manager.deposit_to_bank(50)
-        self.assertEqual(money_manager.get_total_wealth(), 150)
+        self.money_manager.add_money(100)
+        self.money_manager.deposit_to_bank(50)
+        self.assertEqual(self.money_manager.get_total_wealth(), 150)
 
     def test_transfer_all_money_to_bank(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        money_manager.transfer_all_money_to_bank()
-        self.assertEqual(money_manager.money, 0)
-        self.assertEqual(money_manager.bank_account, 100)
+        self.money_manager.add_money(100)
+        self.money_manager.transfer_all_money_to_bank()
+        self.assertEqual(self.money_manager.money, 0)
+        self.assertEqual(self.money_manager.bank_account, 100)
 
     def test_withdraw_all_money_from_bank(self):
-        money_manager = MoneyManager()
-        money_manager.deposit_to_bank(100)
-        money_manager.withdraw_all_money_from_bank()
-        self.assertEqual(money_manager.money, 100)
-        self.assertEqual(money_manager.bank_account, 0)
+        self.money_manager.deposit_to_bank(100)
+        self.money_manager.withdraw_all_money_from_bank()
+        self.assertEqual(self.money_manager.money, 100)
+        self.assertEqual(self.money_manager.bank_account, 0)
 
     def test_decode_money(self):
         json_data = {
@@ -179,20 +177,23 @@ class TestMoneyManager(TestCase):
         )
 
     def test_encode_money(self):
-        money_manager = MoneyManager()
-        money_manager.add_money(100)
-        money_manager.deposit_to_bank(50)
-        money_manager.add_bill("bill1", 20)
-        money_manager.add_bill("bill2", 30)
-        json_data = encode_money(money_manager)
+        self.money_manager.add_money(100)
+        self.money_manager.deposit_to_bank(50)
+        self.money_manager.set_bill("bill1", 20)
+        self.money_manager.set_bill("bill2", 30)
+        json_data = encode_money(self.money_manager)
         self.assertEqual(
             json_data,
             {
                 "money": 100,
                 "bank_account": 50,
                 "bills": {
-                    "bill1": {"amount": 20},
-                    "bill2": {"amount": 30},
+                    "bill1": {
+                        "amount": 20,
+                    },
+                    "bill2": {
+                        "amount": 30,
+                    },
                 },
             },
         )
@@ -210,3 +211,128 @@ class TestMoneyManager(TestCase):
         self.assertEqual(money_manager.money, 0)
         self.assertEqual(money_manager.bank_account, 0)
         self.assertEqual(money_manager.bills, {})
+
+    def test_add_bill_with_interest_and_fee(self):
+        self.money_manager.set_bill(
+            "bill1", 100, interest_rate=0.1, late_fee=25
+        )
+        bill = self.money_manager.get_bill("bill1")
+        self.assertEqual(bill.amount, 100)
+        self.assertEqual(bill.interest_rate, 0.1)
+        self.assertEqual(bill.late_fee, 25)
+
+    def test_apply_bank_interest(self):
+        self.money_manager.deposit_to_bank(100)
+        self.money_manager.apply_bank_interest(0.05)
+        self.assertEqual(self.money_manager.bank_account, 105)
+
+    def test_apply_bank_interest_rounding(self):
+        self.money_manager.deposit_to_bank(99)
+        self.money_manager.apply_bank_interest(0.1)
+        self.assertAlmostEqual(self.money_manager.bank_account, 108)
+
+    def test_apply_interest_to_bill(self):
+        self.money_manager.set_bill("bill1", 100, interest_rate=0.2)
+        self.money_manager.apply_interest_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 120)
+
+    def test_apply_interest_to_bill_no_rate(self):
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.apply_interest_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 100)
+
+    def test_apply_interest_to_nonexistent_bill(self):
+        with self.assertRaises(KeyError):
+            self.money_manager.apply_interest_to_bill("missing_bill")
+
+    def test_apply_late_fee_to_bill(self):
+        self.money_manager.set_bill("bill1", 100, late_fee=15)
+        self.money_manager.apply_late_fee_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 115)
+
+    def test_apply_late_fee_to_bill_no_fee(self):
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.apply_late_fee_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 100)
+
+    def test_apply_late_fee_to_nonexistent_bill(self):
+        with self.assertRaises(KeyError):
+            self.money_manager.apply_late_fee_to_bill("missing_bill")
+
+    def test_encode_money_with_interest_and_fee(self):
+        self.money_manager.set_bill(
+            "bill1", 100, interest_rate=0.1, late_fee=20
+        )
+        json_data = encode_money(self.money_manager)
+        self.assertEqual(json_data["bills"]["bill1"]["amount"], 100)
+        self.assertEqual(json_data["bills"]["bill1"]["interest_rate"], 0.1)
+        self.assertEqual(json_data["bills"]["bill1"]["late_fee"], 20)
+
+    def test_decode_money_with_interest_and_fee(self):
+        json_data = {
+            "money": 0,
+            "bank_account": 0,
+            "bills": {
+                "bill1": {
+                    "amount": 100,
+                    "interest_rate": 0.1,
+                    "late_fee": 20,
+                }
+            },
+        }
+        money_manager = decode_money(json_data)
+        bill = money_manager.get_bill("bill1")
+        self.assertEqual(bill.amount, 100)
+        self.assertEqual(bill.interest_rate, 0.1)
+        self.assertEqual(bill.late_fee, 20)
+
+    def test_apply_negative_interest_to_bill(self):
+        self.money_manager.set_bill("bill1", 100, interest_rate=-0.1)
+        self.money_manager.apply_interest_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 100)
+
+    def test_apply_negative_late_fee_to_bill(self):
+        self.money_manager.set_bill("bill1", 100, late_fee=-20)
+        self.money_manager.apply_late_fee_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 100)
+
+    def test_apply_zero_interest_and_fee(self):
+        self.money_manager.set_bill(
+            "bill1", 100, interest_rate=None, late_fee=None
+        )
+        self.money_manager.apply_interest_to_bill("bill1")
+        self.money_manager.apply_late_fee_to_bill("bill1")
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 100)
+
+    def test_overpay_bill_with_money(self):
+        self.money_manager.add_money(200)
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.pay_bill_with_money("bill1", 150)
+        self.assertEqual(self.money_manager.money, 100)
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 0)
+
+    def test_overpay_bill_with_deposit(self):
+        self.money_manager.deposit_to_bank(200)
+        self.money_manager.set_bill("bill1", 100)
+        self.money_manager.pay_bill_with_deposit("bill1", 150)
+        self.assertEqual(self.money_manager.bank_account, 100)
+        self.assertEqual(self.money_manager.get_bill("bill1").amount, 0)
+
+    def test_bill_entry_defaults(self):
+        bill = BillEntry(amount=100)
+        self.assertEqual(bill.interest_rate, None)
+        self.assertEqual(bill.late_fee, None)
+
+    def test_apply_interest_precision(self):
+        self.money_manager.set_bill("bill1", 99.99, interest_rate=0.05)
+        self.money_manager.apply_interest_to_bill("bill1")
+        self.assertAlmostEqual(
+            self.money_manager.get_bill("bill1").amount, 103.99
+        )
+
+    def test_apply_fee_precision(self):
+        self.money_manager.set_bill("bill1", 99.99, late_fee=0.01)
+        self.money_manager.apply_late_fee_to_bill("bill1")
+        self.assertAlmostEqual(
+            self.money_manager.get_bill("bill1").amount, 100.00
+        )

--- a/tuxemon/combat.py
+++ b/tuxemon/combat.py
@@ -298,15 +298,14 @@ def _handle_win(
         if winner.isplayer:
             set_var(session, "battle_last_result", OutputBattle.won.value)
             set_var(session, "battle_last_winner", "player")
-            client = session.client.event_engine
-            var = ["player", prize]
-            client.execute_action("modify_money", var, True)
+            money_manager = winner.money_controller.money_manager
+            remaining = money_manager.apply_all_battle_shares(prize)
+            money_manager.add_money(remaining)
 
-            if prize > 0:
+            if remaining > 0:
                 formatter = CurrencyFormatter()
-                formatted_prize = formatter.format(prize)
+                formatted_prize = formatter.format(remaining)
                 info["prize"] = formatted_prize
-                set_var(session, "battle_last_prize", str(prize))
                 return T.format("combat_victory_trainer", info)
             else:
                 return T.format("combat_victory", info)

--- a/tuxemon/event/actions/adjust_bill_penalty.py
+++ b/tuxemon/event/actions/adjust_bill_penalty.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event import get_npc
+from tuxemon.event.eventaction import EventAction
+from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class AdjustBillPenaltyAction(EventAction):
+    """
+    Applies a penalty to a bill for a character — either interest or late fee.
+
+    Script usage:
+        .. code-block::
+
+            adjust_bill_penalty <character_slug>,<bill_slug>,<method>
+
+    Script parameters:
+        character_slug: Slug of the character (e.g. "player", "npc_maple").
+        bill_slug: Slug of the bill to modify.
+        method: Either "interest" or "fee".
+
+    Examples:
+        adjust_bill_penalty player,electric_bill,interest
+        adjust_bill_penalty npc_maple,rent,fee
+    """
+
+    name = "adjust_bill_penalty"
+    character: str
+    bill_slug: str
+    method: str
+
+    def start(self, session: Session) -> None:
+        character = get_npc(session, self.character)
+        if character is None:
+            logger.error(f"Character '{self.character}' not found")
+            return
+
+        money_manager = character.money_controller.money_manager
+        if self.method == "interest":
+            money_manager.apply_interest_to_bill(self.bill_slug)
+        elif self.method == "fee":
+            money_manager.apply_late_fee_to_bill(self.bill_slug)
+        else:
+            raise ValueError(
+                f"Invalid method '{self.method}': must be 'interest' or 'fee'"
+            )

--- a/tuxemon/event/actions/set_bill.py
+++ b/tuxemon/event/actions/set_bill.py
@@ -18,38 +18,67 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SetBillAction(EventAction):
     """
-    Set a bill.
+    Initializes or updates a bill for a character, including its amount,
+    interest rate, late fee and share rate.
 
     Script usage:
         .. code-block::
 
-            set_bill <slug>,<bill_slug>,[amount]
+            set_bill <character>,<bill_slug>[,amount][,interest_rate][,late_fee][,share_rate]
 
     Script parameters:
-        character: Either "player" or character slug name (e.g. "npc_maple").
-        bill_slug: Slug of the bill.
-        amount: Amount of money (>= 0) (default 0)
+        character: "player" or the slug of an NPC (e.g. "npc_maple").
+        bill_slug: identifier for the bill (must be translated in en_US base.po).
+        amount: initial amount of the bill (optional, defaults to 0).
+        interest_rate: interest rate applied to the bill (optional, e.g. 0.1 for 10%).
+        late_fee: flat fee added to the bill when triggered (optional, eg. 10).
+        share_rate: percentage of battle earnings automatically applied to the bill
+            (optional, e.g. 0.2 for 20%).
+
+    Examples:
+        set_bill player,bill_cathedral,100,0.1,50,0.5
+        set_bill npc_maple,bill_rent,,0.05,25,0.2
+
+    Notes:
+        - Interest and late fee are stored but not automatically applied.
+        - Use separate actions to trigger interest or fee accumulation.
+        - Amount must be non-negative.
     """
 
     name = "set_bill"
     character: str
     bill_slug: str
     amount: Optional[int] = None
+    interest_rate: Optional[float] = None
+    late_fee: Optional[int] = None
+    share_rate: Optional[float] = None
 
     def start(self, session: Session) -> None:
         character = get_npc(session, self.character)
 
         if character is None:
-            logger.error(f"Character '{self.character}' not found")
+            logger.error(f"Character '{self.character}' not found.")
             return
 
         if not T.has_translation("en_US", self.bill_slug):
-            logger.error(f"Please add {self.bill_slug} to the en_US base.po")
+            logger.warning(
+                f"Missing translation for bill_slug '{self.bill_slug}' in en_US base.po."
+            )
 
         amount = 0 if self.amount is None else self.amount
         if amount < 0:
-            raise AttributeError(f"{amount} must be >= 0")
-        else:
-            money_manager = character.money_controller.money_manager
-            money_manager.add_entry(self.bill_slug, amount)
-            logger.info(f"{character.name}'s have {amount}")
+            raise ValueError(f"Amount must be >= 0, got {amount}.")
+
+        money_manager = character.money_controller.money_manager
+        money_manager.set_bill(
+            bill_name=self.bill_slug,
+            amount=amount,
+            interest_rate=self.interest_rate,
+            late_fee=self.late_fee,
+            share_rate=self.share_rate,
+        )
+
+        logger.info(
+            f"Set bill '{self.bill_slug}' for {character.name} with amount {amount}, "
+            f"interest rate {self.interest_rate}, and late fee {self.late_fee}."
+        )

--- a/tuxemon/money.py
+++ b/tuxemon/money.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC, NPCState
@@ -16,11 +16,49 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BillEntry:
     amount: int = 0
+    interest_rate: Optional[float] = None
+    late_fee: Optional[int] = None
+    share_rate: Optional[float] = None
 
     def get_state(self) -> dict[str, Any]:
-        return {
-            "amount": self.amount,
-        }
+        state: dict[str, Any] = {"amount": self.amount}
+        if self.interest_rate is not None:
+            state["interest_rate"] = self.interest_rate
+        if self.late_fee is not None:
+            state["late_fee"] = self.late_fee
+        return state
+
+    def apply_interest(self) -> None:
+        """Apply interest based on current amount."""
+        if (
+            self.amount > 0
+            and self.interest_rate is not None
+            and self.interest_rate > 0
+        ):
+            interest = int(self.amount * self.interest_rate)
+            self.amount += interest
+
+    def apply_late_fee(self) -> None:
+        """Apply a flat late fee."""
+        if self.amount > 0 and self.late_fee is not None and self.late_fee > 0:
+            self.amount += self.late_fee
+
+    def apply_share(self, earnings: int) -> int:
+        """
+        Deduct a share of earnings and apply it to the bill.
+        Returns the remaining earnings after deduction.
+        """
+        if (
+            self.amount > 0
+            and self.share_rate is not None
+            and self.share_rate > 0
+        ):
+            deduction = int(earnings * self.share_rate)
+            self.amount -= deduction
+            if self.amount < 0:
+                self.amount = 0
+            return earnings - deduction
+        return earnings
 
 
 class MoneyController:
@@ -78,36 +116,54 @@ class MoneyManager:
     def get_bank_balance(self) -> int:
         return self.bank_account
 
-    def add_entry(self, bill_name: str, amount: int) -> None:
-        self.bills[bill_name] = BillEntry(amount)
+    def set_bill(
+        self,
+        bill_name: str,
+        amount: int,
+        interest_rate: Optional[float] = None,
+        late_fee: Optional[int] = None,
+        share_rate: Optional[float] = None,
+    ) -> None:
+        self.bills[bill_name] = BillEntry(
+            amount=amount,
+            interest_rate=interest_rate,
+            late_fee=late_fee,
+            share_rate=share_rate,
+        )
 
     def add_bill(self, bill_name: str, amount: int) -> None:
-        if bill_name in self.bills:
-            self.bills[bill_name].amount += amount
-        else:
-            self.bills[bill_name] = BillEntry(amount)
+        if bill_name not in self.bills:
+            raise KeyError(f"No such bill: {bill_name}")
+
+        self.bills[bill_name].amount += amount
 
     def remove_bill(self, bill_name: str, amount: int) -> None:
-        if bill_name in self.bills:
-            self.bills[bill_name].amount += amount
-            if self.bills[bill_name].amount < 0:
-                del self.bills[bill_name]
-        else:
+        if bill_name not in self.bills:
             raise KeyError(f"No such bill: {bill_name}")
+
+        self.bills[bill_name].amount += amount
+        if self.bills[bill_name].amount < 0:
+            del self.bills[bill_name]
 
     def pay_bill_with_money(self, bill_name: str, amount: int) -> None:
-        if bill_name in self.bills:
-            self.remove_money(amount)
-            self.remove_bill(bill_name, -abs(amount))
-        else:
+        if bill_name not in self.bills:
             raise KeyError(f"No such bill: {bill_name}")
 
+        bill = self.bills[bill_name]
+        payment = min(amount, bill.amount)
+
+        self.remove_money(payment)
+        self.remove_bill(bill_name, -payment)
+
     def pay_bill_with_deposit(self, bill_name: str, amount: int) -> None:
-        if bill_name in self.bills:
-            self.withdraw_from_bank(amount)
-            self.remove_bill(bill_name, -abs(amount))
-        else:
+        if bill_name not in self.bills:
             raise KeyError(f"No such bill: {bill_name}")
+
+        bill = self.bills[bill_name]
+        payment = min(amount, bill.amount)
+
+        self.withdraw_from_bank(payment)
+        self.remove_bill(bill_name, -payment)
 
     def get_bills(self) -> dict[str, BillEntry]:
         return self.bills
@@ -128,6 +184,49 @@ class MoneyManager:
     def withdraw_all_money_from_bank(self) -> None:
         self.money += self.bank_account
         self.bank_account = 0
+
+    def apply_bank_interest(self, interest_rate: float) -> None:
+        if interest_rate < 0:
+            raise ValueError("Interest rate must be non-negative")
+        interest = int(self.bank_account * interest_rate)
+        self.bank_account += interest
+
+    def apply_interest_to_bill(self, bill_name: str) -> None:
+        if bill_name not in self.bills:
+            raise KeyError(f"No such bill: {bill_name}")
+
+        self.bills[bill_name].apply_interest()
+
+    def apply_late_fee_to_bill(self, bill_name: str) -> None:
+        if bill_name not in self.bills:
+            raise KeyError(f"No such bill: {bill_name}")
+
+        self.bills[bill_name].apply_late_fee()
+
+    def apply_share_to_bill(self, bill_name: str, earnings: int) -> int:
+        if bill_name not in self.bills:
+            raise KeyError(f"No such bill: {bill_name}")
+
+        bill = self.bills[bill_name]
+        remaining_earnings = bill.apply_share(earnings)
+
+        if bill.amount <= 0:
+            del self.bills[bill_name]
+
+        return remaining_earnings
+
+    def apply_all_battle_shares(self, earnings: int) -> int:
+        """
+        Applies share deductions from battle earnings to all active bills.
+        Bills with zero or negative amount are removed.
+        Returns the remaining earnings after all deductions.
+        """
+        for bill_name in list(self.bills.keys()):
+            bill = self.bills[bill_name]
+            earnings = bill.apply_share(earnings)
+            if bill.amount <= 0:
+                del self.bills[bill_name]
+        return earnings
 
 
 def decode_money(json_data: Mapping[str, Any]) -> MoneyManager:


### PR DESCRIPTION
In a time of tariffs and economic uncertainty, what better occasion to expand the bill system and reducing the number of variables (game variables) used.

PR updates to `BillEntry`:
- added support for tracking `interest_rate` and `late_fee` directly within each bill
- these attributes allow bills to accrue interest and penalties over time
- the `BillEntry` class now includes: `amount`: the current balance of the bill., `interest_rate`: a percentage applied to the bill during interest calculations and `late_fee`: a flat fee added when a bill is overdue

New event action: `adjust_bill_penalty`:
- introduced a new event action that allows scripts to modify a bill’s `interest_rate` or `late_fee`
- enables events to escalate penalties based on player choices, time delays, or mission outcomes