### PR TITLE
fix various

### DIFF
--- a/mods/tuxemon/db/item/tm_all_in.json
+++ b/mods/tuxemon/db/item/tm_all_in.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "leadership:fury"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_avalanche.json
+++ b/mods/tuxemon/db/item/tm_avalanche.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "calamity:ice:rock"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_blade.json
+++ b/mods/tuxemon/db/item/tm_blade.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "sharp:steel"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_blossom.json
+++ b/mods/tuxemon/db/item/tm_blossom.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "plant:healing:bug"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_earth.json
+++ b/mods/tuxemon/db/item/tm_earth.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "type",
+      "type": "base",
       "parameters": [
+        "types",
         "earth"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_fire.json
+++ b/mods/tuxemon/db/item/tm_fire.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "type",
+      "type": "base",
       "parameters": [
+        "types",
         "fire"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_frostbite.json
+++ b/mods/tuxemon/db/item/tm_frostbite.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "bite:ice"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_metal.json
+++ b/mods/tuxemon/db/item/tm_metal.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "type",
+      "type": "base",
       "parameters": [
+        "types",
         "metal"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_panjandrum.json
+++ b/mods/tuxemon/db/item/tm_panjandrum.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "gadgets:calamity:bomber"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_shadow_boxing.json
+++ b/mods/tuxemon/db/item/tm_shadow_boxing.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "fists:darkness"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_supernova.json
+++ b/mods/tuxemon/db/item/tm_supernova.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "tag",
+      "type": "base",
       "parameters": [
+        "tags",
         "celestial:light"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_surf.json
+++ b/mods/tuxemon/db/item/tm_surf.json
@@ -1,15 +1,17 @@
 {
   "conditions": [
     {
-      "type": "type",
+      "type": "base",
       "parameters": [
+        "types",
         "water"
       ],
       "operator": "is"
     },
     {
-      "type": "shape",
+      "type": "base",
       "parameters": [
+        "shape",
         "piscine:polliwog:leviathan"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_water.json
+++ b/mods/tuxemon/db/item/tm_water.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "type",
+      "type": "base",
       "parameters": [
+        "types",
         "water"
       ],
       "operator": "is"

--- a/mods/tuxemon/db/item/tm_wood.json
+++ b/mods/tuxemon/db/item/tm_wood.json
@@ -1,8 +1,9 @@
 {
   "conditions": [
     {
-      "type": "type",
+      "type": "base",
       "parameters": [
+        "types",
         "wood"
       ],
       "operator": "is"

--- a/tuxemon/core/conditions/base.py
+++ b/tuxemon/core/conditions/base.py
@@ -11,6 +11,7 @@ from tuxemon.tools import check_condition, parse_flag
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
     from tuxemon.session import Session
+    from tuxemon.technique.technique import Technique
 
 
 @dataclass
@@ -27,7 +28,7 @@ class BaseCondition(CoreCondition):
     options: str  # e.g., "water:!fire"
     match: str = "false"  # "true" for all, "false" for any
 
-    def get_dataset(self, target: Monster) -> set[str]:
+    def get_dataset_monster(self, target: Monster) -> set[str]:
         """
         Extracts a set of normalized strings from the target based on the source.
         """
@@ -46,11 +47,30 @@ class BaseCondition(CoreCondition):
         elif self.source == "species":
             return {target.species.strip().lower()}
 
-        raise ValueError(f"Unsupported source: {self.source}")
+        else:
+            raise ValueError(f"Unsupported source: {self.source}")
 
-    def test_with_monster(self, session: Session, target: Monster) -> bool:
-        base = self.get_dataset(target)
+    def get_dataset_technique(self, target: Technique) -> set[str]:
+        """
+        Extracts a set of normalized strings from the target based on the source.
+        """
+        if self.source == "tags":
+            return {tag.strip().lower() for tag in target.tags}
+
+        elif self.source == "types":
+            return {ele.slug.strip().lower() for ele in target.types.current}
+
+        else:
+            raise ValueError(f"Unsupported source: {self.source}")
+
+    def _test_conditions(self, base: set[str]) -> bool:
         conditions = [opt.strip().lower() for opt in self.options.split(":")]
         match_all = parse_flag(self.match)
         results = [check_condition(opt, base) for opt in conditions]
         return all(results) if match_all else any(results)
+
+    def test_with_monster(self, session: Session, target: Monster) -> bool:
+        return self._test_conditions(self.get_dataset_monster(target))
+
+    def test_with_tech(self, session: Session, target: Technique) -> bool:
+        return self._test_conditions(self.get_dataset_technique(target))

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -142,6 +142,7 @@ class Technique:
         self.range = results.range
         self.tech_id = results.tech_id
         self.menu_actions_data = results.menu_actions
+        self.tags = results.tags
 
         if self.effect_manager and results.effects:
             self.effects = self.effect_manager.parse_effects(results.effects)


### PR DESCRIPTION
PR addresses:
- reintroduces the changes for TM items that were previously removed to avoid conflicts with #3028 
- adds `tags` for `Technique`
- updates `BaseCondition` in this way the condition can be used for Techniques too (types + tags)


Detailed:
- `BaseCondition` refactors the original `get_dataset` method into two specialized methods, `get_dataset_monster` and `get_dataset_technique`, to support both `Monster` and `Technique` targets.. it introduces a shared helper method `_test_conditions` to eliminate duplicated logic in `test_with_monster` and `test_with_tech`