### PR TITLE
Monster Menu Visibility Logic Based on Game State

### DIFF
--- a/tuxemon/states/monster/__init__.py
+++ b/tuxemon/states/monster/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -270,6 +270,11 @@ class MonsterMenuHandler:
             msg = T.format("tuxemon_released", params)
             open_dialog(self.client, [msg])
             self.monster_menu.remove_monster_sprite_display(monster)
+
+            num_monsters = len(self.char.monsters)
+            if self.monster_menu.selected_index >= num_monsters:
+                self.monster_menu.change_selection(max(0, num_monsters - 1))
+
             self.monster_menu.refresh_menu_items()
             self.monster_menu.on_menu_selection_change()
         else:
@@ -285,34 +290,53 @@ class MonsterMenuHandler:
         original = monster_menu.get_selected_item()
         if original and original.game_object:
             mon = original.game_object
+            options: list[ChoiceOption] = []
 
-            options = [
+            options.append(
                 ChoiceOption(
                     key="info",
                     display_text=T.translate("monster_menu_info").upper(),
                     action=partial(self.monster_stats, mon),
-                ),
-                ChoiceOption(
-                    key="tech",
-                    display_text=T.translate("monster_menu_tech").upper(),
-                    action=partial(self.monster_techs, mon),
-                ),
-                ChoiceOption(
-                    key="item",
-                    display_text=T.translate("monster_menu_item").upper(),
-                    action=partial(self.monster_item, mon),
-                ),
-                ChoiceOption(
-                    key="move",
-                    display_text=T.translate("monster_menu_move").upper(),
-                    action=partial(self.select_monster, mon),
-                ),
-                ChoiceOption(
-                    key="release",
-                    display_text=T.translate("monster_menu_release").upper(),
-                    action=partial(self.release_monster, mon),
-                ),
-            ]
+                )
+            )
+
+            if mon.moves.moves:
+                options.append(
+                    ChoiceOption(
+                        key="tech",
+                        display_text=T.translate("monster_menu_tech").upper(),
+                        action=partial(self.monster_techs, mon),
+                    )
+                )
+
+            if mon.held_item.item:
+                options.append(
+                    ChoiceOption(
+                        key="item",
+                        display_text=T.translate("monster_menu_item").upper(),
+                        action=partial(self.monster_item, mon),
+                    )
+                )
+
+            if mon.owner and mon.owner.party.party_size > 1:
+                options.append(
+                    ChoiceOption(
+                        key="move",
+                        display_text=T.translate("monster_menu_move").upper(),
+                        action=partial(self.select_monster, mon),
+                    )
+                )
+
+            if mon.owner and mon.owner.party.party_size > 1:
+                options.append(
+                    ChoiceOption(
+                        key="release",
+                        display_text=T.translate(
+                            "monster_menu_release"
+                        ).upper(),
+                        action=partial(self.release_monster, mon),
+                    )
+                )
 
             menu = MenuOptions(options)
             open_choice_dialog(self.client, menu, escape_key_exits=True)


### PR DESCRIPTION
PR updates the logic controlling which options appear in the monster submenu. The goal is to ensure that only relevant actions are presented to the player, improving usability and reducing unnecessary interactions.

Changes:
- **Info**: Always visible. Provides basic stats and details about the selected monster.
- **Techniques**: Visible only if the monster has at least one move/technique.
- **Item**: Visible only if the monster is currently holding an item.
- **Move**: Visible only if the player has more than one monster. It’s unnecessary when only one monster exists.
- **Release**: Visible only if the player has more than one monster. Prevents triggering a release dialog.
- fixes index update logic: previously, releasing Katapill (as shown in the image) triggered an error `[2025-08-10 08:34:15,657] tuxemon.menu.menu - ERROR - Unexpected error in menu event processing: cannot access local variable 'monster' where it is not associated with a value`, this was due to the cursor pointing to a now-invalid index. The fix ensures that when the last monster is deleted, the cursor moves up to a valid entry, preventing the error

<img width="600" height="348" alt="Screenshot_2025-08-10_08-15-32" src="https://github.com/user-attachments/assets/2134cbaa-4e17-4ef0-8e73-945eac5e1da9" />
<img width="600" height="348" alt="Screenshot_2025-08-10_08-14-52" src="https://github.com/user-attachments/assets/083f36e0-643f-4398-86dd-fb7808c3007c" />
