### PR TITLE
Fix: Prevent status effect application on failed technique

### DIFF
--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -46,9 +46,11 @@ class GiveEffect(CoreEffect):
         value = combat.get_tech_hit(user)
         success = tech.potency >= potency and tech.accuracy >= value
 
+        if not success:
+            return TechEffectResult(name=tech.name)
+
         status = Status.create(self.condition, user, player.steps)
-        if success:
-            status.set_combat_state(combat)
+        status.set_combat_state(combat)
 
         immune_info = []
         successful_targets = []

--- a/tuxemon/event/actions/crafting_station.py
+++ b/tuxemon/event/actions/crafting_station.py
@@ -46,7 +46,7 @@ class CraftingStationAction(EventAction):
             )
             return
 
-        character = get_npc(self.session, self.character_slug)
+        character = get_npc(session, self.character_slug)
         if character is None:
             logger.error(
                 f"Character '{self.character_slug}' not found for CraftMenuState."


### PR DESCRIPTION
PR resolves a logic bug in the `GiveEffect` core effect where status effects could be created and applied even when the technique failed due to insufficient potency or accuracy.

Changes:
- added an early return in `apply_tech_target` if the technique fails (`success == False`)
- prevents unnecessary status creation and application when the effect shouldn't trigger