### PR TITLE
Add `char_talk` event action for dynamic NPC dialogue

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -29,6 +29,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.char_run.CharRunAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_speed.CharSpeedAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_stop.CharStopAction
+.. autoscriptinfoclass:: tuxemon.event.actions.char_talk.CharTalkAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_walk.CharWalkAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_wander.CharWanderAction
 .. autoscriptinfoclass:: tuxemon.event.actions.choice_item.ChoiceItemAction

--- a/mods/tuxemon/db/npc/eclipse_crystal_town_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_crystal_town_npcs.json
@@ -1,6 +1,6 @@
 [
   {
-    "slug": "spyder_crystal_magician_fiery",
+    "slug": "eclipse_crystal_magician_fiery",
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -8,7 +8,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_homemaker",
+    "slug": "eclipse_crystal_homemaker",
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -16,7 +16,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_barmaid",
+    "slug": "eclipse_crystal_barmaid",
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -24,7 +24,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_granny",
+    "slug": "eclipse_crystal_granny",
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -32,7 +32,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_maniac_green",
+    "slug": "eclipse_crystal_maniac_green",
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -40,7 +40,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_monk_orange",
+    "slug": "eclipse_crystal_monk_orange",
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -48,7 +48,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_tennisplayer",
+    "slug": "eclipse_crystal_tennisplayer",
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -56,7 +56,7 @@
     }
   },
   {
-    "slug": "spyder_crystal_shopkeeper",
+    "slug": "eclipse_crystal_shopkeeper",
     "template": {
       "sprite_name": "shopassistant_black",
       "combat_front": "shopassistant",

--- a/mods/tuxemon/db/npc/eclipse_lion_mountain_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_lion_mountain_npcs.json
@@ -1,12 +1,12 @@
 [
   {
-    "slug": "spyder_lionmountain_jacques",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_jacques",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_jacques1",
+          "pre_battle": "eclipse_lionmountain_jacques1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_jacques2",
+          "post_battle_lose": "eclipse_lionmountain_jacques2",
           "post_battle_draw": null
         }
       }
@@ -18,13 +18,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_adam",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_adam",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_adam1",
+          "pre_battle": "eclipse_lionmountain_adam1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_adam2",
+          "post_battle_lose": "eclipse_lionmountain_adam2",
           "post_battle_draw": null
         }
       }
@@ -36,13 +36,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_arlene",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_arlene",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_arlene1",
+          "pre_battle": "eclipse_lionmountain_arlene1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_arlene2",
+          "post_battle_lose": "eclipse_lionmountain_arlene2",
           "post_battle_draw": null
         }
       }
@@ -54,13 +54,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_david",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_david",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_david1",
+          "pre_battle": "eclipse_lionmountain_david1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_david2",
+          "post_battle_lose": "eclipse_lionmountain_david2",
           "post_battle_draw": null
         }
       }
@@ -72,13 +72,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_alexander",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_alexander",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_alexander1",
+          "pre_battle": "eclipse_lionmountain_alexander1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_alexander2",
+          "post_battle_lose": "eclipse_lionmountain_alexander2",
           "post_battle_draw": null
         }
       }
@@ -90,13 +90,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_chhurim",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_chhurim",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_chhurim1",
+          "pre_battle": "eclipse_lionmountain_chhurim1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_chhurim2",
+          "post_battle_lose": "eclipse_lionmountain_chhurim2",
           "post_battle_draw": null
         }
       }
@@ -108,13 +108,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_emilio",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_emilio",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_emilio1",
+          "pre_battle": "eclipse_lionmountain_emilio1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_emilio2",
+          "post_battle_lose": "eclipse_lionmountain_emilio2",
           "post_battle_draw": null
         }
       }
@@ -126,13 +126,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_tom",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_tom",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_tom1",
+          "pre_battle": "eclipse_lionmountain_tom1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_tom2",
+          "post_battle_lose": "eclipse_lionmountain_tom2",
           "post_battle_draw": null
         }
       }
@@ -144,13 +144,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_conrad",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_conrad",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_conrad1",
+          "pre_battle": "eclipse_lionmountain_conrad1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_conrad2",
+          "post_battle_lose": "eclipse_lionmountain_conrad2",
           "post_battle_draw": null
         }
       }
@@ -162,13 +162,13 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_kurt",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_lionmountain_kurt",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_lionmountain_kurt1",
+          "pre_battle": "eclipse_lionmountain_kurt1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_lionmountain_kurt2",
+          "post_battle_lose": "eclipse_lionmountain_kurt2",
           "post_battle_draw": null
         }
       }
@@ -180,7 +180,7 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_scientist",
+    "slug": "eclipse_lionmountain_scientist",
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -188,7 +188,7 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_enforcer",
+    "slug": "eclipse_lionmountain_enforcer",
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_agent",
@@ -196,7 +196,7 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_nurse",
+    "slug": "eclipse_lionmountain_nurse",
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -204,7 +204,7 @@
     }
   },
   {
-    "slug": "spyder_lionmountain_snarlon",
+    "slug": "eclipse_lionmountain_snarlon",
     "template": {
       "sprite_name": "landrace",
       "combat_front": "sludgehog",

--- a/mods/tuxemon/db/npc/eclipse_park_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_park_npcs.json
@@ -1,6 +1,6 @@
 [
   {
-    "slug": "spyder_park_reception",
+    "slug": "eclipse_park_reception",
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -8,7 +8,7 @@
     }
   },
   {
-    "slug": "spyder_park_florist",
+    "slug": "eclipse_park_florist",
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -16,7 +16,7 @@
     }
   },
   {
-    "slug": "spyder_park_guardian",
+    "slug": "eclipse_park_guardian",
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -24,7 +24,7 @@
     }
   },
   {
-    "slug": "spyder_park_soldier",
+    "slug": "eclipse_park_soldier",
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -32,7 +32,7 @@
     }
   },
   {
-    "slug": "spyder_park_scientist",
+    "slug": "eclipse_park_scientist",
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -40,7 +40,7 @@
     }
   },
   {
-    "slug": "spyder_park_professor",
+    "slug": "eclipse_park_professor",
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -48,7 +48,7 @@
     }
   },
   {
-    "slug": "spyder_park_tennisplayer",
+    "slug": "eclipse_park_tennisplayer",
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/eclipse_route7_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_route7_npcs.json
@@ -1,6 +1,6 @@
 [
   {
-    "slug": "spyder_route7_arnold",
+    "slug": "eclipse_route7_arnold",
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -8,7 +8,7 @@
     }
   },
   {
-    "slug": "spyder_route7_sylvester",
+    "slug": "eclipse_route7_sylvester",
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -16,7 +16,7 @@
     }
   },
   {
-    "slug": "spyder_route7_fritz",
+    "slug": "eclipse_route7_fritz",
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -24,13 +24,13 @@
     }
   },
   {
-    "slug": "spyder_route7_statius",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_statius",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_statius1",
+          "pre_battle": "eclipse_route7_statius1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_statius2",
+          "post_battle_lose": "eclipse_route7_statius2",
           "post_battle_draw": null
         }
       }
@@ -42,13 +42,13 @@
     }
   },
   {
-    "slug": "spyder_route7_jacopo",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_jacopo",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_jacopo1",
+          "pre_battle": "eclipse_route7_jacopo1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_jacopo2",
+          "post_battle_lose": "eclipse_route7_jacopo2",
           "post_battle_draw": null
         }
       }
@@ -60,13 +60,13 @@
     }
   },
   {
-    "slug": "spyder_route7_pia",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_pia",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_pia1",
+          "pre_battle": "eclipse_route7_pia1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_pia2",
+          "post_battle_lose": "eclipse_route7_pia2",
           "post_battle_draw": null
         }
       }
@@ -78,13 +78,13 @@
     }
   },
   {
-    "slug": "spyder_route7_penitent",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_penitent",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_penitent1",
+          "pre_battle": "eclipse_route7_penitent1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_penitent2",
+          "post_battle_lose": "eclipse_route7_penitent2",
           "post_battle_draw": null
         }
       }
@@ -96,13 +96,13 @@
     }
   },
   {
-    "slug": "spyder_route7_nino",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_nino",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_nino1",
+          "pre_battle": "eclipse_route7_nino1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_nino2",
+          "post_battle_lose": "eclipse_route7_nino2",
           "post_battle_draw": null
         }
       }
@@ -114,13 +114,13 @@
     }
   },
   {
-    "slug": "spyder_route7_hugh",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_hugh",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_hugh1",
+          "pre_battle": "eclipse_route7_hugh1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_hugh2",
+          "post_battle_lose": "eclipse_route7_hugh2",
           "post_battle_draw": null
         }
       }
@@ -132,13 +132,13 @@
     }
   },
   {
-    "slug": "spyder_route7_arnaut",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_arnaut",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_arnaut1",
+          "pre_battle": "eclipse_route7_arnaut1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_arnaut2",
+          "post_battle_lose": "eclipse_route7_arnaut2",
           "post_battle_draw": null
         }
       }
@@ -150,13 +150,13 @@
     }
   },
   {
-    "slug": "spyder_route7_conrad",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_conrad",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_conrad1",
+          "pre_battle": "eclipse_route7_conrad1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_conrad2",
+          "post_battle_lose": "eclipse_route7_conrad2",
           "post_battle_draw": null
         }
       }
@@ -168,13 +168,13 @@
     }
   },
   {
-    "slug": "spyder_route7_manfred",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_manfred",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_manfred1",
+          "pre_battle": "eclipse_route7_manfred1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_manfred2",
+          "post_battle_lose": "eclipse_route7_manfred2",
           "post_battle_draw": null
         }
       }
@@ -186,13 +186,13 @@
     }
   },
   {
-    "slug": "spyder_route7_sordello",
-    "dialogue": {
-      "dialogue": {
+    "slug": "eclipse_route7_sordello",
+    "speech": {
+      "profile": {
         "default": {
-          "pre_battle": "spyder_route7_sordello1",
+          "pre_battle": "eclipse_route7_sordello1",
           "post_battle_win": null,
-          "post_battle_lose": "spyder_route7_sordello2",
+          "post_battle_lose": "eclipse_route7_sordello2",
           "post_battle_draw": null
         }
       }
@@ -204,7 +204,7 @@
     }
   },
   {
-    "slug": "spyder_route7_nurse",
+    "slug": "eclipse_route7_nurse",
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_citypark_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_citypark_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_citypark_bobette",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_citypark_bobette1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_citypark_edith",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_citypark_edith1",
           "post_battle_win": null,
@@ -45,8 +45,8 @@
   },
   {
     "slug": "spyder_citypark_frances",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_citypark_frances1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
@@ -49,8 +49,8 @@
   },
   {
     "slug": "spyder_cottoncafe_cayden",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": null,
           "post_battle_win": null,
@@ -227,8 +227,8 @@
   },
   {
     "slug": "spyder_cottontunnel_carlos",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_cottontunnel_carlos1",
           "post_battle_win": null,
@@ -245,8 +245,8 @@
   },
   {
     "slug": "spyder_confusedperson",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": null,
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_datacenter_fermi",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_datacenter_fermi1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_datacenter_onnes",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_datacenter_onnes1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_datacenter_bayliss",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_datacenter_bayliss1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_datacenter_chomsky",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_datacenter_chomsky1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_datacenter_lagrange",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_datacenter_lagrange1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_dojo_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dojo_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_dojo_ares",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_ares1",
           "post_battle_win": null,
@@ -43,8 +43,8 @@
   },
   {
     "slug": "spyder_dojo_kataro",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_kataro1",
           "post_battle_win": null,
@@ -61,8 +61,8 @@
   },
   {
     "slug": "spyder_dojo_iroh",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_iroh1",
           "post_battle_win": null,
@@ -79,8 +79,8 @@
   },
   {
     "slug": "spyder_dojo_hermes",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_hermes1",
           "post_battle_win": null,
@@ -97,8 +97,8 @@
   },
   {
     "slug": "spyder_dojo_hephastus",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_hephastus1",
           "post_battle_win": null,
@@ -115,8 +115,8 @@
   },
   {
     "slug": "spyder_dojo_orion",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_orion1",
           "post_battle_win": null,
@@ -133,8 +133,8 @@
   },
   {
     "slug": "spyder_dojo_saturn",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_saturn1",
           "post_battle_win": null,
@@ -151,8 +151,8 @@
   },
   {
     "slug": "spyder_dojo_sokka",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_sokka1",
           "post_battle_win": null,
@@ -177,8 +177,8 @@
   },
   {
     "slug": "spyder_dojo_toph",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_toph1",
           "post_battle_win": null,
@@ -219,8 +219,8 @@
   },
   {
     "slug": "spyder_dojo_yangchen",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dojo_yangchen1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
@@ -9,8 +9,8 @@
   },
   {
     "slug": "spyder_dragonscave_benden",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_benden1",
           "post_battle_win": null,
@@ -27,8 +27,8 @@
   },
   {
     "slug": "spyder_dragonscave_cailin",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_cailin1",
           "post_battle_win": null,
@@ -53,8 +53,8 @@
   },
   {
     "slug": "spyder_dragonscave_daenny",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_daenny1",
           "post_battle_win": null,
@@ -71,8 +71,8 @@
   },
   {
     "slug": "spyder_dragonscave_griffin",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_griffin1",
           "post_battle_win": null,
@@ -97,8 +97,8 @@
   },
   {
     "slug": "spyder_dragonscave_lessa",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_lessa1",
           "post_battle_win": null,
@@ -115,8 +115,8 @@
   },
   {
     "slug": "spyder_dragonscave_lucille",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_lucille1",
           "post_battle_win": null,
@@ -133,8 +133,8 @@
   },
   {
     "slug": "spyder_dragonscave_mal",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_mal1",
           "post_battle_win": null,
@@ -151,8 +151,8 @@
   },
   {
     "slug": "spyder_dragonscave_ray",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_ray1",
           "post_battle_win": null,
@@ -169,8 +169,8 @@
   },
   {
     "slug": "spyder_dragonscave_tomas",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_tomas1",
           "post_battle_win": null,
@@ -187,8 +187,8 @@
   },
   {
     "slug": "spyder_dragonscave_tru",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dragonscave_tru1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_dryadsgrove_aquemini",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dryadsgrove_aquemini1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_dryadsgrove_ferris",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dryadsgrove_ferris1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_dryadsgrove_ignatia",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dryadsgrove_ignatia1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_dryadsgrove_petra",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dryadsgrove_petra1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_dryadsgrove_sylvia",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_dryadsgrove_sylvia1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_greenwash_aissa",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_aissa1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_greenwash_alex",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_alex1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_greenwash_broer",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_broer1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_greenwash_chip",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_chip1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_greenwash_clarence",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_clarence1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_greenwash_dempsey",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_dempsey1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_greenwash_dippel",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_dippel1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_greenwash_gluck",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_gluck1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_greenwash_gregor",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_gregor1",
           "post_battle_win": null,
@@ -171,8 +171,8 @@
   },
   {
     "slug": "spyder_greenwash_heidenstam",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_heidenstam1",
           "post_battle_win": null,
@@ -189,8 +189,8 @@
   },
   {
     "slug": "spyder_greenwash_hunt",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_hunt1",
           "post_battle_win": null,
@@ -207,8 +207,8 @@
   },
   {
     "slug": "spyder_greenwash_lewie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_lewie1",
           "post_battle_win": null,
@@ -225,8 +225,8 @@
   },
   {
     "slug": "spyder_greenwash_lewis",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_lewis1",
           "post_battle_win": null,
@@ -243,8 +243,8 @@
   },
   {
     "slug": "spyder_greenwash_looten",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_looten1",
           "post_battle_win": null,
@@ -261,8 +261,8 @@
   },
   {
     "slug": "spyder_greenwash_louis",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_louis1",
           "post_battle_win": null,
@@ -279,8 +279,8 @@
   },
   {
     "slug": "spyder_greenwash_moreau",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_moreau1",
           "post_battle_win": null,
@@ -297,8 +297,8 @@
   },
   {
     "slug": "spyder_greenwash_morehouse",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_greenwash_morehouse1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_hospital_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_hospital_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_hospital1_aurora",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_aurora1",
           "post_battle_win": null,
@@ -27,8 +27,8 @@
   },
   {
     "slug": "spyder_hospital1_luzia",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_luzia1",
           "post_battle_win": null,
@@ -45,8 +45,8 @@
   },
   {
     "slug": "spyder_hospital1_liane",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_liane1",
           "post_battle_win": null,
@@ -63,8 +63,8 @@
   },
   {
     "slug": "spyder_hospital1_fring",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_fring1",
           "post_battle_win": null,
@@ -81,8 +81,8 @@
   },
   {
     "slug": "spyder_hospital1_felu",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_felu1",
           "post_battle_win": null,
@@ -99,8 +99,8 @@
   },
   {
     "slug": "spyder_hospital1_eleni",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_eleni1",
           "post_battle_win": null,
@@ -117,8 +117,8 @@
   },
   {
     "slug": "spyder_hospital1_rakez",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_rakez1",
           "post_battle_win": null,
@@ -143,8 +143,8 @@
   },
   {
     "slug": "spyder_hospital1_zekar",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_zekar1",
           "post_battle_win": null,
@@ -161,8 +161,8 @@
   },
   {
     "slug": "spyder_hospital1_walt",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_walt1",
           "post_battle_win": null,
@@ -179,8 +179,8 @@
   },
   {
     "slug": "spyder_hospital1_rhizome",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_hospital1_rhizome1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_mansion_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_mansion_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_top_jackson",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_top_jackson1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_top_mickey",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_top_mickey1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_top_ricardo",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_top_ricardo1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_top_russell",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_top_russell1",
           "post_battle_win": null,
@@ -113,8 +113,8 @@
   },
   {
     "slug": "spyder_mansion_lyle",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_mansion_pirate1",
           "post_battle_win": null,
@@ -131,8 +131,8 @@
   },
   {
     "slug": "spyder_mansion_lucy",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_mansion_lucy1",
           "post_battle_win": null,
@@ -149,8 +149,8 @@
   },
   {
     "slug": "spyder_mansion_gillette",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_mansion_gillette1",
           "post_battle_win": null,
@@ -215,8 +215,8 @@
   },
   {
     "slug": "spyder_basement_bobby",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_basement_bobby1",
           "post_battle_win": null,
@@ -233,8 +233,8 @@
   },
   {
     "slug": "spyder_basement_catholi",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_basement_catholi1",
           "post_battle_win": null,
@@ -251,8 +251,8 @@
   },
   {
     "slug": "spyder_basement_coralli",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_basement_coralli1",
           "post_battle_win": null,
@@ -277,8 +277,8 @@
   },
   {
     "slug": "spyder_basement_roger",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_basement_roger1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_nimrod_zircon",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_zircon1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_nimrod_xeon",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_xeon1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_nimrod_tru",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_tru1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_nimrod_thatcher",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_thatcher1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_nimrod_rebel",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_rebel1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_nimrod_maverick",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_maverick1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_nimrod_mace",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_mace1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_nimrod_justice",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_justice1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_nimrod_honour",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_honour1",
           "post_battle_win": null,
@@ -163,8 +163,8 @@
   },
   {
     "slug": "spyder_nimrod_chromerobo",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_chromerobo1",
           "post_battle_win": null,
@@ -181,8 +181,8 @@
   },
   {
     "slug": "spyder_nimrod_antimony",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_antimony1",
           "post_battle_win": null,
@@ -199,8 +199,8 @@
   },
   {
     "slug": "spyder_nimrod_bowie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_bowie1",
           "post_battle_win": null,
@@ -217,8 +217,8 @@
   },
   {
     "slug": "spyder_nimrod_archer",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_archer1",
           "post_battle_win": null,
@@ -235,8 +235,8 @@
   },
   {
     "slug": "spyder_nimrod_argon",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_nimrod_argon1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
@@ -9,8 +9,8 @@
   },
   {
     "slug": "spyder_omnichannel_schwartz",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_schwartz1",
           "post_battle_win": null,
@@ -27,8 +27,8 @@
   },
   {
     "slug": "spyder_omnichannel_strauss",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_strauss1",
           "post_battle_win": null,
@@ -45,8 +45,8 @@
   },
   {
     "slug": "spyder_omnichannel_william",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_william1",
           "post_battle_win": null,
@@ -63,8 +63,8 @@
   },
   {
     "slug": "spyder_omnichannel_tohei",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_tohei1",
           "post_battle_win": null,
@@ -105,8 +105,8 @@
   },
   {
     "slug": "spyder_omnichannel_dempsey",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_dempsey1",
           "post_battle_win": null,
@@ -123,8 +123,8 @@
   },
   {
     "slug": "spyder_omnichannel_crane",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_crane1",
           "post_battle_win": null,
@@ -141,8 +141,8 @@
   },
   {
     "slug": "spyder_omnichannel_carnegie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_carnegie1",
           "post_battle_win": null,
@@ -159,8 +159,8 @@
   },
   {
     "slug": "spyder_omnichannel_byrne",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_byrne1",
           "post_battle_win": null,
@@ -177,8 +177,8 @@
   },
   {
     "slug": "spyder_omnichannel_bettger",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_omnichannel_bettger1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_route2_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route2_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_route2_marion",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route2_marion1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_route2_graf",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route2_graf1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_route2_roddick",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route2_roddick1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_route3_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route3_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_route3_qqq",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_qqq1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_route3_zoolander",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_zoolander1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_route3_weaver",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_weaver1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_route3_wanda",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_wanda1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_route3_twig",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_twig1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_route3_surat",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_surat1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_route3_roxby",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_roxby1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_route3_novak",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_novak1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_route3_curie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_curie1",
           "post_battle_win": null,
@@ -163,8 +163,8 @@
   },
   {
     "slug": "spyder_route3_connor",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route3_connor1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_route4_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route4_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_route4_beck",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route4_beck1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_route4_marshall",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route4_marshall1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_route4_rincewind",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route4_rincewind1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_route4_roger",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route4_roger1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_route4_wulf",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route4_wulf1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_route4_rosamund",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route4_rosamund1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_route5_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route5_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_route5_cleo",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route5_cleo1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_route5_edith",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route5_edith1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_route5_hunter",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route5_hunter1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_route5_goliath",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route5_goliath1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_route5_sara",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route5_sara1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_route5_tryphaena",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route5_tryphaena1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_route6_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route6_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_route6_frances",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_frances1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_route6_orion",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_orion1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_route6_ping",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_ping1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_route6_rigel",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_rigel1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_route6_richard",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_richard1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_route6_blair",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_blair1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_route6_gunner",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_gunner1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_route6_mungo",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_mungo1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_route6_maxwell",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_route6_maxwell1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_routea_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routea_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_routea_connie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_connie1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_routea_dagger",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_dagger1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_routea_doris",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_doris1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_routea_joe",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_joe1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_routea_koan",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_koan1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_routea_lexi",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_lexi1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_routea_lotu",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_lotu1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_routea_rosy",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_rosy1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_routea_vince",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routea_vince1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_routeb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routeb_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_routeb_electra",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routeb_electra1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_routeb_cytherea",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routeb_cytherea1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_routeb_nephthys",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routeb_nephthys1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_routeb_sedna",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routeb_sedna1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_routeb_calypso",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routeb_calypso1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_routee_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routee_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_routee_calliope",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routee_calliope1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_routee_aiolos",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_routee_aiolos1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_scoop_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_scoop_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_scoop_alyssa",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_alyssa1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_scoop_paine",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_paine1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_scoop_orba",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_orba1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_scoop_rubid",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_rubid1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_scoop_weaver",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_weaver1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_scoop_turner",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_turner1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_scoop_taggart",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_taggart1",
           "post_battle_win": null,
@@ -135,8 +135,8 @@
   },
   {
     "slug": "spyder_scoop_berys",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_berys1",
           "post_battle_win": null,
@@ -177,8 +177,8 @@
   },
   {
     "slug": "spyder_scoop_donald",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_donald1",
           "post_battle_win": null,
@@ -203,8 +203,8 @@
   },
   {
     "slug": "spyder_scoop_lanth",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_scoop_lanth1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
@@ -9,8 +9,8 @@
   },
   {
     "slug": "spyder_searoutec_river",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_river1",
           "post_battle_win": null,
@@ -27,8 +27,8 @@
   },
   {
     "slug": "spyder_searoutec_nigel",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_nigel1",
           "post_battle_win": null,
@@ -45,8 +45,8 @@
   },
   {
     "slug": "spyder_searoutec_more",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_more1",
           "post_battle_win": null,
@@ -63,8 +63,8 @@
   },
   {
     "slug": "spyder_searoutec_rutherford",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_rutherford1",
           "post_battle_win": null,
@@ -81,8 +81,8 @@
   },
   {
     "slug": "spyder_searoutec_sandy",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_sandy1",
           "post_battle_win": null,
@@ -99,8 +99,8 @@
   },
   {
     "slug": "spyder_searoutec_maurice",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_maurice1",
           "post_battle_win": null,
@@ -117,8 +117,8 @@
   },
   {
     "slug": "spyder_searoutec_leek",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_leek1",
           "post_battle_win": null,
@@ -135,8 +135,8 @@
   },
   {
     "slug": "spyder_searoutec_wade",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_wade1",
           "post_battle_win": null,
@@ -153,8 +153,8 @@
   },
   {
     "slug": "spyder_searoutec_stafford",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_stafford1",
           "post_battle_win": null,
@@ -171,8 +171,8 @@
   },
   {
     "slug": "spyder_searoutec_gil",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_gil1",
           "post_battle_win": null,
@@ -189,8 +189,8 @@
   },
   {
     "slug": "spyder_searoutec_carstair",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_carstair1",
           "post_battle_win": null,
@@ -207,8 +207,8 @@
   },
   {
     "slug": "spyder_searoutec_beech",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_searoutec_beech1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_tunnelb_beryll",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_tunnelb_beryll1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_tunnelb_greta",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_tunnelb_greta1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_tunnelb_iris",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_tunnelb_iris1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_tunnelb_meitner",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_tunnelb_meitner1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_tunnelb_lute",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_tunnelb_lute1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_tunnelb_tommy",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_tunnelb_tommy1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_walled_crassus",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_crassus1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_walled_alexander",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_alexander1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_walled_rufus",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_rufus1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_walled_vanderbilt",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_vanderbilt1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_walled_astor",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_astor1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_walled_ford",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_ford1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_walled_girard",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_girard1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_walled_augustus",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_augustus1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_walled_fugger",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_fugger1",
           "post_battle_win": null,
@@ -163,8 +163,8 @@
   },
   {
     "slug": "spyder_walled_carnegie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_carnegie1",
           "post_battle_win": null,
@@ -181,8 +181,8 @@
   },
   {
     "slug": "spyder_walled_osman",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_osman1",
           "post_battle_win": null,
@@ -199,8 +199,8 @@
   },
   {
     "slug": "spyder_walled_musa",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_musa1",
           "post_battle_win": null,
@@ -217,8 +217,8 @@
   },
   {
     "slug": "spyder_walled_midas",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_walled_midas1",
           "post_battle_win": null,

--- a/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
@@ -1,8 +1,8 @@
 [
   {
     "slug": "spyder_wayfarer1_bismuth",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_bismuth1",
           "post_battle_win": null,
@@ -19,8 +19,8 @@
   },
   {
     "slug": "spyder_wayfarer1_victor",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_victor1",
           "post_battle_win": null,
@@ -37,8 +37,8 @@
   },
   {
     "slug": "spyder_wayfarer1_ratcher",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_ratcher1",
           "post_battle_win": null,
@@ -55,8 +55,8 @@
   },
   {
     "slug": "spyder_wayfarer1_nightshade",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_nightshade1",
           "post_battle_win": null,
@@ -73,8 +73,8 @@
   },
   {
     "slug": "spyder_wayfarer1_morton",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_morton1",
           "post_battle_win": null,
@@ -91,8 +91,8 @@
   },
   {
     "slug": "spyder_wayfarer1_jessie",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_jessie1",
           "post_battle_win": null,
@@ -109,8 +109,8 @@
   },
   {
     "slug": "spyder_wayfarer1_morningstar",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_morningstar1",
           "post_battle_win": null,
@@ -127,8 +127,8 @@
   },
   {
     "slug": "spyder_wayfarer1_james",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_james1",
           "post_battle_win": null,
@@ -145,8 +145,8 @@
   },
   {
     "slug": "spyder_wayfarer1_bravo",
-    "dialogue": {
-      "dialogue": {
+    "speech": {
+      "profile": {
         "default": {
           "pre_battle": "spyder_wayfarer1_bravo1",
           "post_battle_win": null,

--- a/tuxemon/entity_dir/dialogue_profile.py
+++ b/tuxemon/entity_dir/dialogue_profile.py
@@ -28,7 +28,7 @@ class DialogueProfileManager:
             if npc_details.speech:
                 self.dialogue_cache[npc_slug] = npc_details.speech.profile
 
-        dialogue_model: DialogueProfile = self.dialogue_cache[npc_slug]
+        dialogue_model = self.dialogue_cache[npc_slug]
 
         if location:
             return dialogue_model.get_dialogue_for_location(location)

--- a/tuxemon/event/actions/char_talk.py
+++ b/tuxemon/event/actions/char_talk.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon.entity_dir.dialogue_profile import DialogueProfileManager
+from tuxemon.event import get_npc
+from tuxemon.event.eventaction import EventAction
+from tuxemon.locale import T
+from tuxemon.session import Session
+from tuxemon.tools import open_dialog
+from tuxemon.ui.text_formatter import TextFormatter
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class CharTalkAction(EventAction):
+    """
+    Displays dialogue for a character based on context and location.
+
+    This action retrieves dialogue from the character's dialogue profile,
+    optionally using a location-specific override. The dialogue field determines
+    which type of line to display (e.g. greeting, pre_battle, farewell).
+
+    Script usage:
+        .. code-block::
+
+            char_talk <character>,<field>[,location]
+
+    Script parameters:
+        character: Either "player" or the slug of an NPC (e.g. "npc_maple").
+        field: The dialogue type to display. Must be one of:
+            - greeting
+            - idle
+            - farewell
+            - pre_battle
+            - post_battle_win
+            - post_battle_lose
+            - post_battle_draw
+        location: Optional map identifier (e.g. "map.tmx") used to override default dialogue.
+
+    Behavior:
+        - If a location is provided and a location-based override exists, it will be used.
+        - Otherwise, the default dialogue profile is used.
+        - If the dialogue field contains multiple lines, one is selected randomly.
+        - Dialogue text is formatted before display.
+
+    Example:
+        char_talk npc_maple,greeting,map_forest
+    """
+
+    name = "char_talk"
+    character: str
+    field: str
+    location: Optional[str] = None
+
+    def start(self, session: Session) -> None:
+        character = get_npc(session, self.character)
+        if character is None:
+            logger.error(f"{self.character} not found")
+            return
+
+        dialogue = DialogueProfileManager()
+        content = dialogue.get_npc_dialogue_content(
+            character.slug, self.location
+        )
+        line = dialogue.get_dialogue_line(content, self.field)
+
+        if line is None:
+            logger.error(f"{self.character} line {self.field} doesn't exist.")
+            return
+
+        text = TextFormatter.replace_text(session, line, T)
+        open_dialog(client=session.client, text=[T.translate(text)])
+
+    def update(self, session: Session) -> None:
+        try:
+            session.client.get_state_by_name("DialogState")
+        except ValueError:
+            self.stop()


### PR DESCRIPTION
PR introduces the `char_talk` event action, enabling in-game display of dialogue lines defined in NPC JSON files. It allows scripted interactions to dynamically pull context-aware dialogue based on character, dialogue type (e.g. `greeting`, `pre_battle`, `farewell`), and optional location overrides.

Key changes:
- adds support for the `char_talk` event action, which retrieves and displays NPC dialogue using the `DialogueProfileManager`
- supports all defined dialogue types: `greeting`, `idle`, `farewell`, `pre_battle`, `post_battle_win`, `post_battle_lose`, and `post_battle_draw`
- includes location-based overrides for dialogue using map identifiers (e.g. `map_forest`, `route7`)
- fixes the structure of NPC dialogue definitions to align with the expected `DialogueProfile` and `DialogueContent` models
- replaces references to the `spyder` campaign with `eclipse`, reflecting the new campaign setting based on `route7`, `crystal`, and `lion mountain`