### PR TITLE
Refactor `NuPhone` Class to Use `DynamicMenuEntry` and `_get_app_callback` Helper

### DIFF
--- a/mods/tuxemon/db/item/app_banking.json
+++ b/mods/tuxemon/db/item/app_banking.json
@@ -12,6 +12,12 @@
     "consumable": false,
     "visible": false
   },
+  "dynamic_menu": {
+    "position": 0,
+    "label_key": "app_banking",
+    "menu_type": "phone",
+    "state": "NuPhoneBanking"
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_contacts.json
+++ b/mods/tuxemon/db/item/app_contacts.json
@@ -12,6 +12,12 @@
     "consumable": false,
     "visible": false
   },
+  "dynamic_menu": {
+    "position": 1,
+    "label_key": "app_contacts",
+    "menu_type": "phone",
+    "state": "NuPhoneContacts"
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_map.json
+++ b/mods/tuxemon/db/item/app_map.json
@@ -12,6 +12,12 @@
     "consumable": false,
     "visible": false
   },
+  "dynamic_menu": {
+    "position": 2,
+    "label_key": "app_map",
+    "menu_type": "phone",
+    "state": "NuPhoneMap"
+  },
   "use_failure": "generic_failure",
   "use_item": "combat_used_x",
   "use_success": "generic_success"

--- a/mods/tuxemon/db/item/app_tuxepedia.json
+++ b/mods/tuxemon/db/item/app_tuxepedia.json
@@ -12,9 +12,10 @@
     "consumable": false,
     "visible": false
   },
-  "world_menu": {
+  "dynamic_menu": {
     "position": 0,
     "label_key": "menu_tuxepedia",
+    "menu_type": "world",
     "state": "JournalChoice"
   },
   "use_failure": "generic_failure",

--- a/mods/tuxemon/db/item/nu_phone.json
+++ b/mods/tuxemon/db/item/nu_phone.json
@@ -12,9 +12,10 @@
     "consumable": false,
     "visible": false
   },
-  "world_menu": {
+  "dynamic_menu": {
     "position": 3,
     "label_key": "nu_phone",
+    "menu_type": "world",
     "state": "NuPhone"
   },
   "use_failure": "generic_failure",

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -269,10 +269,11 @@ class ItemBehaviors(BaseModel):
     )
 
 
-class WorldMenuEntry(BaseModel):
+class DynamicMenuEntry(BaseModel):
     position: int
     label_key: str
     state: str
+    menu_type: str
     enabled: bool = True
 
 
@@ -326,9 +327,9 @@ class ItemModel(BaseModel, BaseLookupModel):
     animation: Optional[str] = Field(
         None, description="Animation to play for this item"
     )
-    world_menu: Optional[WorldMenuEntry] = Field(
+    dynamic_menu: Optional[DynamicMenuEntry] = Field(
         None,
-        description="Item adds to World Menu a button (position, label -inside the PO -,state, eg. 3:nu_phone:PhoneState)",
+        description="Item adds a button to a specific menu (world, phone, etc.).",
     )
     cost: int = Field(0, description="The standard cost of the item.", ge=0)
     max_wear: int = Field(

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -133,7 +133,7 @@ class Item:
         self.cancel_text = T.translate(results.cancel_text)
 
         self.menu_actions_data = results.menu_actions
-        self.world_menu = results.world_menu
+        self.dynamic_menu = results.dynamic_menu
         self.behaviors = results.behaviors
         self.cost = results.cost
         self.max_wear = results.max_wear

--- a/tuxemon/states/phone/phone.py
+++ b/tuxemon/states/phone/phone.py
@@ -29,119 +29,112 @@ class NuPhone(PygameMenuState):
 
     name: ClassVar[str] = "NuPhone"
 
-    def add_menu_items(
-        self,
-        menu: pygame_menu.Menu,
-        items: Sequence[Item],
-    ) -> None:
-        self._no_signal = False
-
-        def _change_state(state: str, **kwargs: Any) -> MenuGameObj:
-            return partial(self.client.push_state, state, **kwargs)
-
-        def _no_trackers() -> None:
-            no_trackers = T.translate("nu_map_missing")
-            open_dialog(self.client, [no_trackers])
-
-        def _no_signal() -> None:
-            no_signal = T.translate("no_signal")
-            open_dialog(self.client, [no_signal])
-
-        def _uninstall(itm: Item) -> None:
-            open_dialog(
-                self.client,
-                [T.translate("uninstall_app")],
-            )
-
-        column_width = fix_measure(menu._width, 0.25)
-        menu._column_max_width = [
-            column_width,
-            column_width,
-            column_width,
-            column_width,
-        ]
-
-        # menu
-        network = [
-            mt for mt in MAP_TYPES if mt.name in {"town", "clinic", "shop"}
-        ]
-        desc = T.translate("nu_phone")
-        if self.client.map_manager.map_type in network:
-            desc = T.translate("omnichannel_mobile")
-        else:
-            desc = T.translate("no_signal")
-            self._no_signal = True
-        menu.set_title(desc).center_content()
-
-        # no gps tracker (nu map)
-        trackers = self.char.tracker.locations
-
-        for item in items:
-            label = T.translate(item.name).upper()
-            change = None
-            if item.slug == "app_banking":
-                change = (
-                    _no_signal
-                    if self._no_signal
-                    else _change_state("NuPhoneBanking", character=self.char)
-                )
-            elif item.slug == "app_contacts":
-                change = _change_state("NuPhoneContacts", character=self.char)
-            elif item.slug == "app_map":
-                change = (
-                    _change_state("NuPhoneMap", character=self.char)
-                    if trackers
-                    else _no_trackers
-                )
-            new_image = self._create_image(item.sprite)
-            new_image.scale(prepare.SCALE, prepare.SCALE)
-            # image of the app
-            menu.add.banner(
-                new_image,
-                change,
-                selection_effect=HighlightSelection(),
-            )
-            # name of the app
-            menu.add.button(
-                label,
-                action=partial(_uninstall, item),
-                font_size=self.font_type.smaller,
-            )
-            # description of the app
-            menu.add.label(
-                item.description,
-                font_size=self.font_type.smaller,
-                wordwrap=True,
-            )
-
     def __init__(self, character: NPC) -> None:
         width, height = prepare.SCREEN_SIZE
+        self.char = character
 
         theme = self._setup_theme(prepare.BG_PHONE)
         theme.scrollarea_position = locals.POSITION_EAST
         theme.widget_alignment = locals.ALIGN_CENTER
-
-        # menu
         theme.title = True
 
-        self.char = character
-
-        menu_items_map = []
+        self.menu_apps: list[Item] = []
         for itm in self.char.items.get_items():
-            if (
-                itm.category == "phone"
-                and itm.slug != "nu_phone"
-                and itm.slug != "app_tuxepedia"
-            ):
-                menu_items_map.append(itm)
+            if itm.dynamic_menu and itm.dynamic_menu.menu_type == "phone":
+                self.menu_apps.append(itm)
 
-        # 4 columns, then 3 rows (image + label + description)
         columns = 4
-        rows = math.ceil(len(menu_items_map) / columns) * 3
+        rows = math.ceil(len(self.menu_apps) / columns) * 3
 
         super().__init__(
             height=height, width=width, columns=columns, rows=rows
         )
 
-        self.add_menu_items(self.menu, menu_items_map)
+        self.add_menu_items(self.menu, self.menu_apps)
         self.reset_theme()
+
+    def _get_app_callback(self, item: Item) -> Callable[[], Any]:
+        """
+        Returns the appropriate callback for a dynamic menu entry,
+        handling conditional logic based on the item and game state.
+        """
+        dm = item.dynamic_menu
+        if not dm:
+            return lambda: None
+
+        state_name = dm.state
+
+        def _no_trackers() -> None:
+            open_dialog(self.client, [T.translate("nu_map_missing")])
+
+        def _no_signal() -> None:
+            open_dialog(self.client, [T.translate("no_signal")])
+
+        if state_name == "NuPhoneBanking":
+            # Banking app requires a network signal
+            network = [
+                mt for mt in MAP_TYPES if mt.name in {"town", "clinic", "shop"}
+            ]
+            if self.client.map_manager.map_type not in network:
+                return _no_signal
+
+        if state_name == "NuPhoneMap":
+            # Map app requires a tracker
+            if not self.char.tracker.locations:
+                return _no_trackers
+
+        return partial(self.client.push_state, state_name, character=self.char)
+
+    def add_menu_items(
+        self,
+        menu: pygame_menu.Menu,
+        items: Sequence[Item],
+    ) -> None:
+        """Dynamically adds app items to the phone menu."""
+
+        def _uninstall(itm: Item) -> None:
+            open_dialog(self.client, [T.translate("uninstall_app")])
+
+        column_width = fix_measure(menu._width, 0.25)
+        menu._column_max_width = [column_width] * 4
+
+        network = [
+            mt for mt in MAP_TYPES if mt.name in {"town", "clinic", "shop"}
+        ]
+        if self.client.map_manager.map_type in network:
+            desc = T.translate("omnichannel_mobile")
+        else:
+            desc = T.translate("no_signal")
+
+        menu.set_title(desc).center_content()
+
+        for item in items:
+            dm = item.dynamic_menu
+            if dm:
+                label = T.translate(dm.label_key).upper()
+
+                change = self._get_app_callback(item)
+
+                new_image = self._create_image(item.sprite)
+                new_image.scale(prepare.SCALE, prepare.SCALE)
+
+                # App image (banner)
+                menu.add.banner(
+                    new_image,
+                    change,
+                    selection_effect=HighlightSelection(),
+                )
+
+                # App name (button with uninstall action)
+                menu.add.button(
+                    label,
+                    action=partial(_uninstall, item),
+                    font_size=self.font_type.smaller,
+                )
+
+                # App description
+                menu.add.label(
+                    item.description,
+                    font_size=self.font_type.smaller,
+                    wordwrap=True,
+                )

--- a/tuxemon/states/world/world_menus.py
+++ b/tuxemon/states/world/world_menus.py
@@ -185,24 +185,28 @@ class WorldMenuManager:
         entries: list[tuple[int, MenuItem]] = []
 
         for itm in player.items.get_items():
-            wm = itm.world_menu
-            if wm and all(
-                hasattr(wm, attr)
-                for attr in ["position", "label_key", "state", "enabled"]
+            dm = itm.dynamic_menu
+            if (
+                dm
+                and dm.menu_type == "world"
+                and all(
+                    hasattr(dm, attr)
+                    for attr in ["position", "label_key", "state", "enabled"]
+                )
             ):
-                if wm.enabled and wm.label_key not in self.menu_flags._flags:
-                    self.menu_flags.set_enabled(wm.label_key, True)
+                if dm.enabled and dm.label_key not in self.menu_flags._flags:
+                    self.menu_flags.set_enabled(dm.label_key, True)
 
-                if not self.menu_flags.is_enabled(wm.label_key):
+                if not self.menu_flags.is_enabled(dm.label_key):
                     continue
 
-                if not self.item_exists(wm.label_key, current_menu):
-                    label = T.translate(wm.label_key).upper()
+                if not self.item_exists(dm.label_key, current_menu):
+                    label = T.translate(dm.label_key).upper()
                     callback = self._get_change_state_callback(
-                        wm.state, character=player
+                        dm.state, character=player
                     )
                     entries.append(
-                        (wm.position, MenuItem(wm.label_key, label, callback))
+                        (dm.position, MenuItem(dm.label_key, label, callback))
                     )
 
         # Sort and insert to avoid position shifting issues


### PR DESCRIPTION
PR refactors the `NuPhone` class to improve scalability and reduce hardcoded logic by introducing the `DynamicMenuEntry` abstraction and a new `_get_app_callback` helper method.

Key changes:
- replaced the hardcoded `if/elif` logic in `NuPhone` with a scalable callback resolution via `_get_app_callback`
- introduced `DynamicMenuEntry` which extends and rename the old `WorldMenuEntry` class, this change allows the menu entry model to be reused beyond `WorldMenuState`, including in the phone menu, reducing duplication and hardcoding
- improved robustness by handling edge cases such as missing trackers or network signal through dedicated fallback callbacks