### PR TITLE
Add `combat` + `speech` submodel to `NpcModel` with `switch_logic` and relocated `forfeit` field

### DIFF
--- a/mods/tuxemon/db/npc/37707_female.json
+++ b/mods/tuxemon/db/npc/37707_female.json
@@ -1,5 +1,7 @@
 {
   "slug": "37707_female",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "37707_female",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/37707_female_missing.json
+++ b/mods/tuxemon/db/npc/37707_female_missing.json
@@ -1,5 +1,7 @@
 {
   "slug": "37707_female_missing",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "37707_female_missing",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/37707_male.json
+++ b/mods/tuxemon/db/npc/37707_male.json
@@ -1,5 +1,7 @@
 {
   "slug": "37707_male",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "37707_male",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/37707_male_missing.json
+++ b/mods/tuxemon/db/npc/37707_male_missing.json
@@ -1,5 +1,7 @@
 {
   "slug": "37707_male_missing",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "37707_male_missing",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/aeble.json
+++ b/mods/tuxemon/db/npc/aeble.json
@@ -1,5 +1,7 @@
 {
   "slug": "aeble",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "ceo",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/allie.json
+++ b/mods/tuxemon/db/npc/allie.json
@@ -1,5 +1,7 @@
 {
   "slug": "allie",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "omnichannelallie",
     "combat_front": "goth_rose",

--- a/mods/tuxemon/db/npc/azure_npcs.json
+++ b/mods/tuxemon/db/npc/azure_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "unknownwitch",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "witch",
       "combat_front": "witch",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "azure_enforcer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "azure_enforcer2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "azure_knight",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knight",

--- a/mods/tuxemon/db/npc/bob.json
+++ b/mods/tuxemon/db/npc/bob.json
@@ -1,5 +1,7 @@
 {
   "slug": "bob",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/christie.json
+++ b/mods/tuxemon/db/npc/christie.json
@@ -1,5 +1,7 @@
 {
   "slug": "christie",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "christie",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/conworker1.json
+++ b/mods/tuxemon/db/npc/conworker1.json
@@ -1,5 +1,7 @@
 {
   "slug": "conworker1",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/conworker2.json
+++ b/mods/tuxemon/db/npc/conworker2.json
@@ -1,5 +1,7 @@
 {
   "slug": "conworker2",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/conworker3.json
+++ b/mods/tuxemon/db/npc/conworker3.json
@@ -1,5 +1,7 @@
 {
   "slug": "conworker3",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/cotton_breeder.json
+++ b/mods/tuxemon/db/npc/cotton_breeder.json
@@ -1,5 +1,7 @@
 {
   "slug": "cotton_breeder",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/cotton_misa_bro.json
+++ b/mods/tuxemon/db/npc/cotton_misa_bro.json
@@ -1,5 +1,7 @@
 {
   "slug": "cotton_misa_bro",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "childactor_fiery",
     "combat_front": "yellowbelt",

--- a/mods/tuxemon/db/npc/cotton_misa_gramps.json
+++ b/mods/tuxemon/db/npc/cotton_misa_gramps.json
@@ -1,5 +1,7 @@
 {
   "slug": "cotton_misa_gramps",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "granny",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/eclipse_crystal_town_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_crystal_town_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "eclipse_crystal_magician_fiery",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "eclipse_crystal_homemaker",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "eclipse_crystal_barmaid",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "eclipse_crystal_granny",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "eclipse_crystal_maniac_green",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "eclipse_crystal_monk_orange",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "eclipse_crystal_tennisplayer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "eclipse_crystal_shopkeeper",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant_black",
       "combat_front": "shopassistant",

--- a/mods/tuxemon/db/npc/eclipse_lion_mountain_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_lion_mountain_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -173,6 +182,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -181,6 +191,8 @@
   },
   {
     "slug": "eclipse_lionmountain_scientist",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -189,6 +201,8 @@
   },
   {
     "slug": "eclipse_lionmountain_enforcer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_agent",
@@ -197,6 +211,8 @@
   },
   {
     "slug": "eclipse_lionmountain_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -205,6 +221,8 @@
   },
   {
     "slug": "eclipse_lionmountain_snarlon",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "landrace",
       "combat_front": "sludgehog",

--- a/mods/tuxemon/db/npc/eclipse_park_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_park_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "eclipse_park_reception",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "eclipse_park_florist",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "eclipse_park_guardian",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "eclipse_park_soldier",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "eclipse_park_scientist",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "eclipse_park_professor",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "eclipse_park_tennisplayer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/eclipse_route7_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_route7_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "eclipse_route7_arnold",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "eclipse_route7_sylvester",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "eclipse_route7_fritz",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -35,6 +41,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -53,6 +60,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "magician_blonde",
       "combat_front": "magician",
@@ -71,6 +79,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -89,6 +98,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "baller",
@@ -107,6 +117,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor_lapi",
       "combat_front": "professor",
@@ -125,6 +136,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "cooldude_black",
       "combat_front": "rocker",
@@ -143,6 +155,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "winger",
@@ -161,6 +174,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -179,6 +193,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "postboy_green",
       "combat_front": "cooldude",
@@ -197,6 +212,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "coach",
@@ -205,6 +221,8 @@
   },
   {
     "slug": "eclipse_route7_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/grace.json
+++ b/mods/tuxemon/db/npc/grace.json
@@ -1,5 +1,7 @@
 {
   "slug": "grace",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "heroine",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/happy_guy.json
+++ b/mods/tuxemon/db/npc/happy_guy.json
@@ -1,5 +1,7 @@
 {
   "slug": "happy_guy",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "ceo",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/knight1.json
+++ b/mods/tuxemon/db/npc/knight1.json
@@ -1,5 +1,7 @@
 {
   "slug": "knight1",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/knight2.json
+++ b/mods/tuxemon/db/npc/knight2.json
@@ -1,5 +1,7 @@
 {
   "slug": "knight2",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/knight3.json
+++ b/mods/tuxemon/db/npc/knight3.json
@@ -1,5 +1,7 @@
 {
   "slug": "knight3",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/knight4.json
+++ b/mods/tuxemon/db/npc/knight4.json
@@ -1,5 +1,7 @@
 {
   "slug": "knight4",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/kyle.json
+++ b/mods/tuxemon/db/npc/kyle.json
@@ -1,5 +1,7 @@
 {
   "slug": "kyle",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "cooldude",
     "combat_front": "cooldude",

--- a/mods/tuxemon/db/npc/liela.json
+++ b/mods/tuxemon/db/npc/liela.json
@@ -1,5 +1,7 @@
 {
   "slug": "liela",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "heroine",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/maple.json
+++ b/mods/tuxemon/db/npc/maple.json
@@ -1,5 +1,7 @@
 {
   "slug": "maple_girl",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "fashionista_fiery",
     "combat_front": "fashionista",

--- a/mods/tuxemon/db/npc/marissa.json
+++ b/mods/tuxemon/db/npc/marissa.json
@@ -1,5 +1,7 @@
 {
   "slug": "marissa",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "girl1",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/misa.json
+++ b/mods/tuxemon/db/npc/misa.json
@@ -1,5 +1,7 @@
 {
   "slug": "misa",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "fashionista",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/npc_mom.json
+++ b/mods/tuxemon/db/npc/npc_mom.json
@@ -1,5 +1,7 @@
 {
   "slug": "npc_mom",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "girl1",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/npc_test.json
+++ b/mods/tuxemon/db/npc/npc_test.json
@@ -1,5 +1,7 @@
 {
   "slug": "npc_test",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "adventurer",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/npc_wife.json
+++ b/mods/tuxemon/db/npc/npc_wife.json
@@ -1,5 +1,7 @@
 {
   "slug": "npc_wife",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "girl1",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/nurse1.json
+++ b/mods/tuxemon/db/npc/nurse1.json
@@ -1,5 +1,7 @@
 {
   "slug": "nurse1",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "nurse",
     "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/nurse2.json
+++ b/mods/tuxemon/db/npc/nurse2.json
@@ -1,5 +1,7 @@
 {
   "slug": "nurse2",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "nurse",
     "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/omnigrunt.json
+++ b/mods/tuxemon/db/npc/omnigrunt.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt10.json
+++ b/mods/tuxemon/db/npc/omnigrunt10.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt10",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt2.json
+++ b/mods/tuxemon/db/npc/omnigrunt2.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt2",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt3.json
+++ b/mods/tuxemon/db/npc/omnigrunt3.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt3",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt4.json
+++ b/mods/tuxemon/db/npc/omnigrunt4.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt4",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt5.json
+++ b/mods/tuxemon/db/npc/omnigrunt5.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt5",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt6.json
+++ b/mods/tuxemon/db/npc/omnigrunt6.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt6",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt7.json
+++ b/mods/tuxemon/db/npc/omnigrunt7.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt7",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt8.json
+++ b/mods/tuxemon/db/npc/omnigrunt8.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt8",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt9.json
+++ b/mods/tuxemon/db/npc/omnigrunt9.json
@@ -1,5 +1,7 @@
 {
   "slug": "omnigrunt9",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt_zeke.json
+++ b/mods/tuxemon/db/npc/omnigrunt_zeke.json
@@ -1,5 +1,7 @@
 {
   "slug": "zeke",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/penguin.json
+++ b/mods/tuxemon/db/npc/penguin.json
@@ -1,5 +1,7 @@
 {
   "slug": "penguin",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "penguin",
     "combat_front": "penguin",

--- a/mods/tuxemon/db/npc/postboy.json
+++ b/mods/tuxemon/db/npc/postboy.json
@@ -1,5 +1,7 @@
 {
   "slug": "postboy",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "postboy",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/professor.json
+++ b/mods/tuxemon/db/npc/professor.json
@@ -1,5 +1,7 @@
 {
   "slug": "professor",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "professor",
     "combat_front": "professor",

--- a/mods/tuxemon/db/npc/red.json
+++ b/mods/tuxemon/db/npc/red.json
@@ -1,5 +1,7 @@
 {
   "slug": "npc_red",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "adventurer",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/rock.json
+++ b/mods/tuxemon/db/npc/rock.json
@@ -1,5 +1,7 @@
 {
   "slug": "rock",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "boulder",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/shady_guy.json
+++ b/mods/tuxemon/db/npc/shady_guy.json
@@ -1,5 +1,7 @@
 {
   "slug": "shady_guy",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "ninja",
     "combat_front": "ninja",

--- a/mods/tuxemon/db/npc/speck.json
+++ b/mods/tuxemon/db/npc/speck.json
@@ -1,5 +1,7 @@
 {
   "slug": "speck",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "beachcomber",
     "combat_front": "beachgoer",

--- a/mods/tuxemon/db/npc/spyder_boulder.json
+++ b/mods/tuxemon/db/npc/spyder_boulder.json
@@ -1,5 +1,7 @@
 {
   "slug": "spyder_boulder",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "boulder",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_candy_henrik",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_rookie",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_candy_eliane",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_candycafe_nora",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_candyhouse2_indiana",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_candyhouse2_barney",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "spyder_candyhouse3_joanie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "catgirl",
       "combat_front": "catgirl",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "spyder_candyhouse1_tillie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "spyder_candyhouse1_sawyer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "adventurer",
@@ -65,6 +81,8 @@
   },
   {
     "slug": "spyder_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -73,6 +91,8 @@
   },
   {
     "slug": "spyder_candyinn_cott",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -81,6 +101,8 @@
   },
   {
     "slug": "spyder_candyinn_lyle",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "pirate",
@@ -89,6 +111,8 @@
   },
   {
     "slug": "spyder_candyinn_bob",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_rose",
       "combat_front": "adventurer",
@@ -97,6 +121,8 @@
   },
   {
     "slug": "spyder_candyinn_prof",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor_lapi",
       "combat_front": "professor",
@@ -105,6 +131,8 @@
   },
   {
     "slug": "spyder_candyinn_jess",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "adventurer",
@@ -113,6 +141,8 @@
   },
   {
     "slug": "spyder_candyinn_james",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -121,6 +151,8 @@
   },
   {
     "slug": "spyder_candyport_monk",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -129,6 +161,8 @@
   },
   {
     "slug": "spyder_candyinn_monk",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",

--- a/mods/tuxemon/db/npc/spyder_citypark_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_citypark_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "catgirl_green",
       "combat_front": "catgirl",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -37,6 +39,8 @@
   },
   {
     "slug": "spyder_citypark_florist",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -55,6 +59,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_black",
       "combat_front": "florist",
@@ -63,6 +68,8 @@
   },
   {
     "slug": "spyder_citypark_magdalene",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -71,6 +78,8 @@
   },
   {
     "slug": "spyder_citypark_prue",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -79,6 +88,8 @@
   },
   {
     "slug": "spyder_citypark_mack",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -87,6 +98,8 @@
   },
   {
     "slug": "spyder_citypark_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -95,6 +108,8 @@
   },
   {
     "slug": "spyder_citypark_cd1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -103,6 +118,8 @@
   },
   {
     "slug": "spyder_citypark_cd2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -111,6 +128,8 @@
   },
   {
     "slug": "spyder_citypark_restoration",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -119,6 +138,8 @@
   },
   {
     "slug": "spyder_citypark_potion1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -127,6 +148,8 @@
   },
   {
     "slug": "spyder_citypark_potion2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -135,6 +158,8 @@
   },
   {
     "slug": "spyder_citypark_house_maniac",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_cottontown_barmaid",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid",
       "combat_front": "barmaid",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_cottontown_monk",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "monk",
       "combat_front": "monk",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_cottontown_hacker",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician",
       "combat_front": "magician",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_cottonhouse1_rodger",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_cottonhouse1_lila",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker_blonde",
       "combat_front": "adventurer",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "spyder_cottoncafe_juliana",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker_black",
       "combat_front": "adventurer",
@@ -59,6 +71,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -67,6 +80,8 @@
   },
   {
     "slug": "spyder_cottoncafe_wilford",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "shopassistant",
@@ -75,6 +90,8 @@
   },
   {
     "slug": "spyder_cottoncafe_hillary",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -83,6 +100,8 @@
   },
   {
     "slug": "spyder_cottoncafe_lotus",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny_lapi",
       "combat_front": "adventurer",
@@ -91,6 +110,8 @@
   },
   {
     "slug": "spyder_cottonartshop_phoenix",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "adventurer",
@@ -99,6 +120,8 @@
   },
   {
     "slug": "spyder_cottonartshop_philis",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny_green",
       "combat_front": "adventurer",
@@ -107,6 +130,8 @@
   },
   {
     "slug": "spyder_cottonhouse2_sidney",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "catgirl_fiery",
       "combat_front": "catgirl",
@@ -115,6 +140,8 @@
   },
   {
     "slug": "spyder_cottonartshop_luvinia",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist",
       "combat_front": "florist",
@@ -123,6 +150,8 @@
   },
   {
     "slug": "spyder_cottonhouse2_neva",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -131,6 +160,8 @@
   },
   {
     "slug": "spyder_cottonhouse2_davis",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper_blonde",
       "combat_front": "adventurer",
@@ -139,6 +170,8 @@
   },
   {
     "slug": "spyder_cottonartshop_carter",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper_brown",
       "combat_front": "adventurer",
@@ -147,6 +180,8 @@
   },
   {
     "slug": "spyder_cottoncenter_ada",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -155,6 +190,8 @@
   },
   {
     "slug": "spyder_shopkeeper",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -163,6 +200,8 @@
   },
   {
     "slug": "spyder_cottontunnel_box1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -171,6 +210,8 @@
   },
   {
     "slug": "spyder_cottontunnel_box2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -179,6 +220,8 @@
   },
   {
     "slug": "spyder_cottontunnel_box3",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -187,6 +230,8 @@
   },
   {
     "slug": "spyder_cottontunnel_box4",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -195,6 +240,8 @@
   },
   {
     "slug": "spyder_cottontunnel_box5",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -203,6 +250,8 @@
   },
   {
     "slug": "spyder_cottontunnel_box6",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -211,6 +260,8 @@
   },
   {
     "slug": "spyder_cottontunnel_professor",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor_fiery",
       "combat_front": "professor",
@@ -219,6 +270,8 @@
   },
   {
     "slug": "spyder_cottontunnel_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant_black",
       "combat_front": "shopassistant",
@@ -237,6 +290,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -255,6 +309,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "childactor_fiery",
       "combat_front": "tennisplayer_fiery",

--- a/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -91,6 +96,8 @@
   },
   {
     "slug": "spyder_box_goldpass",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -99,6 +106,8 @@
   },
   {
     "slug": "spyder_datacenter_s1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -107,6 +116,8 @@
   },
   {
     "slug": "spyder_datacenter_s2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -115,6 +126,8 @@
   },
   {
     "slug": "spyder_datacenter_s3",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -123,6 +136,8 @@
   },
   {
     "slug": "spyder_datacenter_s4",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -131,6 +146,8 @@
   },
   {
     "slug": "spyder_datacenter_s5",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -139,6 +156,8 @@
   },
   {
     "slug": "spyder_datacenter_s6",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -147,6 +166,8 @@
   },
   {
     "slug": "spyder_datacenter_s7",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_dojo_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dojo_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -19,6 +20,8 @@
   },
   {
     "slug": "spyder_dojo_fu",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny_yellow",
       "combat_front": "adventurer",
@@ -27,6 +30,8 @@
   },
   {
     "slug": "spyder_dojo_fu_student1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "childactor_black",
       "combat_front": "childactor",
@@ -35,6 +40,8 @@
   },
   {
     "slug": "spyder_dojo_fu_student2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "childactor_blonde",
       "combat_front": "childactor",
@@ -53,6 +60,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -71,6 +79,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -89,6 +98,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -107,6 +117,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -125,6 +136,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",
@@ -143,6 +155,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -161,6 +174,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",
@@ -169,6 +183,8 @@
   },
   {
     "slug": "spyder_dojo_thri",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "riddler",
@@ -187,6 +203,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -195,6 +212,8 @@
   },
   {
     "slug": "spyder_dojo_tu",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "ninja_red",
       "combat_front": "ninja",
@@ -203,6 +222,8 @@
   },
   {
     "slug": "spyder_dojo_wan",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "ninja_blue",
       "combat_front": "ninja",
@@ -211,6 +232,8 @@
   },
   {
     "slug": "spyder_dojo_xiang",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny_green",
       "combat_front": "adventurer",
@@ -229,6 +252,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -237,6 +261,8 @@
   },
   {
     "slug": "spyder_dojo_yin",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -245,6 +271,8 @@
   },
   {
     "slug": "spyder_dojo_zhao",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -253,6 +281,8 @@
   },
   {
     "slug": "spyder_dojo_zhu",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_rose",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_dragonscave_angrybrute",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -19,6 +21,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -37,6 +40,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_blue",
       "combat_front": "dragonrider",
@@ -45,6 +49,8 @@
   },
   {
     "slug": "spyder_dragonscave_concernedbrute",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -63,6 +69,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider",
       "combat_front": "dragonrider",
@@ -81,6 +88,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_fiery",
       "combat_front": "dragonrider",
@@ -89,6 +97,8 @@
   },
   {
     "slug": "spyder_dragonscave_lazybrute",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -107,6 +117,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -125,6 +136,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -143,6 +155,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss_fiery",
       "combat_front": "spyder_boss",
@@ -161,6 +174,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -179,6 +193,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_green",
       "combat_front": "dragonrider",
@@ -197,6 +212,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knightlord",
@@ -205,6 +221,8 @@
   },
   {
     "slug": "spyder_drokoro",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "drokoro",
       "combat_front": "noclass",
@@ -213,6 +231,8 @@
   },
   {
     "slug": "spyder_dragonscave_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "waternymph",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "metalnymph",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "firenymph",
       "combat_front": "firenymph",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "earthnymph",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "woodnymph",
@@ -91,6 +96,8 @@
   },
   {
     "slug": "spyder_volcoli",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "volcoli",
       "combat_front": "noclass",
@@ -99,6 +106,8 @@
   },
   {
     "slug": "spyder_dryadsgrove_boy",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "childactor_black",
       "combat_front": "yellowbelt",
@@ -107,6 +116,8 @@
   },
   {
     "slug": "spyder_dryadsgrove_dad",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_gray",
       "combat_front": "yellowbelt",

--- a/mods/tuxemon/db/npc/spyder_flower_city_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_flower_city_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_flower_cady",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "snugglepot",
       "combat_front": "yellowbelt",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_flower_fez",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "yellowbelt",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_flower_mieke",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "catgirl_blue",
       "combat_front": "catgirl",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_flower_sandy",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "childactor",
       "combat_front": "yellowbelt",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_flower_teach",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "spyder_flower_monk",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "spyder_flowerhouse1_willie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "spyder_flowerhouse2_pip",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -65,6 +81,8 @@
   },
   {
     "slug": "spyder_flowerhouse1_jonette",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -73,6 +91,8 @@
   },
   {
     "slug": "spyder_flower_lissa",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist",
       "combat_front": "florist",
@@ -81,6 +101,8 @@
   },
   {
     "slug": "spyder_flowerhouse2_bruce",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -89,6 +111,8 @@
   },
   {
     "slug": "spyder_flowerpetshop_denzel",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper_blonde",
       "combat_front": "adventurer",
@@ -97,6 +121,8 @@
   },
   {
     "slug": "spyder_flowerpetshop_titus",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant_grey",
       "combat_front": "shopassistant",
@@ -105,6 +131,8 @@
   },
   {
     "slug": "spyder_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "aviator",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -163,6 +172,8 @@
   },
   {
     "slug": "spyder_greenwash_guard",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -181,6 +192,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "postboy_red",
       "combat_front": "cooldude",
@@ -199,6 +211,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -217,6 +230,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -235,6 +249,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -253,6 +268,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -271,6 +287,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -289,6 +306,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -307,6 +325,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -315,6 +334,8 @@
   },
   {
     "slug": "spyder_greenwash_norton",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -323,6 +344,8 @@
   },
   {
     "slug": "spyder_greenwash_selby",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/spyder_hospital_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_hospital_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss_blonde",
       "combat_front": "spyder_boss",
@@ -19,6 +20,8 @@
   },
   {
     "slug": "spyder_hospital1_pem",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -37,6 +40,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss_fiery",
       "combat_front": "spyder_boss",
@@ -55,6 +59,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss_green",
       "combat_front": "spyder_boss",
@@ -73,6 +78,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -91,6 +97,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -109,6 +116,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss_lapi",
       "combat_front": "spyder_boss",
@@ -127,6 +135,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -135,6 +144,8 @@
   },
   {
     "slug": "spyder_hospital1_rea",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss",
       "combat_front": "spyder_boss",
@@ -153,6 +164,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -171,6 +183,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -189,6 +202,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -197,6 +211,8 @@
   },
   {
     "slug": "spyder_hospital1_smith",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -205,6 +221,8 @@
   },
   {
     "slug": "spyder_hospital1_lesley",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -213,6 +231,8 @@
   },
   {
     "slug": "spyder_hospital1_trafford",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -221,6 +241,8 @@
   },
   {
     "slug": "spyder_hospital1_marylyn",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -229,6 +251,8 @@
   },
   {
     "slug": "spyder_hospital1_melanie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",
@@ -237,6 +261,8 @@
   },
   {
     "slug": "spyder_hospital1_audie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_leather_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_leather_town_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_leathergym_chadine",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "barmaid",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_leathergym_chadfort",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_leathergym_chad",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_leathergym_bradfort",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "postboy_green",
       "combat_front": "adventurer",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_leathergym_brad",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "spyder_leathergym_gigachad",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_brown",
       "combat_front": "magician",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "spyder_leathergym_virgin",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "adventurer",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "spyder_leather_eula",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid",
       "combat_front": "barmaid",
@@ -65,6 +81,8 @@
   },
   {
     "slug": "spyder_leatherhouse2_memphis",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -73,6 +91,8 @@
   },
   {
     "slug": "spyder_leathermuseum_davie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -81,6 +101,8 @@
   },
   {
     "slug": "spyder_leathershaft1_cole",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -89,6 +111,8 @@
   },
   {
     "slug": "spyder_leathershaft1_rutherford",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -97,6 +121,8 @@
   },
   {
     "slug": "spyder_leathershaft1_beryll",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -105,6 +131,8 @@
   },
   {
     "slug": "spyder_leathershaft1_surat",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -113,6 +141,8 @@
   },
   {
     "slug": "spyder_leathershaft1_roxby",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -121,6 +151,8 @@
   },
   {
     "slug": "spyder_leathershaft2_colin",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
@@ -129,6 +161,8 @@
   },
   {
     "slug": "spyder_leatherhouse1_roger",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "adventurer",
@@ -137,6 +171,8 @@
   },
   {
     "slug": "spyder_leathermuseum_kasey",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "postboy_red",
       "combat_front": "adventurer",
@@ -145,6 +181,8 @@
   },
   {
     "slug": "spyder_leathermuseum_historian",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -153,6 +191,8 @@
   },
   {
     "slug": "spyder_leathermuseum_security",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -161,6 +201,8 @@
   },
   {
     "slug": "spyder_leathermuseum_visitor",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -169,6 +211,8 @@
   },
   {
     "slug": "spyder_leatherhouse1_gail",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -177,6 +221,8 @@
   },
   {
     "slug": "spyder_leatherhouse2_elias",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "snugglepot",
       "combat_front": "snugglepot",
@@ -185,6 +231,8 @@
   },
   {
     "slug": "spyder_leatherhouse2_gabe",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -193,6 +241,8 @@
   },
   {
     "slug": "spyder_leather_filbur",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -201,6 +251,8 @@
   },
   {
     "slug": "spyder_leathermuseum_giles",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_rose",
       "combat_front": "adventurer",
@@ -209,6 +261,8 @@
   },
   {
     "slug": "spyder_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_log.json
+++ b/mods/tuxemon/db/npc/spyder_log.json
@@ -1,5 +1,7 @@
 {
   "slug": "spyder_log",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "log",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_mansion_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_mansion_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "rogue_red",
       "combat_front": "rogue",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "mage",
@@ -73,6 +77,8 @@
   },
   {
     "slug": "spyder_top_penelope",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -81,6 +87,8 @@
   },
   {
     "slug": "spyder_top_maura",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "barmaid",
@@ -89,6 +97,8 @@
   },
   {
     "slug": "spyder_top_lenny",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician",
       "combat_front": "magician",
@@ -97,6 +107,8 @@
   },
   {
     "slug": "spyder_mansion_drinkingbuddya",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "rogue_green",
       "combat_front": "rogue",
@@ -105,6 +117,8 @@
   },
   {
     "slug": "spyder_mansion_wayne",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_black",
       "combat_front": "magician",
@@ -123,6 +137,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "pirate",
@@ -141,6 +156,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -159,6 +175,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "magician_brown",
       "combat_front": "magician",
@@ -167,6 +184,8 @@
   },
   {
     "slug": "spyder_mansion_drinkingbuddyb",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "warrior",
       "combat_front": "enforcer_rookie",
@@ -175,6 +194,8 @@
   },
   {
     "slug": "spyder_mansion_lainey",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "barmaid",
       "combat_front": "barmaid",
@@ -183,6 +204,8 @@
   },
   {
     "slug": "spyder_mansion_rolo",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",
@@ -191,6 +214,8 @@
   },
   {
     "slug": "spyder_mansion_tamara",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -199,6 +224,8 @@
   },
   {
     "slug": "spyder_mansion_reed",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -207,6 +234,8 @@
   },
   {
     "slug": "spyder_mansion_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -225,6 +254,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "postboy",
       "combat_front": "rocker",
@@ -243,6 +273,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "disciple",
       "combat_front": "healer",
@@ -261,6 +292,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "dancer",
@@ -269,6 +301,8 @@
   },
   {
     "slug": "spyder_basement_josephine",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "disciple",
       "combat_front": "healer",
@@ -287,6 +321,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer_lapi",
       "combat_front": "tennisplayer",
@@ -295,6 +330,8 @@
   },
   {
     "slug": "spyder_basement_josh",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "baller",
@@ -303,6 +340,8 @@
   },
   {
     "slug": "spyder_basement_garret",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "rogue_green",
       "combat_front": "rogue",
@@ -311,6 +350,8 @@
   },
   {
     "slug": "spyder_basement_flick",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",

--- a/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist_brown",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "robot",
       "combat_front": "xeon",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knightlord",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "aviator",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -173,6 +182,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "robot",
       "combat_front": "chrome_robo",
@@ -191,6 +201,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -209,6 +220,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_boss",
@@ -227,6 +239,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -245,6 +258,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist_black",
@@ -253,6 +267,8 @@
   },
   {
     "slug": "spyder_nimrod_dirk",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -261,6 +277,8 @@
   },
   {
     "slug": "spyder_nimrod_jake",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -269,6 +287,8 @@
   },
   {
     "slug": "spyder_nimrod_jervis",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -277,6 +297,8 @@
   },
   {
     "slug": "spyder_nimrod_elara",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",

--- a/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_omnichannel_beaverbrook",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -19,6 +21,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "rogue",
       "combat_front": "rogue",
@@ -37,6 +40,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "warrior",
       "combat_front": "warrior",
@@ -55,6 +59,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_black",
       "combat_front": "yellowbelt",
@@ -73,6 +78,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -81,6 +87,8 @@
   },
   {
     "slug": "spyder_omnichannel_worm",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "37707_female",
       "combat_front": "ceo",
@@ -89,6 +97,8 @@
   },
   {
     "slug": "spyder_omnichannel_enforcer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -97,6 +107,8 @@
   },
   {
     "slug": "spyder_omnichannel_thedukeofdeadair",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "rogue_red",
       "combat_front": "rogue",
@@ -115,6 +127,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss",
       "combat_front": "spyder_boss",
@@ -133,6 +146,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -151,6 +165,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -169,6 +184,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -187,6 +203,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -195,6 +212,8 @@
   },
   {
     "slug": "spyder_omnichannel_talbot",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -203,6 +222,8 @@
   },
   {
     "slug": "spyder_omnichannel_gore",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -211,6 +232,8 @@
   },
   {
     "slug": "spyder_omnichannel_danita",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -219,6 +242,8 @@
   },
   {
     "slug": "spyder_omnichannel_ethan",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_paintings.json
+++ b/mods/tuxemon/db/npc/spyder_paintings.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "p_one",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "p_one",
       "combat_front": "noclass",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "p_two",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "p_two",
       "combat_front": "noclass",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "p_three",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "p_three",
       "combat_front": "noclass",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "p_four",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "p_four",
       "combat_front": "noclass",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "p_five",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "p_five",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_paper_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_paper_town_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_grannypiper",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny_yellow",
       "combat_front": "adventurer",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_conileaffrolicking",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "conileaf",
       "combat_front": "adventurer",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_rockittenfrolicking",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "rockitten",
       "combat_front": "adventurer",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_papermart_harith",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "adventurer",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_papermart_miles",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "tennisplayer",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "spyder_papermart_shirley",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "spyder_papermart_rafael",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer_lapi",
       "combat_front": "tennisplayer",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "spyder_papertown_mom",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker",
       "combat_front": "adventurer",
@@ -65,6 +81,8 @@
   },
   {
     "slug": "spyder_papertown_silver",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist",
       "combat_front": "florist",
@@ -73,6 +91,8 @@
   },
   {
     "slug": "spyder_papermanor_princeton",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "adventurer",
@@ -81,6 +101,8 @@
   },
   {
     "slug": "spyder_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_route1_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route1_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_route1_bjorn",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_route2_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route2_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "tennisplayer",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer_fiery",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/spyder_route3_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route3_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "overseer",
       "combat_front": "overseer",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knight",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "fisher",
       "combat_front": "fisher",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -173,6 +182,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -181,6 +191,8 @@
   },
   {
     "slug": "spyder_route3_ryland",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -189,6 +201,8 @@
   },
   {
     "slug": "spyder_route3_miner1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -197,6 +211,8 @@
   },
   {
     "slug": "spyder_route3_miner2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -205,6 +221,8 @@
   },
   {
     "slug": "spyder_route3_miner3",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",

--- a/mods/tuxemon/db/npc/spyder_route4_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route4_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "yellowbelt",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_blue",
       "combat_front": "yellowbelt",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "alchemist",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -109,6 +115,8 @@
   },
   {
     "slug": "spyder_route4_super",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -117,6 +125,8 @@
   },
   {
     "slug": "spyder_route4_boost",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -125,6 +135,8 @@
   },
   {
     "slug": "spyder_route4_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_route5_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route5_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "catgirl_blonde",
       "combat_front": "catgirl",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -109,6 +115,8 @@
   },
   {
     "slug": "spyder_route5_lexia",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny_lapi",
       "combat_front": "adventurer",
@@ -117,6 +125,8 @@
   },
   {
     "slug": "spyder_route5_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_route6_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route6_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_brown",
       "combat_front": "florist",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor_blue",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/spyder_routea_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routea_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "rocker",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "boss_red",
       "combat_front": "rocker",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "catgirl_violet",
       "combat_front": "catgirl",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -163,6 +172,8 @@
   },
   {
     "slug": "spyder_routea_jarod",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -171,6 +182,8 @@
   },
   {
     "slug": "spyder_routea_john",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -179,6 +192,8 @@
   },
   {
     "slug": "spyder_routea_super",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -187,6 +202,8 @@
   },
   {
     "slug": "spyder_routea_cureall",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -195,6 +212,8 @@
   },
   {
     "slug": "spyder_routea_tea",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -203,6 +222,8 @@
   },
   {
     "slug": "spyder_routea_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_routeb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routeb_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_agent",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_agent",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_rookie",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight_yellow",
       "combat_front": "enforcer_boss",

--- a/mods/tuxemon/db/npc/spyder_routee_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routee_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_agent",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_rookie",

--- a/mods/tuxemon/db/npc/spyder_scoop_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_scoop_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -127,6 +134,8 @@
   },
   {
     "slug": "spyder_scoop_arachne",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "spyderboss_blonde",
       "combat_front": "spyder_boss",
@@ -145,6 +154,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor_black",
       "combat_front": "professor",
@@ -153,6 +163,8 @@
   },
   {
     "slug": "spyder_scoop_cochinia",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "cochini",
@@ -161,6 +173,8 @@
   },
   {
     "slug": "spyder_scoop_cochinib",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "cochini",
@@ -169,6 +183,8 @@
   },
   {
     "slug": "spyder_scoop_cochinic",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "cochini",
@@ -187,6 +203,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "cooldude_fiery",
       "combat_front": "cooldude",
@@ -195,6 +212,8 @@
   },
   {
     "slug": "spyder_scoop_landrace",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "landrace",
       "combat_front": "sludgehog",
@@ -213,6 +232,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -221,6 +241,8 @@
   },
   {
     "slug": "spyder_scoop_lapinoua",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "lapinou",
@@ -229,6 +251,8 @@
   },
   {
     "slug": "spyder_scoop_lapinoub",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "lapinou",
@@ -237,6 +261,8 @@
   },
   {
     "slug": "spyder_scoop_lapinouc",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "lapinou",
@@ -245,6 +271,8 @@
   },
   {
     "slug": "spyder_scoop_nash",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -253,6 +281,8 @@
   },
   {
     "slug": "spyder_scoop_reese",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/spyder_screen.json
+++ b/mods/tuxemon/db/npc/spyder_screen.json
@@ -1,5 +1,7 @@
 {
   "slug": "spyder_screen",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "screen",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_searoutec_alpha",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_red",
       "combat_front": "swimmer",
@@ -19,6 +21,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_orange",
       "combat_front": "swimmer",
@@ -37,6 +40,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "dragonrider_blue",
       "combat_front": "dragonrider",
@@ -55,6 +59,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_green",
       "combat_front": "swimmer",
@@ -73,6 +78,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -91,6 +97,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "fisher",
       "combat_front": "fisher",
@@ -109,6 +116,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "fisher_fiery",
       "combat_front": "fisher",
@@ -127,6 +135,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "swimmer",
       "combat_front": "swimmer",
@@ -145,6 +154,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_blue",
       "combat_front": "swimmer",
@@ -163,6 +173,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "yellowbelt",
@@ -181,6 +192,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_blue",
       "combat_front": "swimmer",
@@ -199,6 +211,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_blue",
       "combat_front": "yellowbelt",
@@ -217,6 +230,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_red",
       "combat_front": "swimmer",
@@ -225,6 +239,8 @@
   },
   {
     "slug": "spyder_searoutec_beta",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "swimmer_orange",
       "combat_front": "swimmer",

--- a/mods/tuxemon/db/npc/spyder_sign.json
+++ b/mods/tuxemon/db/npc/spyder_sign.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_sign",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "sign",
       "combat_front": "noclass",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_sign_flower1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "sign",
       "combat_front": "noclass",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_sign_flower2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "sign",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_statues.json
+++ b/mods/tuxemon/db/npc/spyder_statues.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_statue_blue",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "statue_blue",
       "combat_front": "noclass",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_statue_red",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "statue_red",
       "combat_front": "noclass",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_statue_orange",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "statue_orange",
       "combat_front": "noclass",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_statue_grey",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "statue_grey",
       "combat_front": "noclass",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_statue_green",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "statue_green",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_timber_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_timber_town_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_timberhouse_zed",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_timbercafe_grady",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "magician",
       "combat_front": "magician",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_outsidewalled_rogue",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "rogue_green",
       "combat_front": "rogue",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_outsidewalled_midas",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",

--- a/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "florist_brown",
       "combat_front": "florist",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_gray",
       "combat_front": "yellowbelt",
@@ -109,6 +115,8 @@
   },
   {
     "slug": "spyder_tunnelb_rhincus",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -117,6 +125,8 @@
   },
   {
     "slug": "spyder_tunnelb_shammer",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -125,6 +135,8 @@
   },
   {
     "slug": "spyder_tunnelb_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_tuxeballs.json
+++ b/mods/tuxemon/db/npc/spyder_tuxeballs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_tuxeball_green",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tuxeball_green",
       "combat_front": "noclass",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_tuxeball_red",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tuxeball_red",
       "combat_front": "noclass",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_tuxeball_violet",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tuxeball_violet",
       "combat_front": "noclass",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_tuxeball_yellow",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tuxeball_yellow",
       "combat_front": "noclass",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_tuxeball",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "tuxeball",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_unique_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_unique_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "spyder_dante",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "adventurer",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "spyder_shady",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "cooldude_blue",
       "combat_front": "cooldude",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "spyder_captain",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "spyder_billie",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "fashionista",
       "combat_front": "fashionista",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "spyder_cathedral_nurse",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "spyder_shopkeeper",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "shopassistant",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "spyder_shopassistant",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "shopassistant",

--- a/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -173,6 +182,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -191,6 +201,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -209,6 +220,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -227,6 +239,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",

--- a/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
@@ -11,6 +11,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -29,6 +30,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -47,6 +49,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -65,6 +68,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",
@@ -83,6 +87,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -101,6 +106,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -119,6 +125,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -137,6 +144,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -155,6 +163,7 @@
         }
       }
     },
+    "combat": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -163,6 +172,8 @@
   },
   {
     "slug": "spyder_wayfarer2_gae",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -171,6 +182,8 @@
   },
   {
     "slug": "spyder_wayfarer1_addy",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -179,6 +192,8 @@
   },
   {
     "slug": "spyder_wayfarer1_wes",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -187,6 +202,8 @@
   },
   {
     "slug": "spyder_wayfarer2_kim",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
@@ -195,6 +212,8 @@
   },
   {
     "slug": "spyder_wayfarer1_norm",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopkeeper_brown",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/taba_acolyte_1.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_1.json
@@ -1,5 +1,7 @@
 {
   "slug": "acolyte",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_2.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_2.json
@@ -1,5 +1,7 @@
 {
   "slug": "garth",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_3.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_3.json
@@ -1,5 +1,7 @@
 {
   "slug": "acolyte3",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_4.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_4.json
@@ -1,5 +1,7 @@
 {
   "slug": "loch",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_cam.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_cam.json
@@ -1,5 +1,7 @@
 {
   "slug": "cam",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_greeter.json
+++ b/mods/tuxemon/db/npc/taba_greeter.json
@@ -1,5 +1,7 @@
 {
   "slug": "taba_greeter",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "shopassistant",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/taba_houses.json
+++ b/mods/tuxemon/db/npc/taba_houses.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "taba_house1_husband",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "taba_house1_wife",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "heroine",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "taba_house2_owner",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "taba_house2_reader1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "heroine_brown",
       "combat_front": "heroine",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "taba_house2_reader2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "heroine_red",
       "combat_front": "heroine",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "taba_house3_owner",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker_black",
       "combat_front": "heroine",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "taba_house3_client1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "taba_house3_client2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -65,6 +81,8 @@
   },
   {
     "slug": "taba_house4_client1",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -73,6 +91,8 @@
   },
   {
     "slug": "taba_house4_waiter",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant_grey",
       "combat_front": "adventurer",
@@ -81,6 +101,8 @@
   },
   {
     "slug": "taba_house4_client2",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "shopassistant_red",
       "combat_front": "adventurer",
@@ -89,6 +111,8 @@
   },
   {
     "slug": "taba_house4_owner",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",

--- a/mods/tuxemon/db/npc/tabanurse.json
+++ b/mods/tuxemon/db/npc/tabanurse.json
@@ -1,5 +1,7 @@
 {
   "slug": "tabanurse",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "nurse",
     "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/tallon.json
+++ b/mods/tuxemon/db/npc/tallon.json
@@ -1,5 +1,7 @@
 {
   "slug": "tallon",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "ninja",
     "combat_front": "ninja",

--- a/mods/tuxemon/db/npc/test_npcs.json
+++ b/mods/tuxemon/db/npc/test_npcs.json
@@ -1,6 +1,8 @@
 [
   {
     "slug": "test_npc001",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -9,6 +11,8 @@
   },
   {
     "slug": "test_npc002",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -17,6 +21,8 @@
   },
   {
     "slug": "test_npc003",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -25,6 +31,8 @@
   },
   {
     "slug": "test_npc004",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -33,6 +41,8 @@
   },
   {
     "slug": "test_npc005",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -41,6 +51,8 @@
   },
   {
     "slug": "test_npc006",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -49,6 +61,8 @@
   },
   {
     "slug": "test_npc007",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -57,6 +71,8 @@
   },
   {
     "slug": "test_npc008",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -65,6 +81,8 @@
   },
   {
     "slug": "test_npc009",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -73,6 +91,8 @@
   },
   {
     "slug": "test_npc010",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -81,6 +101,8 @@
   },
   {
     "slug": "test_npc011",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -89,6 +111,8 @@
   },
   {
     "slug": "test_npc012",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -97,6 +121,8 @@
   },
   {
     "slug": "test_npc013",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -105,6 +131,8 @@
   },
   {
     "slug": "test_npc014",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -113,6 +141,8 @@
   },
   {
     "slug": "test_npc015",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -121,6 +151,8 @@
   },
   {
     "slug": "test_npc016",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -129,6 +161,8 @@
   },
   {
     "slug": "test_npc017",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -137,6 +171,8 @@
   },
   {
     "slug": "test_npc018",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -145,6 +181,8 @@
   },
   {
     "slug": "test_npc019",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -153,6 +191,8 @@
   },
   {
     "slug": "test_npc020",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -161,6 +201,8 @@
   },
   {
     "slug": "test_npc021",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -169,6 +211,8 @@
   },
   {
     "slug": "test_npc022",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -177,6 +221,8 @@
   },
   {
     "slug": "test_npc023",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -185,6 +231,8 @@
   },
   {
     "slug": "test_npc024",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -193,6 +241,8 @@
   },
   {
     "slug": "test_npc025",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -201,6 +251,8 @@
   },
   {
     "slug": "test_npc026",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -209,6 +261,8 @@
   },
   {
     "slug": "test_npc027",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -217,6 +271,8 @@
   },
   {
     "slug": "test_npc028",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -225,6 +281,8 @@
   },
   {
     "slug": "test_npc029",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -233,6 +291,8 @@
   },
   {
     "slug": "test_npc030",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -241,6 +301,8 @@
   },
   {
     "slug": "test_npc031",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -249,6 +311,8 @@
   },
   {
     "slug": "test_npc032",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -257,6 +321,8 @@
   },
   {
     "slug": "test_npc033",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -265,6 +331,8 @@
   },
   {
     "slug": "test_npc034",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -273,6 +341,8 @@
   },
   {
     "slug": "test_npc035",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -281,6 +351,8 @@
   },
   {
     "slug": "test_npc036",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -289,6 +361,8 @@
   },
   {
     "slug": "test_npc037",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -297,6 +371,8 @@
   },
   {
     "slug": "test_npc038",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -305,6 +381,8 @@
   },
   {
     "slug": "test_npc039",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -313,6 +391,8 @@
   },
   {
     "slug": "test_npc040",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -321,6 +401,8 @@
   },
   {
     "slug": "test_npc041",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -329,6 +411,8 @@
   },
   {
     "slug": "test_npc042",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -337,6 +421,8 @@
   },
   {
     "slug": "test_npc043",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -345,6 +431,8 @@
   },
   {
     "slug": "test_npc044",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -353,6 +441,8 @@
   },
   {
     "slug": "test_npc045",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -361,6 +451,8 @@
   },
   {
     "slug": "test_npc046",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -369,6 +461,8 @@
   },
   {
     "slug": "test_npc047",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -377,6 +471,8 @@
   },
   {
     "slug": "test_npc048",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -385,6 +481,8 @@
   },
   {
     "slug": "test_npc049",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -393,6 +491,8 @@
   },
   {
     "slug": "test_npc050",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -401,6 +501,8 @@
   },
   {
     "slug": "test_npc051",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -409,6 +511,8 @@
   },
   {
     "slug": "test_npc052",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -417,6 +521,8 @@
   },
   {
     "slug": "test_npc053",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -425,6 +531,8 @@
   },
   {
     "slug": "test_npc054",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -433,6 +541,8 @@
   },
   {
     "slug": "test_npc055",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -441,6 +551,8 @@
   },
   {
     "slug": "test_npc056",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -449,6 +561,8 @@
   },
   {
     "slug": "test_npc057",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -457,6 +571,8 @@
   },
   {
     "slug": "test_npc058",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -465,6 +581,8 @@
   },
   {
     "slug": "test_npc059",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -473,6 +591,8 @@
   },
   {
     "slug": "test_npc060",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -481,6 +601,8 @@
   },
   {
     "slug": "test_npc061",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -489,6 +611,8 @@
   },
   {
     "slug": "test_npc062",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -497,6 +621,8 @@
   },
   {
     "slug": "test_npc063",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -505,6 +631,8 @@
   },
   {
     "slug": "test_npc064",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -513,6 +641,8 @@
   },
   {
     "slug": "test_npc065",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -521,6 +651,8 @@
   },
   {
     "slug": "test_npc066",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -529,6 +661,8 @@
   },
   {
     "slug": "test_npc067",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -537,6 +671,8 @@
   },
   {
     "slug": "test_npc068",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -545,6 +681,8 @@
   },
   {
     "slug": "test_npc069",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -553,6 +691,8 @@
   },
   {
     "slug": "test_npc070",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -561,6 +701,8 @@
   },
   {
     "slug": "test_npc071",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -569,6 +711,8 @@
   },
   {
     "slug": "test_npc072",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -577,6 +721,8 @@
   },
   {
     "slug": "test_npc073",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -585,6 +731,8 @@
   },
   {
     "slug": "test_npc074",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -593,6 +741,8 @@
   },
   {
     "slug": "test_npc075",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -601,6 +751,8 @@
   },
   {
     "slug": "test_npc076",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -609,6 +761,8 @@
   },
   {
     "slug": "test_npc077",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -617,6 +771,8 @@
   },
   {
     "slug": "test_npc078",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -625,6 +781,8 @@
   },
   {
     "slug": "test_npc079",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -633,6 +791,8 @@
   },
   {
     "slug": "test_npc080",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -641,6 +801,8 @@
   },
   {
     "slug": "test_npc081",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -649,6 +811,8 @@
   },
   {
     "slug": "test_npc082",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -657,6 +821,8 @@
   },
   {
     "slug": "test_npc083",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -665,6 +831,8 @@
   },
   {
     "slug": "test_npc084",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -673,6 +841,8 @@
   },
   {
     "slug": "test_npc085",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -681,6 +851,8 @@
   },
   {
     "slug": "test_npc086",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -689,6 +861,8 @@
   },
   {
     "slug": "test_npc087",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -697,6 +871,8 @@
   },
   {
     "slug": "test_npc088",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -705,6 +881,8 @@
   },
   {
     "slug": "test_npc089",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -713,6 +891,8 @@
   },
   {
     "slug": "test_npc090",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -721,6 +901,8 @@
   },
   {
     "slug": "test_npc091",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -729,6 +911,8 @@
   },
   {
     "slug": "test_npc092",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -737,6 +921,8 @@
   },
   {
     "slug": "test_npc093",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -745,6 +931,8 @@
   },
   {
     "slug": "test_npc094",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -753,6 +941,8 @@
   },
   {
     "slug": "test_npc095",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -761,6 +951,8 @@
   },
   {
     "slug": "test_npc096",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -769,6 +961,8 @@
   },
   {
     "slug": "test_npc097",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -777,6 +971,8 @@
   },
   {
     "slug": "test_npc098",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -785,6 +981,8 @@
   },
   {
     "slug": "test_npc099",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -793,6 +991,8 @@
   },
   {
     "slug": "test_npc100",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -801,6 +1001,8 @@
   },
   {
     "slug": "test_npc101",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -809,6 +1011,8 @@
   },
   {
     "slug": "test_npc102",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -817,6 +1021,8 @@
   },
   {
     "slug": "test_npc103",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -825,6 +1031,8 @@
   },
   {
     "slug": "test_npc104",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -833,6 +1041,8 @@
   },
   {
     "slug": "test_npc105",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -841,6 +1051,8 @@
   },
   {
     "slug": "test_npc106",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -849,6 +1061,8 @@
   },
   {
     "slug": "test_npc107",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -857,6 +1071,8 @@
   },
   {
     "slug": "test_npc108",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -865,6 +1081,8 @@
   },
   {
     "slug": "test_npc109",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -873,6 +1091,8 @@
   },
   {
     "slug": "test_npc110",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -881,6 +1101,8 @@
   },
   {
     "slug": "test_npc111",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -889,6 +1111,8 @@
   },
   {
     "slug": "test_npc112",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -897,6 +1121,8 @@
   },
   {
     "slug": "test_npc113",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -905,6 +1131,8 @@
   },
   {
     "slug": "test_npc114",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -913,6 +1141,8 @@
   },
   {
     "slug": "test_npc115",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -921,6 +1151,8 @@
   },
   {
     "slug": "test_npc116",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -929,6 +1161,8 @@
   },
   {
     "slug": "test_npc117",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -937,6 +1171,8 @@
   },
   {
     "slug": "test_npc118",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -945,6 +1181,8 @@
   },
   {
     "slug": "test_npc119",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -953,6 +1191,8 @@
   },
   {
     "slug": "test_npc120",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -961,6 +1201,8 @@
   },
   {
     "slug": "test_npc121",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -969,6 +1211,8 @@
   },
   {
     "slug": "test_npc122",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -977,6 +1221,8 @@
   },
   {
     "slug": "test_npc123",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -985,6 +1231,8 @@
   },
   {
     "slug": "test_npc124",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -993,6 +1241,8 @@
   },
   {
     "slug": "test_npc125",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1001,6 +1251,8 @@
   },
   {
     "slug": "test_npc126",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1009,6 +1261,8 @@
   },
   {
     "slug": "test_npc127",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1017,6 +1271,8 @@
   },
   {
     "slug": "test_npc128",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1025,6 +1281,8 @@
   },
   {
     "slug": "test_npc129",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1033,6 +1291,8 @@
   },
   {
     "slug": "test_npc130",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1041,6 +1301,8 @@
   },
   {
     "slug": "test_npc131",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1049,6 +1311,8 @@
   },
   {
     "slug": "test_npc132",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1057,6 +1321,8 @@
   },
   {
     "slug": "test_npc133",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1065,6 +1331,8 @@
   },
   {
     "slug": "test_npc134",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1073,6 +1341,8 @@
   },
   {
     "slug": "test_npc135",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1081,6 +1351,8 @@
   },
   {
     "slug": "test_npc136",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1089,6 +1361,8 @@
   },
   {
     "slug": "test_npc137",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1097,6 +1371,8 @@
   },
   {
     "slug": "test_npc138",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1105,6 +1381,8 @@
   },
   {
     "slug": "test_npc139",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1113,6 +1391,8 @@
   },
   {
     "slug": "test_npc140",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1121,6 +1401,8 @@
   },
   {
     "slug": "test_npc141",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1129,6 +1411,8 @@
   },
   {
     "slug": "test_npc142",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1137,6 +1421,8 @@
   },
   {
     "slug": "test_npc143",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1145,6 +1431,8 @@
   },
   {
     "slug": "test_npc144",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1153,6 +1441,8 @@
   },
   {
     "slug": "test_npc145",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1161,6 +1451,8 @@
   },
   {
     "slug": "test_npc146",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1169,6 +1461,8 @@
   },
   {
     "slug": "test_npc147",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1177,6 +1471,8 @@
   },
   {
     "slug": "test_npc148",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1185,6 +1481,8 @@
   },
   {
     "slug": "test_npc149",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1193,6 +1491,8 @@
   },
   {
     "slug": "test_npc150",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1201,6 +1501,8 @@
   },
   {
     "slug": "test_npc151",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1209,6 +1511,8 @@
   },
   {
     "slug": "test_npc152",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1217,6 +1521,8 @@
   },
   {
     "slug": "test_npc153",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1225,6 +1531,8 @@
   },
   {
     "slug": "test_npc154",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1233,6 +1541,8 @@
   },
   {
     "slug": "test_npc155",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1241,6 +1551,8 @@
   },
   {
     "slug": "test_npc156",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1249,6 +1561,8 @@
   },
   {
     "slug": "test_npc157",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1257,6 +1571,8 @@
   },
   {
     "slug": "test_npc158",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1265,6 +1581,8 @@
   },
   {
     "slug": "test_npc159",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1273,6 +1591,8 @@
   },
   {
     "slug": "test_npc160",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1281,6 +1601,8 @@
   },
   {
     "slug": "test_npc161",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1289,6 +1611,8 @@
   },
   {
     "slug": "test_npc162",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1297,6 +1621,8 @@
   },
   {
     "slug": "test_npc163",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1305,6 +1631,8 @@
   },
   {
     "slug": "test_npc164",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1313,6 +1641,8 @@
   },
   {
     "slug": "test_npc165",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1321,6 +1651,8 @@
   },
   {
     "slug": "test_npc166",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1329,6 +1661,8 @@
   },
   {
     "slug": "test_npc167",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1337,6 +1671,8 @@
   },
   {
     "slug": "test_npc168",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1345,6 +1681,8 @@
   },
   {
     "slug": "test_npc169",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1353,6 +1691,8 @@
   },
   {
     "slug": "test_npc170",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1361,6 +1701,8 @@
   },
   {
     "slug": "test_npc171",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1369,6 +1711,8 @@
   },
   {
     "slug": "test_npc172",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1377,6 +1721,8 @@
   },
   {
     "slug": "test_npc173",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1385,6 +1731,8 @@
   },
   {
     "slug": "test_npc174",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1393,6 +1741,8 @@
   },
   {
     "slug": "test_npc175",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1401,6 +1751,8 @@
   },
   {
     "slug": "test_npc176",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1409,6 +1761,8 @@
   },
   {
     "slug": "test_npc177",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1417,6 +1771,8 @@
   },
   {
     "slug": "test_npc178",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1425,6 +1781,8 @@
   },
   {
     "slug": "test_npc179",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1433,6 +1791,8 @@
   },
   {
     "slug": "test_npc180",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1441,6 +1801,8 @@
   },
   {
     "slug": "test_npc181",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1449,6 +1811,8 @@
   },
   {
     "slug": "test_npc182",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1457,6 +1821,8 @@
   },
   {
     "slug": "test_npc183",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1465,6 +1831,8 @@
   },
   {
     "slug": "test_npc184",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1473,6 +1841,8 @@
   },
   {
     "slug": "test_npc185",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1481,6 +1851,8 @@
   },
   {
     "slug": "test_npc186",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1489,6 +1861,8 @@
   },
   {
     "slug": "test_npc187",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1497,6 +1871,8 @@
   },
   {
     "slug": "test_npc188",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1505,6 +1881,8 @@
   },
   {
     "slug": "test_npc189",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1513,6 +1891,8 @@
   },
   {
     "slug": "test_npc190",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1521,6 +1901,8 @@
   },
   {
     "slug": "test_npc191",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1529,6 +1911,8 @@
   },
   {
     "slug": "test_npc192",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1537,6 +1921,8 @@
   },
   {
     "slug": "test_npc193",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1545,6 +1931,8 @@
   },
   {
     "slug": "test_npc194",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1553,6 +1941,8 @@
   },
   {
     "slug": "test_npc195",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1561,6 +1951,8 @@
   },
   {
     "slug": "test_npc196",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1569,6 +1961,8 @@
   },
   {
     "slug": "test_npc197",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1577,6 +1971,8 @@
   },
   {
     "slug": "test_npc198",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1585,6 +1981,8 @@
   },
   {
     "slug": "test_npc199",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1593,6 +1991,8 @@
   },
   {
     "slug": "test_npc200",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1601,6 +2001,8 @@
   },
   {
     "slug": "test_npc201",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1609,6 +2011,8 @@
   },
   {
     "slug": "test_npc202",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1617,6 +2021,8 @@
   },
   {
     "slug": "test_npc203",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1625,6 +2031,8 @@
   },
   {
     "slug": "test_npc204",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1633,6 +2041,8 @@
   },
   {
     "slug": "test_npc205",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1641,6 +2051,8 @@
   },
   {
     "slug": "test_npc206",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1649,6 +2061,8 @@
   },
   {
     "slug": "test_npc207",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1657,6 +2071,8 @@
   },
   {
     "slug": "test_npc208",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1665,6 +2081,8 @@
   },
   {
     "slug": "test_npc209",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1673,6 +2091,8 @@
   },
   {
     "slug": "test_npc210",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1681,6 +2101,8 @@
   },
   {
     "slug": "test_npc211",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1689,6 +2111,8 @@
   },
   {
     "slug": "test_npc212",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1697,6 +2121,8 @@
   },
   {
     "slug": "test_npc213",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1705,6 +2131,8 @@
   },
   {
     "slug": "test_npc214",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1713,6 +2141,8 @@
   },
   {
     "slug": "test_npc215",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1721,6 +2151,8 @@
   },
   {
     "slug": "test_npc216",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1729,6 +2161,8 @@
   },
   {
     "slug": "test_npc217",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1737,6 +2171,8 @@
   },
   {
     "slug": "test_npc218",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1745,6 +2181,8 @@
   },
   {
     "slug": "test_npc219",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1753,6 +2191,8 @@
   },
   {
     "slug": "test_npc220",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1761,6 +2201,8 @@
   },
   {
     "slug": "test_npc221",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1769,6 +2211,8 @@
   },
   {
     "slug": "test_npc222",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1777,6 +2221,8 @@
   },
   {
     "slug": "test_npc223",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1785,6 +2231,8 @@
   },
   {
     "slug": "test_npc224",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1793,6 +2241,8 @@
   },
   {
     "slug": "test_npc225",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1801,6 +2251,8 @@
   },
   {
     "slug": "test_npc226",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1809,6 +2261,8 @@
   },
   {
     "slug": "test_npc227",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1817,6 +2271,8 @@
   },
   {
     "slug": "test_npc228",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1825,6 +2281,8 @@
   },
   {
     "slug": "test_npc229",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1833,6 +2291,8 @@
   },
   {
     "slug": "test_npc230",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1841,6 +2301,8 @@
   },
   {
     "slug": "test_npc231",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1849,6 +2311,8 @@
   },
   {
     "slug": "test_npc232",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1857,6 +2321,8 @@
   },
   {
     "slug": "test_npc233",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1865,6 +2331,8 @@
   },
   {
     "slug": "test_npc234",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1873,6 +2341,8 @@
   },
   {
     "slug": "test_npc235",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1881,6 +2351,8 @@
   },
   {
     "slug": "test_npc236",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1889,6 +2361,8 @@
   },
   {
     "slug": "test_npc237",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1897,6 +2371,8 @@
   },
   {
     "slug": "test_npc238",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1905,6 +2381,8 @@
   },
   {
     "slug": "test_npc239",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1913,6 +2391,8 @@
   },
   {
     "slug": "test_npc240",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1921,6 +2401,8 @@
   },
   {
     "slug": "test_npc241",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1929,6 +2411,8 @@
   },
   {
     "slug": "test_npc242",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1937,6 +2421,8 @@
   },
   {
     "slug": "test_npc243",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1945,6 +2431,8 @@
   },
   {
     "slug": "test_npc244",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1953,6 +2441,8 @@
   },
   {
     "slug": "test_npc245",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1961,6 +2451,8 @@
   },
   {
     "slug": "test_npc246",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1969,6 +2461,8 @@
   },
   {
     "slug": "test_npc247",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1977,6 +2471,8 @@
   },
   {
     "slug": "test_npc248",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1985,6 +2481,8 @@
   },
   {
     "slug": "test_npc249",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1993,6 +2491,8 @@
   },
   {
     "slug": "test_npc250",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2001,6 +2501,8 @@
   },
   {
     "slug": "test_npc251",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2009,6 +2511,8 @@
   },
   {
     "slug": "test_npc252",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2017,6 +2521,8 @@
   },
   {
     "slug": "test_npc253",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2025,6 +2531,8 @@
   },
   {
     "slug": "test_npc254",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2033,6 +2541,8 @@
   },
   {
     "slug": "test_npc255",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2041,6 +2551,8 @@
   },
   {
     "slug": "test_npc256",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2049,6 +2561,8 @@
   },
   {
     "slug": "test_npc257",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2057,6 +2571,8 @@
   },
   {
     "slug": "test_npc258",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2065,6 +2581,8 @@
   },
   {
     "slug": "test_npc259",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2073,6 +2591,8 @@
   },
   {
     "slug": "test_npc260",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2081,6 +2601,8 @@
   },
   {
     "slug": "test_npc261",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2089,6 +2611,8 @@
   },
   {
     "slug": "test_npc262",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2097,6 +2621,8 @@
   },
   {
     "slug": "test_npc263",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2105,6 +2631,8 @@
   },
   {
     "slug": "test_npc264",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2113,6 +2641,8 @@
   },
   {
     "slug": "test_npc265",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2121,6 +2651,8 @@
   },
   {
     "slug": "test_npc266",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2129,6 +2661,8 @@
   },
   {
     "slug": "test_npc267",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2137,6 +2671,8 @@
   },
   {
     "slug": "test_npc268",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2145,6 +2681,8 @@
   },
   {
     "slug": "test_npc269",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2153,6 +2691,8 @@
   },
   {
     "slug": "test_npc270",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2161,6 +2701,8 @@
   },
   {
     "slug": "test_npc271",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2169,6 +2711,8 @@
   },
   {
     "slug": "test_npc272",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2177,6 +2721,8 @@
   },
   {
     "slug": "test_npc273",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2185,6 +2731,8 @@
   },
   {
     "slug": "test_npc274",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2193,6 +2741,8 @@
   },
   {
     "slug": "test_npc275",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2201,6 +2751,8 @@
   },
   {
     "slug": "test_npc276",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2209,6 +2761,8 @@
   },
   {
     "slug": "test_npc277",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2217,6 +2771,8 @@
   },
   {
     "slug": "test_npc278",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2225,6 +2781,8 @@
   },
   {
     "slug": "test_npc279",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2233,6 +2791,8 @@
   },
   {
     "slug": "test_npc280",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2241,6 +2801,8 @@
   },
   {
     "slug": "test_npc281",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2249,6 +2811,8 @@
   },
   {
     "slug": "test_npc282",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2257,6 +2821,8 @@
   },
   {
     "slug": "test_npc283",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2265,6 +2831,8 @@
   },
   {
     "slug": "test_npc284",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2273,6 +2841,8 @@
   },
   {
     "slug": "test_npc285",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2281,6 +2851,8 @@
   },
   {
     "slug": "test_npc286",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2289,6 +2861,8 @@
   },
   {
     "slug": "test_npc287",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2297,6 +2871,8 @@
   },
   {
     "slug": "test_npc288",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2305,6 +2881,8 @@
   },
   {
     "slug": "test_npc289",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2313,6 +2891,8 @@
   },
   {
     "slug": "test_npc290",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2321,6 +2901,8 @@
   },
   {
     "slug": "test_npc291",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2329,6 +2911,8 @@
   },
   {
     "slug": "test_npc292",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2337,6 +2921,8 @@
   },
   {
     "slug": "test_npc293",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2345,6 +2931,8 @@
   },
   {
     "slug": "test_npc294",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2353,6 +2941,8 @@
   },
   {
     "slug": "test_npc295",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2361,6 +2951,8 @@
   },
   {
     "slug": "test_npc296",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2369,6 +2961,8 @@
   },
   {
     "slug": "test_npc297",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2377,6 +2971,8 @@
   },
   {
     "slug": "test_npc298",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2385,6 +2981,8 @@
   },
   {
     "slug": "test_npc299",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2393,6 +2991,8 @@
   },
   {
     "slug": "test_npc300",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2401,6 +3001,8 @@
   },
   {
     "slug": "test_npc301",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2409,6 +3011,8 @@
   },
   {
     "slug": "test_npc302",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2417,6 +3021,8 @@
   },
   {
     "slug": "test_npc303",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2425,6 +3031,8 @@
   },
   {
     "slug": "test_npc304",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2433,6 +3041,8 @@
   },
   {
     "slug": "test_npc305",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2441,6 +3051,8 @@
   },
   {
     "slug": "test_npc306",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2449,6 +3061,8 @@
   },
   {
     "slug": "test_npc307",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2457,6 +3071,8 @@
   },
   {
     "slug": "test_npc308",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2465,6 +3081,8 @@
   },
   {
     "slug": "test_npc309",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2473,6 +3091,8 @@
   },
   {
     "slug": "test_npc310",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2481,6 +3101,8 @@
   },
   {
     "slug": "test_npc311",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2489,6 +3111,8 @@
   },
   {
     "slug": "test_npc312",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2497,6 +3121,8 @@
   },
   {
     "slug": "test_npc313",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2505,6 +3131,8 @@
   },
   {
     "slug": "test_npc314",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2513,6 +3141,8 @@
   },
   {
     "slug": "test_npc315",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2521,6 +3151,8 @@
   },
   {
     "slug": "test_npc316",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2529,6 +3161,8 @@
   },
   {
     "slug": "test_npc317",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2537,6 +3171,8 @@
   },
   {
     "slug": "test_npc318",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2545,6 +3181,8 @@
   },
   {
     "slug": "test_npc319",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2553,6 +3191,8 @@
   },
   {
     "slug": "test_npc320",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2561,6 +3201,8 @@
   },
   {
     "slug": "test_npc321",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2569,6 +3211,8 @@
   },
   {
     "slug": "test_npc322",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2577,6 +3221,8 @@
   },
   {
     "slug": "test_npc323",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2585,6 +3231,8 @@
   },
   {
     "slug": "test_npc324",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2593,6 +3241,8 @@
   },
   {
     "slug": "test_npc325",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2601,6 +3251,8 @@
   },
   {
     "slug": "test_npc326",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2609,6 +3261,8 @@
   },
   {
     "slug": "test_npc327",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2617,6 +3271,8 @@
   },
   {
     "slug": "test_npc328",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2625,6 +3281,8 @@
   },
   {
     "slug": "test_npc329",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2633,6 +3291,8 @@
   },
   {
     "slug": "test_npc330",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2641,6 +3301,8 @@
   },
   {
     "slug": "test_npc331",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2649,6 +3311,8 @@
   },
   {
     "slug": "test_npc332",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2657,6 +3321,8 @@
   },
   {
     "slug": "test_npc333",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2665,6 +3331,8 @@
   },
   {
     "slug": "test_npc334",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2673,6 +3341,8 @@
   },
   {
     "slug": "test_npc335",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2681,6 +3351,8 @@
   },
   {
     "slug": "test_npc336",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2689,6 +3361,8 @@
   },
   {
     "slug": "test_npc337",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2697,6 +3371,8 @@
   },
   {
     "slug": "test_npc338",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2705,6 +3381,8 @@
   },
   {
     "slug": "test_npc339",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2713,6 +3391,8 @@
   },
   {
     "slug": "test_npc340",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2721,6 +3401,8 @@
   },
   {
     "slug": "test_npc341",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2729,6 +3411,8 @@
   },
   {
     "slug": "test_npc342",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2737,6 +3421,8 @@
   },
   {
     "slug": "test_npc343",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2745,6 +3431,8 @@
   },
   {
     "slug": "test_npc344",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2753,6 +3441,8 @@
   },
   {
     "slug": "test_npc345",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2761,6 +3451,8 @@
   },
   {
     "slug": "test_npc346",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2769,6 +3461,8 @@
   },
   {
     "slug": "test_npc347",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2777,6 +3471,8 @@
   },
   {
     "slug": "test_npc348",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2785,6 +3481,8 @@
   },
   {
     "slug": "test_npc349",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2793,6 +3491,8 @@
   },
   {
     "slug": "test_npc350",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2801,6 +3501,8 @@
   },
   {
     "slug": "test_npc351",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2809,6 +3511,8 @@
   },
   {
     "slug": "test_npc352",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2817,6 +3521,8 @@
   },
   {
     "slug": "test_npc353",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2825,6 +3531,8 @@
   },
   {
     "slug": "test_npc354",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2833,6 +3541,8 @@
   },
   {
     "slug": "test_npc355",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2841,6 +3551,8 @@
   },
   {
     "slug": "test_npc356",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2849,6 +3561,8 @@
   },
   {
     "slug": "test_npc357",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2857,6 +3571,8 @@
   },
   {
     "slug": "test_npc358",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2865,6 +3581,8 @@
   },
   {
     "slug": "test_npc359",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2873,6 +3591,8 @@
   },
   {
     "slug": "test_npc360",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2881,6 +3601,8 @@
   },
   {
     "slug": "test_npc361",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2889,6 +3611,8 @@
   },
   {
     "slug": "test_npc362",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2897,6 +3621,8 @@
   },
   {
     "slug": "test_npc363",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2905,6 +3631,8 @@
   },
   {
     "slug": "test_npc364",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2913,6 +3641,8 @@
   },
   {
     "slug": "test_npc365",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2921,6 +3651,8 @@
   },
   {
     "slug": "test_npc366",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2929,6 +3661,8 @@
   },
   {
     "slug": "test_npc367",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2937,6 +3671,8 @@
   },
   {
     "slug": "test_npc368",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2945,6 +3681,8 @@
   },
   {
     "slug": "test_npc369",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2953,6 +3691,8 @@
   },
   {
     "slug": "test_npc370",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2961,6 +3701,8 @@
   },
   {
     "slug": "test_npc371",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2969,6 +3711,8 @@
   },
   {
     "slug": "test_npc372",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2977,6 +3721,8 @@
   },
   {
     "slug": "test_npc373",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2985,6 +3731,8 @@
   },
   {
     "slug": "test_npc374",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2993,6 +3741,8 @@
   },
   {
     "slug": "test_npc375",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3001,6 +3751,8 @@
   },
   {
     "slug": "test_npc376",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3009,6 +3761,8 @@
   },
   {
     "slug": "test_npc377",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3017,6 +3771,8 @@
   },
   {
     "slug": "test_npc378",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3025,6 +3781,8 @@
   },
   {
     "slug": "test_npc379",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3033,6 +3791,8 @@
   },
   {
     "slug": "test_npc380",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3041,6 +3801,8 @@
   },
   {
     "slug": "test_npc381",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3049,6 +3811,8 @@
   },
   {
     "slug": "test_npc382",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3057,6 +3821,8 @@
   },
   {
     "slug": "test_npc383",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3065,6 +3831,8 @@
   },
   {
     "slug": "test_npc384",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3073,6 +3841,8 @@
   },
   {
     "slug": "test_npc385",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3081,6 +3851,8 @@
   },
   {
     "slug": "test_npc386",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3089,6 +3861,8 @@
   },
   {
     "slug": "test_npc387",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3097,6 +3871,8 @@
   },
   {
     "slug": "test_npc388",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3105,6 +3881,8 @@
   },
   {
     "slug": "test_npc389",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3113,6 +3891,8 @@
   },
   {
     "slug": "test_npc390",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3121,6 +3901,8 @@
   },
   {
     "slug": "test_npc391",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3129,6 +3911,8 @@
   },
   {
     "slug": "test_npc392",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3137,6 +3921,8 @@
   },
   {
     "slug": "test_npc393",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3145,6 +3931,8 @@
   },
   {
     "slug": "test_npc394",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3153,6 +3941,8 @@
   },
   {
     "slug": "test_npc395",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3161,6 +3951,8 @@
   },
   {
     "slug": "test_npc396",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3169,6 +3961,8 @@
   },
   {
     "slug": "test_npc397",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3177,6 +3971,8 @@
   },
   {
     "slug": "test_npc398",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3185,6 +3981,8 @@
   },
   {
     "slug": "test_npc399",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3193,6 +3991,8 @@
   },
   {
     "slug": "test_npc400",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3201,6 +4001,8 @@
   },
   {
     "slug": "test_npc401",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3209,6 +4011,8 @@
   },
   {
     "slug": "test_npc402",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3217,6 +4021,8 @@
   },
   {
     "slug": "test_npc403",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3225,6 +4031,8 @@
   },
   {
     "slug": "test_npc404",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3233,6 +4041,8 @@
   },
   {
     "slug": "test_npc405",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3241,6 +4051,8 @@
   },
   {
     "slug": "test_npc406",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3249,6 +4061,8 @@
   },
   {
     "slug": "test_npc407",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3257,6 +4071,8 @@
   },
   {
     "slug": "test_npc408",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3265,6 +4081,8 @@
   },
   {
     "slug": "test_npc409",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3273,6 +4091,8 @@
   },
   {
     "slug": "test_npc410",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3281,6 +4101,8 @@
   },
   {
     "slug": "test_npc411",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3289,6 +4111,8 @@
   },
   {
     "slug": "test_npc412",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3297,6 +4121,8 @@
   },
   {
     "slug": "test_npc413",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3305,6 +4131,8 @@
   },
   {
     "slug": "test_npc414",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3313,6 +4141,8 @@
   },
   {
     "slug": "test_npc415",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3321,6 +4151,8 @@
   },
   {
     "slug": "test_npc416",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3329,6 +4161,8 @@
   },
   {
     "slug": "test_npc417",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3337,6 +4171,8 @@
   },
   {
     "slug": "test_npc418",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3345,6 +4181,8 @@
   },
   {
     "slug": "test_npc419",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3353,6 +4191,8 @@
   },
   {
     "slug": "test_npc420",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3361,6 +4201,8 @@
   },
   {
     "slug": "test_npc421",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3369,6 +4211,8 @@
   },
   {
     "slug": "test_npc422",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3377,6 +4221,8 @@
   },
   {
     "slug": "test_npc423",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3385,6 +4231,8 @@
   },
   {
     "slug": "test_npc424",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3393,6 +4241,8 @@
   },
   {
     "slug": "test_npc425",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3401,6 +4251,8 @@
   },
   {
     "slug": "test_npc426",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3409,6 +4261,8 @@
   },
   {
     "slug": "test_npc427",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3417,6 +4271,8 @@
   },
   {
     "slug": "test_npc428",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3425,6 +4281,8 @@
   },
   {
     "slug": "test_npc429",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3433,6 +4291,8 @@
   },
   {
     "slug": "test_npc430",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3441,6 +4301,8 @@
   },
   {
     "slug": "test_npc431",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3449,6 +4311,8 @@
   },
   {
     "slug": "test_npc432",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3457,6 +4321,8 @@
   },
   {
     "slug": "test_npc433",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3465,6 +4331,8 @@
   },
   {
     "slug": "test_npc434",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3473,6 +4341,8 @@
   },
   {
     "slug": "test_npc435",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3481,6 +4351,8 @@
   },
   {
     "slug": "test_npc436",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3489,6 +4361,8 @@
   },
   {
     "slug": "test_npc437",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3497,6 +4371,8 @@
   },
   {
     "slug": "test_npc438",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3505,6 +4381,8 @@
   },
   {
     "slug": "test_npc439",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3513,6 +4391,8 @@
   },
   {
     "slug": "test_npc440",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3521,6 +4401,8 @@
   },
   {
     "slug": "test_npc441",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3529,6 +4411,8 @@
   },
   {
     "slug": "test_npc442",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3537,6 +4421,8 @@
   },
   {
     "slug": "test_npc443",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3545,6 +4431,8 @@
   },
   {
     "slug": "test_npc444",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3553,6 +4441,8 @@
   },
   {
     "slug": "test_npc445",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3561,6 +4451,8 @@
   },
   {
     "slug": "test_npc446",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3569,6 +4461,8 @@
   },
   {
     "slug": "test_npc447",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3577,6 +4471,8 @@
   },
   {
     "slug": "test_npc448",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3585,6 +4481,8 @@
   },
   {
     "slug": "test_npc449",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3593,6 +4491,8 @@
   },
   {
     "slug": "test_npc450",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3601,6 +4501,8 @@
   },
   {
     "slug": "test_npc451",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3609,6 +4511,8 @@
   },
   {
     "slug": "test_npc452",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3617,6 +4521,8 @@
   },
   {
     "slug": "test_npc453",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3625,6 +4531,8 @@
   },
   {
     "slug": "test_npc454",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3633,6 +4541,8 @@
   },
   {
     "slug": "test_npc455",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3641,6 +4551,8 @@
   },
   {
     "slug": "test_npc456",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3649,6 +4561,8 @@
   },
   {
     "slug": "test_npc457",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3657,6 +4571,8 @@
   },
   {
     "slug": "test_npc458",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3665,6 +4581,8 @@
   },
   {
     "slug": "test_npc459",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3673,6 +4591,8 @@
   },
   {
     "slug": "test_npc460",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3681,6 +4601,8 @@
   },
   {
     "slug": "test_npc461",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3689,6 +4611,8 @@
   },
   {
     "slug": "test_npc462",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3697,6 +4621,8 @@
   },
   {
     "slug": "test_npc463",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3705,6 +4631,8 @@
   },
   {
     "slug": "test_npc464",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3713,6 +4641,8 @@
   },
   {
     "slug": "test_npc465",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3721,6 +4651,8 @@
   },
   {
     "slug": "test_npc466",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3729,6 +4661,8 @@
   },
   {
     "slug": "test_npc467",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3737,6 +4671,8 @@
   },
   {
     "slug": "test_npc468",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3745,6 +4681,8 @@
   },
   {
     "slug": "test_npc469",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3753,6 +4691,8 @@
   },
   {
     "slug": "test_npc470",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3761,6 +4701,8 @@
   },
   {
     "slug": "test_npc471",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3769,6 +4711,8 @@
   },
   {
     "slug": "test_npc472",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3777,6 +4721,8 @@
   },
   {
     "slug": "test_npc473",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3785,6 +4731,8 @@
   },
   {
     "slug": "test_npc474",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3793,6 +4741,8 @@
   },
   {
     "slug": "test_npc475",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3801,6 +4751,8 @@
   },
   {
     "slug": "test_npc476",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3809,6 +4761,8 @@
   },
   {
     "slug": "test_npc477",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3817,6 +4771,8 @@
   },
   {
     "slug": "test_npc478",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3825,6 +4781,8 @@
   },
   {
     "slug": "test_npc479",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3833,6 +4791,8 @@
   },
   {
     "slug": "test_npc480",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3841,6 +4801,8 @@
   },
   {
     "slug": "test_npc481",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3849,6 +4811,8 @@
   },
   {
     "slug": "test_npc482",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3857,6 +4821,8 @@
   },
   {
     "slug": "test_npc483",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3865,6 +4831,8 @@
   },
   {
     "slug": "test_npc484",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3873,6 +4841,8 @@
   },
   {
     "slug": "test_npc485",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3881,6 +4851,8 @@
   },
   {
     "slug": "test_npc486",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3889,6 +4861,8 @@
   },
   {
     "slug": "test_npc487",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3897,6 +4871,8 @@
   },
   {
     "slug": "test_npc488",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3905,6 +4881,8 @@
   },
   {
     "slug": "test_npc489",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3913,6 +4891,8 @@
   },
   {
     "slug": "test_npc490",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3921,6 +4901,8 @@
   },
   {
     "slug": "test_npc491",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3929,6 +4911,8 @@
   },
   {
     "slug": "test_npc492",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3937,6 +4921,8 @@
   },
   {
     "slug": "test_npc493",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3945,6 +4931,8 @@
   },
   {
     "slug": "test_npc494",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3953,6 +4941,8 @@
   },
   {
     "slug": "test_npc495",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3961,6 +4951,8 @@
   },
   {
     "slug": "test_npc496",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3969,6 +4961,8 @@
   },
   {
     "slug": "test_npc497",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3977,6 +4971,8 @@
   },
   {
     "slug": "test_npc498",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3985,6 +4981,8 @@
   },
   {
     "slug": "test_npc499",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3993,6 +4991,8 @@
   },
   {
     "slug": "test_npc500",
+    "speech": {"profile": {"default": {}}},
+    "combat": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/timmy.json
+++ b/mods/tuxemon/db/npc/timmy.json
@@ -1,6 +1,8 @@
 {
   "slug": "timmy",
   "gender": "male",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "childactor",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/tuxeball.json
+++ b/mods/tuxemon/db/npc/tuxeball.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxeball",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "tuxeball",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_green.json
+++ b/mods/tuxemon/db/npc/tuxeball_green.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxeball_green",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "tuxeball_green",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_red.json
+++ b/mods/tuxemon/db/npc/tuxeball_red.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxeball_red",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "tuxeball_red",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_violet.json
+++ b/mods/tuxemon/db/npc/tuxeball_violet.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxeball_violet",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "tuxeball_violet",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_yellow.json
+++ b/mods/tuxemon/db/npc/tuxeball_yellow.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxeball_yellow",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "tuxeball_yellow",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxemart.json
+++ b/mods/tuxemon/db/npc/tuxemart.json
@@ -1,5 +1,7 @@
 {
   "slug": "tuxemart_keeper",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "shopassistant",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/wild_encounter.json
+++ b/mods/tuxemon/db/npc/wild_encounter.json
@@ -1,5 +1,7 @@
 {
   "slug": "wild_encounter",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "invisible",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/xerogrund1.json
+++ b/mods/tuxemon/db/npc/xerogrund1.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrund1",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrund2.json
+++ b/mods/tuxemon/db/npc/xerogrund2.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrund2",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt1.json
+++ b/mods/tuxemon/db/npc/xerogrunt1.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt1",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt10.json
+++ b/mods/tuxemon/db/npc/xerogrunt10.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt10",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt2.json
+++ b/mods/tuxemon/db/npc/xerogrunt2.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt2",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt3.json
+++ b/mods/tuxemon/db/npc/xerogrunt3.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt3",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt4.json
+++ b/mods/tuxemon/db/npc/xerogrunt4.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt4",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt5.json
+++ b/mods/tuxemon/db/npc/xerogrunt5.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt5",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt6.json
+++ b/mods/tuxemon/db/npc/xerogrunt6.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt6",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt7.json
+++ b/mods/tuxemon/db/npc/xerogrunt7.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt7",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt8.json
+++ b/mods/tuxemon/db/npc/xerogrunt8.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt8",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt9.json
+++ b/mods/tuxemon/db/npc/xerogrunt9.json
@@ -1,5 +1,7 @@
 {
   "slug": "xerogrunt9",
+  "speech": {"profile": {"default": {}}},
+  "combat": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -480,7 +480,7 @@ class AIManager:
             )
             return available_monsters[0]
 
-        strategy = getattr(character, "strategy", None)
+        strategy = character.combat.switch_logic
         logger.debug(f"{character.name} strategy: {strategy}")
 
         # If no strategy, pick the next available monster in order

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1403,20 +1403,32 @@ class NpcSpeech(BaseModel):
     )
 
 
+class NpcCombatModel(BaseModel):
+    forfeit: bool = Field(
+        False,
+        description="Whether the NPC allows the player to forfeit during combat",
+    )
+    switch_logic: Optional[str] = Field(
+        None,
+        description=(
+            "Defines how the NPC selects a replacement monster when one faints. "
+            "Examples include 'random', 'lv_highest', or 'healthiest'."
+        ),
+    )
+
+
 class NpcModel(BaseModel, BaseLookupModel):
     table_name: ClassVar[str] = "npc"
     slug: str = Field(..., description="Slug of the name of the NPC")
-    forfeit: bool = Field(False, description="Whether you can forfeit or not")
     template: NpcTemplateModel
+    combat: NpcCombatModel
     monsters: Sequence[PartyMemberModel] = Field(
         [], description="List of monsters in the NPCs party"
     )
     items: Sequence[BagItemModel] = Field(
         [], description="List of items in the NPCs bag"
     )
-    speech: Optional[NpcSpeech] = Field(
-        None, description="Dialogue for this NPC"
-    )
+    speech: NpcSpeech
 
     @classmethod
     def lookup(cls, slug: str, db: ModData) -> NpcModel:

--- a/tuxemon/entity_dir/dialogue_profile.py
+++ b/tuxemon/entity_dir/dialogue_profile.py
@@ -25,8 +25,7 @@ class DialogueProfileManager:
         """
         if npc_slug not in self.dialogue_cache:
             npc_details: NpcModel = NpcModel.lookup(npc_slug, db)
-            if npc_details.speech:
-                self.dialogue_cache[npc_slug] = npc_details.speech.profile
+            self.dialogue_cache[npc_slug] = npc_details.speech.profile
 
         dialogue_model = self.dialogue_cache[npc_slug]
 

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -65,15 +65,14 @@ class CreateNpcAction(EventAction):
         npc.behavior = self.behavior
         npc_details = load_party(slug)
         npc.template = npc_details.template
-        npc.forfeit = npc_details.forfeit
+        npc.combat = npc_details.combat
         game_variables = session.player.game_variables
         if npc_details.monsters:
             load_party_monsters(npc, npc_details, game_variables)
         if npc_details.items:
             load_party_items(npc, npc_details, game_variables)
         npc.sprite_controller.load_sprites(npc.template)
-        if npc_details.speech:
-            npc.dialogue = merge_dialogue(npc_details.speech.profile, None)
+        npc.dialogue = merge_dialogue(npc_details.speech.profile, None)
 
 
 lookup_cache: dict[str, NpcModel] = {}

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -100,6 +100,7 @@ class NPC(Entity[NPCState]):
         # load initial data from the npc database
         npc_data = NpcModel.lookup(npc_slug, db)
         self.template = npc_data.template
+        self.combat = npc_data.combat
 
         # This is the NPC's name to be used in dialog
         self.name = T.translate(self.slug)
@@ -108,7 +109,6 @@ class NPC(Entity[NPCState]):
         self.behavior: Optional[str] = "wander"  # not used for now
         self.game_variables: dict[str, Any] = {}  # Tracks the game state
         self.battle_handler = BattlesHandler()
-        self.forfeit: bool = False
         # Tracks Tuxepedia (monster seen or caught)
         self.tuxepedia = Tuxepedia()
         self.relationships = Relationships()

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -65,7 +65,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             self.enemy = cmb.players[0]
             self.opponents = cmb.field_monsters.get_monsters(self.enemy)
         self.menu_visibility = cmb._menu_visibility
-        self.menu_visibility.menu_forfeit = self.enemy.forfeit
+        self.menu_visibility.menu_forfeit = self.enemy.combat.forfeit
         params = {"name": monster.name}
         message = T.format("combat_monster_choice", params)
         self.combat.dialog.alert(message)


### PR DESCRIPTION
PR follows up on #3019 by introducing a new `combat` submodel within `NpcModel`, designed to encapsulate all combat-related configuration for NPCs.

Specifically:
- added `NpcCombatModel` as a dedicated submodel for combat logic
- moved `forfeit` from the root of `NpcModel` into `NpcCombatModel` for better semantic grouping
- introduced `switch_logic`** field to define how NPCs choose replacement monsters during battle (e.g., `"random"`, `"lv_highest"`, `"healthiest"`)

This structural change improves clarity and modularity by isolating combat behavior from other NPC attributes. It also lays the groundwork for future extensions, such as AI behavior, difficulty scaling, or scripted combat events, without cluttering the top-level NPC schema.

I'm going to beautifiy in another PR.