### PR TITLE
save upgrade flow to include technique renaming

### DIFF
--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Mapping
+import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from tuxemon import db
@@ -10,71 +11,101 @@ from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.save import SaveData
+logger = logging.getLogger(__name__)
 
 """
-This module is for handling breaking changes to the save file.
+Handles breaking changes to the save file format.
 
-Renaming maps:
-  - Increment the value of SAVE_VERSION (e.g. from 1 to 2)
-  - Add an entry to MAP_RENAMES consisting of:
-    - The previous value of SAVE_VERSION (e.g. 1) mapping to
-    - A 'dictionary' made up of pairs of:
-        - The name of each map that has been renamed (the key)
-        - The new name of the map (the value)
-    Keys and values are separated by colons, each key-value pair is separated
-    by a comma, e.g.
-        MAP_RENAMES = {
-            # 1: {'before1.tmx': 'after1.tmx', 'before2.tmx': 'after2.tmx'},
-        }
+This module ensures that older save files remain compatible with newer
+versions of the game by applying necessary upgrades.
 
-Other changes:
-(If you have changed the codebase in such a way that older save files cannot
-be loaded)
-    - Increment the value of SAVE_VERSION
-    - Amend the `upgrade_save` function as necessary
+Upgrade strategy:
+
+1. **SAVE_VERSION**
+    Increment this value whenever the save file structure changes in
+        a way that older versions cannot load.
+    Each version bump should correspond to a function in `VERSION_UPGRADES`.
+
+2. **Versioned Upgrades**
+    Add a function like `upgrade_from_vX_to_vY(save_data)` for each version
+        bump.
+    Register it in the `VERSION_UPGRADES` dictionary.
+    These functions apply changes specific to that version transition.
+
+3. **Universal Fixes**
+    Some changes (e.g. renaming monsters or techniques) should be applied
+        regardless of version.
+    These are handled in `apply_universal_fixes(npc_state)` and are always
+        run.
+
+Example:
+    SAVE_VERSION = 3
+
+    def upgrade_from_v2_to_v3(save_data: dict[str, Any]) -> None:
+        # Apply changes introduced in version 3
+        pass
+
+    VERSION_UPGRADES = {
+        0: upgrade_from_v0_to_v1,
+        1: upgrade_from_v1_to_v2,
+        2: upgrade_from_v2_to_v3,
+    }
+
+Notes:
+- Always update `SAVE_VERSION` when introducing breaking changes.
+- Keep universal fixes minimal and focused on data consistency.
 """
 
 SAVE_VERSION = 2
-MAP_RENAMES: Mapping[int, Mapping[str, str]] = {
-    # 0: {'before1.tmx': 'after1.tmx', 'before2.tmx': 'after2.tmx'},
-}
+
 
 MONSTER_RENAMES: dict[str, str] = {"axylightl": "axolightl"}  # old: new
+TECHNIQUE_RENAMES: dict[str, str] = {}  # old: new
 
 
-def upgrade_save(save_data: dict[str, Any]) -> SaveData:
-    """
-    Updates savegame if necessary.
-
-    This function can modify the passed save data.
-
-    Parameters:
-        save_data: The save data.
-
-    Returns:
-        Modified save data.
-    """
-    if "npc_state" not in save_data:
-        save_data = update_save_data(save_data)
-
-    save_data["npc_state"] = upgrade_npc_state(save_data["npc_state"])
-
-    # version = save_data.get("version", 0)
-    # for i in range(version, SAVE_VERSION):
-    #    _update_current_map(i, save_data)
-
-    return save_data  # type: ignore[return-value]
+def upgrade_from_v0_to_v1(save_data: dict[str, Any]) -> None:
+    # Placeholder for any changes introduced in version 1
+    pass
 
 
-def upgrade_npc_state(npc_state: dict[str, Any]) -> dict[str, Any]:
+def upgrade_from_v1_to_v2(save_data: dict[str, Any]) -> None:
+    logger.info("Applying upgrade from version 1 to 2")
+    npc_state = save_data.get("npc_state", {})
     _handle_change_tuxepedia(npc_state)
-    _handle_change_monster_name(npc_state)
     _handle_change_plague(npc_state)
     _handle_change_money(npc_state)
     _handle_change_teleport_faint(npc_state)
     _handle_change_contacts(npc_state)
 
-    return npc_state
+
+def apply_universal_fixes(npc_state: dict[str, Any]) -> None:
+    _handle_change_monster_name(npc_state)
+    _handle_change_tech_slug(npc_state)
+
+
+VERSION_UPGRADES: dict[int, Callable[[dict[str, Any]], None]] = {
+    0: upgrade_from_v0_to_v1,
+    1: upgrade_from_v1_to_v2,
+}
+
+
+def upgrade_save(save_data: dict[str, Any]) -> SaveData:
+    """
+    Updates savegame if necessary.
+    This function can modify the passed save data.
+    """
+    if "npc_state" not in save_data:
+        save_data = update_save_data(save_data)
+
+    version = save_data.get("version", 0)
+    for i in range(version, SAVE_VERSION):
+        upgrade_func = VERSION_UPGRADES.get(i)
+        if upgrade_func:
+            upgrade_func(save_data)
+
+    save_data["version"] = SAVE_VERSION
+    apply_universal_fixes(save_data["npc_state"])
+    return save_data  # type: ignore[return-value]
 
 
 def update_save_data(old_save_data: dict[str, Any]) -> dict[str, Any]:
@@ -217,3 +248,23 @@ def _handle_change_monster_name(save_data: dict[str, Any]) -> None:
         }
         for entry, value in save_data["tuxepedia"].items()
     }
+
+
+def _handle_change_tech_slug(save_data: dict[str, Any]) -> None:
+    """
+    Updates tech slug in the save data based on the TECH_RENAMES dictionary.
+    """
+
+    def update_moves(moves: list[dict[str, Any]]) -> None:
+        for move in moves:
+            if move["slug"] in TECHNIQUE_RENAMES:
+                move["slug"] = TECHNIQUE_RENAMES[move["slug"]]
+
+    # Update monsters in the save data
+    for monster in save_data["monsters"]:
+        update_moves(monster["moves"])
+
+    # Update monsters in the monster boxes
+    for value in save_data["monster_boxes"].values():
+        for element in value:
+            update_moves(element["moves"])


### PR DESCRIPTION
PR improves the save upgrade system. It also introduces support for renaming techniques across all relevant parts of the save data.

Key changes:
- refactored the save upgrade system to better support versioned upgrades and universal fixes
- introduced `_handle_change_tech_slug(save_data)` to rename technique slugs using the `TECHNIQUE_RENAMES` dictionary, applies to all monsters in the main save data and applies to all monsters stored in monster boxes (preparing change proposed by @Sanglorian in #3030)
- registered `_handle_change_tech_slug` in `apply_universal_fixes(npc_state)` so it runs regardless of save version
- updated `upgrade_save` to apply versioned upgrades via the `VERSION_UPGRADES` dictionary and then apply universal fixes
- replaced the older `upgrade_npc_state` approach with a more modular and extensible upgrade strategy
- clarified the upgrade strategy in the module docstring, including how and when universal fixes are applied