### PR TITLE
Replace trainer battle flag with combat type to support new battle modes

### DIFF
--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -45,7 +45,7 @@ class TestRewardSystem(unittest.TestCase):
 
     def test_reward_system_winner(self):
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -54,7 +54,7 @@ class TestRewardSystem(unittest.TestCase):
 
     def test_reward_system_money(self):
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -64,7 +64,7 @@ class TestRewardSystem(unittest.TestCase):
 
     def test_reward_system_experience(self):
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -75,7 +75,7 @@ class TestRewardSystem(unittest.TestCase):
 
     def test_reward_system_update(self):
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
         self.assertTrue(rewards.update)
@@ -170,7 +170,7 @@ class TestRewardSystem(unittest.TestCase):
         self.winner.owner.monsters = mock_monsters
 
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -189,7 +189,9 @@ class TestRewardSystem(unittest.TestCase):
 
     def test_award_rewards_no_winners(self):
         empty_tracker = DamageTracker()
-        reward_system = RewardSystem(empty_tracker, is_trainer_battle=True)
+        reward_system = RewardSystem(
+            empty_tracker, MagicMock(combat_type="trainer")
+        )
         rewards = reward_system.award_rewards(self.loser)
 
         self.assertEqual(len(rewards.winners), 0)
@@ -201,7 +203,7 @@ class TestRewardSystem(unittest.TestCase):
     def test_award_rewards_no_new_moves(self):
         self.winner.moves.update_moves.return_value = []
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -223,7 +225,7 @@ class TestRewardSystem(unittest.TestCase):
         self.damage_tracker.log_damage(second_winner, self.loser, 5, 1)
 
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -234,7 +236,7 @@ class TestRewardSystem(unittest.TestCase):
     def test_award_rewards_with_held_item_modifier(self):
         self.winner.held_item.get_item.return_value.slug = "xp_booster"
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 
@@ -243,7 +245,7 @@ class TestRewardSystem(unittest.TestCase):
     def test_award_rewards_non_player_monster(self):
         self.winner.owner.isplayer = False
         reward_system = RewardSystem(
-            self.damage_tracker, is_trainer_battle=True
+            self.damage_tracker, MagicMock(combat_type="trainer")
         )
         rewards = reward_system.award_rewards(self.loser)
 

--- a/tuxemon/ai.py
+++ b/tuxemon/ai.py
@@ -248,7 +248,10 @@ class OpponentEvaluator:
         Scores opponents based on their current health, status effects, and power level.
         Higher scores indicate better targets.
         """
-        if not self.combat.is_trainer_battle or not self.combat.is_double:
+        if (
+            not self.combat.context.is_trainer_battle
+            or not self.combat.is_double
+        ):
             return 1.0
 
         owner = self.user.get_owner()
@@ -552,7 +555,7 @@ class AI:
 
         self.decision_strategy = (
             TrainerAIDecisionStrategy(self.evaluator, self.tracker)
-            if self.combat.is_trainer_battle
+            if self.combat.context.is_trainer_battle
             else WildAIDecisionStrategy(self.evaluator, self.tracker)
         )
 

--- a/tuxemon/states/combat/combat.py
+++ b/tuxemon/states/combat/combat.py
@@ -161,7 +161,6 @@ class CombatState(CombatAnimations):
 
         super().__init__(context=context)
         self._lock_update = self.client.config.combat_click_to_continue
-        self.is_trainer_battle = context.combat_type == CombatType.TRAINER
         self.show_combat_dialog()
         self.transition_phase(CombatPhase.BEGIN)
         self.task(
@@ -641,7 +640,7 @@ class CombatState(CombatAnimations):
                 players=opponents if opponents else players,
                 turns=self._turn,
                 prize=self._prize if result_type == "won" else 0,
-                trainer_battle=self.is_trainer_battle,
+                trainer_battle=self.context.is_trainer_battle,
             )
         return message
 
@@ -1067,7 +1066,7 @@ class CombatState(CombatAnimations):
         Parameters:
             monster: Monster that was fainted.
         """
-        reward_system = RewardSystem(self._damage_map, self.is_trainer_battle)
+        reward_system = RewardSystem(self._damage_map, self.context)
         rewards = reward_system.award_rewards(monster)
 
         # Update combat state with rewards

--- a/tuxemon/states/combat/combat_animations.py
+++ b/tuxemon/states/combat/combat_animations.py
@@ -77,7 +77,6 @@ class CombatAnimations(Menu[None], ABC):
         self.is_double = context.is_double_battle
         self.field_monsters = FieldMonsters()
         self.sprite_map = MonsterSpriteMap()
-        self.is_trainer_battle = False
         self.capdevs: list[CaptureDeviceSprite] = []
         self.bars = CombatBars(self.graphics)
         layout_manager = LayoutManager(scaled_layouts, layout_groups)
@@ -96,7 +95,9 @@ class CombatAnimations(Menu[None], ABC):
         for player, layout in self.hud_manager.layout.items():
             self.animate_party_hud_in(player, layout["party"][0])
 
-        for player in self.players[: 2 if self.is_trainer_battle else 1]:
+        for player in self.players[
+            : 2 if self.context.is_trainer_battle else 1
+        ]:
             self.task(partial(self.animate_trainer_leave, player), interval=3)
 
     def blink(self, sprite: Sprite) -> None:
@@ -400,7 +401,7 @@ class CombatAnimations(Menu[None], ABC):
                 displayed (e.g. "hud0", etc.).
             animate: Whether the HUD should be animated (slide in) or not.
         """
-        trainer_battle = self.is_trainer_battle
+        trainer_battle = self.context.is_trainer_battle
         menu = self.graphics.menu
         owner = monster.get_owner()
         hud_rect = self.hud_manager.get_rect(owner, hud_position)
@@ -470,7 +471,7 @@ class CombatAnimations(Menu[None], ABC):
     def animate_party_hud_left(
         self, home: Rect
     ) -> tuple[Optional[Sprite], int, int]:
-        if self.is_trainer_battle and not self.is_double:
+        if self.context.is_trainer_battle and not self.is_double:
             tray = self._load_sprite(
                 self.graphics.hud.tray_opponent,
                 {"bottom": home.bottom, "right": 0, "layer": hud_layer},
@@ -589,7 +590,7 @@ class CombatAnimations(Menu[None], ABC):
         )
 
         # Load and animate opponent
-        if self.is_trainer_battle:
+        if self.context.is_trainer_battle:
             combat_front = opponent.template.combat_front
             enemy = self.load_sprite(
                 f"gfx/sprites/player/{combat_front}.png",
@@ -627,7 +628,7 @@ class CombatAnimations(Menu[None], ABC):
         self.sprite_map.add_sprite(player, player_back)
         self.flip_sprites(enemy, player_back)
         self.animate_sprites(enemy, back_island, front_island, player_back)
-        if not self.is_trainer_battle:
+        if not self.context.is_trainer_battle:
             sound = self.players[1].monsters[0].combat_call
             self.play_sound_effect(sound, 1.5)
 

--- a/tuxemon/states/combat/combat_menus.py
+++ b/tuxemon/states/combat/combat_menus.py
@@ -85,7 +85,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             ("menu_item", self.open_item_menu),
         )
 
-        if self.combat.is_trainer_battle:
+        if self.combat.context.is_trainer_battle:
             menu_items_map = common_menu_items + (
                 ("menu_forfeit", self.forfeit),
             )

--- a/tuxemon/states/combat/reward_system.py
+++ b/tuxemon/states/combat/reward_system.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from tuxemon.states.combat.combat_classes import DamageTracker
     from tuxemon.technique.technique import Technique
     from tuxemon.monster import Monster
+    from .combat_context import CombatContext
 
 from dataclasses import dataclass
 
@@ -41,10 +42,10 @@ class RewardData:
 
 class RewardSystem:
     def __init__(
-        self, damage_map: DamageTracker, is_trainer_battle: bool
+        self, damage_map: DamageTracker, combat_context: CombatContext
     ) -> None:
         self.damage_map = damage_map
-        self.is_trainer_battle = is_trainer_battle
+        self.combat_context = combat_context
 
     def award_rewards(self, monster: Monster) -> RewardData:
         """
@@ -128,7 +129,7 @@ class RewardSystem:
                     )
 
                     # Add money for trainer battles
-                    if self.is_trainer_battle:
+                    if self.combat_context.is_trainer_battle:
                         rewards_data.prize += awarded_money
 
                     # Update HUD or handle level-up externally


### PR DESCRIPTION
With the recent addition of `CombatType.HORDE`, the previous approach of using a boolean flag (`is_trainer_battle`) was no longer sufficient to represent all possible combat scenarios. This pull request updates the battle initialization logic to store the full `combat_type` instead of a derived boolean.

Key changes:
- this change allows the battle system to distinguish between multiple combat types (e.g. TRAINER, MONSTER, HORDE) without relying on individual flags
- ensures future extensibility as more combat types are added
- aligns with the `CombatContext` class, which already uses `combat_type` to determine battle behavior and messages
- updated the initialization of `RewardSystem`:  previously, it received only a boolean `is_trainer_battle`, while now it receives the full `CombatContext`, which includes `combat_type`, this change enables future flexibility in reward logic, for example, allowing different reward paths for horde battles, wild encounters, or trainer fights

Previously, `CombatState` stored a derived boolean flag `is_trainer_battle`, which was set during initialization. With the shift to storing `combat_type` directly, that flag was removed.

As a result, any logic that previously relied on `self.combat.is_trainer_battle` now uses the `CombatContext`'s property:  
```self.combat.context.is_trainer_battle```