### PR TITLE
Pass `local_session` to `CommandProcessor` instead of `client`

### DIFF
--- a/tuxemon/cli/commands/action.py
+++ b/tuxemon/cli/commands/action.py
@@ -52,7 +52,7 @@ class ActionParentCommand(CLICommand):
         Parameters:
             ctx: Contains references to parts of the game and CLI interface.
         """
-        actions = ctx.client.event_engine.action_manager.get_actions()
+        actions = ctx.session.client.event_engine.action_manager.get_actions()
         for action in actions:
             command = ActionCommand()
             command.name = action.name
@@ -76,7 +76,7 @@ class ActionCommand(CLICommand):
         line = f"{self.name} {line}"
         name, args = parse_action_string(line)
         try:
-            ctx.client.event_engine.execute_action(name, args)
+            ctx.session.client.event_engine.execute_action(name, args)
         except Exception as e:
             print(f"Error executing action {e}", file=sys.stderr)
             traceback.print_exc()

--- a/tuxemon/cli/commands/print.py
+++ b/tuxemon/cli/commands/print.py
@@ -23,6 +23,6 @@ class PrintCommand(CLICommand):
         """
         variable = line.strip()
         if variable:
-            ctx.client.event_engine.execute_action("print", [variable])
+            ctx.session.client.event_engine.execute_action("print", [variable])
         else:
-            ctx.client.event_engine.execute_action("print", [])
+            ctx.session.client.event_engine.execute_action("print", [])

--- a/tuxemon/cli/commands/random_encounter.py
+++ b/tuxemon/cli/commands/random_encounter.py
@@ -21,6 +21,6 @@ class RandomEncounterCommand(CLICommand):
             ctx: Contains references to parts of the game and CLI interface.
             line: Complete text as entered into the prompt.
         """
-        ctx.client.event_engine.execute_action(
+        ctx.session.client.event_engine.execute_action(
             "random_encounter", ["default_encounter", 100]
         )

--- a/tuxemon/cli/commands/test.py
+++ b/tuxemon/cli/commands/test.py
@@ -40,7 +40,9 @@ class TestConditionParentCommand(CLICommand):
         Parameters:
             ctx: Contains references to parts of the game and CLI interface.
         """
-        conditions = ctx.client.event_engine.condition_manager.get_conditions()
+        conditions = (
+            ctx.session.client.event_engine.condition_manager.get_conditions()
+        )
         for condition in conditions:
             command = TestConditionCommand()
             command.name = condition.name
@@ -74,7 +76,7 @@ class TestConditionCommand(CLICommand):
         except ValueError:
             raise ParseError
         try:
-            result = ctx.client.event_engine.check_condition(cond)
+            result = ctx.session.client.event_engine.check_condition(cond)
             print(result)
         except Exception:
             traceback.print_exc()

--- a/tuxemon/cli/commands/trainer_battle.py
+++ b/tuxemon/cli/commands/trainer_battle.py
@@ -34,7 +34,7 @@ class TrainerBattleCommand(CLICommand):
         elif len(args) == 1:
             trainer = args[0]
             try:
-                action = ctx.client.event_engine.execute_action
+                action = ctx.session.client.event_engine.execute_action
                 action("create_npc", (trainer, 7, 6))
                 action("start_battle", (trainer,))
                 action("remove_npc", (trainer,))

--- a/tuxemon/cli/commands/whereami.py
+++ b/tuxemon/cli/commands/whereami.py
@@ -23,7 +23,7 @@ class WhereAmICommand(CLICommand):
             ctx: Contains references to parts of the game and CLI interface.
             line: Input text after the command name.
         """
-        current_map = ctx.client.event_engine.current_map
+        current_map = ctx.session.client.event_engine.current_map
         if current_map:
             name = current_map.data.filename
             print(name)

--- a/tuxemon/cli/context.py
+++ b/tuxemon/cli/context.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from tuxemon.cli.clicommand import CLICommand
     from tuxemon.cli.formatter import Formatter
     from tuxemon.cli.processor import CommandProcessor
-    from tuxemon.client import LocalPygameClient
+    from tuxemon.session import Session
 
 
 @dataclass
@@ -19,7 +19,7 @@ class InvokeContext:
     """
 
     processor: CommandProcessor
-    client: LocalPygameClient
+    session: Session
     root_command: CLICommand
     current_command: CLICommand
     formatter: Formatter

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -19,7 +19,7 @@ from tuxemon.plugin import (
 )
 
 if TYPE_CHECKING:
-    from tuxemon.client import LocalPygameClient
+    from tuxemon.session import Session
 
 
 class MetaCommand(CLICommand):
@@ -63,13 +63,14 @@ class CommandProcessor:
     A class to enable an interactive debug command line.
 
     Parameters:
-        client: LocalPygameClient which will be controlled by the debug prompt.
+        session: Session which will be controlled by the debug prompt.
         prompt: Default text to display before the input area, ie "> ".
     """
 
-    def __init__(self, client: LocalPygameClient, prompt: str = "> ") -> None:
+    def __init__(self, session: Session, prompt: str = "> ") -> None:
         self.prompt = prompt
-        self.client = client
+        self.session = session
+        self.client = session.client
         folder = Path(__file__).parent / "commands"
         # TODO: add folder(s) from mods
         commands = list(self.collect_commands(folder))
@@ -81,7 +82,7 @@ class CommandProcessor:
         """
         ctx = InvokeContext(
             processor=self,
-            client=self.client,
+            session=self.session,
             root_command=self.root_command,
             current_command=self.root_command,
             formatter=Formatter(),

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -177,7 +177,7 @@ class LocalPygameClient:
             # behavior for the game.  at some point, a lock should be
             # implemented so that actions executed here have exclusive
             # control of the game loop and state.
-            self.cli = CommandProcessor(self)
+            self.cli = CommandProcessor(local_session)
             thread = Thread(target=self.cli.run)
             thread.daemon = True
             thread.start()

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -7,11 +7,13 @@ import time
 from collections.abc import Mapping, Sequence
 from enum import Enum
 from pathlib import Path
+from threading import Thread
 from typing import Any, Optional, TypeVar, Union, overload
 
 from tuxemon.audio import MusicPlayerState, SoundManager
 from tuxemon.boundary import BoundaryChecker
 from tuxemon.camera import CameraManager
+from tuxemon.cli.processor import CommandProcessor
 from tuxemon.config import TuxemonConfig
 from tuxemon.constants import paths
 from tuxemon.event import get_event_bus
@@ -98,11 +100,11 @@ class HeadlessClient:
         self.current_music = MusicPlayerState()
         self.sound_manager = SoundManager()
 
-        # if self.config.cli:
-        #    self.cli = CommandProcessor(self)
-        #    thread = Thread(target=self.cli.run)
-        #    thread.daemon = True
-        #    thread.start()
+        if self.config.cli:
+            self.cli = CommandProcessor(local_session)
+            thread = Thread(target=self.cli.run)
+            thread.daemon = True
+            thread.start()
 
         # Set up rumble support for gamepads
         self.rumble_manager = RumbleManager()
@@ -185,6 +187,7 @@ class HeadlessClient:
     def perform_cleanup(self) -> None:
         """Handles necessary cleanup before shutting down."""
         self.current_music.stop()
+        local_session.reset()
         logger.info("Performing cleanup before exiting...")
 
     def update_states(self, time_delta: float) -> None:


### PR DESCRIPTION
PR updates the initialization of `CommandProcessor` to receive the full `local_session` object rather than just the `client`. This change improves flexibility and aligns with the evolving structure of the command system, allowing CLI commands to access broader session-level context.

Changes:
- `CommandProcessor.__init__` now takes a `Session` object
- `LocalPygameClient` and `HeadlessClient` both pass `local_session` to the CLI thread
- `InvokeContext` is updated to use `session` instead of `client`

Passing the full session enables future CLI commands to interact with session-level components beyond the client, such as networking, event state, or persistent data. This avoids tightly coupling the CLI to a specific client implementation. `HeadlessClient` can now use the CLI without needing to mimic or inherit from `LocalPygameClient`, and without requiring a `Union` type or interface workaround. This sets the stage for more modular CLI tooling.