### PR TITLE
Refactor `CheckMaxTechCondition` and Introduce `GetPendingMovesAction` for Move Management

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -51,6 +51,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.fadeout_music.FadeoutMusicAction
 .. autoscriptinfoclass:: tuxemon.event.actions.format_variable.FormatVariableAction
 .. autoscriptinfoclass:: tuxemon.event.actions.get_monster_tech.GetMonsterTechAction
+.. autoscriptinfoclass:: tuxemon.event.actions.get_pending_moves.GetPendingMovesAction
 .. autoscriptinfoclass:: tuxemon.event.actions.get_party_monsters.GetPartyMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.get_player_monster.GetPlayerMonsterAction
 .. autoscriptinfoclass:: tuxemon.event.actions.give_experience.GiveExperienceAction

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -74,10 +74,10 @@ events:
   Check Max Moves:
     actions:
     - translated_dialog new_tech_delete
-    - get_monster_tech chosen_tech
+    - get_pending_moves chosen_tech
     - remove_tech chosen_tech
     conditions:
-    - is check_max_tech
+    - is check_max_tech player
     - is current_state MainCombatMenuState:WorldState
     type: event
   Choice Surf:

--- a/mods/tuxemon/maps/xero.yaml
+++ b/mods/tuxemon/maps/xero.yaml
@@ -2,10 +2,10 @@ events:
   Check Max Moves:
     actions:
     - translated_dialog new_tech_delete
-    - get_monster_tech chosen_tech
+    - get_pending_moves chosen_tech
     - remove_tech chosen_tech
     conditions:
-    - is check_max_tech
+    - is check_max_tech player
     - is current_state MainCombatMenuState
     type: event
   Evolution all:

--- a/tests/tuxemon/test_monster_moves_handler.py
+++ b/tests/tuxemon/test_monster_moves_handler.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 from tuxemon.monster_dir.moves import MonsterMovesHandler
 
@@ -13,6 +14,7 @@ class TestMonsterMovesHandler(unittest.TestCase):
         self.technique = MagicMock()
         self.moveset = [MagicMock()]
         self.moves = [MagicMock()]
+        self.monster_id = UUID("123e4567-e89b-12d3-a456-426655440000")
 
     def test_init(self):
         self.assertEqual(self.handler.moves, [])
@@ -26,18 +28,18 @@ class TestMonsterMovesHandler(unittest.TestCase):
         self.assertEqual(self.handler.moveset, self.moveset)
 
     def test_learn(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.assertIn(self.technique, self.handler.moves)
 
     def test_forget(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.handler.forget(self.technique)
         self.assertNotIn(self.technique, self.handler.moves)
 
     def test_replace_move(self):
         technique1 = MagicMock()
         technique2 = MagicMock()
-        self.handler.learn(technique1)
+        self.handler.learn(self.monster_id, technique1)
         self.handler.replace_move(0, technique2)
         self.assertEqual(self.handler.moves[0], technique2)
 
@@ -61,7 +63,7 @@ class TestMonsterMovesHandler(unittest.TestCase):
         ) as mock_create:
             mock_create.return_value = MagicMock()
             self.handler.set_moveset(moveset)
-            self.handler.set_moves(2)
+            self.handler.set_moves(self.monster_id, 2)
             self.assertEqual(len(self.handler.moves), 2)
 
     def test_update_moves(self):
@@ -90,24 +92,24 @@ class TestMonsterMovesHandler(unittest.TestCase):
         ) as mock_create:
             mock_create.return_value = MagicMock()
             self.handler.set_moveset(moveset)
-            self.handler.set_moves(2)
+            self.handler.set_moves(self.monster_id, 2)
             new_techniques = self.handler.update_moves(3, 1)
             self.assertEqual(len(new_techniques), 1)
 
     def test_recharge_moves(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.handler.recharge_moves()
 
     def test_full_recharge_moves(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.handler.full_recharge_moves()
 
     def test_set_stats(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.handler.set_stats()
 
     def test_find_tech_by_id(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         found_technique = self.handler.find_tech_by_id(
             self.technique.instance_id
         )
@@ -115,15 +117,15 @@ class TestMonsterMovesHandler(unittest.TestCase):
 
     def test_has_moves(self):
         self.assertFalse(self.handler.has_moves())
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.assertTrue(self.handler.has_moves())
 
     def test_has_move(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         self.assertTrue(self.handler.has_move(self.technique.slug))
 
     def test_get_moves(self):
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         moves = self.handler.get_moves()
         self.assertIn(self.technique, moves)
 
@@ -139,7 +141,7 @@ class TestMonsterMovesHandler(unittest.TestCase):
 
     def test_remove_forced(self):
         self.technique.slug = "shockwave"
-        self.handler.learn(self.technique)
+        self.handler.learn(self.monster_id, self.technique)
         removed = self.handler.remove_forced(self.technique)
         self.assertTrue(removed)
         self.assertNotIn(self.technique, self.handler.moves)

--- a/tuxemon/core/effects/learn_mm.py
+++ b/tuxemon/core/effects/learn_mm.py
@@ -47,7 +47,7 @@ class LearnMmEffect(CoreEffect):
                 return ItemEffectResult(name=item.name)
 
             tech = Technique.create(tech_slug)
-            target.moves.learn(tech)
+            target.moves.learn(target.instance_id, tech)
 
             return ItemEffectResult(name=item.name, success=True)
 

--- a/tuxemon/core/effects/learn_tm.py
+++ b/tuxemon/core/effects/learn_tm.py
@@ -35,5 +35,5 @@ class LearnTmEffect(CoreEffect):
         if target.moves.has_move(self.technique):
             return ItemEffectResult(name=item.name)
         tech = Technique.create(self.technique)
-        target.moves.learn(tech)
+        target.moves.learn(target.instance_id, tech)
         return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/event/actions/add_tech.py
+++ b/tuxemon/event/actions/add_tech.py
@@ -81,5 +81,5 @@ class AddTechAction(EventAction):
         if monster.moves.has_move(tech.slug):
             logger.warning(f"{monster.name} already knows {tech.name}")
         else:
-            monster.moves.learn(tech)
+            monster.moves.learn(monster.instance_id, tech)
             logger.info(f"{monster.name} learned {tech.name}!")

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -125,7 +125,7 @@ class DojoMethodAction(EventAction):
 
     def learn(self, monster: Monster, technique: str) -> None:
         tech = Technique.create(technique)
-        monster.moves.learn(tech)
+        monster.moves.learn(monster.instance_id, tech)
         logger.info(f"{tech.name} learned!")
         self.client.sound_manager.play_sound("sound_confirm")
         self.client.pop_state()

--- a/tuxemon/event/actions/get_monster_tech.py
+++ b/tuxemon/event/actions/get_monster_tech.py
@@ -60,7 +60,7 @@ class GetMonsterTechAction(EventAction):
 
     name = "get_monster_tech"
     variable_name: str
-    monster_id: Optional[str] = None
+    monster_id: str
     skip_eligibility_check: Optional[str] = None
     filter_name: Optional[str] = None
     value_name: Optional[str] = None
@@ -79,24 +79,8 @@ class GetMonsterTechAction(EventAction):
 
         if not skip_check:
             if not monster.moves.can_forget(technique):
-                logger.debug(f"{technique.slug} is not forgettable, skipping.")
-                return False
-            entry = next(
-                (
-                    m
-                    for m in monster.moves.moveset
-                    if m.technique == technique.slug
-                ),
-                None,
-            )
-            if entry is None:
-                logger.warning(f"No moveset entry found for {technique.slug}")
-                return False
-            if not monster.moves.is_move_eligible(
-                move=entry, level=monster.level, evolution_stage=monster.stage
-            ):
                 logger.debug(
-                    f"{technique.slug} not eligible for {monster.name} at level {monster.level} and stage {monster.stage}"
+                    f"Technique '{technique.slug}' is not forgettable — skipping."
                 )
                 return False
 
@@ -146,23 +130,18 @@ class GetMonsterTechAction(EventAction):
         self.result = False
         self.choose = False
         player = session.player
-        client = session.client
 
-        if self.monster_id is None:
-            monsters = client.event_data.get("check_max_tech", [])
-            client.event_data.pop("check_max_tech")
-        else:
-            if self.monster_id not in player.game_variables:
-                logger.error(f"Game variable {self.monster_id} not found")
-                return
-            monster_id = UUID(
-                player.game_variables[self.monster_id],
-            )
-            monster = get_monster_by_iid(self.session, monster_id)
-            if monster is None:
-                logger.error(f"Monster not found")
-                return
-            monsters = [monster]
+        if self.monster_id not in player.game_variables:
+            logger.error(f"Game variable {self.monster_id} not found")
+            return
+        monster_id = UUID(
+            player.game_variables[self.monster_id],
+        )
+        monster = get_monster_by_iid(self.session, monster_id)
+        if monster is None:
+            logger.error(f"Monster not found")
+            return
+        monsters = [monster]
 
         for mon in monsters:
             self.monster: Monster = mon

--- a/tuxemon/event/actions/get_pending_moves.py
+++ b/tuxemon/event/actions/get_pending_moves.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.menu.interface import MenuItem
+from tuxemon.monster import Monster
+from tuxemon.session import Session
+from tuxemon.states.techniques import TechniqueMenuState
+from tuxemon.technique.technique import Technique
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class GetPendingMovesAction(EventAction):
+    """
+    Display a menu of pending techniques for monsters listed in
+    event_data["check_max_tech"], and store the selected technique ID
+    in a game variable.
+
+    Script usage:
+        .. code-block::
+
+            get_pending_moves <variable_name>
+
+    Script parameters:
+        variable_name: Name of the game variable to store the selected
+            technique ID.
+
+    Example:
+        - "get_pending_moves chosen_move"
+    """
+
+    name = "get_pending_moves"
+    variable_name: str
+
+    def validate(self, technique: Optional[Technique]) -> bool:
+        monster = self.monster
+
+        if technique is None:
+            return False
+
+        if not monster.moves.can_forget(technique):
+            logger.debug(
+                f"Technique '{technique.slug}' is not forgettable — skipping."
+            )
+            return False
+
+        logger.debug(f"Technique '{technique.slug}' is valid for selection.")
+        return True
+
+    def set_var(self, menu_item: MenuItem[Technique]) -> None:
+        technique = menu_item.game_object
+
+        self.session.player.game_variables[self.variable_name] = (
+            technique.instance_id.hex
+        )
+        self.session.client.pop_state()
+
+    def start(self, session: Session) -> None:
+        self.session = session
+        player = session.player
+
+        monsters: list[Monster] = session.client.event_data.get(
+            "check_max_tech", []
+        )
+        if not monsters:
+            logger.warning("No monsters found in event_data['check_max_tech']")
+            return
+
+        for mon in monsters:
+            self.monster = mon
+            menu = session.client.push_state(
+                TechniqueMenuState(
+                    character=player,
+                    techniques=mon.moves.get_moves(),
+                    monster=mon,
+                )
+            )
+            menu.escape_key_exits = False
+            menu.is_valid_entry = self.validate  # type: ignore[method-assign]
+            menu.on_menu_selection = self.set_var  # type: ignore[assignment]
+
+        session.client.event_data.pop("check_max_tech", None)
+
+    def update(self, session: Session) -> None:
+        try:
+            session.client.get_state_by_name("TechniqueMenuState")
+        except ValueError:
+            self.stop()

--- a/tuxemon/event/actions/learn_tech_by_method.py
+++ b/tuxemon/event/actions/learn_tech_by_method.py
@@ -62,7 +62,7 @@ class LearnTechByMethodAction(EventAction):
             return
 
         technique_obj = monster.moves.learn_by_method(
-            self.technique, method_enum
+            monster.instance_id, self.technique, method_enum
         )
 
         if technique_obj:

--- a/tuxemon/event/conditions/check_max_tech.py
+++ b/tuxemon/event/conditions/check_max_tech.py
@@ -2,49 +2,84 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
-from tuxemon.event import MapCondition
+from tuxemon.event import MapCondition, get_npc
 from tuxemon.event.eventcondition import EventCondition
+from tuxemon.monster import Monster
 from tuxemon.prepare import MAX_MOVES
 from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class CheckMaxTechCondition(EventCondition):
     """
-    Check to see the player has at least one tuxemon with more
-    than the max number of techniques in its party.
+    Condition to check whether a character (player or NPC) has at least one
+    Tuxemon with more techniques than a specified threshold.
 
-    If yes, then it saves automatically the monster_id and
-    inside the dictionary event_data.
+    This condition is used in event scripting to trigger actions based on
+    the number of techniques a Tuxemon possesses. If the condition is met,
+    the matching monsters are stored in the session's `event_data` dictionary
+    under the key `"check_max_tech"`.
 
     Script usage:
         .. code-block::
 
-            is check_max_tech [nr]
+            is check_max_tech <character>[,nr]
 
     Script parameters:
-        nr: Number of tech, default the constant
+        character: Either "player" or NPC slug name (e.g. "npc_maple").
+        nr: Optional integer specifying the minimum number of techniques.
+            Defaults to the constant MAX_MOVES.
 
-    eg. "is check_max_tech"
-    eg. "is check_max_tech 2"
-
+    Examples:
+        - "is check_max_tech player"
+        - "is check_max_tech npc_maple,2"
     """
 
     name = "check_max_tech"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
-        player = session.player
-        max_techs = (
-            MAX_MOVES
-            if not condition.parameters
-            else int(condition.parameters[0])
+        target_name = condition.parameters[0]
+
+        target_character = get_npc(session, target_name)
+        if target_character is None:
+            logger.error(f"Character '{target_name}' not found.")
+            return False
+
+        try:
+            max_techs = (
+                int(condition.parameters[1])
+                if len(condition.parameters) > 1
+                else MAX_MOVES
+            )
+        except ValueError:
+            logger.error(
+                f"Invalid technique threshold: {condition.parameters[1]}"
+            )
+            return False
+
+        logger.debug(f"Technique threshold set to: {max_techs}")
+
+        matching_monsters: list[Monster] = []
+        for monster in target_character.monsters:
+            num_moves = len(monster.moves.current_moves)
+            logger.debug(
+                f"Checking monster: {monster.name} (ID: {monster.instance_id}) with {num_moves} moves"
+            )
+
+            if num_moves > max_techs:
+                logger.debug(
+                    f"  Monster '{monster.name}' exceeds technique threshold"
+                )
+                matching_monsters.append(monster)
+
+        session.client.event_data[self.name] = matching_monsters
+        logger.debug(
+            f"Matching monsters stored: {[m.name for m in matching_monsters]}"
         )
-        monsters = [
-            monster
-            for monster in player.monsters
-            if len(monster.moves.current_moves) > max_techs
-        ]
-        session.client.event_data[self.name] = monsters
-        return bool(monsters)
+
+        return bool(matching_monsters)

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -202,7 +202,7 @@ class Monster:
     def spawn_base(cls, slug: str, level: int) -> Monster:
         monster = cls.create(slug)
         monster.set_level(level)
-        monster.moves.set_moves(level, monster.stage)
+        monster.moves.set_moves(monster.instance_id, level, monster.stage)
         monster.current_hp = monster.hp
         return monster
 

--- a/tuxemon/monster_dir/evolution.py
+++ b/tuxemon/monster_dir/evolution.py
@@ -49,7 +49,9 @@ class Evolution:
                 and move.learning_method == LearningMethod.EVOLUTION
             ):
                 new_monster.moves.learn_by_method(
-                    move.technique, move.learning_method
+                    new_monster.instance_id,
+                    move.technique,
+                    move.learning_method,
                 )
 
         owner.party.remove_monster(self.monster)

--- a/tuxemon/monster_dir/moves.py
+++ b/tuxemon/monster_dir/moves.py
@@ -30,6 +30,7 @@ class MonsterMovesHandler:
     ):
         self.moves = moves if moves is not None else []
         self.moveset = list(moveset) if moveset is not None else []
+        self.pending_moves: dict[UUID, list[str]] = {}
 
     @property
     def current_moves(self) -> list[Technique]:
@@ -39,15 +40,26 @@ class MonsterMovesHandler:
         """Sets the raw moveset data from the database."""
         self.moveset = list(moveset)
 
-    def learn(self, technique: Technique) -> None:
+    def add_move(self, technique: Technique) -> None:
         """
         Adds a technique to this tuxemon's moveset.
-
-        Parameters:
-            technique: The technique for the monster to learn.
         """
-
         self.moves.append(technique)
+
+    def learn(
+        self,
+        monster_iid: UUID,
+        technique: Technique,
+        max_moves: int = prepare.MAX_MOVES,
+    ) -> None:
+        """
+        Adds a technique to this tuxemon's moveset.
+        """
+        if len(self.moves) >= max_moves:
+            # self.pending_moves.setdefault(monster_iid, []).append(technique.slug)
+            self.moves.append(technique)
+        else:
+            self.moves.append(technique)
 
     def forget(self, technique: Technique) -> bool:
         """
@@ -74,20 +86,51 @@ class MonsterMovesHandler:
         method: LearningMethod = LearningMethod.LEVEL_UP,
     ) -> bool:
         if move.learning_method != method:
-            return False
-        return move.level_learned <= level and (
-            move.evolution_stage_learned is None
-            or (
-                evolution_stage is not None
-                and move.evolution_stage_learned == evolution_stage
+            logger.debug(
+                f"Move '{move.technique}' not eligible: learning method is '{move.learning_method}', expected '{method}'."
             )
-        )
+            return False
+
+        if move.level_learned > level:
+            logger.debug(
+                f"Move '{move.technique}' not eligible: requires level {move.level_learned}, current level is {level}."
+            )
+            return False
+
+        if move.evolution_stage_learned is not None:
+            if evolution_stage is None:
+                logger.debug(
+                    f"Move '{move.technique}' not eligible: requires evolution stage '{move.evolution_stage_learned}', but none provided."
+                )
+                return False
+            if move.evolution_stage_learned != evolution_stage:
+                logger.debug(
+                    f"Move '{move.technique}' not eligible: requires evolution stage '{move.evolution_stage_learned}', current stage is '{evolution_stage}'."
+                )
+                return False
+
+        logger.debug(f"Move '{move.technique}' is eligible.")
+        return True
 
     def can_forget(self, technique: Technique) -> bool:
         entry = next(
             (m for m in self.moveset if m.technique == technique.slug), None
         )
-        return entry is not None and entry.can_be_forgotten
+
+        if entry is None:
+            logger.debug(
+                f"Technique '{technique.slug}' not found in moveset — assuming it can be forgotten."
+            )
+            return True
+
+        if not entry.can_be_forgotten:
+            logger.debug(
+                f"Technique '{technique.slug}' is marked as non-forgettable."
+            )
+            return False
+
+        logger.debug(f"Technique '{technique.slug}' can be forgotten.")
+        return True
 
     def remove_forced(self, technique: Technique) -> bool:
         if technique in self.moves:
@@ -108,6 +151,7 @@ class MonsterMovesHandler:
 
     def set_moves(
         self,
+        monster_iid: UUID,
         level: int,
         evolution_stage: Optional[EvolutionStage] = None,
         max_moves: int = prepare.MAX_MOVES,
@@ -139,7 +183,7 @@ class MonsterMovesHandler:
         moves_to_learn = eligible_moves[-max_moves:]
         for move_name in moves_to_learn:
             technique = Technique.create(move_name)
-            self.learn(technique)
+            self.learn(monster_iid, technique)
             logger.debug(
                 f"Monster learned technique: {technique.slug} at level {level} and stage {evolution_stage}"
             )
@@ -176,6 +220,7 @@ class MonsterMovesHandler:
 
     def learn_by_method(
         self,
+        monster_iid: UUID,
         technique_slug: str,
         methods: Union[LearningMethod, set[LearningMethod]],
     ) -> Optional[Technique]:
@@ -190,7 +235,7 @@ class MonsterMovesHandler:
             return None
 
         technique = Technique.create(technique_slug)
-        self.learn(technique)
+        self.learn(monster_iid, technique)
         logger.debug(
             f"Monster learned technique via {move_data.learning_method.value.upper()}: {technique_slug}"
         )
@@ -222,6 +267,12 @@ class MonsterMovesHandler:
 
     def get_moves(self) -> list[Technique]:
         return self.moves
+
+    def get_pending_moves(self, monster_iid: UUID) -> list[str]:
+        return self.pending_moves.get(monster_iid, [])
+
+    def clear_pending_moves(self, monster_iid: UUID) -> None:
+        self.pending_moves.pop(monster_iid, None)
 
     def encode_moves(self) -> Sequence[Mapping[str, Any]]:
         return encode_moves(self.moves)


### PR DESCRIPTION
PR refactors the `CheckMaxTechCondition` event condition and introduces a new event action, `GetPendingMovesAction`, to improve how the game handles monsters with too many techniques.

The goal is to separate concerns between detecting technique overflow and managing player interaction when resolving it. These changes lay the groundwork for future enhancements, such as prompting the player with a yes/no decision when a monster learns a new technique beyond the allowed limit.

`CheckMaxTechCondition` improvements:
- condition now accepts either `"player"` or an NPC slug name as the target character
- added robust parsing for the optional technique threshold (`nr`), with error logging for invalid values
- replaced the previous list comprehension with a loop that logs each monster’s move count and inclusion decision.
- Still stores matching monsters in `session.client.event_data["check_max_tech"]` to support downstream actions like `GetMonsterTechAction`, this is temporary
- rewrote the class docstring

New Event Action `GetPendingMovesAction`:
- added a dedicated event action to handle pending techniques separately from general-purpose move selection
- avoids mixing logic with `GetMonsterTechAction`, which was originally designed for broader filtering and eligibility checks
- separation is necessary to support future behavior where a monster that learns a new technique above the max will be prompted with a yes/no decision, that flow requires a distinct and focused action
- additional operations (e.g. confirming or forgetting moves) will be introduced in a future PR

Simplification of `GetMonsterTechAction`:
- with `GetPendingMovesAction` now handling pending move logic, `GetMonsterTechAction` was simplified to focus solely on filtered technique selection
- removed bridging logic and reliance on `event_data` for pending move handling