### PR TITLE
Rename `char_position` condition to `char_at_position` to avoid conflict with existing event action

### DIFF
--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -6,6 +6,7 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.button_pressed.ButtonPressedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.camera_position.CameraPositionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_at.CharAtCondition
+.. autoscriptinfoclass:: tuxemon.event.conditions.char_at_position.CharAtPositionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_defeated.CharDefeatedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_exists.CharExistsCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_facing.CharFacingCondition
@@ -13,7 +14,6 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_facing_tile.CharFacingTileCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_in.CharInCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_moved.CharMovedCondition
-.. autoscriptinfoclass:: tuxemon.event.conditions.char_position.CharPositionCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_sprite.CharSpriteCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.check_char_parameter.CheckCharParameterCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.check_evolution.CheckEvolutionCondition

--- a/tuxemon/event/conditions/char_at_position.py
+++ b/tuxemon/event/conditions/char_at_position.py
@@ -13,23 +13,22 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class CharPositionCondition(EventCondition):
+class CharAtPositionCondition(EventCondition):
     """
     Check to see if the character is at the position on the map.
 
     Script usage:
         .. code-block::
 
-            is char_position <character>,<tile_pos_x>,<tile_pos_y>
+            is char_at_position <character>,<tile_pos_x>,<tile_pos_y>
 
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple").
         tile_pos_x: X position to set the character to.
         tile_pos_y: Y position to set the character to.
-
     """
 
-    name = "char_position"
+    name = "char_at_position"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
         character = get_npc(session, condition.parameters[0])


### PR DESCRIPTION
PR renames the `char_position` event condition to `char_at_position` to resolve a naming conflict with an existing event action of the same name.