### PR TITLE
Pre/Post-Battle Dialog: Replace `translated_dialog` with `char_talk`

### DIFF
--- a/mods/tuxemon/maps/spyder_candy_hospital1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital1.tmx
@@ -106,11 +106,11 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_aurora"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_aurora1"/>
+    <property name="act03" value="char_talk spyder_hospital1_aurora,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster exclawvate,40,spyder_hospital1_aurora,5,10"/>
     <property name="act06" value="start_battle player,spyder_hospital1_aurora"/>
-    <property name="act07" value="translated_dialog spyder_hospital1_aurora2"/>
+    <property name="act07" value="char_talk spyder_hospital1_aurora,post_battle_lose"/>
     <property name="act08" value="set_variable hospital1aurora:yes"/>
     <property name="cond1" value="not variable_set hospital1aurora:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -126,14 +126,14 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_eleni"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_eleni1"/>
+    <property name="act03" value="char_talk spyder_hospital1_eleni,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster boltnu,30,spyder_hospital1_eleni,5,10"/>
     <property name="act06" value="add_monster taupypus,30,spyder_hospital1_eleni,5,10"/>
     <property name="act07" value="add_monster snaki,30,spyder_hospital1_eleni,5,10"/>
     <property name="act08" value="add_monster galnec,30,spyder_hospital1_eleni,5,10"/>
     <property name="act09" value="start_battle player,spyder_hospital1_eleni"/>
-    <property name="act10" value="translated_dialog spyder_hospital1_eleni2"/>
+    <property name="act10" value="char_talk spyder_hospital1_eleni,post_battle_lose"/>
     <property name="act11" value="set_variable hospital1eleni:yes"/>
     <property name="cond1" value="not variable_set hospital1eleni:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -150,12 +150,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_felu"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_felu1"/>
+    <property name="act03" value="char_talk spyder_hospital1_felu,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster anu,30,spyder_hospital1_felu,5,10"/>
     <property name="act06" value="add_monster galnec,30,spyder_hospital1_felu,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_felu"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_felu2"/>
+    <property name="act08" value="char_talk spyder_hospital1_felu,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1felu:yes"/>
     <property name="cond1" value="not variable_set hospital1felu:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -171,12 +171,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_fring"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_fring1"/>
+    <property name="act03" value="char_talk spyder_hospital1_fring,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster anu,30,spyder_hospital1_fring,5,10"/>
     <property name="act06" value="add_monster selket,30,spyder_hospital1_fring,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_fring"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_fring2"/>
+    <property name="act08" value="char_talk spyder_hospital1_fring,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1fring:yes"/>
     <property name="cond1" value="not variable_set hospital1fring:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -192,12 +192,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_walt"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_walt1"/>
+    <property name="act03" value="char_talk spyder_hospital1_walt,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster anu,34,spyder_hospital1_walt,5,10"/>
     <property name="act06" value="add_monster taupypus,27,spyder_hospital1_walt,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_walt"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_walt2"/>
+    <property name="act08" value="char_talk spyder_hospital1_walt,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1walt:yes"/>
     <property name="cond1" value="not variable_set hospital1walt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -213,12 +213,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_liane"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_liane1"/>
+    <property name="act03" value="char_talk spyder_hospital1_liane,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster boltnu,36,spyder_hospital1_liane,5,10"/>
     <property name="act06" value="add_monster snaki,36,spyder_hospital1_liane,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_liane"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_liane2"/>
+    <property name="act08" value="char_talk spyder_hospital1_liane,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1liane:yes"/>
     <property name="cond1" value="not variable_set hospital1liane:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -266,12 +266,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_fring"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_fring1"/>
+    <property name="act03" value="char_talk spyder_hospital1_fring,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster anu,30,spyder_hospital1_fring,5,10"/>
     <property name="act06" value="add_monster selket,30,spyder_hospital1_fring,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_fring"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_fring2"/>
+    <property name="act08" value="char_talk spyder_hospital1_fring,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1fring:yes"/>
     <property name="cond1" value="not variable_set hospital1fring:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -281,12 +281,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_walt"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_walt1"/>
+    <property name="act03" value="char_talk spyder_hospital1_walt,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster anu,34,spyder_hospital1_walt,5,10"/>
     <property name="act06" value="add_monster taupypus,27,spyder_hospital1_walt,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_walt"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_walt2"/>
+    <property name="act08" value="char_talk spyder_hospital1_walt,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1walt:yes"/>
     <property name="cond1" value="not variable_set hospital1walt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -311,42 +311,42 @@
   </object>
   <object id="99" name="Talk Felu" type="event" x="48" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_felu2"/>
+    <property name="act1" value="char_talk spyder_hospital1_felu,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_felu"/>
     <property name="cond1" value="is variable_set hospital1felu:yes"/>
    </properties>
   </object>
   <object id="100" name="Post Talk Fring" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_fring2"/>
+    <property name="act1" value="char_talk spyder_hospital1_fring,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_fring"/>
     <property name="cond1" value="is variable_set hospital1fring:yes"/>
    </properties>
   </object>
   <object id="101" name="Post Talk Aurora" type="event" x="48" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_aurora2"/>
+    <property name="act1" value="char_talk spyder_hospital1_aurora,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_aurora"/>
     <property name="cond1" value="is variable_set hospital1aurora:yes"/>
    </properties>
   </object>
   <object id="102" name="Post Talk Eleni" type="event" x="256" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_eleni2"/>
+    <property name="act1" value="char_talk spyder_hospital1_eleni,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_eleni"/>
     <property name="cond1" value="is variable_set hospital1eleni:yes"/>
    </properties>
   </object>
   <object id="103" name="Post Talk Liane" type="event" x="256" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_liane2"/>
+    <property name="act1" value="char_talk spyder_hospital1_liane,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_liane"/>
     <property name="cond1" value="is variable_set hospital1liane:yes"/>
    </properties>
   </object>
   <object id="104" name="Post Talk Walt" type="event" x="272" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_walt2"/>
+    <property name="act1" value="char_talk spyder_hospital1_walt,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_walt"/>
     <property name="cond1" value="is variable_set hospital1walt:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_candy_hospital2.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital2.tmx
@@ -145,12 +145,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_luzia"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_luzia1"/>
+    <property name="act03" value="char_talk spyder_hospital1_luzia,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster galnec,36,spyder_hospital1_luzia,5,10"/>
     <property name="act06" value="add_monster exclawvate,36,spyder_hospital1_luzia,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_luzia"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_luzia2"/>
+    <property name="act08" value="char_talk spyder_hospital1_luzia,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1luzia:yes"/>
     <property name="cond1" value="not variable_set hospital1luzia:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -166,12 +166,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_zekar"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_zekar1"/>
+    <property name="act03" value="char_talk spyder_hospital1_zekar,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster selket,32,spyder_hospital1_zekar,5,10"/>
     <property name="act06" value="add_monster taupypus,32,spyder_hospital1_zekar,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_zekar"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_zekar2"/>
+    <property name="act08" value="char_talk spyder_hospital1_zekar,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1zekar:yes"/>
     <property name="cond1" value="not variable_set hospital1zekar:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -201,12 +201,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_rakez"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_rakez1"/>
+    <property name="act03" value="char_talk spyder_hospital1_rakez,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster pipis,30,spyder_hospital1_rakez,5,10"/>
     <property name="act06" value="add_monster strella,30,spyder_hospital1_rakez,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_rakez"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_rakez2"/>
+    <property name="act08" value="char_talk spyder_hospital1_rakez,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1rakez:yes"/>
     <property name="cond1" value="not variable_set hospital1rakez:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -223,12 +223,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_hospital1_rhizome"/>
-    <property name="act03" value="translated_dialog spyder_hospital1_rhizome1"/>
+    <property name="act03" value="char_talk spyder_hospital1_rhizome,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster flacono,33,spyder_hospital1_rhizome,5,10"/>
     <property name="act06" value="add_monster fancair,33,spyder_hospital1_rhizome,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_rhizome"/>
-    <property name="act08" value="translated_dialog spyder_hospital1_rhizome2"/>
+    <property name="act08" value="char_talk spyder_hospital1_rhizome,post_battle_lose"/>
     <property name="act09" value="set_variable hospital1rhizome:yes"/>
     <property name="cond1" value="not variable_set hospital1rhizome:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -264,28 +264,28 @@
   </object>
   <object id="111" name="Post Talk Zekar" type="event" x="48" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_zekar2"/>
+    <property name="act1" value="char_talk spyder_hospital1_zekar,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_zekar"/>
     <property name="cond1" value="is variable_set hospital1zekar:yes"/>
    </properties>
   </object>
   <object id="112" name="Post Talk Rakez" type="event" x="32" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_rakez2"/>
+    <property name="act1" value="char_talk spyder_hospital1_rakez,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_rakez"/>
     <property name="cond1" value="is variable_set hospital1rakez:yes"/>
    </properties>
   </object>
   <object id="113" name="Post Talk Luzia" type="event" x="176" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_luzia2"/>
+    <property name="act1" value="char_talk spyder_hospital1_luzia,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_luzia"/>
     <property name="cond1" value="is variable_set hospital1luzia:yes"/>
    </properties>
   </object>
   <object id="114" name="Post Talk Rhizome" type="event" x="256" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_hospital1_rhizome2"/>
+    <property name="act1" value="char_talk spyder_hospital1_rhizome,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_rhizome"/>
     <property name="cond1" value="is variable_set hospital1rhizome:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -230,11 +230,11 @@
   </object>
   <object id="53" name="Talk Frances" type="event" x="448" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_citypark_frances1"/>
+    <property name="act1" value="char_talk spyder_citypark_frances,pre_battle"/>
     <property name="act2" value="add_monster shybulb,8,spyder_citypark_frances,5,10"/>
     <property name="act3" value="add_monster shybulb,8,spyder_citypark_frances,5,10"/>
     <property name="act4" value="start_battle player,spyder_citypark_frances"/>
-    <property name="act5" value="translated_dialog spyder_citypark_frances2"/>
+    <property name="act5" value="char_talk spyder_citypark_frances,post_battle_lose"/>
     <property name="act6" value="set_variable citypark_frances:yes"/>
     <property name="behav1" value="talk spyder_citypark_frances"/>
     <property name="cond1" value="not variable_set citypark_frances:yes"/>
@@ -249,10 +249,10 @@
   </object>
   <object id="55" name="Talk Bobette" type="event" x="256" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_citypark_bobette1"/>
+    <property name="act1" value="char_talk spyder_citypark_bobette,pre_battle"/>
     <property name="act2" value="add_monster aardorn,10,spyder_citypark_bobette,5,10"/>
     <property name="act3" value="start_battle player,spyder_citypark_bobette"/>
-    <property name="act4" value="translated_dialog spyder_citypark_bobette2"/>
+    <property name="act4" value="char_talk spyder_citypark_bobette,post_battle_lose"/>
     <property name="act5" value="set_variable citypark_bobette:yes"/>
     <property name="behav1" value="talk spyder_citypark_bobette"/>
     <property name="cond1" value="not variable_set citypark_bobette:yes"/>
@@ -267,11 +267,11 @@
   </object>
   <object id="57" name="Talk Edith" type="event" x="608" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_citypark_edith1"/>
+    <property name="act1" value="char_talk spyder_citypark_edith,pre_battle"/>
     <property name="act2" value="add_monster squabbit,8,spyder_citypark_edith,5,10"/>
     <property name="act3" value="add_monster squabbit,8,spyder_citypark_edith,5,10"/>
     <property name="act4" value="start_battle player,spyder_citypark_edith"/>
-    <property name="act5" value="translated_dialog spyder_citypark_edith2"/>
+    <property name="act5" value="char_talk spyder_citypark_edith,post_battle_lose"/>
     <property name="act6" value="set_variable citypark_edith:yes"/>
     <property name="behav1" value="talk spyder_citypark_edith"/>
     <property name="cond1" value="not variable_set citypark_edith:yes"/>
@@ -477,11 +477,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_citypark_bobette"/>
-    <property name="act3" value="translated_dialog spyder_citypark_bobette1"/>
+    <property name="act3" value="char_talk spyder_citypark_bobette,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster aardorn,10,spyder_citypark_bobette,5,10"/>
     <property name="act6" value="start_battle player,spyder_citypark_bobette"/>
-    <property name="act7" value="translated_dialog spyder_citypark_bobette2"/>
+    <property name="act7" value="char_talk spyder_citypark_bobette,post_battle_lose"/>
     <property name="act8" value="set_variable citypark_bobette:yes"/>
     <property name="cond1" value="not variable_set citypark_bobette:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -592,21 +592,21 @@
   </object>
   <object id="293" name="Post Talk Bobette" type="event" x="256" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_citypark_bobette2"/>
+    <property name="act1" value="char_talk spyder_citypark_bobette,post_battle_lose"/>
     <property name="behav1" value="talk spyder_citypark_bobette"/>
     <property name="cond1" value="is variable_set citypark_bobette:yes"/>
    </properties>
   </object>
   <object id="294" name="Post Talk Frances" type="event" x="448" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_citypark_frances2"/>
+    <property name="act1" value="char_talk spyder_citypark_frances,post_battle_lose"/>
     <property name="behav1" value="talk spyder_citypark_frances"/>
     <property name="cond1" value="is variable_set citypark_frances:yes"/>
    </properties>
   </object>
   <object id="295" name="Post Talk Edith" type="event" x="624" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_citypark_edith2"/>
+    <property name="act1" value="char_talk spyder_citypark_edith,post_battle_lose"/>
     <property name="behav1" value="talk spyder_citypark_edith"/>
     <property name="cond1" value="is variable_set citypark_edith:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.yaml
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.yaml
@@ -155,7 +155,7 @@ events:
     type: event
   Post Talk Carlos:
     actions:
-    - translated_dialog spyder_cottontunnel_carlos2
+    - char_talk spyder_cottontunnel_carlos,post_battle_lose
     behav:
     - talk spyder_cottontunnel_carlos
     conditions:
@@ -220,12 +220,12 @@ events:
     actions:
     - lock_controls
     - pathfind_to_char player,spyder_cottontunnel_carlos
-    - translated_dialog spyder_cottontunnel_carlos1
+    - char_talk spyder_cottontunnel_carlos,pre_battle
     - unlock_controls
     - add_monster agnidon,35,spyder_cottontunnel_carlos,5,10
     - add_monster legko,35,spyder_cottontunnel_carlos,5,10
     - start_battle player,spyder_cottontunnel_carlos
-    - translated_dialog spyder_cottontunnel_carlos2
+    - char_talk spyder_cottontunnel_carlos,post_battle_lose
     - set_variable cottontunnelcarlos:yes
     conditions:
     - not variable_set cottontunnelcarlos:yes

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -183,7 +183,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_datacenter_fermi"/>
-    <property name="act03" value="translated_dialog spyder_datacenter_fermi1"/>
+    <property name="act03" value="char_talk spyder_datacenter_fermi,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster chromeye,35,spyder_datacenter_fermi,5,10"/>
     <property name="act06" value="add_monster angrito,35,spyder_datacenter_fermi,5,10"/>
@@ -191,7 +191,7 @@
     <property name="act08" value="add_monster happito,35,spyder_datacenter_fermi,5,10"/>
     <property name="act09" value="add_monster neutrito,35,spyder_datacenter_fermi,5,10"/>
     <property name="act10" value="start_battle player,spyder_datacenter_fermi"/>
-    <property name="act11" value="translated_dialog spyder_datacenter_fermi2"/>
+    <property name="act11" value="char_talk spyder_datacenter_fermi,post_battle_lose"/>
     <property name="act12" value="set_variable datacenterfermi:yes"/>
     <property name="cond1" value="not variable_set datacenterfermi:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -208,12 +208,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_datacenter_onnes"/>
-    <property name="act03" value="translated_dialog spyder_datacenter_onnes1"/>
+    <property name="act03" value="char_talk spyder_datacenter_onnes,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster ouroboutlet,45,spyder_datacenter_onnes,5,10"/>
     <property name="act06" value="add_monster angrito,40,spyder_datacenter_onnes,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_onnes"/>
-    <property name="act08" value="translated_dialog spyder_datacenter_onnes2"/>
+    <property name="act08" value="char_talk spyder_datacenter_onnes,post_battle_lose"/>
     <property name="act09" value="set_variable datacenteronnes:yes"/>
     <property name="cond1" value="not variable_set datacenteronnes:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -230,12 +230,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_datacenter_bayliss"/>
-    <property name="act03" value="translated_dialog spyder_datacenter_bayliss1"/>
+    <property name="act03" value="char_talk spyder_datacenter_bayliss,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster sockeserp,45,spyder_datacenter_bayliss,5,10"/>
     <property name="act06" value="add_monster sadito,40,spyder_datacenter_bayliss,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_bayliss"/>
-    <property name="act08" value="translated_dialog spyder_datacenter_bayliss2"/>
+    <property name="act08" value="char_talk spyder_datacenter_bayliss,post_battle_lose"/>
     <property name="act09" value="set_variable datacenterbayliss:yes"/>
     <property name="cond1" value="not variable_set datacenterbayliss:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -252,12 +252,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_datacenter_chomsky"/>
-    <property name="act03" value="translated_dialog spyder_datacenter_chomsky1"/>
+    <property name="act03" value="char_talk spyder_datacenter_chomsky,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster fancair,45,spyder_datacenter_chomsky,5,10"/>
     <property name="act06" value="add_monster happito,40,spyder_datacenter_chomsky,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_chomsky"/>
-    <property name="act08" value="translated_dialog spyder_datacenter_chomsky2"/>
+    <property name="act08" value="char_talk spyder_datacenter_chomsky,post_battle_lose"/>
     <property name="act09" value="set_variable datacenterchomsky:yes"/>
     <property name="cond1" value="not variable_set datacenterchomsky:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -274,12 +274,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_datacenter_lagrange"/>
-    <property name="act03" value="translated_dialog spyder_datacenter_lagrange1"/>
+    <property name="act03" value="char_talk spyder_datacenter_lagrange,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster windeye,45,spyder_datacenter_lagrange,5,10"/>
     <property name="act06" value="add_monster neutrito,45,spyder_datacenter_lagrange,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_lagrange"/>
-    <property name="act08" value="translated_dialog spyder_datacenter_lagrange2"/>
+    <property name="act08" value="char_talk spyder_datacenter_lagrange,post_battle_lose"/>
     <property name="act09" value="set_variable datacenterlagrange:yes"/>
     <property name="cond1" value="not variable_set datacenterlagrange:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -502,35 +502,35 @@
   </object>
   <object id="118" name="Talk Lagrange" type="event" x="48" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_datacenter_lagrange2"/>
+    <property name="act1" value="char_talk spyder_datacenter_lagrange,post_battle_lose"/>
     <property name="behav1" value="talk spyder_datacenter_lagrange"/>
     <property name="cond1" value="is variable_set datacenterlagrange:yes"/>
    </properties>
   </object>
   <object id="119" name="Talk Chomsky" type="event" x="144" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_datacenter_chomsky2"/>
+    <property name="act1" value="char_talk spyder_datacenter_chomsky,post_battle_lose"/>
     <property name="behav1" value="talk spyder_datacenter_chomsky"/>
     <property name="cond1" value="is variable_set datacenterchomsky:yes"/>
    </properties>
   </object>
   <object id="120" name="Talk Bayliss" type="event" x="208" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_datacenter_bayliss2"/>
+    <property name="act1" value="char_talk spyder_datacenter_bayliss,post_battle_lose"/>
     <property name="behav1" value="talk spyder_datacenter_bayliss"/>
     <property name="cond1" value="is variable_set datacenterbayliss:yes"/>
    </properties>
   </object>
   <object id="121" name="Talk Fermi" type="event" x="144" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_datacenter_fermi2"/>
+    <property name="act1" value="char_talk spyder_datacenter_fermi,post_battle_lose"/>
     <property name="behav1" value="talk spyder_datacenter_fermi"/>
     <property name="cond1" value="is variable_set datacenterfermi:yes"/>
    </properties>
   </object>
   <object id="122" name="Talk Onnes" type="event" x="208" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_datacenter_onnes2"/>
+    <property name="act1" value="char_talk spyder_datacenter_onnes,post_battle_lose"/>
     <property name="behav1" value="talk spyder_datacenter_onnes"/>
     <property name="cond1" value="is variable_set datacenteronnes:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_dojo2.tmx
+++ b/mods/tuxemon/maps/spyder_dojo2.tmx
@@ -133,7 +133,7 @@
   </object>
   <object id="28" name="Talk Iroh" type="event" x="128" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_iroh1"/>
+    <property name="act11" value="char_talk spyder_dojo_iroh,pre_battle"/>
     <property name="act12" value="add_monster cardiwing,20,spyder_dojo_iroh,5,10"/>
     <property name="act13" value="add_monster djinnbo,20,spyder_dojo_iroh,5,10"/>
     <property name="act14" value="add_monster abesnaki,20,spyder_dojo_iroh,5,10"/>
@@ -146,7 +146,7 @@
     <property name="act24" value="add_tech iid_slot_3,radiance"/>
     <property name="act25" value="add_tech iid_slot_4,demiurge"/>
     <property name="act30" value="start_battle player,spyder_dojo_iroh"/>
-    <property name="act31" value="translated_dialog spyder_dojo_iroh2"/>
+    <property name="act31" value="char_talk spyder_dojo_iroh,post_battle_lose"/>
     <property name="act32" value="set_variable dojoiroh:yes"/>
     <property name="act40" value="set_monster_health"/>
     <property name="act50" value="set_monster_status"/>
@@ -156,13 +156,13 @@
   </object>
   <object id="29" name="Talk Yangchen" type="event" x="144" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_yangchen1"/>
+    <property name="act11" value="char_talk spyder_dojo_yangchen,pre_battle"/>
     <property name="act12" value="add_monster sapsnap,20,spyder_dojo_yangchen,5,10"/>
     <property name="act13" value="add_monster trapsnap,20,spyder_dojo_yangchen,5,10"/>
     <property name="act14" value="add_monster dandylion,20,spyder_dojo_yangchen,5,10"/>
     <property name="act15" value="add_monster budaye,20,spyder_dojo_yangchen,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_yangchen"/>
-    <property name="act17" value="translated_dialog spyder_dojo_yangchen2"/>
+    <property name="act17" value="char_talk spyder_dojo_yangchen,post_battle_lose"/>
     <property name="act18" value="set_variable dojoyangchen:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -172,10 +172,10 @@
   </object>
   <object id="30" name="Talk Kataro" type="event" x="160" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_kataro1"/>
+    <property name="act11" value="char_talk spyder_dojo_kataro,pre_battle"/>
     <property name="act12" value="add_monster hydrone,20,spyder_dojo_kataro,5,10"/>
     <property name="act13" value="start_battle player,spyder_dojo_kataro"/>
-    <property name="act14" value="translated_dialog spyder_dojo_kataro2"/>
+    <property name="act14" value="char_talk spyder_dojo_kataro,post_battle_lose"/>
     <property name="act15" value="set_variable dojokataro:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -185,13 +185,13 @@
   </object>
   <object id="19" name="Talk Sokka" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_sokka1"/>
+    <property name="act11" value="char_talk spyder_dojo_sokka,pre_battle"/>
     <property name="act12" value="add_monster hydrone,20,spyder_dojo_sokka,5,10"/>
     <property name="act13" value="add_monster miaownolith,20,spyder_dojo_sokka,5,10"/>
     <property name="act14" value="add_monster embazook,20,spyder_dojo_sokka,5,10"/>
     <property name="act15" value="add_monster grintrock,20,spyder_dojo_sokka,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_sokka"/>
-    <property name="act17" value="translated_dialog spyder_dojo_sokka2"/>
+    <property name="act17" value="char_talk spyder_dojo_sokka,post_battle_lose"/>
     <property name="act18" value="set_variable dojosokka:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -201,7 +201,7 @@
   </object>
   <object id="32" name="Talk Toph" type="event" x="192" y="0" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_dojo_toph1"/>
+    <property name="act01" value="char_talk spyder_dojo_toph,pre_battle"/>
     <property name="act02" value="add_monster rockat,20,spyder_dojo_toph,5,10"/>
     <property name="act03" value="add_monster rhincus,20,spyder_dojo_toph,5,10"/>
     <property name="act04" value="add_monster aardorn,20,spyder_dojo_toph,5,10"/>
@@ -209,7 +209,7 @@
     <property name="act06" value="add_monster forturtle,20,spyder_dojo_toph,5,10"/>
     <property name="act07" value="add_monster vivipere,20,spyder_dojo_toph,5,10"/>
     <property name="act08" value="start_battle player,spyder_dojo_toph"/>
-    <property name="act09" value="translated_dialog spyder_dojo_toph2"/>
+    <property name="act09" value="char_talk spyder_dojo_toph,post_battle_lose"/>
     <property name="act10" value="set_variable dojotoph:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -263,35 +263,35 @@
   </object>
   <object id="33" name="Post Talk Iroh" type="event" x="128" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_iroh2"/>
+    <property name="act1" value="char_talk spyder_dojo_iroh,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_iroh"/>
     <property name="cond1" value="is variable_set dojoiroh:yes"/>
    </properties>
   </object>
   <object id="34" name="Post Talk Yangchen" type="event" x="144" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_yangchen2"/>
+    <property name="act1" value="char_talk spyder_dojo_yangchen,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_yangchen"/>
     <property name="cond1" value="is variable_set dojoyangchen:yes"/>
    </properties>
   </object>
   <object id="35" name="Post Talk Kataro" type="event" x="160" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_kataro2"/>
+    <property name="act1" value="char_talk spyder_dojo_kataro,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_kataro"/>
     <property name="cond1" value="is variable_set dojokataro:yes"/>
    </properties>
   </object>
   <object id="36" name="Post Talk Sokka" type="event" x="176" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_sokka2"/>
+    <property name="act1" value="char_talk spyder_dojo_sokka,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_sokka"/>
     <property name="cond1" value="is variable_set dojosokka:yes"/>
    </properties>
   </object>
   <object id="37" name="Post Talk Toph" type="event" x="192" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_toph2"/>
+    <property name="act1" value="char_talk spyder_dojo_toph,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_toph"/>
     <property name="cond1" value="is variable_set dojotoph:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -133,13 +133,13 @@
   </object>
   <object id="28" name="Talk Saturn" type="event" x="128" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_saturn1"/>
+    <property name="act11" value="char_talk spyder_dojo_saturn,pre_battle"/>
     <property name="act12" value="add_monster hampotamos,30,spyder_dojo_saturn,5,10"/>
     <property name="act13" value="add_monster baobaraffe,30,spyder_dojo_saturn,5,10"/>
     <property name="act14" value="add_monster shnark,30,spyder_dojo_saturn,5,10"/>
     <property name="act15" value="add_monster sludgehog,30,spyder_dojo_saturn,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_saturn"/>
-    <property name="act17" value="translated_dialog spyder_dojo_saturn2"/>
+    <property name="act17" value="char_talk spyder_dojo_saturn,post_battle_lose"/>
     <property name="act18" value="set_variable dojosaturn:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -151,13 +151,13 @@
   </object>
   <object id="29" name="Talk Hephastus" type="event" x="144" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_hephastus1"/>
+    <property name="act11" value="char_talk spyder_dojo_hephastus,pre_battle"/>
     <property name="act12" value="add_monster mystikapi,30,spyder_dojo_hephastus,5,10"/>
     <property name="act13" value="add_monster lightmare,30,spyder_dojo_hephastus,5,10"/>
     <property name="act14" value="add_monster loliferno,30,spyder_dojo_hephastus,5,10"/>
     <property name="act15" value="add_monster embra,30,spyder_dojo_hephastus,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_hephastus"/>
-    <property name="act17" value="translated_dialog spyder_dojo_hephastus2"/>
+    <property name="act17" value="char_talk spyder_dojo_hephastus,post_battle_lose"/>
     <property name="act18" value="set_variable dojohephastus:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -169,13 +169,13 @@
   </object>
   <object id="19" name="Talk Hermes" type="event" x="160" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_hermes1"/>
+    <property name="act11" value="char_talk spyder_dojo_hermes,pre_battle"/>
     <property name="act12" value="add_monster capiti,30,spyder_dojo_hermes,5,10"/>
     <property name="act13" value="add_monster graffiki,30,spyder_dojo_hermes,5,10"/>
     <property name="act14" value="add_monster volcoli,30,spyder_dojo_hermes,5,10"/>
     <property name="act15" value="add_monster eaglace,30,spyder_dojo_hermes,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_hermes"/>
-    <property name="act17" value="translated_dialog spyder_dojo_hermes2"/>
+    <property name="act17" value="char_talk spyder_dojo_hermes,post_battle_lose"/>
     <property name="act18" value="set_variable dojohermes:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -187,13 +187,13 @@
   </object>
   <object id="13" name="Talk Orion" type="event" x="176" y="0" width="16" height="16">
    <properties>
-    <property name="act11" value="translated_dialog spyder_dojo_orion1"/>
+    <property name="act11" value="char_talk spyder_dojo_orion,pre_battle"/>
     <property name="act12" value="add_monster skwib,30,spyder_dojo_orion,5,10"/>
     <property name="act13" value="add_monster miaownolith,30,spyder_dojo_orion,5,10"/>
     <property name="act14" value="add_monster grimachin,30,spyder_dojo_orion,5,10"/>
     <property name="act15" value="add_monster drashimi,30,spyder_dojo_orion,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_orion"/>
-    <property name="act17" value="translated_dialog spyder_dojo_orion2"/>
+    <property name="act17" value="char_talk spyder_dojo_orion,post_battle_lose"/>
     <property name="act18" value="set_variable dojoorion:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -205,13 +205,13 @@
   </object>
   <object id="39" name="Talk Ares" type="event" x="192" y="0" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_dojo_ares1"/>
+    <property name="act01" value="char_talk spyder_dojo_ares,pre_battle"/>
     <property name="act02" value="add_monster urcine,30,spyder_dojo_ares,5,10"/>
     <property name="act03" value="add_monster flambear,30,spyder_dojo_ares,5,10"/>
     <property name="act04" value="add_monster boltnu,30,spyder_dojo_ares,5,10"/>
     <property name="act05" value="add_monster tourbidi,30,spyder_dojo_ares,5,10"/>
     <property name="act08" value="start_battle player,spyder_dojo_ares"/>
-    <property name="act09" value="translated_dialog spyder_dojo_ares2"/>
+    <property name="act09" value="char_talk spyder_dojo_ares,post_battle_lose"/>
     <property name="act10" value="set_variable dojoares:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
@@ -265,35 +265,35 @@
   </object>
   <object id="32" name="Post Talk Saturn" type="event" x="128" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_saturn2"/>
+    <property name="act1" value="char_talk spyder_dojo_saturn,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_saturn"/>
     <property name="cond1" value="is variable_set dojosaturn:yes"/>
    </properties>
   </object>
   <object id="33" name="Post Talk Hephastus" type="event" x="144" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_hephastus2"/>
+    <property name="act1" value="char_talk spyder_dojo_hephastus,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_hephastus"/>
     <property name="cond1" value="is variable_set dojohephastus:yes"/>
    </properties>
   </object>
   <object id="34" name="Post Talk Hermes" type="event" x="160" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_hermes2"/>
+    <property name="act1" value="char_talk spyder_dojo_hermes,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_hermes"/>
     <property name="cond1" value="is variable_set dojohermes:yes"/>
    </properties>
   </object>
   <object id="35" name="Post Talk Orion" type="event" x="176" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_orion2"/>
+    <property name="act1" value="char_talk spyder_dojo_orion,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_orion"/>
     <property name="cond1" value="is variable_set dojoorion:yes"/>
    </properties>
   </object>
   <object id="36" name="Post Talk Ares" type="event" x="192" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dojo_ares2"/>
+    <property name="act1" value="char_talk spyder_dojo_ares,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dojo_ares"/>
     <property name="cond1" value="is variable_set dojoares:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -113,10 +113,10 @@
   </object>
   <object id="62" name="Talk Tomas" type="event" x="288" y="512" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_tomas1"/>
+    <property name="act1" value="char_talk spyder_dragonscave_tomas,pre_battle"/>
     <property name="act2" value="add_monster allagon,35,spyder_dragonscave_tomas,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_tomas"/>
-    <property name="act4" value="translated_dialog spyder_dragonscave_tomas2"/>
+    <property name="act4" value="char_talk spyder_dragonscave_tomas,post_battle_lose"/>
     <property name="act6" value="set_variable dragonscavetomas:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_tomas"/>
     <property name="cond1" value="not variable_set dragonscavetomas:yes"/>
@@ -130,10 +130,10 @@
   </object>
   <object id="64" name="Talk Lessa" type="event" x="256" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_lessa1"/>
+    <property name="act1" value="char_talk spyder_dragonscave_lessa,pre_battle"/>
     <property name="act2" value="add_monster allagon,37,spyder_dragonscave_lessa,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_lessa"/>
-    <property name="act4" value="translated_dialog spyder_dragonscave_lessa2"/>
+    <property name="act4" value="char_talk spyder_dragonscave_lessa,post_battle_lose"/>
     <property name="act6" value="set_variable dragonscavelessa:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_lessa"/>
     <property name="cond1" value="not variable_set dragonscavelessa:yes"/>
@@ -148,10 +148,10 @@
   </object>
   <object id="66" name="Talk Cailin" type="event" x="112" y="432" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_cailin1"/>
+    <property name="act1" value="char_talk spyder_dragonscave_cailin,pre_battle"/>
     <property name="act2" value="add_monster dragarbor,36,spyder_dragonscave_cailin,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_cailin"/>
-    <property name="act4" value="translated_dialog spyder_dragonscave_cailin2"/>
+    <property name="act4" value="char_talk spyder_dragonscave_cailin,post_battle_lose"/>
     <property name="act6" value="set_variable dragonscavecailin:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_cailin"/>
     <property name="cond1" value="not variable_set dragonscavecailin:yes"/>
@@ -166,10 +166,10 @@
   </object>
   <object id="68" name="Talk Griffin" type="event" x="96" y="608" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_griffin1"/>
+    <property name="act1" value="char_talk spyder_dragonscave_griffin,pre_battle"/>
     <property name="act2" value="add_monster bigfin,35,spyder_dragonscave_griffin,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_griffin"/>
-    <property name="act4" value="translated_dialog spyder_dragonscave_griffin2"/>
+    <property name="act4" value="char_talk spyder_dragonscave_griffin,post_battle_lose"/>
     <property name="act6" value="set_variable dragonscavegriffin:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_griffin"/>
     <property name="cond1" value="not variable_set dragonscavegriffin:yes"/>
@@ -184,10 +184,10 @@
   </object>
   <object id="70" name="Talk Daenny" type="event" x="176" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_daenny1"/>
+    <property name="act1" value="char_talk spyder_dragonscave_daenny,pre_battle"/>
     <property name="act2" value="add_monster eaglace,37,spyder_dragonscave_daenny,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_daenny"/>
-    <property name="act4" value="translated_dialog spyder_dragonscave_daenny2"/>
+    <property name="act4" value="char_talk spyder_dragonscave_daenny,post_battle_lose"/>
     <property name="act6" value="set_variable dragonscavedaenny:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_daenny"/>
     <property name="cond1" value="not variable_set dragonscavedaenny:yes"/>
@@ -201,11 +201,11 @@
   </object>
   <object id="72" name="Talk Benden" type="event" x="96" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_benden1"/>
+    <property name="act1" value="char_talk spyder_dragonscave_benden,pre_battle"/>
     <property name="act2" value="add_monster dragarbor,36,spyder_dragonscave_benden,5,10"/>
     <property name="act3" value="add_monster sapragon,38,spyder_dragonscave_benden,5,10"/>
     <property name="act4" value="start_battle player,spyder_dragonscave_benden"/>
-    <property name="act5" value="translated_dialog spyder_dragonscave_benden2"/>
+    <property name="act5" value="char_talk spyder_dragonscave_benden,post_battle_lose"/>
     <property name="act6" value="set_monster_health"/>
     <property name="act7" value="set_monster_status"/>
     <property name="act8" value="set_variable dragonscavebenden:yes"/>
@@ -296,11 +296,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_tomas"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_tomas1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_tomas,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster allagon,35,spyder_dragonscave_tomas,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_tomas"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_tomas2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_tomas,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavetomas:yes"/>
     <property name="cond1" value="not variable_set dragonscavetomas:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -310,11 +310,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_daenny"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_daenny1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_daenny,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster eaglace,37,spyder_dragonscave_daenny,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_daenny"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_daenny2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_daenny,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavedaenny:yes"/>
     <property name="cond1" value="not variable_set dragonscavedaenny:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -324,11 +324,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_cailin"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_cailin1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_cailin,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster dragarbor,36,spyder_dragonscave_cailin,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_cailin"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_cailin2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_cailin,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavecailin:yes"/>
     <property name="cond1" value="not variable_set dragonscavecailin:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -338,11 +338,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_lessa"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_lessa1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_lessa,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster allagon,37,spyder_dragonscave_lessa,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_lessa"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_lessa2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_lessa,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavelessa:yes"/>
     <property name="cond1" value="not variable_set dragonscavelessa:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -352,11 +352,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_griffin"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_griffin1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_griffin,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster bigfin,35,spyder_dragonscave_griffin,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_griffin"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_griffin2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_griffin,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavegriffin:yes"/>
     <property name="cond1" value="not variable_set dragonscavegriffin:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -366,12 +366,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_dragonscave_benden"/>
-    <property name="act03" value="translated_dialog spyder_dragonscave_benden1"/>
+    <property name="act03" value="char_talk spyder_dragonscave_benden,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster dragarbor,36,spyder_dragonscave_benden,5,10"/>
     <property name="act06" value="add_monster sapragon,38,spyder_dragonscave_benden,5,10"/>
     <property name="act07" value="start_battle player,spyder_dragonscave_benden"/>
-    <property name="act08" value="translated_dialog spyder_dragonscave_benden2"/>
+    <property name="act08" value="char_talk spyder_dragonscave_benden,post_battle_lose"/>
     <property name="act09" value="set_monster_health"/>
     <property name="act10" value="set_monster_status"/>
     <property name="act11" value="set_variable dragonscavebenden:yes"/>
@@ -383,11 +383,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_ray"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_ray1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_ray,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster ghosteeth,40,spyder_dragonscave_ray,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_ray"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_ray2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_ray,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscaveray:yes"/>
     <property name="cond1" value="not variable_set dragonscaveray:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -397,13 +397,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_dragonscave_tru"/>
-    <property name="act03" value="translated_dialog spyder_dragonscave_tru1"/>
+    <property name="act03" value="char_talk spyder_dragonscave_tru,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster embazook,40,spyder_dragonscave_tru,5,10"/>
     <property name="act06" value="add_monster arthrobolt,40,spyder_dragonscave_tru,5,10"/>
     <property name="act07" value="add_monster hydrone,40,spyder_dragonscave_tru,5,10"/>
     <property name="act08" value="start_battle player,spyder_dragonscave_tru"/>
-    <property name="act09" value="translated_dialog spyder_dragonscave_tru2"/>
+    <property name="act09" value="char_talk spyder_dragonscave_tru,post_battle_lose"/>
     <property name="act10" value="set_variable dragonscavetru:yes"/>
     <property name="cond1" value="not variable_set dragonscavetru:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -413,11 +413,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_lucille"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_lucille1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_lucille,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster coleorus,40,spyder_dragonscave_lucille,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_lucille"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_lucille2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_lucille,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavelucille:yes"/>
     <property name="cond1" value="not variable_set dragonscavelucille:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -427,11 +427,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_dragonscave_mal"/>
-    <property name="act3" value="translated_dialog spyder_dragonscave_mal1"/>
+    <property name="act3" value="char_talk spyder_dragonscave_mal,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster djinnbo,40,spyder_dragonscave_mal,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_mal"/>
-    <property name="act7" value="translated_dialog spyder_dragonscave_mal2"/>
+    <property name="act7" value="char_talk spyder_dragonscave_mal,post_battle_lose"/>
     <property name="act8" value="set_variable dragonscavemal:yes"/>
     <property name="cond1" value="not variable_set dragonscavemal:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -459,35 +459,35 @@
   </object>
   <object id="106" name="Post Talk Cailin" type="event" x="176" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_cailin2"/>
+    <property name="act1" value="char_talk spyder_dragonscave_cailin,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dragonscave_cailin"/>
     <property name="cond1" value="is variable_set dragonscavecailin:yes"/>
    </properties>
   </object>
   <object id="107" name="Post Talk Daenny" type="event" x="192" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_daenny2"/>
+    <property name="act1" value="char_talk spyder_dragonscave_daenny,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dragonscave_daenny"/>
     <property name="cond1" value="is variable_set dragonscavedaenny:yes"/>
    </properties>
   </object>
   <object id="108" name="Post Talk Tomas" type="event" x="176" y="544" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_tomas2"/>
+    <property name="act1" value="char_talk spyder_dragonscave_tomas,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dragonscave_tomas"/>
     <property name="cond1" value="is variable_set dragonscavetomas:yes"/>
    </properties>
   </object>
   <object id="109" name="Post Talk Griffin" type="event" x="192" y="544" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_griffin2"/>
+    <property name="act1" value="char_talk spyder_dragonscave_griffin,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dragonscave_griffin"/>
     <property name="cond1" value="is variable_set dragonscavegriffin:yes"/>
    </properties>
   </object>
   <object id="110" name="Post Talk Lessa" type="event" x="208" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dragonscave_lessa2"/>
+    <property name="act1" value="char_talk spyder_dragonscave_lessa,post_battle_lose"/>
     <property name="behav1" value="talk spyder_dragonscave_lessa"/>
     <property name="cond1" value="is variable_set dragonscavelessa:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -571,12 +571,12 @@
   </object>
   <object id="209" name="Talk Aquemini" type="event" x="528" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dryadsgrove_aquemini1"/>
+    <property name="act1" value="char_talk spyder_dryadsgrove_aquemini,pre_battle"/>
     <property name="act2" value="add_monster vivitrans,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act3" value="add_monster nudimind,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act4" value="add_monster noctalo,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_aquemini"/>
-    <property name="act6" value="translated_dialog spyder_dryadsgrove_aquemini2"/>
+    <property name="act6" value="char_talk spyder_dryadsgrove_aquemini,post_battle_lose"/>
     <property name="act7" value="set_variable dryadsgroveaquemini:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_aquemini"/>
     <property name="cond1" value="not variable_set dryadsgroveaquemini:yes"/>
@@ -603,12 +603,12 @@
   </object>
   <object id="214" name="Talk Ignatia" type="event" x="384" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dryadsgrove_ignatia1"/>
+    <property name="act1" value="char_talk spyder_dryadsgrove_ignatia,pre_battle"/>
     <property name="act2" value="add_monster vivicinder,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act3" value="add_monster masknake,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act4" value="add_monster criniotherme,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_ignatia"/>
-    <property name="act6" value="translated_dialog spyder_dryadsgrove_ignatia2"/>
+    <property name="act6" value="char_talk spyder_dryadsgrove_ignatia,post_battle_lose"/>
     <property name="act7" value="set_variable dryadsgroveignatia:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_ignatia"/>
     <property name="cond1" value="not variable_set dryadsgroveignatia:yes"/>
@@ -623,12 +623,12 @@
   </object>
   <object id="216" name="Talk Petra" type="event" x="240" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dryadsgrove_petra1"/>
+    <property name="act1" value="char_talk spyder_dryadsgrove_petra,pre_battle"/>
     <property name="act2" value="add_monster vivitron,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act3" value="add_monster sumchon,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act4" value="add_monster exapode,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_petra"/>
-    <property name="act6" value="translated_dialog spyder_dryadsgrove_petra2"/>
+    <property name="act6" value="char_talk spyder_dryadsgrove_petra,post_battle_lose"/>
     <property name="act7" value="set_variable dryadsgrovepetra:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_petra"/>
     <property name="cond1" value="not variable_set dryadsgrovepetra:yes"/>
@@ -644,12 +644,12 @@
   </object>
   <object id="218" name="Talk Sylvia" type="event" x="224" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dryadsgrove_sylvia1"/>
+    <property name="act1" value="char_talk spyder_dryadsgrove_sylvia,pre_battle"/>
     <property name="act2" value="add_monster viviphyta,50,spyder_dryadsgrove_sylvia,5,10"/>
     <property name="act3" value="add_monster dandylion,50,spyder_dryadsgrove_sylvia,5,10"/>
     <property name="act4" value="add_monster narcileaf,50,spyder_dryadsgrove_sylvia,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_sylvia"/>
-    <property name="act6" value="translated_dialog spyder_dryadsgrove_sylvia2"/>
+    <property name="act6" value="char_talk spyder_dryadsgrove_sylvia,post_battle_lose"/>
     <property name="act7" value="set_variable dryadsgrovesylvia:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_sylvia"/>
     <property name="cond1" value="not variable_set dryadsgrovesylvia:yes"/>
@@ -673,13 +673,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_dryadsgrove_aquemini"/>
-    <property name="act03" value="translated_dialog spyder_dryadsgrove_aquemini1"/>
+    <property name="act03" value="char_talk spyder_dryadsgrove_aquemini,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster vivitrans,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act06" value="add_monster nudimind,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act07" value="add_monster noctalo,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_aquemini"/>
-    <property name="act09" value="translated_dialog spyder_dryadsgrove_aquemini2"/>
+    <property name="act09" value="char_talk spyder_dryadsgrove_aquemini,post_battle_lose"/>
     <property name="act10" value="set_variable dryadsgroveaquemini:yes"/>
     <property name="cond1" value="not variable_set dryadsgroveaquemini:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -689,13 +689,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_dryadsgrove_ignatia"/>
-    <property name="act03" value="translated_dialog spyder_dryadsgrove_ignatia1"/>
+    <property name="act03" value="char_talk spyder_dryadsgrove_ignatia,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster vivicinder,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act06" value="add_monster masknake,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act07" value="add_monster criniotherme,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_ignatia"/>
-    <property name="act09" value="translated_dialog spyder_dryadsgrove_ignatia2"/>
+    <property name="act09" value="char_talk spyder_dryadsgrove_ignatia,post_battle_lose"/>
     <property name="act10" value="set_variable dryadsgroveignatia:yes"/>
     <property name="cond1" value="not variable_set dryadsgroveignatia:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -705,13 +705,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_dryadsgrove_petra"/>
-    <property name="act03" value="translated_dialog spyder_dryadsgrove_petra1"/>
+    <property name="act03" value="char_talk spyder_dryadsgrove_petra,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster vivitron,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act06" value="add_monster sumchon,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act07" value="add_monster exapode,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_petra"/>
-    <property name="act09" value="translated_dialog spyder_dryadsgrove_petra2"/>
+    <property name="act09" value="char_talk spyder_dryadsgrove_petra,post_battle_lose"/>
     <property name="act10" value="set_variable dryadsgrovepetra:yes"/>
     <property name="cond1" value="not variable_set dryadsgrovepetra:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -726,12 +726,12 @@
   </object>
   <object id="226" name="Talk Ferris" type="event" x="592" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_dryadsgrove_ferris1"/>
+    <property name="act1" value="char_talk spyder_dryadsgrove_ferris,pre_battle"/>
     <property name="act2" value="add_monster viviteel,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act3" value="add_monster allagon,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act4" value="add_monster araignee,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_ferris"/>
-    <property name="act6" value="translated_dialog spyder_dryadsgrove_ferris2"/>
+    <property name="act6" value="char_talk spyder_dryadsgrove_ferris,post_battle_lose"/>
     <property name="act7" value="set_variable dryadsgroveferris:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_ferris"/>
     <property name="cond1" value="not variable_set dryadsgroveferris:yes"/>
@@ -741,13 +741,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_dryadsgrove_ferris"/>
-    <property name="act03" value="translated_dialog spyder_dryadsgrove_ferris1"/>
+    <property name="act03" value="char_talk spyder_dryadsgrove_ferris,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster viviteel,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act06" value="add_monster allagon,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act07" value="add_monster araignee,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_ferris"/>
-    <property name="act09" value="translated_dialog spyder_dryadsgrove_ferris2"/>
+    <property name="act09" value="char_talk spyder_dryadsgrove_ferris,post_battle_lose"/>
     <property name="act10" value="set_variable dryadsgroveferris:yes"/>
     <property name="cond1" value="not variable_set dryadsgroveferris:yes"/>
     <property name="cond2" value="is char_at player"/>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -66,13 +66,13 @@
   </object>
   <object id="45" name="Talk Looten" type="event" x="80" y="464" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_greenwash_looten1"/>
+    <property name="act10" value="char_talk spyder_greenwash_looten,pre_battle"/>
     <property name="act11" value="add_monster bearloch,30,spyder_greenwash_looten,5,10"/>
     <property name="act12" value="add_monster rocktot,30,spyder_greenwash_looten,5,10"/>
     <property name="act13" value="add_monster foxko,30,spyder_greenwash_looten,5,10"/>
     <property name="act14" value="add_monster agnsher,30,spyder_greenwash_looten,5,10"/>
     <property name="act20" value="start_battle player,spyder_greenwash_looten"/>
-    <property name="act21" value="translated_dialog spyder_greenwash_looten2"/>
+    <property name="act21" value="char_talk spyder_greenwash_looten,post_battle_lose"/>
     <property name="act22" value="translated_dialog spyder_greenwash_looten3"/>
     <property name="act23" value="translated_dialog spyder_greenwash_looten4"/>
     <property name="act40" value="set_variable gotaardant:yes"/>
@@ -133,13 +133,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_greenwash_chip"/>
-    <property name="act03" value="translated_dialog spyder_greenwash_chip1"/>
+    <property name="act03" value="char_talk spyder_greenwash_chip,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster av8r,22,spyder_greenwash_chip,5,10"/>
     <property name="act06" value="add_monster criniotherme,22,spyder_greenwash_chip,5,10"/>
     <property name="act07" value="add_monster tikorch,22,spyder_greenwash_chip,5,10"/>
     <property name="act08" value="start_battle player,spyder_greenwash_chip"/>
-    <property name="act09" value="translated_dialog spyder_greenwash_chip2"/>
+    <property name="act09" value="char_talk spyder_greenwash_chip,post_battle_lose"/>
     <property name="act10" value="set_variable greenwashchip:yes"/>
     <property name="cond1" value="not variable_set greenwashchip:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -149,12 +149,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_clarence"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_clarence1"/>
+    <property name="act3" value="char_talk spyder_greenwash_clarence,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster pigabyte,25,spyder_greenwash_clarence,5,10"/>
     <property name="act6" value="add_monster cochini,23,spyder_greenwash_clarence,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_clarence"/>
-    <property name="act8" value="translated_dialog spyder_greenwash_clarence2"/>
+    <property name="act8" value="char_talk spyder_greenwash_clarence,post_battle_lose"/>
     <property name="act9" value="set_variable greenwashclarence:yes"/>
     <property name="cond1" value="not variable_set greenwashclarence:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -177,11 +177,11 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_greenwash_broer"/>
-    <property name="act03" value="translated_dialog spyder_greenwash_broer1"/>
+    <property name="act03" value="char_talk spyder_greenwash_broer,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster coleorus,26,spyder_greenwash_broer,5,10"/>
     <property name="act06" value="start_battle player,spyder_greenwash_broer"/>
-    <property name="act07" value="translated_dialog spyder_greenwash_broer2"/>
+    <property name="act07" value="char_talk spyder_greenwash_broer,post_battle_lose"/>
     <property name="act08" value="add_item potion"/>
     <property name="act09" value="translated_dialog potion,,center,center,center"/>
     <property name="act10" value="set_variable greenwashbroer:yes"/>
@@ -200,11 +200,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_lewie"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_lewie1"/>
+    <property name="act3" value="char_talk spyder_greenwash_lewie,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster agnite,26,spyder_greenwash_lewie,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_lewie"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_lewie2"/>
+    <property name="act7" value="char_talk spyder_greenwash_lewie,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashlewie:yes"/>
     <property name="cond1" value="not variable_set greenwashlewie:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -221,12 +221,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_morehouse"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_morehouse1"/>
+    <property name="act3" value="char_talk spyder_greenwash_morehouse,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster eyenemy,20,spyder_greenwash_morehouse,5,10"/>
     <property name="act6" value="add_monster eyesore,20,spyder_greenwash_morehouse,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_morehouse"/>
-    <property name="act8" value="translated_dialog spyder_greenwash_morehouse2"/>
+    <property name="act8" value="char_talk spyder_greenwash_morehouse,post_battle_lose"/>
     <property name="act9" value="set_variable greenwashmorehouse:yes"/>
     <property name="cond1" value="not variable_set greenwashmorehouse:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -234,35 +234,35 @@
   </object>
   <object id="89" name="Post Talk Broer" type="event" x="160" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_broer2"/>
+    <property name="act1" value="char_talk spyder_greenwash_broer,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_broer"/>
     <property name="cond1" value="is variable_set greenwashbroer:yes"/>
    </properties>
   </object>
   <object id="90" name="Post Talk Clarence" type="event" x="176" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_clarence2"/>
+    <property name="act1" value="char_talk spyder_greenwash_clarence,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_clarence"/>
     <property name="cond1" value="is variable_set greenwashclarence:yes"/>
    </properties>
   </object>
   <object id="91" name="Post Talk Lewie" type="event" x="144" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_lewie2"/>
+    <property name="act1" value="char_talk spyder_greenwash_lewie,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_lewie"/>
     <property name="cond1" value="is variable_set greenwashlewie:yes"/>
    </properties>
   </object>
   <object id="92" name="Post Talk Chip" type="event" x="96" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_chip2"/>
+    <property name="act1" value="char_talk spyder_greenwash_chip,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_chip"/>
     <property name="cond1" value="is variable_set greenwashchip:yes"/>
    </properties>
   </object>
   <object id="93" name="Post Talk Morehouse" type="event" x="144" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_morehouse2"/>
+    <property name="act1" value="char_talk spyder_greenwash_morehouse,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_morehouse"/>
     <property name="cond1" value="is variable_set greenwashmorehouse:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -218,12 +218,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_gregor"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_gregor1"/>
+    <property name="act3" value="char_talk spyder_greenwash_gregor,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster sclairus,22,spyder_greenwash_gregor,5,10"/>
     <property name="act6" value="add_monster cateye,22,spyder_greenwash_gregor,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_gregor"/>
-    <property name="act8" value="translated_dialog spyder_greenwash_gregor2"/>
+    <property name="act8" value="char_talk spyder_greenwash_gregor,post_battle_lose"/>
     <property name="act9" value="set_variable greenwashgregor:yes"/>
     <property name="cond1" value="not variable_set greenwashgregor:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -240,11 +240,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_alex"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_alex1"/>
+    <property name="act3" value="char_talk spyder_greenwash_alex,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster shybulb,25,spyder_greenwash_alex,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_alex"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_alex2"/>
+    <property name="act7" value="char_talk spyder_greenwash_alex,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashalex:yes"/>
     <property name="cond1" value="not variable_set greenwashalex:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -261,12 +261,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_hunt"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_hunt1"/>
+    <property name="act3" value="char_talk spyder_greenwash_hunt,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cateye,25,spyder_greenwash_hunt,5,10"/>
     <property name="act6" value="add_monster propellercat,25,spyder_greenwash_hunt,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_hunt"/>
-    <property name="act8" value="translated_dialog spyder_greenwash_hunt2"/>
+    <property name="act8" value="char_talk spyder_greenwash_hunt,post_battle_lose"/>
     <property name="act9" value="set_variable greenwashhunt:yes"/>
     <property name="cond1" value="not variable_set greenwashhunt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -276,12 +276,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_hunt"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_hunt1"/>
+    <property name="act3" value="char_talk spyder_greenwash_hunt,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cateye,25,spyder_greenwash_hunt,5,10"/>
     <property name="act6" value="add_monster propellercat,25,spyder_greenwash_hunt,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_hunt"/>
-    <property name="act8" value="translated_dialog spyder_greenwash_hunt2"/>
+    <property name="act8" value="char_talk spyder_greenwash_hunt,post_battle_lose"/>
     <property name="act9" value="set_variable greenwashhunt:yes"/>
     <property name="cond1" value="not variable_set greenwashhunt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -298,11 +298,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_lewis"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_lewis1"/>
+    <property name="act3" value="char_talk spyder_greenwash_lewis,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster pharfan,24,spyder_greenwash_lewis,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_lewis"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_lewis2"/>
+    <property name="act7" value="char_talk spyder_greenwash_lewis,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashlewis:yes"/>
     <property name="cond1" value="not variable_set greenwashlewis:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -312,11 +312,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_lewis"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_lewis1"/>
+    <property name="act3" value="char_talk spyder_greenwash_lewis,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster pharfan,24,spyder_greenwash_lewis,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_lewis"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_lewis2"/>
+    <property name="act7" value="char_talk spyder_greenwash_lewis,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashlewis:yes"/>
     <property name="cond1" value="not variable_set greenwashlewis:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -333,11 +333,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_louis"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_louis1"/>
+    <property name="act3" value="char_talk spyder_greenwash_louis,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cateye,24,spyder_greenwash_louis,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_louis"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_louis2"/>
+    <property name="act7" value="char_talk spyder_greenwash_louis,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashlouis:yes"/>
     <property name="cond1" value="not variable_set greenwashlouis:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -367,11 +367,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_gluck"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_gluck1"/>
+    <property name="act3" value="char_talk spyder_greenwash_gluck,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster narcileaf,25,spyder_greenwash_gluck,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_gluck"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_gluck2"/>
+    <property name="act7" value="char_talk spyder_greenwash_gluck,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashgluck:yes"/>
     <property name="cond1" value="not variable_set greenwashgluck:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -381,11 +381,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_gluck"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_gluck1"/>
+    <property name="act3" value="char_talk spyder_greenwash_gluck,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster narcileaf,25,spyder_greenwash_gluck,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_gluck"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_gluck2"/>
+    <property name="act7" value="char_talk spyder_greenwash_gluck,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashgluck:yes"/>
     <property name="cond1" value="not variable_set greenwashgluck:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -393,42 +393,42 @@
   </object>
   <object id="109" name="Post Talk Alex" type="event" x="144" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_alex2"/>
+    <property name="act1" value="char_talk spyder_greenwash_alex,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_alex"/>
     <property name="cond1" value="is variable_set greenwashalex:yes"/>
    </properties>
   </object>
   <object id="110" name="Post Talk Louis" type="event" x="144" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_louis2"/>
+    <property name="act1" value="char_talk spyder_greenwash_louis,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_louis"/>
     <property name="cond1" value="is variable_set greenwashlouis:yes"/>
    </properties>
   </object>
   <object id="111" name="Post Talk Lewis" type="event" x="256" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_lewis2"/>
+    <property name="act1" value="char_talk spyder_greenwash_lewis,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_lewis"/>
     <property name="cond1" value="is variable_set greenwashlewis:yes"/>
    </properties>
   </object>
   <object id="112" name="Post Talk Hunt" type="event" x="304" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_hunt2"/>
+    <property name="act1" value="char_talk spyder_greenwash_hunt,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_hunt"/>
     <property name="cond1" value="is variable_set greenwashhunt:yes"/>
    </properties>
   </object>
   <object id="113" name="Post Talk Gluck" type="event" x="448" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_gluck2"/>
+    <property name="act1" value="char_talk spyder_greenwash_gluck,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_gluck"/>
     <property name="cond1" value="is variable_set greenwashgluck:yes"/>
    </properties>
   </object>
   <object id="114" name="Post Talk Gregor" type="event" x="352" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_gregor2"/>
+    <property name="act1" value="char_talk spyder_greenwash_gregor,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_gregor"/>
     <property name="cond1" value="is variable_set greenwashgregor:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -126,11 +126,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_aissa"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_aissa1"/>
+    <property name="act3" value="char_talk spyder_greenwash_aissa,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cateye,22,spyder_greenwash_aissa,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_aissa"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_aissa2"/>
+    <property name="act7" value="char_talk spyder_greenwash_aissa,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashaissa:yes"/>
     <property name="cond1" value="not variable_set greenwashaissa:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -140,12 +140,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_dippel"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_dippel1"/>
+    <property name="act3" value="char_talk spyder_greenwash_dippel,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster criniotherme,22,spyder_greenwash_dippel,5,10"/>
     <property name="act6" value="add_monster tikorch,22,spyder_greenwash_dippel,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_dippel"/>
-    <property name="act8" value="translated_dialog spyder_greenwash_dippel2"/>
+    <property name="act8" value="char_talk spyder_greenwash_dippel,post_battle_lose"/>
     <property name="act9" value="set_variable greenwashdippel:yes"/>
     <property name="cond1" value="not variable_set greenwashdippel:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -155,11 +155,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_moreau"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_moreau1"/>
+    <property name="act3" value="char_talk spyder_greenwash_moreau,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster sclairus,26,spyder_greenwash_moreau,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_moreau"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_moreau2"/>
+    <property name="act7" value="char_talk spyder_greenwash_moreau,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashmoreau:yes"/>
     <property name="cond1" value="not variable_set greenwashmoreau:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -176,11 +176,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_dempsey"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_dempsey1"/>
+    <property name="act3" value="char_talk spyder_greenwash_dempsey,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster masknake,25,spyder_greenwash_dempsey,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_dempsey"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_dempsey1"/>
+    <property name="act7" value="char_talk spyder_greenwash_dempsey,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashdempsey:yes"/>
     <property name="cond1" value="not variable_set greenwashdempsey:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -197,11 +197,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_greenwash_heidenstam"/>
-    <property name="act3" value="translated_dialog spyder_greenwash_heidenstam1"/>
+    <property name="act3" value="char_talk spyder_greenwash_heidenstam,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster foofle,10,spyder_greenwash_heidenstam,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_heidenstam"/>
-    <property name="act7" value="translated_dialog spyder_greenwash_heidenstam2"/>
+    <property name="act7" value="char_talk spyder_greenwash_heidenstam,post_battle_lose"/>
     <property name="act8" value="set_variable greenwashheidenstam:yes"/>
     <property name="cond1" value="not variable_set greenwashheidenstam:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -308,35 +308,35 @@
   </object>
   <object id="122" name="Post Talk Moreau" type="event" x="192" y="400" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_moreau2"/>
+    <property name="act1" value="char_talk spyder_greenwash_moreau,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_moreau"/>
     <property name="cond1" value="is variable_set greenwashmoreau:yes"/>
    </properties>
   </object>
   <object id="123" name="Post Talk Heidenstam" type="event" x="80" y="336" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_heidenstam2"/>
+    <property name="act1" value="char_talk spyder_greenwash_heidenstam,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_heidenstam"/>
     <property name="cond1" value="is variable_set greenwashheidenstam:yes"/>
    </properties>
   </object>
   <object id="124" name="Post Talk Dempsey" type="event" x="48" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_dempsey1"/>
+    <property name="act1" value="char_talk spyder_greenwash_dempsey,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_dempsey"/>
     <property name="cond1" value="is variable_set greenwashdempsey:yes"/>
    </properties>
   </object>
   <object id="125" name="Post Talk Dippel" type="event" x="96" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_dippel2"/>
+    <property name="act1" value="char_talk spyder_greenwash_dippel,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_dippel"/>
     <property name="cond1" value="is variable_set greenwashdippel:yes"/>
    </properties>
   </object>
   <object id="126" name="Post Talk Aissa" type="event" x="96" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_greenwash_aissa2"/>
+    <property name="act1" value="char_talk spyder_greenwash_aissa,post_battle_lose"/>
     <property name="behav1" value="talk spyder_greenwash_aissa"/>
     <property name="cond1" value="is variable_set greenwashaissa:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -227,12 +227,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_mansion_gillette"/>
-    <property name="act3" value="translated_dialog spyder_mansion_gillette1"/>
+    <property name="act3" value="char_talk spyder_mansion_gillette,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster djinnbo,22,spyder_mansion_gillette,5,10"/>
     <property name="act6" value="add_monster ghosteeth,22,spyder_mansion_gillette,5,10"/>
     <property name="act7" value="start_battle player,spyder_mansion_gillette"/>
-    <property name="act8" value="translated_dialog spyder_mansion_gillette2"/>
+    <property name="act8" value="char_talk spyder_mansion_gillette,post_battle_lose"/>
     <property name="act9" value="set_variable mansiongillette:yes"/>
     <property name="cond1" value="not variable_set mansiongillette:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -242,12 +242,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_mansion_lucy"/>
-    <property name="act3" value="translated_dialog spyder_mansion_lucy1"/>
+    <property name="act3" value="char_talk spyder_mansion_lucy,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster elofly,15,spyder_mansion_lucy,5,10"/>
     <property name="act6" value="add_monster budaye,15,spyder_mansion_lucy,5,10"/>
     <property name="act7" value="start_battle player,spyder_mansion_lucy"/>
-    <property name="act8" value="translated_dialog spyder_mansion_lucy2"/>
+    <property name="act8" value="char_talk spyder_mansion_lucy,post_battle_lose"/>
     <property name="act9" value="set_variable mansionlucy:yes"/>
     <property name="cond1" value="not variable_set mansionlucy:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -257,12 +257,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_mansion_lyle"/>
-    <property name="act3" value="translated_dialog spyder_mansion_pirate1"/>
+    <property name="act3" value="char_talk spyder_mansion_lyle,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster foofle,20,spyder_mansion_lyle,5,10"/>
     <property name="act6" value="add_monster shybulb,20,spyder_mansion_lyle,5,10"/>
     <property name="act7" value="start_battle player,spyder_mansion_lyle"/>
-    <property name="act8" value="translated_dialog spyder_mansion_pirate2"/>
+    <property name="act8" value="char_talk spyder_mansion_lyle,post_battle_lose"/>
     <property name="act9" value="set_variable mansionlyle:yes"/>
     <property name="cond1" value="not variable_set mansionlyle:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -319,14 +319,14 @@
   </object>
   <object id="71" name="Post Talk Gillette" type="event" x="128" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_mansion_gillette2"/>
+    <property name="act1" value="char_talk spyder_mansion_gillette,post_battle_lose"/>
     <property name="behav1" value="talk spyder_mansion_gillette"/>
     <property name="cond1" value="is variable_set mansiongillette:yes"/>
    </properties>
   </object>
   <object id="72" name="Post Talk Lucy" type="event" x="224" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_mansion_lucy2"/>
+    <property name="act1" value="char_talk spyder_mansion_lucy,post_battle_lose"/>
     <property name="behav1" value="talk spyder_mansion_lucy"/>
     <property name="cond1" value="is variable_set mansionlucy:yes"/>
     <property name="cond2" value="is variable_set tealucy:yes"/>
@@ -334,7 +334,7 @@
   </object>
   <object id="73" name="Post Talk Lyle" type="event" x="0" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_mansion_pirate2"/>
+    <property name="act1" value="char_talk spyder_mansion_lyle,post_battle_lose"/>
     <property name="behav1" value="talk spyder_mansion_lyle"/>
     <property name="cond1" value="is variable_set mansionlyle:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -148,12 +148,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_basement_coralli"/>
-    <property name="act3" value="translated_dialog spyder_basement_coralli1"/>
+    <property name="act3" value="char_talk spyder_basement_coralli,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster tumbleworm,22,spyder_basement_coralli,5,10"/>
     <property name="act6" value="add_monster elofly,22,spyder_basement_coralli,5,10"/>
     <property name="act7" value="start_battle player,spyder_basement_coralli"/>
-    <property name="act8" value="translated_dialog spyder_basement_coralli2"/>
+    <property name="act8" value="char_talk spyder_basement_coralli,post_battle_lose"/>
     <property name="act9" value="set_variable basementcoralli:yes"/>
     <property name="cond1" value="not variable_set basementcoralli:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -163,11 +163,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_basement_bobby"/>
-    <property name="act3" value="translated_dialog spyder_basement_bobby1"/>
+    <property name="act3" value="char_talk spyder_basement_bobby,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster capiti,26,spyder_basement_bobby,5,10"/>
     <property name="act6" value="start_battle player,spyder_basement_bobby"/>
-    <property name="act7" value="translated_dialog spyder_basement_bobby2"/>
+    <property name="act7" value="char_talk spyder_basement_bobby,post_battle_lose"/>
     <property name="act8" value="set_variable basementbobby:yes"/>
     <property name="cond1" value="not variable_set basementbobby:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -177,11 +177,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_basement_roger"/>
-    <property name="act3" value="translated_dialog spyder_basement_roger1"/>
+    <property name="act3" value="char_talk spyder_basement_roger,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster polyrock,22,spyder_basement_roger,5,10"/>
     <property name="act6" value="start_battle player,spyder_basement_roger"/>
-    <property name="act7" value="translated_dialog spyder_basement_roger2"/>
+    <property name="act7" value="char_talk spyder_basement_roger,post_battle_lose"/>
     <property name="act8" value="set_variable basementroger:yes"/>
     <property name="cond1" value="not variable_set basementroger:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -191,12 +191,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_basement_catholi"/>
-    <property name="act3" value="translated_dialog spyder_basement_catholi1"/>
+    <property name="act3" value="char_talk spyder_basement_catholi,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster foofle,20,spyder_basement_catholi,5,10"/>
     <property name="act6" value="add_monster rosarin,24,spyder_basement_catholi,5,10"/>
     <property name="act7" value="start_battle player,spyder_basement_catholi"/>
-    <property name="act8" value="translated_dialog spyder_basement_catholi2"/>
+    <property name="act8" value="char_talk spyder_basement_catholi,post_battle_lose"/>
     <property name="act9" value="set_variable basementcatholi:yes"/>
     <property name="cond1" value="not variable_set basementcatholi:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -254,28 +254,28 @@
   </object>
   <object id="65" name="Post Talk Bobby" type="event" x="128" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_basement_bobby2"/>
+    <property name="act1" value="char_talk spyder_basement_bobby,post_battle_lose"/>
     <property name="behav1" value="talk spyder_basement_bobby"/>
     <property name="cond1" value="is variable_set basementbobby:yes"/>
    </properties>
   </object>
   <object id="67" name="Post Talk Coralli" type="event" x="320" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_basement_coralli2"/>
+    <property name="act1" value="char_talk spyder_basement_coralli,post_battle_lose"/>
     <property name="behav1" value="talk spyder_basement_coralli"/>
     <property name="cond1" value="is variable_set basementcoralli:yes"/>
    </properties>
   </object>
   <object id="68" name="Post Talk Catholi" type="event" x="176" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_basement_catholi2"/>
+    <property name="act1" value="char_talk spyder_basement_catholi,post_battle_lose"/>
     <property name="behav1" value="talk spyder_basement_catholi"/>
     <property name="cond1" value="is variable_set basementcatholi:yes"/>
    </properties>
   </object>
   <object id="69" name="Post Talk Roger" type="event" x="240" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_basement_roger2"/>
+    <property name="act1" value="char_talk spyder_basement_roger,post_battle_lose"/>
     <property name="behav1" value="talk spyder_basement_roger"/>
     <property name="cond1" value="is variable_set basementroger:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -94,12 +94,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_top_mickey"/>
-    <property name="act3" value="translated_dialog spyder_top_mickey1"/>
+    <property name="act3" value="char_talk spyder_top_mickey,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster gectile,25,spyder_top_mickey,5,10"/>
     <property name="act6" value="add_monster cardiwing,25,spyder_top_mickey,5,10"/>
     <property name="act7" value="start_battle player,spyder_top_mickey"/>
-    <property name="act8" value="translated_dialog spyder_top_mickey2"/>
+    <property name="act8" value="char_talk spyder_top_mickey,post_battle_lose"/>
     <property name="act9" value="set_variable mansiontop_mickey:yes"/>
     <property name="cond1" value="not variable_set mansiontop_mickey:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -145,13 +145,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_top_russell"/>
-    <property name="act03" value="translated_dialog spyder_top_russell1"/>
+    <property name="act03" value="char_talk spyder_top_russell,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster av8r,22,spyder_top_russell,5,10"/>
     <property name="act06" value="add_monster mrmoswitch,22,spyder_top_russell,5,10"/>
     <property name="act07" value="add_monster k9,22,spyder_top_russell,5,10"/>
     <property name="act08" value="start_battle player,spyder_top_russell"/>
-    <property name="act09" value="translated_dialog spyder_top_russell2"/>
+    <property name="act09" value="char_talk spyder_top_russell,post_battle_lose"/>
     <property name="act10" value="set_variable mansiontop_russell:yes"/>
     <property name="cond1" value="not variable_set mansiontop_russell:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -161,12 +161,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_top_ricardo"/>
-    <property name="act3" value="translated_dialog spyder_top_ricardo1"/>
+    <property name="act3" value="char_talk spyder_top_ricardo,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster lapinou,22,spyder_top_ricardo,5,10"/>
     <property name="act6" value="add_monster squabbit,22,spyder_top_ricardo,5,10"/>
     <property name="act7" value="start_battle player,spyder_top_ricardo"/>
-    <property name="act8" value="translated_dialog spyder_top_ricardo2"/>
+    <property name="act8" value="char_talk spyder_top_ricardo,post_battle_lose"/>
     <property name="act9" value="set_variable mansiontop_ricardo:yes"/>
     <property name="cond1" value="not variable_set mansiontop_ricardo:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -176,11 +176,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_top_jackson"/>
-    <property name="act3" value="translated_dialog spyder_top_jackson1"/>
+    <property name="act3" value="char_talk spyder_top_jackson,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster viviteel,26,spyder_top_jackson,5,10"/>
     <property name="act6" value="start_battle player,spyder_top_jackson"/>
-    <property name="act7" value="translated_dialog spyder_top_jackson2"/>
+    <property name="act7" value="char_talk spyder_top_jackson,post_battle_lose"/>
     <property name="act8" value="set_variable mansiontop_jackson:yes"/>
     <property name="cond1" value="not variable_set mansiontop_jackson:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -240,28 +240,28 @@
   </object>
   <object id="60" name="Post Talk Jackson" type="event" x="96" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_top_jackson2"/>
+    <property name="act1" value="char_talk spyder_top_jackson,post_battle_lose"/>
     <property name="behav1" value="talk spyder_top_jackson"/>
     <property name="cond1" value="is variable_set mansiontop_jackson:yes"/>
    </properties>
   </object>
   <object id="61" name="Post Talk Russell" type="event" x="112" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_top_russell2"/>
+    <property name="act1" value="char_talk spyder_top_russell,post_battle_lose"/>
     <property name="behav1" value="talk spyder_top_russell"/>
     <property name="cond1" value="is variable_set mansiontop_russell:yes"/>
    </properties>
   </object>
   <object id="62" name="Post Talk Mickey" type="event" x="128" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_top_mickey2"/>
+    <property name="act1" value="char_talk spyder_top_mickey,post_battle_lose"/>
     <property name="behav1" value="talk spyder_top_mickey"/>
     <property name="cond1" value="is variable_set mansiontop_mickey:yes"/>
    </properties>
   </object>
   <object id="63" name="Post Talk Ricardo" type="event" x="144" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_top_ricardo2"/>
+    <property name="act1" value="char_talk spyder_top_ricardo,post_battle_lose"/>
     <property name="behav1" value="talk spyder_top_ricardo"/>
     <property name="cond1" value="is variable_set mansiontop_ricardo:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -110,10 +110,10 @@
   </object>
   <object id="41" name="Talk Rebel" type="event" x="192" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_rebel1"/>
+    <property name="act1" value="char_talk spyder_nimrod_rebel,pre_battle"/>
     <property name="act2" value="add_monster grimachin,25,spyder_nimrod_rebel,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_rebel"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_rebel2"/>
+    <property name="act4" value="char_talk spyder_nimrod_rebel,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodrebel:yes"/>
     <property name="behav1" value="talk spyder_nimrod_rebel"/>
     <property name="cond1" value="not variable_set nimrodrebel:yes"/>
@@ -127,11 +127,11 @@
   </object>
   <object id="43" name="Talk Bowie" type="event" x="16" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_bowie1"/>
+    <property name="act1" value="char_talk spyder_nimrod_bowie,pre_battle"/>
     <property name="act2" value="add_monster tigrock,35,spyder_nimrod_bowie,5,10"/>
     <property name="act3" value="add_monster embazook,35,spyder_nimrod_bowie,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_bowie"/>
-    <property name="act5" value="translated_dialog spyder_nimrod_bowie2"/>
+    <property name="act5" value="char_talk spyder_nimrod_bowie,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodbowie:yes"/>
     <property name="behav1" value="talk spyder_nimrod_bowie"/>
     <property name="cond1" value="not variable_set nimrodbowie:yes"/>
@@ -146,14 +146,14 @@
   </object>
   <object id="45" name="Talk Tru" type="event" x="96" y="240" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_nimrod_tru1"/>
+    <property name="act01" value="char_talk spyder_nimrod_tru,pre_battle"/>
     <property name="act02" value="add_monster grimachin,20,spyder_nimrod_tru,5,10"/>
     <property name="act03" value="add_monster tigrock,25,spyder_nimrod_tru,5,10"/>
     <property name="act04" value="add_monster komodraw,25,spyder_nimrod_tru,5,10"/>
     <property name="act05" value="add_monster sharpfin,25,spyder_nimrod_tru,5,10"/>
     <property name="act06" value="add_monster embazook,25,spyder_nimrod_tru,5,10"/>
     <property name="act07" value="start_battle player,spyder_nimrod_tru"/>
-    <property name="act08" value="translated_dialog spyder_nimrod_tru2"/>
+    <property name="act08" value="char_talk spyder_nimrod_tru,post_battle_lose"/>
     <property name="act09" value="translated_dialog spyder_nimrod_tru3"/>
     <property name="act10" value="set_variable nimrodtru:yes"/>
     <property name="act11" value="pathfind spyder_nimrod_jake,0,17"/>
@@ -180,11 +180,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_rebel"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_rebel1"/>
+    <property name="act3" value="char_talk spyder_nimrod_rebel,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster grimachin,25,spyder_nimrod_rebel,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_rebel"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_rebel2"/>
+    <property name="act7" value="char_talk spyder_nimrod_rebel,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodrebel:yes"/>
     <property name="cond1" value="not variable_set nimrodrebel:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -194,7 +194,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_nimrod_tru"/>
-    <property name="act03" value="translated_dialog spyder_nimrod_tru1"/>
+    <property name="act03" value="char_talk spyder_nimrod_tru,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster grimachin,20,spyder_nimrod_tru,5,10"/>
     <property name="act06" value="add_monster tigrock,25,spyder_nimrod_tru,5,10"/>
@@ -202,7 +202,7 @@
     <property name="act08" value="add_monster sharpfin,25,spyder_nimrod_tru,5,10"/>
     <property name="act09" value="add_monster embazook,25,spyder_nimrod_tru,5,10"/>
     <property name="act10" value="start_battle player,spyder_nimrod_tru"/>
-    <property name="act11" value="translated_dialog spyder_nimrod_tru2"/>
+    <property name="act11" value="char_talk spyder_nimrod_tru,post_battle_lose"/>
     <property name="act12" value="translated_dialog spyder_nimrod_tru3"/>
     <property name="act13" value="set_variable nimrodtru:yes"/>
     <property name="act14" value="pathfind spyder_nimrod_jake,0,17"/>
@@ -215,12 +215,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_bowie"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_bowie1"/>
+    <property name="act3" value="char_talk spyder_nimrod_bowie,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster tigrock,35,spyder_nimrod_bowie,5,10"/>
     <property name="act6" value="add_monster embazook,35,spyder_nimrod_bowie,5,10"/>
     <property name="act7" value="start_battle player,spyder_nimrod_bowie"/>
-    <property name="act8" value="translated_dialog spyder_nimrod_bowie2"/>
+    <property name="act8" value="char_talk spyder_nimrod_bowie,post_battle_lose"/>
     <property name="act9" value="set_variable nimrodbowie:yes"/>
     <property name="cond1" value="not variable_set nimrodbowie:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -228,14 +228,14 @@
   </object>
   <object id="58" name="Post Talk Rebel" type="event" x="176" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_rebel2"/>
+    <property name="act1" value="char_talk spyder_nimrod_rebel,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_rebel"/>
     <property name="cond1" value="is variable_set nimrodrebel:yes"/>
    </properties>
   </object>
   <object id="59" name="Post Talk Bowie" type="event" x="32" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_bowie2"/>
+    <property name="act1" value="char_talk spyder_nimrod_bowie,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_bowie"/>
     <property name="cond1" value="is variable_set nimrodbowie:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -75,11 +75,11 @@
   </object>
   <object id="14" name="Talk Thatcher" type="event" x="32" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_thatcher1"/>
+    <property name="act1" value="char_talk spyder_nimrod_thatcher,pre_battle"/>
     <property name="act2" value="add_monster squabbit,20,spyder_nimrod_thatcher,5,10"/>
     <property name="act3" value="add_monster viviteel,25,spyder_nimrod_thatcher,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_thatcher"/>
-    <property name="act5" value="translated_dialog spyder_nimrod_thatcher2"/>
+    <property name="act5" value="char_talk spyder_nimrod_thatcher,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodthatcher:yes"/>
     <property name="behav1" value="talk spyder_nimrod_thatcher"/>
     <property name="cond1" value="not variable_set nimrodthatcher:yes"/>
@@ -94,11 +94,11 @@
   </object>
   <object id="17" name="Talk Honour" type="event" x="256" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_honour1"/>
+    <property name="act1" value="char_talk spyder_nimrod_honour,pre_battle"/>
     <property name="act2" value="add_monster embazook,20,spyder_nimrod_honour,5,10"/>
     <property name="act3" value="add_monster sharpfin,20,spyder_nimrod_honour,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_honour"/>
-    <property name="act5" value="translated_dialog spyder_nimrod_honour2"/>
+    <property name="act5" value="char_talk spyder_nimrod_honour,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodhonour:yes"/>
     <property name="behav1" value="talk spyder_nimrod_honour"/>
     <property name="cond1" value="not variable_set nimrodhonour:yes"/>
@@ -112,10 +112,10 @@
   </object>
   <object id="19" name="Talk Antimony" type="event" x="80" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_antimony1"/>
+    <property name="act1" value="char_talk spyder_nimrod_antimony,pre_battle"/>
     <property name="act2" value="add_monster komodraw,30,spyder_nimrod_antimony,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_antimony"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_antimony2"/>
+    <property name="act4" value="char_talk spyder_nimrod_antimony,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodantimony:yes"/>
     <property name="behav1" value="talk spyder_nimrod_antimony"/>
     <property name="cond1" value="not variable_set nimrodantimony:yes"/>
@@ -131,10 +131,10 @@
   </object>
   <object id="21" name="Talk Chrome Robo" type="event" x="128" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_chromerobo1"/>
+    <property name="act1" value="char_talk spyder_nimrod_chromerobo,pre_battle"/>
     <property name="act2" value="add_monster chrome_robo,20,spyder_nimrod_chromerobo,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_chromerobo"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_chromerobo2"/>
+    <property name="act4" value="char_talk spyder_nimrod_chromerobo,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodchromerobo_middle:yes"/>
     <property name="act7" value="remove_npc spyder_nimrod_chromerobo"/>
     <property name="behav1" value="talk spyder_nimrod_chromerobo"/>
@@ -152,7 +152,7 @@
   <object id="25" name="Talk Xeon" type="event" x="176" y="240" width="16" height="16">
    <properties>
     <property name="act3" value="start_battle player,spyder_nimrod_xeon"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_xeon2"/>
+    <property name="act4" value="char_talk spyder_nimrod_xeon,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodxeon_middle:yes"/>
     <property name="act7" value="remove_npc spyder_nimrod_xeon"/>
     <property name="behav1" value="talk spyder_nimrod_xeon"/>
@@ -168,10 +168,10 @@
   </object>
   <object id="27" name="Talk Argon" type="event" x="192" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_argon1"/>
+    <property name="act1" value="char_talk spyder_nimrod_argon,pre_battle"/>
     <property name="act2" value="add_monster chrome_robo,25,spyder_nimrod_argon,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_argon"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_argon2"/>
+    <property name="act4" value="char_talk spyder_nimrod_argon,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodargon:yes"/>
     <property name="behav1" value="talk spyder_nimrod_argon"/>
     <property name="cond1" value="not variable_set nimrodargon:yes"/>
@@ -186,12 +186,12 @@
   </object>
   <object id="30" name="Talk Archer" type="event" x="32" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_archer1"/>
+    <property name="act1" value="char_talk spyder_nimrod_archer,pre_battle"/>
     <property name="act2" value="add_monster sharpfin,20,spyder_nimrod_archer,5,10"/>
     <property name="act3" value="add_monster av8r,20,spyder_nimrod_archer,5,10"/>
     <property name="act4" value="add_monster grimachin,20,spyder_nimrod_archer,5,10"/>
     <property name="act5" value="start_battle player,spyder_nimrod_archer"/>
-    <property name="act6" value="translated_dialog spyder_nimrod_archer2"/>
+    <property name="act6" value="char_talk spyder_nimrod_archer,post_battle_lose"/>
     <property name="act7" value="set_variable nimrodarcher:yes"/>
     <property name="behav1" value="talk spyder_nimrod_archer"/>
     <property name="cond1" value="not variable_set nimrodarcher:yes"/>
@@ -207,11 +207,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_argon"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_argon1"/>
+    <property name="act3" value="char_talk spyder_nimrod_argon,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster chrome_robo,25,spyder_nimrod_argon,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_argon"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_argon2"/>
+    <property name="act7" value="char_talk spyder_nimrod_argon,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodargon:yes"/>
     <property name="cond1" value="not variable_set nimrodargon:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -221,12 +221,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_honour"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_honour1"/>
+    <property name="act3" value="char_talk spyder_nimrod_honour,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster embazook,20,spyder_nimrod_honour,5,10"/>
     <property name="act6" value="add_monster sharpfin,20,spyder_nimrod_honour,5,10"/>
     <property name="act7" value="start_battle player,spyder_nimrod_honour"/>
-    <property name="act8" value="translated_dialog spyder_nimrod_honour2"/>
+    <property name="act8" value="char_talk spyder_nimrod_honour,post_battle_lose"/>
     <property name="act9" value="set_variable nimrodhonour:yes"/>
     <property name="cond1" value="not variable_set nimrodhonour:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -236,11 +236,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_xeon"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_xeon1"/>
+    <property name="act3" value="char_talk spyder_nimrod_xeon,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster xeon,20,spyder_nimrod_xeon,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_xeon"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_xeon2"/>
+    <property name="act7" value="char_talk spyder_nimrod_xeon,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodxeon_middle:yes"/>
     <property name="act9" value="remove_npc spyder_nimrod_xeon"/>
     <property name="cond1" value="not variable_set nimrodxeon_middle:yes"/>
@@ -251,11 +251,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_chromerobo"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_chromerobo1"/>
+    <property name="act3" value="char_talk spyder_nimrod_chromerobo,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster chrome_robo,20,spyder_nimrod_chromerobo,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_chromerobo"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_chromerobo2"/>
+    <property name="act7" value="char_talk spyder_nimrod_chromerobo,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodchromerobo_middle:yes"/>
     <property name="act9" value="remove_npc spyder_nimrod_chromerobo"/>
     <property name="cond1" value="not variable_set nimrodchromerobo_middle:yes"/>
@@ -266,13 +266,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_nimrod_archer"/>
-    <property name="act03" value="translated_dialog spyder_nimrod_archer1"/>
+    <property name="act03" value="char_talk spyder_nimrod_archer,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster sharpfin,20,spyder_nimrod_archer,5,10"/>
     <property name="act06" value="add_monster av8r,20,spyder_nimrod_archer,5,10"/>
     <property name="act07" value="add_monster grimachin,20,spyder_nimrod_archer,5,10"/>
     <property name="act08" value="start_battle player,spyder_nimrod_archer"/>
-    <property name="act09" value="translated_dialog spyder_nimrod_archer2"/>
+    <property name="act09" value="char_talk spyder_nimrod_archer,post_battle_lose"/>
     <property name="act10" value="set_variable nimrodarcher:yes"/>
     <property name="cond1" value="not variable_set nimrodarcher:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -282,11 +282,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_antimony"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_antimony1"/>
+    <property name="act3" value="char_talk spyder_nimrod_antimony,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster komodraw,30,spyder_nimrod_antimony,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_antimony"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_antimony2"/>
+    <property name="act7" value="char_talk spyder_nimrod_antimony,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodantimony:yes"/>
     <property name="cond1" value="not variable_set nimrodantimony:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -294,35 +294,35 @@
   </object>
   <object id="45" name="Post Talk Archer" type="event" x="64" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_archer2"/>
+    <property name="act1" value="char_talk spyder_nimrod_archer,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_archer"/>
     <property name="cond1" value="is variable_set nimrodarcher:yes"/>
    </properties>
   </object>
   <object id="46" name="Post Talk Antimony" type="event" x="80" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_antimony2"/>
+    <property name="act1" value="char_talk spyder_nimrod_antimony,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_antimony"/>
     <property name="cond1" value="is variable_set nimrodantimony:yes"/>
    </properties>
   </object>
   <object id="47" name="Post Talk Argon" type="event" x="96" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_argon2"/>
+    <property name="act1" value="char_talk spyder_nimrod_argon,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_argon"/>
     <property name="cond1" value="is variable_set nimrodargon:yes"/>
    </properties>
   </object>
   <object id="48" name="Post Talk Thatcher" type="event" x="112" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_thatcher2"/>
+    <property name="act1" value="char_talk spyder_nimrod_thatcher,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_thatcher"/>
     <property name="cond1" value="is variable_set nimrodthatcher:yes"/>
    </properties>
   </object>
   <object id="49" name="Post Talk Honour" type="event" x="128" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_honour2"/>
+    <property name="act1" value="char_talk spyder_nimrod_honour,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_honour"/>
     <property name="cond1" value="is variable_set nimrodhonour:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -91,10 +91,10 @@
   </object>
   <object id="31" name="Talk Maverick" type="event" x="128" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_maverick1"/>
+    <property name="act1" value="char_talk spyder_nimrod_maverick,pre_battle"/>
     <property name="act2" value="add_monster av8r,25,spyder_nimrod_maverick,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_maverick"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_maverick2"/>
+    <property name="act4" value="char_talk spyder_nimrod_maverick,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodmaverick:yes"/>
     <property name="behav1" value="talk spyder_nimrod_maverick"/>
     <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
@@ -109,11 +109,11 @@
   </object>
   <object id="33" name="Talk Justice" type="event" x="224" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_justice1"/>
+    <property name="act1" value="char_talk spyder_nimrod_justice,pre_battle"/>
     <property name="act2" value="add_monster ghosteeth,16,spyder_nimrod_justice,5,10"/>
     <property name="act3" value="add_monster ghosteeth,16,spyder_nimrod_justice,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_justice"/>
-    <property name="act5" value="translated_dialog spyder_nimrod_justice2"/>
+    <property name="act5" value="char_talk spyder_nimrod_justice,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodjustice:yes"/>
     <property name="behav1" value="talk spyder_nimrod_justice"/>
     <property name="cond1" value="not variable_set nimrodjustice:yes"/>
@@ -127,10 +127,10 @@
   </object>
   <object id="35" name="Talk Zircon" type="event" x="176" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_zircon1"/>
+    <property name="act1" value="char_talk spyder_nimrod_zircon,pre_battle"/>
     <property name="act2" value="add_monster dark_robo,25,spyder_nimrod_zircon,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_zircon"/>
-    <property name="act4" value="translated_dialog spyder_nimrod_zircon2"/>
+    <property name="act4" value="char_talk spyder_nimrod_zircon,post_battle_lose"/>
     <property name="act6" value="set_variable nimrodzircon:yes"/>
     <property name="behav1" value="talk spyder_nimrod_zircon"/>
     <property name="cond1" value="not variable_set nimrodzircon:yes"/>
@@ -146,12 +146,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_justice"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_justice1"/>
+    <property name="act3" value="char_talk spyder_nimrod_justice,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster ghosteeth,16,spyder_nimrod_justice,5,10"/>
     <property name="act6" value="add_monster ghosteeth,16,spyder_nimrod_justice,5,10"/>
     <property name="act7" value="start_battle player,spyder_nimrod_justice"/>
-    <property name="act8" value="translated_dialog spyder_nimrod_justice2"/>
+    <property name="act8" value="char_talk spyder_nimrod_justice,post_battle_lose"/>
     <property name="act9" value="set_variable nimrodjustice:yes"/>
     <property name="cond1" value="not variable_set nimrodjustice:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -161,11 +161,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_zircon"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_zircon1"/>
+    <property name="act3" value="char_talk spyder_nimrod_zircon,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster dark_robo,25,spyder_nimrod_zircon,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_zircon"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_zircon2"/>
+    <property name="act7" value="char_talk spyder_nimrod_zircon,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodzircon:yes"/>
     <property name="cond1" value="not variable_set nimrodzircon:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -175,11 +175,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_nimrod_maverick"/>
-    <property name="act3" value="translated_dialog spyder_nimrod_maverick1"/>
+    <property name="act3" value="char_talk spyder_nimrod_maverick,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster av8r,25,spyder_nimrod_maverick,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_maverick"/>
-    <property name="act7" value="translated_dialog spyder_nimrod_maverick2"/>
+    <property name="act7" value="char_talk spyder_nimrod_maverick,post_battle_lose"/>
     <property name="act8" value="set_variable nimrodmaverick:yes"/>
     <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -196,13 +196,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_nimrod_mace"/>
-    <property name="act03" value="translated_dialog spyder_nimrod_mace1"/>
+    <property name="act03" value="char_talk spyder_nimrod_mace,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster embazook,20,spyder_nimrod_mace,5,10"/>
     <property name="act06" value="add_monster av8r,20,spyder_nimrod_mace,5,10"/>
     <property name="act07" value="add_monster komodraw,25,spyder_nimrod_mace,5,10"/>
     <property name="act08" value="start_battle player,spyder_nimrod_mace"/>
-    <property name="act09" value="translated_dialog spyder_nimrod_mace2"/>
+    <property name="act09" value="char_talk spyder_nimrod_mace,post_battle_lose"/>
     <property name="act10" value="set_variable nimrodmace:yes"/>
     <property name="cond1" value="not variable_set nimrodmace:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -210,12 +210,12 @@
   </object>
   <object id="46" name="Talk Mace" type="event" x="240" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_mace1"/>
+    <property name="act1" value="char_talk spyder_nimrod_mace,pre_battle"/>
     <property name="act2" value="add_monster embazook,20,spyder_nimrod_mace,5,10"/>
     <property name="act3" value="add_monster av8r,20,spyder_nimrod_mace,5,10"/>
     <property name="act4" value="add_monster komodraw,25,spyder_nimrod_mace,5,10"/>
     <property name="act5" value="start_battle player,spyder_nimrod_mace"/>
-    <property name="act6" value="translated_dialog spyder_nimrod_mace2"/>
+    <property name="act6" value="char_talk spyder_nimrod_mace,post_battle_lose"/>
     <property name="act7" value="set_variable nimrodmace:yes"/>
     <property name="behav1" value="talk spyder_nimrod_mace"/>
     <property name="cond1" value="not variable_set nimrodmace:yes"/>
@@ -223,28 +223,28 @@
   </object>
   <object id="47" name="Post Talk Justice" type="event" x="208" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_justice2"/>
+    <property name="act1" value="char_talk spyder_nimrod_justice,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_justice"/>
     <property name="cond1" value="is variable_set nimrodjustice:yes"/>
    </properties>
   </object>
   <object id="48" name="Post Talk Mace" type="event" x="224" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_mace2"/>
+    <property name="act1" value="char_talk spyder_nimrod_mace,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_mace"/>
     <property name="cond1" value="is variable_set nimrodmace:yes"/>
    </properties>
   </object>
   <object id="49" name="Post Talk Maverick" type="event" x="112" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_maverick2"/>
+    <property name="act1" value="char_talk spyder_nimrod_maverick,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_maverick"/>
     <property name="cond1" value="is variable_set nimrodmaverick:yes"/>
    </properties>
   </object>
   <object id="50" name="Post Talk Zircon" type="event" x="176" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_nimrod_zircon2"/>
+    <property name="act1" value="char_talk spyder_nimrod_zircon,post_battle_lose"/>
     <property name="behav1" value="talk spyder_nimrod_zircon"/>
     <property name="cond1" value="is variable_set nimrodzircon:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -98,11 +98,11 @@
   </object>
   <object id="25" name="Talk William" type="event" x="144" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_omnichannel_william1"/>
+    <property name="act1" value="char_talk spyder_omnichannel_william,pre_battle"/>
     <property name="act2" value="add_monster elowind,36,spyder_omnichannel_william,5,10"/>
     <property name="act3" value="add_monster cardiwing,36,spyder_omnichannel_william,5,10"/>
     <property name="act4" value="start_battle player,spyder_omnichannel_william"/>
-    <property name="act5" value="translated_dialog spyder_omnichannel_william2"/>
+    <property name="act5" value="char_talk spyder_omnichannel_william,post_battle_lose"/>
     <property name="act6" value="set_variable omnichannelwilliam:yes"/>
     <property name="behav1" value="talk spyder_omnichannel_william"/>
     <property name="cond1" value="not variable_set omnichannelwilliam:yes"/>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -104,12 +104,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_schwartz"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_schwartz1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_schwartz,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster grinflare,35,spyder_omnichannel_schwartz,5,10"/>
     <property name="act6" value="add_monster strella,35,spyder_omnichannel_schwartz,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_schwartz"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_schwartz2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_schwartz,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannel2schwartz:yes"/>
     <property name="cond1" value="not variable_set omnichannel2schwartz:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -127,12 +127,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_bettger"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_bettger1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_bettger,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster grintrock,35,spyder_omnichannel_bettger,5,10"/>
     <property name="act6" value="add_monster rabbitosaur,35,spyder_omnichannel_bettger,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_bettger"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_bettger2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_bettger,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannel2bettger:yes"/>
     <property name="cond1" value="not variable_set omnichannel2bettger:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -150,11 +150,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_tohei"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_tohei1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_tohei,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster sludgehog,40,spyder_omnichannel_tohei,5,10"/>
     <property name="act6" value="start_battle player,spyder_omnichannel_tohei"/>
-    <property name="act7" value="translated_dialog spyder_omnichannel_tohei2"/>
+    <property name="act7" value="char_talk spyder_omnichannel_tohei,post_battle_lose"/>
     <property name="act8" value="set_variable omnichannel2tohei:yes"/>
     <property name="cond1" value="not variable_set omnichannel2tohei:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -172,12 +172,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_crane"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_crane1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_crane,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cochini,35,spyder_omnichannel_crane,5,10"/>
     <property name="act6" value="add_monster sharpfin,35,spyder_omnichannel_crane,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_crane"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_crane2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_crane,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannel2crane:yes"/>
     <property name="cond1" value="not variable_set omnichannel2crane:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -195,12 +195,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_dempsey"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_dempsey1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_dempsey,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster squabbit,20,spyder_omnichannel_dempsey,5,10"/>
     <property name="act6" value="add_monster squabbit,20,spyder_omnichannel_dempsey,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_dempsey"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_dempsey2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_dempsey,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannel2dempsey:yes"/>
     <property name="cond1" value="not variable_set omnichannel2dempsey:yes"/>
     <property name="cond2" value="is char_at player"/>

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -119,12 +119,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_strauss"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_strauss1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_strauss,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster budaye,36,spyder_omnichannel_strauss,5,10"/>
     <property name="act6" value="add_monster frondly,40,spyder_omnichannel_strauss,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_strauss"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_strauss2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_strauss,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannelstrauss:yes"/>
     <property name="cond1" value="not variable_set omnichannelstrauss:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -134,12 +134,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_carnegie"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_carnegie1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_carnegie,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster elofly,38,spyder_omnichannel_carnegie,5,10"/>
     <property name="act6" value="add_monster elostorm,38,spyder_omnichannel_carnegie,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_carnegie"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_carnegie2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_carnegie,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannelcarnegie:yes"/>
     <property name="cond1" value="not variable_set omnichannelcarnegie:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -149,12 +149,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_omnichannel_byrne"/>
-    <property name="act3" value="translated_dialog spyder_omnichannel_byrne1"/>
+    <property name="act3" value="char_talk spyder_omnichannel_byrne,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster rockat,36,spyder_omnichannel_byrne,5,10"/>
     <property name="act6" value="add_monster jemuar,40,spyder_omnichannel_byrne,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_byrne"/>
-    <property name="act8" value="translated_dialog spyder_omnichannel_byrne2"/>
+    <property name="act8" value="char_talk spyder_omnichannel_byrne,post_battle_lose"/>
     <property name="act9" value="set_variable omnichannelbyrne:yes"/>
     <property name="cond1" value="not variable_set omnichannelbyrne:yes"/>
     <property name="cond2" value="is char_at player"/>

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -385,10 +385,10 @@
   </object>
   <object id="161" name="Talk roddick" type="event" x="192" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_roddick1"/>
+    <property name="act1" value="char_talk spyder_route2_roddick,pre_battle"/>
     <property name="act2" value="add_monster spighter,8,spyder_route2_roddick,5,10"/>
     <property name="act3" value="start_battle player,spyder_route2_roddick"/>
-    <property name="act4" value="translated_dialog spyder_route2_roddick2"/>
+    <property name="act4" value="char_talk spyder_route2_roddick,post_battle_lose"/>
     <property name="act5" value="set_variable route2roddick:yes"/>
     <property name="behav1" value="talk spyder_route2_roddick"/>
     <property name="cond1" value="not variable_set route2roddick:yes"/>
@@ -396,11 +396,11 @@
   </object>
   <object id="162" name="Talk marion" type="event" x="208" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_marion1"/>
+    <property name="act1" value="char_talk spyder_route2_marion,pre_battle"/>
     <property name="act2" value="add_monster aardorn,7,spyder_route2_marion,5,10"/>
     <property name="act3" value="add_monster aardorn,7,spyder_route2_marion,5,10"/>
     <property name="act4" value="start_battle player,spyder_route2_marion"/>
-    <property name="act5" value="translated_dialog spyder_route2_marion2"/>
+    <property name="act5" value="char_talk spyder_route2_marion,post_battle_lose"/>
     <property name="act6" value="set_variable route2marion:yes"/>
     <property name="behav1" value="talk spyder_route2_marion"/>
     <property name="cond1" value="not variable_set route2marion:yes"/>
@@ -408,12 +408,12 @@
   </object>
   <object id="163" name="Talk graf" type="event" x="224" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_graf1"/>
+    <property name="act1" value="char_talk spyder_route2_graf,pre_battle"/>
     <property name="act2" value="add_monster cardiling,7,spyder_route2_graf,5,10"/>
     <property name="act3" value="add_monster cataspike,5,spyder_route2_graf,5,10"/>
     <property name="act4" value="add_monster cataspike,5,spyder_route2_graf,5,10"/>
     <property name="act5" value="start_battle player,spyder_route2_graf"/>
-    <property name="act6" value="translated_dialog spyder_route2_graf2"/>
+    <property name="act6" value="char_talk spyder_route2_graf,post_battle_lose"/>
     <property name="act7" value="set_variable route2graf:yes"/>
     <property name="behav1" value="talk spyder_route2_graf"/>
     <property name="cond1" value="not variable_set route2graf:yes"/>
@@ -452,11 +452,11 @@
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route2_roddick"/>
 	<property name="act3" value="char_face player,spyder_route2_roddick"/>
-	<property name="act4" value="translated_dialog spyder_route2_roddick1"/>
+	<property name="act4" value="char_talk spyder_route2_roddick,pre_battle"/>
     <property name="act5" value="unlock_controls"/>
     <property name="act6" value="add_monster spighter,8,spyder_route2_roddick,5,10"/>
     <property name="act7" value="start_battle player,spyder_route2_roddick"/>
-    <property name="act8" value="translated_dialog spyder_route2_roddick2"/>
+    <property name="act8" value="char_talk spyder_route2_roddick,post_battle_lose"/>
     <property name="act9" value="set_variable route2roddick:yes"/>
     <property name="cond1" value="not variable_set route2roddick:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -467,12 +467,12 @@
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route2_marion"/>
 	<property name="act3" value="char_face player,spyder_route2_marion"/>
-    <property name="act4" value="translated_dialog spyder_route2_marion1"/>
+    <property name="act4" value="char_talk spyder_route2_marion,pre_battle"/>
     <property name="act5" value="unlock_controls"/>
     <property name="act6" value="add_monster aardorn,7,spyder_route2_marion,5,10"/>
     <property name="act7" value="add_monster aardorn,7,spyder_route2_marion,5,10"/>
     <property name="act8" value="start_battle player,spyder_route2_marion"/>
-    <property name="act9" value="translated_dialog spyder_route2_marion2"/>
+    <property name="act9" value="char_talk spyder_route2_marion,post_battle_lose"/>
     <property name="act10" value="set_variable route2marion:yes"/>
     <property name="cond1" value="not variable_set route2marion:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -483,13 +483,13 @@
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_route2_graf"/>
 	<property name="act03" value="char_face player,spyder_route2_graf"/>
-    <property name="act04" value="translated_dialog spyder_route2_graf1"/>
+    <property name="act04" value="char_talk spyder_route2_graf,pre_battle"/>
     <property name="act05" value="unlock_controls"/>
     <property name="act06" value="add_monster cardiling,7,spyder_route2_graf,5,10"/>
     <property name="act07" value="add_monster cataspike,5,spyder_route2_graf,5,10"/>
     <property name="act08" value="add_monster cataspike,5,spyder_route2_graf,5,10"/>
     <property name="act09" value="start_battle player,spyder_route2_graf"/>
-    <property name="act10" value="translated_dialog spyder_route2_graf2"/>
+    <property name="act10" value="char_talk spyder_route2_graf,post_battle_lose"/>
     <property name="act11" value="set_variable route2graf:yes"/>
     <property name="cond1" value="not variable_set route2graf:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -545,21 +545,21 @@
   </object>
   <object id="211" name="Post Talk roddick" type="event" x="192" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_roddick2"/>
+    <property name="act1" value="char_talk spyder_route2_roddick,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route2_roddick"/>
     <property name="cond1" value="is variable_set route2roddick:yes"/>
    </properties>
   </object>
   <object id="212" name="Post Talk marion" type="event" x="208" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_marion2"/>
+    <property name="act1" value="char_talk spyder_route2_marion,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route2_marion"/>
     <property name="cond1" value="is variable_set route2marion:yes"/>
    </properties>
   </object>
   <object id="213" name="Post Talk graf" type="event" x="224" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route2_graf2"/>
+    <property name="act1" value="char_talk spyder_route2_graf,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route2_graf"/>
     <property name="cond1" value="is variable_set route2graf:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -202,13 +202,13 @@
   </object>
   <object id="593" name="Zoolander Talk" type="event" x="64" y="320" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_route3_zoolander1"/>
+    <property name="act01" value="char_talk spyder_route3_zoolander,pre_battle"/>
     <property name="act02" value="add_monster eruptibus,14,spyder_route3_zoolander,5,10"/>
     <property name="act03" value="add_monster rockat,14,spyder_route3_zoolander,5,10"/>
     <property name="act04" value="add_monster forturtle,16,spyder_route3_zoolander,5,10"/>
     <property name="act05" value="add_monster grinflare,16,spyder_route3_zoolander,5,10"/>
     <property name="act06" value="start_battle player,spyder_route3_zoolander"/>
-    <property name="act07" value="translated_dialog spyder_route3_zoolander2"/>
+    <property name="act07" value="char_talk spyder_route3_zoolander,post_battle_lose"/>
     <property name="act08" value="add_item sledgehammer"/>
     <property name="act09" value="translated_dialog sledgehammer,,center,center,center"/>
     <property name="act10" value="set_variable zoolanderdefeat:yes"/>
@@ -225,10 +225,10 @@
   </object>
   <object id="595" name="Rookie Talk" type="event" x="80" y="0" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_qqq1"/>
+    <property name="act1" value="char_talk spyder_route3_qqq,pre_battle"/>
     <property name="act2" value="add_monster cardiling,16,spyder_route3_qqq,5,10"/>
     <property name="act3" value="start_battle player,spyder_route3_qqq"/>
-    <property name="act4" value="translated_dialog spyder_route3_qqq2"/>
+    <property name="act4" value="char_talk spyder_route3_qqq,post_battle_lose"/>
     <property name="act6" value="set_variable ambushedbyqqq:yes"/>
     <property name="act7" value="pathfind spyder_route3_qqq,0,2"/>
     <property name="act8" value="remove_npc spyder_route3_qqq"/>
@@ -245,11 +245,11 @@
   </object>
   <object id="597" name="Enforcer Talk" type="event" x="256" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_weaver1"/>
+    <property name="act1" value="char_talk spyder_route3_weaver,pre_battle"/>
     <property name="act2" value="add_monster pythwire,12,spyder_route3_weaver,5,10"/>
     <property name="act3" value="add_monster squabbit,12,spyder_route3_weaver,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_weaver"/>
-    <property name="act5" value="translated_dialog spyder_route3_weaver2"/>
+    <property name="act5" value="char_talk spyder_route3_weaver,post_battle_lose"/>
     <property name="act6" value="set_variable route3weaver:yes"/>
     <property name="behav1" value="talk spyder_route3_weaver"/>
     <property name="cond1" value="not variable_set route3weaver:yes"/>
@@ -367,10 +367,10 @@
   </object>
   <object id="612" name="Novak Talk" type="event" x="144" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_novak1"/>
+    <property name="act1" value="char_talk spyder_route3_novak,pre_battle"/>
     <property name="act2" value="add_monster elofly,13,spyder_route3_novak,5,10"/>
     <property name="act3" value="start_battle player,spyder_route3_novak"/>
-    <property name="act4" value="translated_dialog spyder_route3_novak2"/>
+    <property name="act4" value="char_talk spyder_route3_novak,post_battle_lose"/>
     <property name="act6" value="set_variable route3novak:yes"/>
     <property name="behav1" value="talk spyder_route3_novak"/>
     <property name="cond1" value="not variable_set route3novak:yes"/>
@@ -384,10 +384,10 @@
   </object>
   <object id="614" name="Curie Talk" type="event" x="496" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_curie1"/>
+    <property name="act1" value="char_talk spyder_route3_curie,pre_battle"/>
     <property name="act2" value="add_monster propellercat,13,spyder_route3_curie,5,10"/>
     <property name="act3" value="start_battle player,spyder_route3_curie"/>
-    <property name="act4" value="translated_dialog spyder_route3_curie2"/>
+    <property name="act4" value="char_talk spyder_route3_curie,post_battle_lose"/>
     <property name="act6" value="set_variable route3curie:yes"/>
     <property name="behav1" value="talk spyder_route3_curie"/>
     <property name="cond1" value="not variable_set route3curie:yes"/>
@@ -401,7 +401,7 @@
   </object>
   <object id="616" name="Connor Talk" type="event" x="304" y="16" width="16" height="16">
    <properties>
-    <property name="act00" value="translated_dialog spyder_route3_connor1"/>
+    <property name="act00" value="char_talk spyder_route3_connor,pre_battle"/>
     <property name="act01" value="add_monster weavifly,12,spyder_route3_connor,5,10"/>
     <property name="act02" value="add_monster cataspike,8,spyder_route3_connor,5,10"/>
     <property name="act03" value="add_monster cataspike,8,spyder_route3_connor,5,10"/>
@@ -409,7 +409,7 @@
     <property name="act05" value="add_monster cataspike,8,spyder_route3_connor,5,10"/>
     <property name="act06" value="add_monster cataspike,8,spyder_route3_connor,5,10"/>
     <property name="act07" value="start_battle player,spyder_route3_connor"/>
-    <property name="act08" value="translated_dialog spyder_route3_connor2"/>
+    <property name="act08" value="char_talk spyder_route3_connor,post_battle_lose"/>
     <property name="act09" value="set_variable route3connor:yes"/>
     <property name="behav1" value="talk spyder_route3_connor"/>
     <property name="cond1" value="not variable_set route3connor:yes"/>
@@ -423,7 +423,7 @@
   </object>
   <object id="618" name="Talk Wanda" type="event" x="528" y="320" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_route3_wanda1"/>
+    <property name="act01" value="char_talk spyder_route3_wanda,pre_battle"/>
     <property name="act02" value="add_monster nudiflot_male,8,spyder_route3_wanda,5,10"/>
     <property name="act03" value="add_monster nudiflot_female,8,spyder_route3_wanda,5,10"/>
     <property name="act04" value="add_monster nudiflot_male,8,spyder_route3_wanda,5,10"/>
@@ -431,7 +431,7 @@
     <property name="act06" value="add_monster nudiflot_male,8,spyder_route3_wanda,5,10"/>
     <property name="act07" value="add_monster nudiflot_female,8,spyder_route3_wanda,5,10"/>
     <property name="act08" value="start_battle player,spyder_route3_wanda"/>
-    <property name="act09" value="translated_dialog spyder_route3_wanda2"/>
+    <property name="act09" value="char_talk spyder_route3_wanda,post_battle_lose"/>
     <property name="act10" value="add_item fishing_rod"/>
     <property name="act11" value="translated_dialog fishing_rod,,center,center,center"/>
     <property name="act12" value="set_variable route3wanda:yes"/>
@@ -455,11 +455,11 @@
   </object>
   <object id="621" name="Talk Twig" type="event" x="416" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_twig1"/>
+    <property name="act1" value="char_talk spyder_route3_twig,pre_battle"/>
     <property name="act2" value="add_monster aardorn,11,spyder_route3_twig,5,10"/>
     <property name="act3" value="add_monster foofle,11,spyder_route3_twig,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_twig"/>
-    <property name="act5" value="translated_dialog spyder_route3_twig2"/>
+    <property name="act5" value="char_talk spyder_route3_twig,post_battle_lose"/>
     <property name="act6" value="set_variable route3twig:yes"/>
     <property name="behav1" value="talk spyder_route3_twig"/>
     <property name="cond1" value="not variable_set route3twig:yes"/>
@@ -481,11 +481,11 @@
   </object>
   <object id="624" name="Talk Surat" type="event" x="128" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_surat1"/>
+    <property name="act1" value="char_talk spyder_route3_surat,pre_battle"/>
     <property name="act2" value="add_monster rockat,12,spyder_route3_surat,5,10"/>
     <property name="act3" value="add_monster foofle,12,spyder_route3_surat,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_surat"/>
-    <property name="act5" value="translated_dialog spyder_route3_surat2"/>
+    <property name="act5" value="char_talk spyder_route3_surat,post_battle_lose"/>
     <property name="act6" value="set_variable route3surat:yes"/>
     <property name="behav1" value="talk spyder_route3_surat"/>
     <property name="cond1" value="not variable_set route3surat:yes"/>
@@ -506,11 +506,11 @@
   </object>
   <object id="627" name="Talk Roxby" type="event" x="224" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_roxby1"/>
+    <property name="act1" value="char_talk spyder_route3_roxby,pre_battle"/>
     <property name="act2" value="add_monster rockitten,13,spyder_route3_roxby,5,10"/>
     <property name="act3" value="add_monster ignibus,13,spyder_route3_roxby,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_roxby"/>
-    <property name="act5" value="translated_dialog spyder_route3_roxby2"/>
+    <property name="act5" value="char_talk spyder_route3_roxby,post_battle_lose"/>
     <property name="act6" value="set_variable route3roxby:yes"/>
     <property name="behav1" value="talk spyder_route3_roxby"/>
     <property name="cond1" value="not variable_set route3roxby:yes"/>
@@ -554,12 +554,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route3_weaver"/>
-    <property name="act3" value="translated_dialog spyder_route3_weaver1"/>
+    <property name="act3" value="char_talk spyder_route3_weaver,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster pythwire,12,spyder_route3_weaver,5,10"/>
     <property name="act6" value="add_monster squabbit,12,spyder_route3_weaver,5,10"/>
     <property name="act7" value="start_battle player,spyder_route3_weaver"/>
-    <property name="act8" value="translated_dialog spyder_route3_weaver2"/>
+    <property name="act8" value="char_talk spyder_route3_weaver,post_battle_lose"/>
     <property name="act9" value="set_variable route3weaver:yes"/>
     <property name="cond1" value="not variable_set route3weaver:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -569,12 +569,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route3_twig"/>
-    <property name="act3" value="translated_dialog spyder_route3_twig1"/>
+    <property name="act3" value="char_talk spyder_route3_twig,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster aardorn,11,spyder_route3_twig,5,10"/>
     <property name="act6" value="add_monster foofle,11,spyder_route3_twig,5,10"/>
     <property name="act7" value="start_battle player,spyder_route3_twig"/>
-    <property name="act8" value="translated_dialog spyder_route3_twig2"/>
+    <property name="act8" value="char_talk spyder_route3_twig,post_battle_lose"/>
     <property name="act9" value="set_variable route3twig:yes"/>
     <property name="cond1" value="not variable_set route3twig:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -584,7 +584,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_route3_wanda"/>
-    <property name="act03" value="translated_dialog spyder_route3_wanda1"/>
+    <property name="act03" value="char_talk spyder_route3_wanda,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster nudiflot_male,8,spyder_route3_wanda,5,10"/>
     <property name="act06" value="add_monster nudiflot_female,8,spyder_route3_wanda,5,10"/>
@@ -593,7 +593,7 @@
     <property name="act09" value="add_monster nudiflot_male,8,spyder_route3_wanda,5,10"/>
     <property name="act10" value="add_monster nudiflot_female,8,spyder_route3_wanda,5,10"/>
     <property name="act11" value="start_battle player,spyder_route3_wanda"/>
-    <property name="act12" value="translated_dialog spyder_route3_wanda2"/>
+    <property name="act12" value="char_talk spyder_route3_wanda,post_battle_lose"/>
     <property name="act13" value="add_item fishing_rod"/>
     <property name="act14" value="translated_dialog fishing_rod,,center,center,center"/>
     <property name="act15" value="set_variable route3wanda:yes"/>
@@ -605,11 +605,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route3_novak"/>
-    <property name="act3" value="translated_dialog spyder_route3_novak1"/>
+    <property name="act3" value="char_talk spyder_route3_novak,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster elofly,13,spyder_route3_novak,5,10"/>
     <property name="act6" value="start_battle player,spyder_route3_novak"/>
-    <property name="act7" value="translated_dialog spyder_route3_novak2"/>
+    <property name="act7" value="char_talk spyder_route3_novak,post_battle_lose"/>
     <property name="act8" value="set_variable route3novak:yes"/>
     <property name="cond1" value="not variable_set route3novak:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -617,9 +617,9 @@
   </object>
   <object id="684" name="Rookie Talk" type="event" x="16" y="48" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog spyder_route3_qqq1"/>
+    <property name="act2" value="char_talk spyder_route3_qqq,pre_battle"/>
     <property name="act3" value="add_monster cardiling,16,spyder_route3_qqq,5,10"/>
-    <property name="act4" value="translated_dialog spyder_route3_qqq2"/>
+    <property name="act4" value="char_talk spyder_route3_qqq,post_battle_lose"/>
     <property name="act6" value="set_variable ambushedbyqqq:yes"/>
     <property name="act7" value="pathfind spyder_route3_qqq,0,2"/>
     <property name="act8" value="remove_npc spyder_route3_qqq"/>
@@ -674,35 +674,35 @@
   </object>
   <object id="708" name="Post Curie Talk" type="event" x="512" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_curie2"/>
+    <property name="act1" value="char_talk spyder_route3_curie,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route3_curie"/>
     <property name="cond1" value="is variable_set route3curie:yes"/>
    </properties>
   </object>
   <object id="709" name="Post Novak Talk" type="event" x="144" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_novak2"/>
+    <property name="act1" value="char_talk spyder_route3_novak,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route3_novak"/>
     <property name="cond1" value="is variable_set route3novak:yes"/>
    </properties>
   </object>
   <object id="710" name="Post Talk Wanda" type="event" x="480" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_wanda2"/>
+    <property name="act1" value="char_talk spyder_route3_wanda,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route3_wanda"/>
     <property name="cond1" value="is variable_set route3wanda:yes"/>
    </properties>
   </object>
   <object id="711" name="Post Connor Talk" type="event" x="320" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_connor2"/>
+    <property name="act1" value="char_talk spyder_route3_connor,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route3_connor"/>
     <property name="cond1" value="is variable_set route3connor:yes"/>
    </properties>
   </object>
   <object id="712" name="Post Enforcer Talk" type="event" x="240" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route3_weaver2"/>
+    <property name="act1" value="char_talk spyder_route3_weaver,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route3_weaver"/>
     <property name="cond1" value="is variable_set route3weaver:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -94,11 +94,11 @@
   </object>
   <object id="48" name="Talk Marshall" type="event" x="32" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_marshall1"/>
+    <property name="act1" value="char_talk spyder_route4_marshall,pre_battle"/>
     <property name="act2" value="add_monster puparmor,16,spyder_route4_marshall,5,10"/>
     <property name="act3" value="add_monster puparmor,16,spyder_route4_marshall,5,10"/>
     <property name="act4" value="start_battle player,spyder_route4_marshall"/>
-    <property name="act5" value="translated_dialog spyder_route4_marshall2"/>
+    <property name="act5" value="char_talk spyder_route4_marshall,post_battle_lose"/>
     <property name="act6" value="set_variable route4marshall:yes"/>
     <property name="behav1" value="talk spyder_route4_marshall"/>
     <property name="cond1" value="not variable_set route4marshall:yes"/>
@@ -281,10 +281,10 @@
   </object>
   <object id="71" name="Talk Roger" type="event" x="176" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_roger1"/>
+    <property name="act1" value="char_talk spyder_route4_roger,pre_battle"/>
     <property name="act2" value="add_monster rabbitosaur,16,spyder_route4_roger,5,10"/>
     <property name="act3" value="start_battle player,spyder_route4_roger"/>
-    <property name="act4" value="translated_dialog spyder_route4_roger2"/>
+    <property name="act4" value="char_talk spyder_route4_roger,post_battle_lose"/>
     <property name="act6" value="set_variable route4roger:yes"/>
     <property name="behav1" value="talk spyder_route4_roger"/>
     <property name="cond1" value="not variable_set route4roger:yes"/>
@@ -298,12 +298,12 @@
   </object>
   <object id="73" name="Talk Wulf" type="event" x="32" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_wulf1"/>
+    <property name="act1" value="char_talk spyder_route4_wulf,pre_battle"/>
     <property name="act2" value="add_monster cowpignon,14,spyder_route4_wulf,5,10"/>
     <property name="act3" value="add_monster cowpignon,14,spyder_route4_wulf,5,10"/>
     <property name="act4" value="add_monster shybulb,14,spyder_route4_wulf,5,10"/>
     <property name="act5" value="start_battle player,spyder_route4_wulf"/>
-    <property name="act6" value="translated_dialog spyder_route4_wulf2"/>
+    <property name="act6" value="char_talk spyder_route4_wulf,post_battle_lose"/>
     <property name="act7" value="set_variable route4wulf:yes"/>
     <property name="behav1" value="talk spyder_route4_wulf"/>
     <property name="cond1" value="not variable_set route4wulf:yes"/>
@@ -318,11 +318,11 @@
   </object>
   <object id="75" name="Talk Rincewind" type="event" x="208" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_rincewind1"/>
+    <property name="act1" value="char_talk spyder_route4_rincewind,pre_battle"/>
     <property name="act2" value="add_monster k9,16,spyder_route4_rincewind,5,10"/>
     <property name="act3" value="add_monster k9,16,spyder_route4_rincewind,5,10"/>
     <property name="act4" value="start_battle player,spyder_route4_rincewind"/>
-    <property name="act5" value="translated_dialog spyder_route4_rincewind2"/>
+    <property name="act5" value="char_talk spyder_route4_rincewind,post_battle_lose"/>
     <property name="act6" value="set_variable route4rincewind:yes"/>
     <property name="behav1" value="talk spyder_route4_rincewind"/>
     <property name="cond1" value="not variable_set route4rincewind:yes"/>
@@ -336,10 +336,10 @@
   </object>
   <object id="77" name="Talk Rosamund" type="event" x="176" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_rosamund1"/>
+    <property name="act1" value="char_talk spyder_route4_rosamund,pre_battle"/>
     <property name="act2" value="add_monster foofle,18,spyder_route4_rosamund,5,10"/>
     <property name="act3" value="start_battle player,spyder_route4_rosamund"/>
-    <property name="act4" value="translated_dialog spyder_route4_rosamund2"/>
+    <property name="act4" value="char_talk spyder_route4_rosamund,post_battle_lose"/>
     <property name="act6" value="set_variable route4rosamund:yes"/>
     <property name="behav1" value="talk spyder_route4_rosamund"/>
     <property name="cond1" value="not variable_set route4rosamund:yes"/>
@@ -354,12 +354,12 @@
   </object>
   <object id="79" name="Talk Beck" type="event" x="32" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_beck1"/>
+    <property name="act1" value="char_talk spyder_route4_beck,pre_battle"/>
     <property name="act2" value="add_monster katapill,14,spyder_route4_beck,5,10"/>
     <property name="act3" value="add_monster tumbleworm,12,spyder_route4_beck,5,10"/>
     <property name="act4" value="add_monster spighter,12,spyder_route4_beck,5,10"/>
     <property name="act5" value="start_battle player,spyder_route4_beck"/>
-    <property name="act6" value="translated_dialog spyder_route4_beck2"/>
+    <property name="act6" value="char_talk spyder_route4_beck,post_battle_lose"/>
     <property name="act7" value="set_variable route4beck:yes"/>
     <property name="behav1" value="talk spyder_route4_beck"/>
     <property name="cond1" value="not variable_set route4beck:yes"/>
@@ -383,12 +383,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route4_marshall"/>
-    <property name="act3" value="translated_dialog spyder_route4_marshall1"/>
+    <property name="act3" value="char_talk spyder_route4_marshall,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster puparmor,16,spyder_route4_marshall,5,10"/>
     <property name="act6" value="add_monster puparmor,16,spyder_route4_marshall,5,10"/>
     <property name="act7" value="start_battle player,spyder_route4_marshall"/>
-    <property name="act8" value="translated_dialog spyder_route4_marshall2"/>
+    <property name="act8" value="char_talk spyder_route4_marshall,post_battle_lose"/>
     <property name="act9" value="set_variable route4marshall:yes"/>
     <property name="cond1" value="not variable_set route4marshall:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -398,13 +398,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_route4_beck"/>
-    <property name="act03" value="translated_dialog spyder_route4_beck1"/>
+    <property name="act03" value="char_talk spyder_route4_beck,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster katapill,14,spyder_route4_beck,5,10"/>
     <property name="act06" value="add_monster tumbleworm,12,spyder_route4_beck,5,10"/>
     <property name="act07" value="add_monster spighter,12,spyder_route4_beck,5,10"/>
     <property name="act08" value="start_battle player,spyder_route4_beck"/>
-    <property name="act09" value="translated_dialog spyder_route4_beck2"/>
+    <property name="act09" value="char_talk spyder_route4_beck,post_battle_lose"/>
     <property name="act10" value="set_variable route4beck:yes"/>
     <property name="cond1" value="not variable_set route4beck:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -414,13 +414,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_route4_wulf"/>
-    <property name="act03" value="translated_dialog spyder_route4_wulf1"/>
+    <property name="act03" value="char_talk spyder_route4_wulf,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster cowpignon,14,spyder_route4_wulf,5,10"/>
     <property name="act06" value="add_monster cowpignon,14,spyder_route4_wulf,5,10"/>
     <property name="act07" value="add_monster shybulb,14,spyder_route4_wulf,5,10"/>
     <property name="act08" value="start_battle player,spyder_route4_wulf"/>
-    <property name="act09" value="translated_dialog spyder_route4_wulf2"/>
+    <property name="act09" value="char_talk spyder_route4_wulf,post_battle_lose"/>
     <property name="act10" value="set_variable route4wulf:yes"/>
     <property name="cond1" value="not variable_set route4wulf:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -430,11 +430,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route4_rosamund"/>
-    <property name="act3" value="translated_dialog spyder_route4_rosamund1"/>
+    <property name="act3" value="char_talk spyder_route4_rosamund,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster foofle,18,spyder_route4_rosamund,5,10"/>
     <property name="act6" value="start_battle player,spyder_route4_rosamund"/>
-    <property name="act7" value="translated_dialog spyder_route4_rosamund2"/>
+    <property name="act7" value="char_talk spyder_route4_rosamund,post_battle_lose"/>
     <property name="act8" value="set_variable route4rosamund:yes"/>
     <property name="cond1" value="not variable_set route4rosamund:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -499,42 +499,42 @@
   </object>
   <object id="93" name="Post Talk Rincewind" type="event" x="288" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_rincewind2"/>
+    <property name="act1" value="char_talk spyder_route4_rincewind,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route4_rincewind"/>
     <property name="cond1" value="is variable_set route4rincewind:yes"/>
    </properties>
   </object>
   <object id="94" name="Post Talk Roger" type="event" x="144" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_roger2"/>
+    <property name="act1" value="char_talk spyder_route4_roger,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route4_roger"/>
     <property name="cond1" value="is variable_set route4roger:yes"/>
    </properties>
   </object>
   <object id="95" name="Post Talk Rosamund" type="event" x="192" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_rosamund2"/>
+    <property name="act1" value="char_talk spyder_route4_rosamund,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route4_rosamund"/>
     <property name="cond1" value="is variable_set route4rosamund:yes"/>
    </properties>
   </object>
   <object id="96" name="Post Talk Marshall" type="event" x="16" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_marshall2"/>
+    <property name="act1" value="char_talk spyder_route4_marshall,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route4_marshall"/>
     <property name="cond1" value="is variable_set route4marshall:yes"/>
    </properties>
   </object>
   <object id="97" name="Post Talk Beck" type="event" x="16" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_beck2"/>
+    <property name="act1" value="char_talk spyder_route4_beck,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route4_beck"/>
     <property name="cond1" value="is variable_set route4beck:yes"/>
    </properties>
   </object>
   <object id="98" name="Post Talk Wulf" type="event" x="16" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route4_wulf2"/>
+    <property name="act1" value="char_talk spyder_route4_wulf,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route4_wulf"/>
     <property name="cond1" value="is variable_set route4wulf:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -233,10 +233,10 @@
   </object>
   <object id="48" name="Talk Sara" type="event" x="352" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_sara1"/>
+    <property name="act1" value="char_talk spyder_route5_sara,pre_battle"/>
     <property name="act2" value="add_monster capiti,20,spyder_route5_sara,5,10"/>
     <property name="act3" value="start_battle player,spyder_route5_sara"/>
-    <property name="act4" value="translated_dialog spyder_route5_sara2"/>
+    <property name="act4" value="char_talk spyder_route5_sara,post_battle_lose"/>
     <property name="act6" value="set_variable route5sara:yes"/>
     <property name="behav1" value="talk spyder_route5_sara"/>
     <property name="cond1" value="not variable_set route5sara:yes"/>
@@ -246,10 +246,10 @@
    <properties>
     <property name="act10" value="char_stop player"/>
     <property name="act30" value="pathfind spyder_route5_goliath,36,9"/>
-    <property name="act40" value="translated_dialog spyder_route5_goliath1"/>
+    <property name="act40" value="char_talk spyder_route5_goliath,pre_battle"/>
     <property name="act44" value="add_monster spighter,35,spyder_route5_goliath,5,10"/>
     <property name="act45" value="start_battle player,spyder_route5_goliath"/>
-    <property name="act46" value="translated_dialog spyder_route5_goliath2"/>
+    <property name="act46" value="char_talk spyder_route5_goliath,post_battle_lose"/>
     <property name="act50" value="pathfind spyder_route5_goliath,35,4"/>
     <property name="act80" value="remove_npc spyder_route5_goliath"/>
     <property name="act90" value="set_variable route5goliath:yes"/>
@@ -272,10 +272,10 @@
   </object>
   <object id="54" name="Talk Edith" type="event" x="320" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_edith1"/>
+    <property name="act1" value="char_talk spyder_route5_edith,pre_battle"/>
     <property name="act2" value="add_monster aardart,20,spyder_route5_edith,5,10"/>
     <property name="act3" value="start_battle player,spyder_route5_edith"/>
-    <property name="act4" value="translated_dialog spyder_route5_edith2"/>
+    <property name="act4" value="char_talk spyder_route5_edith,post_battle_lose"/>
     <property name="act6" value="set_variable route5edith:yes"/>
     <property name="behav1" value="talk spyder_route5_edith"/>
     <property name="cond1" value="not variable_set route5edith:yes"/>
@@ -290,12 +290,12 @@
   </object>
   <object id="56" name="Talk Hunter" type="event" x="96" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_hunter1"/>
+    <property name="act1" value="char_talk spyder_route5_hunter,pre_battle"/>
     <property name="act2" value="add_monster elowind,18,spyder_route5_hunter,5,10"/>
     <property name="act3" value="add_monster elofly,16,spyder_route5_hunter,5,10"/>
     <property name="act4" value="add_monster elofly,16,spyder_route5_hunter,5,10"/>
     <property name="act5" value="start_battle player,spyder_route5_hunter"/>
-    <property name="act6" value="translated_dialog spyder_route5_hunter2"/>
+    <property name="act6" value="char_talk spyder_route5_hunter,post_battle_lose"/>
     <property name="act7" value="set_variable route5hunter:yes"/>
     <property name="behav1" value="talk spyder_route5_hunter"/>
     <property name="cond1" value="not variable_set route5hunter:yes"/>
@@ -309,11 +309,11 @@
   </object>
   <object id="58" name="Talk Cleo" type="event" x="336" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_cleo1"/>
+    <property name="act1" value="char_talk spyder_route5_cleo,pre_battle"/>
     <property name="act2" value="add_monster memnomnom,20,spyder_route5_cleo,5,10"/>
     <property name="act3" value="add_monster memnomnom,20,spyder_route5_cleo,5,10"/>
     <property name="act4" value="start_battle player,spyder_route5_cleo"/>
-    <property name="act5" value="translated_dialog spyder_route5_cleo2"/>
+    <property name="act5" value="char_talk spyder_route5_cleo,post_battle_lose"/>
     <property name="act6" value="set_variable route5cleo:yes"/>
     <property name="behav1" value="talk spyder_route5_cleo"/>
     <property name="cond1" value="not variable_set route5cleo:yes"/>
@@ -327,11 +327,11 @@
   </object>
   <object id="60" name="Talk Tryphaena" type="event" x="272" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_tryphaena1"/>
+    <property name="act1" value="char_talk spyder_route5_tryphaena,pre_battle"/>
     <property name="act2" value="add_monster miaownolith,24,spyder_route5_tryphaena,5,10"/>
     <property name="act3" value="add_monster criniotherme,22,spyder_route5_tryphaena,5,10"/>
     <property name="act4" value="start_battle player,spyder_route5_tryphaena"/>
-    <property name="act5" value="translated_dialog spyder_route5_tryphaena2"/>
+    <property name="act5" value="char_talk spyder_route5_tryphaena,post_battle_lose"/>
     <property name="act6" value="set_variable route5tryphaena:yes"/>
     <property name="behav1" value="talk spyder_route5_tryphaena"/>
     <property name="cond1" value="not variable_set route5tryphaena:yes"/>
@@ -355,11 +355,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route5_sara"/>
-    <property name="act3" value="translated_dialog spyder_route5_sara1"/>
+    <property name="act3" value="char_talk spyder_route5_sara,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster capiti,20,spyder_route5_sara,5,10"/>
     <property name="act6" value="start_battle player,spyder_route5_sara"/>
-    <property name="act7" value="translated_dialog spyder_route5_sara2"/>
+    <property name="act7" value="char_talk spyder_route5_sara,post_battle_lose"/>
     <property name="act8" value="set_variable route5sara:yes"/>
     <property name="cond1" value="not variable_set route5sara:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -369,12 +369,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route5_cleo"/>
-    <property name="act3" value="translated_dialog spyder_route5_cleo1"/>
+    <property name="act3" value="char_talk spyder_route5_cleo,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster memnomnom,20,spyder_route5_cleo,5,10"/>
     <property name="act6" value="add_monster memnomnom,20,spyder_route5_cleo,5,10"/>
     <property name="act7" value="start_battle player,spyder_route5_cleo"/>
-    <property name="act8" value="translated_dialog spyder_route5_cleo2"/>
+    <property name="act8" value="char_talk spyder_route5_cleo,post_battle_lose"/>
     <property name="act9" value="set_variable route5cleo:yes"/>
     <property name="cond1" value="not variable_set route5cleo:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -384,12 +384,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route5_tryphaena"/>
-    <property name="act3" value="translated_dialog spyder_route5_tryphaena1"/>
+    <property name="act3" value="char_talk spyder_route5_tryphaena,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster miaownolith,24,spyder_route5_tryphaena,5,10"/>
     <property name="act6" value="add_monster criniotherme,22,spyder_route5_tryphaena,5,10"/>
     <property name="act7" value="start_battle player,spyder_route5_tryphaena"/>
-    <property name="act8" value="translated_dialog spyder_route5_tryphaena2"/>
+    <property name="act8" value="char_talk spyder_route5_tryphaena,post_battle_lose"/>
     <property name="act9" value="set_variable route5tryphaena:yes"/>
     <property name="cond1" value="not variable_set route5tryphaena:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -399,11 +399,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route5_edith"/>
-    <property name="act3" value="translated_dialog spyder_route5_edith1"/>
+    <property name="act3" value="char_talk spyder_route5_edith,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster aardart,20,spyder_route5_edith,5,10"/>
     <property name="act6" value="start_battle player,spyder_route5_edith"/>
-    <property name="act7" value="translated_dialog spyder_route5_edith2"/>
+    <property name="act7" value="char_talk spyder_route5_edith,post_battle_lose"/>
     <property name="act8" value="set_variable route5edith:yes"/>
     <property name="cond1" value="not variable_set route5edith:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -411,35 +411,35 @@
   </object>
   <object id="68" name="Post Talk Sara" type="event" x="272" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_sara2"/>
+    <property name="act1" value="char_talk spyder_route5_sara,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route5_sara"/>
     <property name="cond1" value="is variable_set route5sara:yes"/>
    </properties>
   </object>
   <object id="69" name="Post Talk Edith" type="event" x="272" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_edith2"/>
+    <property name="act1" value="char_talk spyder_route5_edith,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route5_edith"/>
     <property name="cond1" value="is variable_set route5edith:yes"/>
    </properties>
   </object>
   <object id="70" name="Post Talk Tryphaena" type="event" x="256" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_tryphaena2"/>
+    <property name="act1" value="char_talk spyder_route5_tryphaena,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route5_tryphaena"/>
     <property name="cond1" value="is variable_set route5tryphaena:yes"/>
    </properties>
   </object>
   <object id="71" name="Post Talk Cleo" type="event" x="256" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_cleo2"/>
+    <property name="act1" value="char_talk spyder_route5_cleo,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route5_cleo"/>
     <property name="cond1" value="is variable_set route5cleo:yes"/>
    </properties>
   </object>
   <object id="72" name="Post Talk Hunter" type="event" x="32" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route5_hunter2"/>
+    <property name="act1" value="char_talk spyder_route5_hunter,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route5_hunter"/>
     <property name="cond1" value="is variable_set route5hunter:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -228,12 +228,12 @@
   </object>
   <object id="192" name="Talk Frances" type="event" x="512" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_frances1"/>
+    <property name="act1" value="char_talk spyder_route6_frances,pre_battle"/>
     <property name="act2" value="add_monster narcileaf,30,spyder_route6_frances,5,10"/>
     <property name="act3" value="add_monster shybulb,30,spyder_route6_frances,5,10"/>
     <property name="act4" value="add_monster shybulb,30,spyder_route6_frances,5,10"/>
     <property name="act5" value="start_battle player,spyder_route6_frances"/>
-    <property name="act6" value="translated_dialog spyder_route6_frances2"/>
+    <property name="act6" value="char_talk spyder_route6_frances,post_battle_lose"/>
     <property name="act7" value="set_variable route6frances:yes"/>
     <property name="behav1" value="talk spyder_route6_frances"/>
     <property name="cond1" value="not variable_set route6frances:yes"/>
@@ -248,11 +248,11 @@
   </object>
   <object id="194" name="Talk Ping" type="event" x="400" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_ping1"/>
+    <property name="act1" value="char_talk spyder_route6_ping,pre_battle"/>
     <property name="act2" value="add_monster foofle,30,spyder_route6_ping,5,10"/>
     <property name="act3" value="add_monster foofle,30,spyder_route6_ping,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_ping"/>
-    <property name="act5" value="translated_dialog spyder_route6_ping2"/>
+    <property name="act5" value="char_talk spyder_route6_ping,post_battle_lose"/>
     <property name="act6" value="set_variable route6ping:yes"/>
     <property name="behav1" value="talk spyder_route6_ping"/>
     <property name="cond1" value="not variable_set route6ping:yes"/>
@@ -267,11 +267,11 @@
   </object>
   <object id="196" name="Talk Richard" type="event" x="416" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_richard1"/>
+    <property name="act1" value="char_talk spyder_route6_richard,pre_battle"/>
     <property name="act2" value="add_monster hydrone,30,spyder_route6_richard,5,10"/>
     <property name="act3" value="add_monster pigabyte,30,spyder_route6_richard,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_richard"/>
-    <property name="act5" value="translated_dialog spyder_route6_richard2"/>
+    <property name="act5" value="char_talk spyder_route6_richard,post_battle_lose"/>
     <property name="act6" value="set_variable route6richard:yes"/>
     <property name="behav1" value="talk spyder_route6_richard"/>
     <property name="cond1" value="not variable_set route6richard:yes"/>
@@ -286,11 +286,11 @@
   </object>
   <object id="198" name="Talk Blair" type="event" x="560" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_blair1"/>
+    <property name="act1" value="char_talk spyder_route6_blair,pre_battle"/>
     <property name="act2" value="add_monster grintrock,30,spyder_route6_blair,5,10"/>
     <property name="act3" value="add_monster grinflare,30,spyder_route6_blair,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_blair"/>
-    <property name="act5" value="translated_dialog spyder_route6_blair2"/>
+    <property name="act5" value="char_talk spyder_route6_blair,post_battle_lose"/>
     <property name="act6" value="set_variable route6blair:yes"/>
     <property name="behav1" value="talk spyder_route6_blair"/>
     <property name="cond1" value="not variable_set route6blair:yes"/>
@@ -305,11 +305,11 @@
   </object>
   <object id="200" name="Talk Maxwell" type="event" x="160" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_maxwell1"/>
+    <property name="act1" value="char_talk spyder_route6_maxwell,pre_battle"/>
     <property name="act2" value="add_monster propellercat,30,spyder_route6_maxwell,5,10"/>
     <property name="act3" value="add_monster birdling,30,spyder_route6_maxwell,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_maxwell"/>
-    <property name="act5" value="translated_dialog spyder_route6_maxwell2"/>
+    <property name="act5" value="char_talk spyder_route6_maxwell,post_battle_lose"/>
     <property name="act6" value="set_variable route6maxwell:yes"/>
     <property name="behav1" value="talk spyder_route6_maxwell"/>
     <property name="cond1" value="not variable_set route6maxwell:yes"/>
@@ -324,11 +324,11 @@
   </object>
   <object id="202" name="Talk Orion" type="event" x="352" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_orion1"/>
+    <property name="act1" value="char_talk spyder_route6_orion,pre_battle"/>
     <property name="act2" value="add_monster spighter,20,spyder_route6_orion,5,10"/>
     <property name="act3" value="add_monster zunna,30,spyder_route6_orion,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_orion"/>
-    <property name="act5" value="translated_dialog spyder_route6_orion2"/>
+    <property name="act5" value="char_talk spyder_route6_orion,post_battle_lose"/>
     <property name="act6" value="set_variable route6orion:yes"/>
     <property name="behav1" value="talk spyder_route6_orion"/>
     <property name="cond1" value="not variable_set route6orion:yes"/>
@@ -343,10 +343,10 @@
   </object>
   <object id="204" name="Talk Mungo" type="event" x="528" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_mungo1"/>
+    <property name="act1" value="char_talk spyder_route6_mungo,pre_battle"/>
     <property name="act2" value="add_monster noctula,20,spyder_route6_mungo,5,10"/>
     <property name="act3" value="start_battle player,spyder_route6_mungo"/>
-    <property name="act4" value="translated_dialog spyder_route6_mungo2"/>
+    <property name="act4" value="char_talk spyder_route6_mungo,post_battle_lose"/>
     <property name="act6" value="set_variable route6mungo:yes"/>
     <property name="behav1" value="talk spyder_route6_mungo"/>
     <property name="cond1" value="not variable_set route6mungo:yes"/>
@@ -361,10 +361,10 @@
   </object>
   <object id="206" name="Talk Rigel" type="event" x="448" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_rigel1"/>
+    <property name="act1" value="char_talk spyder_route6_rigel,pre_battle"/>
     <property name="act2" value="add_monster ignibus,30,spyder_route6_rigel,5,10"/>
     <property name="act3" value="start_battle player,spyder_route6_rigel"/>
-    <property name="act4" value="translated_dialog spyder_route6_rigel2"/>
+    <property name="act4" value="char_talk spyder_route6_rigel,post_battle_lose"/>
     <property name="act6" value="set_variable route6rigel:yes"/>
     <property name="behav1" value="talk spyder_route6_rigel"/>
     <property name="cond1" value="not variable_set route6rigel:yes"/>
@@ -380,11 +380,11 @@
   </object>
   <object id="208" name="Talk Gunner" type="event" x="464" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_gunner1"/>
+    <property name="act1" value="char_talk spyder_route6_gunner,pre_battle"/>
     <property name="act2" value="add_monster enduros,20,spyder_route6_gunner,5,10"/>
     <property name="act3" value="add_monster viviteel,20,spyder_route6_gunner,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_gunner"/>
-    <property name="act5" value="translated_dialog spyder_route6_gunner2"/>
+    <property name="act5" value="char_talk spyder_route6_gunner,post_battle_lose"/>
     <property name="act6" value="set_variable route6gunner:yes"/>
     <property name="act90" value="pathfind spyder_route6_gunner,28,17"/>
     <property name="behav1" value="talk spyder_route6_gunner"/>
@@ -425,12 +425,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route6_maxwell"/>
-    <property name="act3" value="translated_dialog spyder_route6_maxwell1"/>
+    <property name="act3" value="char_talk spyder_route6_maxwell,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster propellercat,30,spyder_route6_maxwell,5,10"/>
     <property name="act6" value="add_monster birdling,30,spyder_route6_maxwell,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_maxwell"/>
-    <property name="act8" value="translated_dialog spyder_route6_maxwell2"/>
+    <property name="act8" value="char_talk spyder_route6_maxwell,post_battle_lose"/>
     <property name="act9" value="set_variable route6maxwell:yes"/>
     <property name="cond1" value="not variable_set route6maxwell:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -440,12 +440,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route6_orion"/>
-    <property name="act3" value="translated_dialog spyder_route6_orion1"/>
+    <property name="act3" value="char_talk spyder_route6_orion,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster spighter,20,spyder_route6_orion,5,10"/>
     <property name="act6" value="add_monster zunna,30,spyder_route6_orion,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_orion"/>
-    <property name="act8" value="translated_dialog spyder_route6_orion2"/>
+    <property name="act8" value="char_talk spyder_route6_orion,post_battle_lose"/>
     <property name="act9" value="set_variable route6orion:yes"/>
     <property name="cond1" value="not variable_set route6orion:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -455,12 +455,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route6_richard"/>
-    <property name="act3" value="translated_dialog spyder_route6_richard1"/>
+    <property name="act3" value="char_talk spyder_route6_richard,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster hydrone,30,spyder_route6_richard,5,10"/>
     <property name="act6" value="add_monster pigabyte,30,spyder_route6_richard,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_richard"/>
-    <property name="act8" value="translated_dialog spyder_route6_richard2"/>
+    <property name="act8" value="char_talk spyder_route6_richard,post_battle_lose"/>
     <property name="act9" value="set_variable route6richard:yes"/>
     <property name="cond1" value="not variable_set route6richard:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -470,12 +470,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route6_blair"/>
-    <property name="act3" value="translated_dialog spyder_route6_blair1"/>
+    <property name="act3" value="char_talk spyder_route6_blair,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster grintrock,30,spyder_route6_blair,5,10"/>
     <property name="act6" value="add_monster grinflare,30,spyder_route6_blair,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_blair"/>
-    <property name="act8" value="translated_dialog spyder_route6_blair2"/>
+    <property name="act8" value="char_talk spyder_route6_blair,post_battle_lose"/>
     <property name="act9" value="set_variable route6blair:yes"/>
     <property name="cond1" value="not variable_set route6blair:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -485,11 +485,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_route6_mungo"/>
-    <property name="act3" value="translated_dialog spyder_route6_mungo1"/>
+    <property name="act3" value="char_talk spyder_route6_mungo,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster noctula,20,spyder_route6_mungo,5,10"/>
     <property name="act6" value="start_battle player,spyder_route6_mungo"/>
-    <property name="act7" value="translated_dialog spyder_route6_mungo2"/>
+    <property name="act7" value="char_talk spyder_route6_mungo,post_battle_lose"/>
     <property name="act8" value="set_variable route6mungo:yes"/>
     <property name="cond1" value="not variable_set route6mungo:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -595,49 +595,49 @@
   </object>
   <object id="236" name="Post Talk Maxwell" type="event" x="176" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_maxwell2"/>
+    <property name="act1" value="char_talk spyder_route6_maxwell,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_maxwell"/>
     <property name="cond1" value="is variable_set route6maxwell:yes"/>
    </properties>
   </object>
   <object id="237" name="Post Talk Ping" type="event" x="384" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_ping2"/>
+    <property name="act1" value="char_talk spyder_route6_ping,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_ping"/>
     <property name="cond1" value="is variable_set route6ping:yes"/>
    </properties>
   </object>
   <object id="238" name="Post Talk Orion" type="event" x="368" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_orion2"/>
+    <property name="act1" value="char_talk spyder_route6_orion,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_orion"/>
     <property name="cond1" value="is variable_set route6orion:yes"/>
    </properties>
   </object>
   <object id="239" name="Post Talk Frances" type="event" x="368" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_frances2"/>
+    <property name="act1" value="char_talk spyder_route6_frances,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_frances"/>
     <property name="cond1" value="is variable_set route6frances:yes"/>
    </properties>
   </object>
   <object id="240" name="Post Talk Mungo" type="event" x="384" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_mungo2"/>
+    <property name="act1" value="char_talk spyder_route6_mungo,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_mungo"/>
     <property name="cond1" value="is variable_set route6mungo:yes"/>
    </properties>
   </object>
   <object id="241" name="Post Talk Richard" type="event" x="352" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_richard2"/>
+    <property name="act1" value="char_talk spyder_route6_richard,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_richard"/>
     <property name="cond1" value="is variable_set route6richard:yes"/>
    </properties>
   </object>
   <object id="242" name="Post Talk Blair" type="event" x="352" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_route6_blair2"/>
+    <property name="act1" value="char_talk spyder_route6_blair,post_battle_lose"/>
     <property name="behav1" value="talk spyder_route6_blair"/>
     <property name="cond1" value="is variable_set route6blair:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -193,12 +193,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_doris"/>
-    <property name="act3" value="translated_dialog spyder_routea_doris1"/>
+    <property name="act3" value="char_talk spyder_routea_doris,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster shybulb,12,spyder_routea_doris,5,10"/>
     <property name="act6" value="add_monster trapsnap,14,spyder_routea_doris,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_doris"/>
-    <property name="act8" value="translated_dialog spyder_routea_doris2"/>
+    <property name="act8" value="char_talk spyder_routea_doris,post_battle_lose"/>
     <property name="act9" value="set_variable routeadoris:yes"/>
     <property name="cond1" value="not variable_set routeadoris:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -215,11 +215,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_dagger"/>
-    <property name="act3" value="translated_dialog spyder_routea_dagger1"/>
+    <property name="act3" value="char_talk spyder_routea_dagger,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cardiwing,16,spyder_routea_dagger,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_dagger"/>
-    <property name="act7" value="translated_dialog spyder_routea_dagger2"/>
+    <property name="act7" value="char_talk spyder_routea_dagger,post_battle_lose"/>
     <property name="act8" value="set_variable routeadagger:yes"/>
     <property name="cond1" value="not variable_set routeadagger:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -229,12 +229,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_doris"/>
-    <property name="act3" value="translated_dialog spyder_routea_doris1"/>
+    <property name="act3" value="char_talk spyder_routea_doris,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster shybulb,12,spyder_routea_doris,5,10"/>
     <property name="act6" value="add_monster trapsnap,14,spyder_routea_doris,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_doris"/>
-    <property name="act8" value="translated_dialog spyder_routea_doris2"/>
+    <property name="act8" value="char_talk spyder_routea_doris,post_battle_lose"/>
     <property name="act9" value="set_variable routeadoris:yes"/>
     <property name="cond1" value="not variable_set routeadoris:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -244,11 +244,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_dagger"/>
-    <property name="act3" value="translated_dialog spyder_routea_dagger1"/>
+    <property name="act3" value="char_talk spyder_routea_dagger,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster cardiwing,16,spyder_routea_dagger,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_dagger"/>
-    <property name="act7" value="translated_dialog spyder_routea_dagger2"/>
+    <property name="act7" value="char_talk spyder_routea_dagger,post_battle_lose"/>
     <property name="act8" value="set_variable routeadagger:yes"/>
     <property name="cond1" value="not variable_set routeadagger:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -265,12 +265,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_koan"/>
-    <property name="act3" value="translated_dialog spyder_routea_koan1"/>
+    <property name="act3" value="char_talk spyder_routea_koan,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster shybulb,12,spyder_routea_koan,5,10"/>
     <property name="act6" value="add_monster budaye,12,spyder_routea_koan,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_koan"/>
-    <property name="act8" value="translated_dialog spyder_routea_koan2"/>
+    <property name="act8" value="char_talk spyder_routea_koan,post_battle_lose"/>
     <property name="act9" value="set_variable routeakoan:yes"/>
     <property name="cond1" value="not variable_set routeakoan:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -286,12 +286,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_lexi"/>
-    <property name="act3" value="translated_dialog spyder_routea_lexi1"/>
+    <property name="act3" value="char_talk spyder_routea_lexi,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster vamporm,14,spyder_routea_lexi,5,10"/>
     <property name="act6" value="add_monster katapill,14,spyder_routea_lexi,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_lexi"/>
-    <property name="act8" value="translated_dialog spyder_routea_lexi2"/>
+    <property name="act8" value="char_talk spyder_routea_lexi,post_battle_lose"/>
     <property name="act9" value="set_variable routealexi:yes"/>
     <property name="cond1" value="not variable_set routealexi:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -308,12 +308,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_lotu"/>
-    <property name="act3" value="translated_dialog spyder_routea_lotu1"/>
+    <property name="act3" value="char_talk spyder_routea_lotu,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster narcileaf,14,spyder_routea_lotu,5,10"/>
     <property name="act6" value="add_monster tarpeur,14,spyder_routea_lotu,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_lotu"/>
-    <property name="act8" value="translated_dialog spyder_routea_lotu2"/>
+    <property name="act8" value="char_talk spyder_routea_lotu,post_battle_lose"/>
     <property name="act9" value="set_variable routealotu:yes"/>
     <property name="cond1" value="not variable_set routealotu:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -323,12 +323,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_connie"/>
-    <property name="act3" value="translated_dialog spyder_routea_connie1"/>
+    <property name="act3" value="char_talk spyder_routea_connie,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster sharpfin,14,spyder_routea_connie,5,10"/>
     <property name="act6" value="add_monster bigfin,14,spyder_routea_connie,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_connie"/>
-    <property name="act8" value="translated_dialog spyder_routea_connie2"/>
+    <property name="act8" value="char_talk spyder_routea_connie,post_battle_lose"/>
     <property name="act9" value="set_variable routeaconnie:yes"/>
     <property name="cond1" value="not variable_set routeaconnie:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -350,11 +350,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_joe"/>
-    <property name="act3" value="translated_dialog spyder_routea_joe1"/>
+    <property name="act3" value="char_talk spyder_routea_joe,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster katapill,16,spyder_routea_joe,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_joe"/>
-    <property name="act7" value="translated_dialog spyder_routea_joe2"/>
+    <property name="act7" value="char_talk spyder_routea_joe,post_battle_lose"/>
     <property name="act8" value="set_variable routeajoe:yes"/>
     <property name="cond1" value="not variable_set routeajoe:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -364,11 +364,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_joe"/>
-    <property name="act3" value="translated_dialog spyder_routea_joe1"/>
+    <property name="act3" value="char_talk spyder_routea_joe,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster katapill,16,spyder_routea_joe,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_joe"/>
-    <property name="act7" value="translated_dialog spyder_routea_joe2"/>
+    <property name="act7" value="char_talk spyder_routea_joe,post_battle_lose"/>
     <property name="act8" value="set_variable routeajoe:yes"/>
     <property name="cond1" value="not variable_set routeajoe:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -384,11 +384,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routea_rosy"/>
-    <property name="act3" value="translated_dialog spyder_routea_rosy1"/>
+    <property name="act3" value="char_talk spyder_routea_rosy,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster shammer,16,spyder_routea_rosy,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_rosy"/>
-    <property name="act7" value="translated_dialog spyder_routea_rosy2"/>
+    <property name="act7" value="char_talk spyder_routea_rosy,post_battle_lose"/>
     <property name="act8" value="set_variable routearosy:yes"/>
     <property name="cond1" value="not variable_set routearosy:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -421,7 +421,7 @@
   </object>
   <object id="95" name="Talk Vince1" type="event" x="48" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_vince1"/>
+    <property name="act1" value="char_talk spyder_routea_vince,pre_battle"/>
     <property name="act2" value="set_variable vincefirst:yes"/>
     <property name="behav1" value="talk spyder_routea_vince"/>
     <property name="cond1" value="not variable_set vincefirst:yes"/>
@@ -429,7 +429,7 @@
   </object>
   <object id="96" name="Talk Vince2" type="event" x="32" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_vince2"/>
+    <property name="act1" value="char_talk spyder_routea_vince,post_battle_lose"/>
     <property name="act2" value="set_variable vincesecond:yes"/>
     <property name="behav1" value="talk spyder_routea_vince"/>
     <property name="cond1" value="is variable_set vincefirst:yes"/>
@@ -502,21 +502,21 @@
   </object>
   <object id="119" name="Post Talk Koan" type="event" x="16" y="592" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_koan2"/>
+    <property name="act1" value="char_talk spyder_routea_koan,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_koan"/>
     <property name="cond1" value="is variable_set routeakoan:yes"/>
    </properties>
   </object>
   <object id="120" name="Post Talk Lexi" type="event" x="16" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_lexi2"/>
+    <property name="act1" value="char_talk spyder_routea_lexi,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_lexi"/>
     <property name="cond1" value="is variable_set routealexi:yes"/>
    </properties>
   </object>
   <object id="121" name="Post Talk Dagger" type="event" x="16" y="352" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_dagger2"/>
+    <property name="act1" value="char_talk spyder_routea_dagger,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_dagger"/>
     <property name="cond1" value="is variable_set routeadagger:yes"/>
    </properties>
@@ -532,35 +532,35 @@
   </object>
   <object id="123" name="Post Talk Rosy" type="event" x="176" y="256" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_rosy2"/>
+    <property name="act1" value="char_talk spyder_routea_rosy,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_rosy"/>
     <property name="cond1" value="is variable_set routearosy:yes"/>
    </properties>
   </object>
   <object id="124" name="Post Talk Doris" type="event" x="160" y="320" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_doris2"/>
+    <property name="act1" value="char_talk spyder_routea_doris,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_doris"/>
     <property name="cond1" value="is variable_set routeadoris:yes"/>
    </properties>
   </object>
   <object id="125" name="Post Talk Connie" type="event" x="192" y="400" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_connie2"/>
+    <property name="act1" value="char_talk spyder_routea_connie,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_connie"/>
     <property name="cond1" value="is variable_set routeaconnie:yes"/>
    </properties>
   </object>
   <object id="126" name="Post Talk Joe" type="event" x="192" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_joe2"/>
+    <property name="act1" value="char_talk spyder_routea_joe,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_joe"/>
     <property name="cond1" value="is variable_set routeajoe:yes"/>
    </properties>
   </object>
   <object id="127" name="Talk Lotu" type="event" x="240" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routea_lotu2"/>
+    <property name="act1" value="char_talk spyder_routea_lotu,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_lotu"/>
     <property name="cond1" value="is variable_set routealotu:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_routeb.tmx
+++ b/mods/tuxemon/maps/spyder_routeb.tmx
@@ -88,13 +88,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_routeb_electra"/>
-    <property name="act03" value="translated_dialog spyder_routeb_electra1"/>
+    <property name="act03" value="char_talk spyder_routeb_electra,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster dracune,35,spyder_routeb_electra,5,10"/>
     <property name="act06" value="add_monster pantherafira,45,spyder_routeb_electra,5,10"/>
     <property name="act07" value="add_monster tumbleworm,40,spyder_routeb_electra,5,10"/>
     <property name="act08" value="start_battle player,spyder_routeb_electra"/>
-    <property name="act09" value="translated_dialog spyder_routeb_electra2"/>
+    <property name="act09" value="char_talk spyder_routeb_electra,post_battle_lose"/>
     <property name="act10" value="set_variable routebelectra:yes"/>
     <property name="cond1" value="not variable_set routebelectra:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -111,13 +111,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_routeb_cytherea"/>
-    <property name="act03" value="translated_dialog spyder_routeb_cytherea1"/>
+    <property name="act03" value="char_talk spyder_routeb_cytherea,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster fluttaflap,35,spyder_routeb_cytherea,5,10"/>
     <property name="act06" value="add_monster criniotherme,35,spyder_routeb_cytherea,5,10"/>
     <property name="act07" value="add_monster tumblebee,40,spyder_routeb_cytherea,5,10"/>
     <property name="act08" value="start_battle player,spyder_routeb_cytherea"/>
-    <property name="act09" value="translated_dialog spyder_routeb_cytherea2"/>
+    <property name="act09" value="char_talk spyder_routeb_cytherea,post_battle_lose"/>
     <property name="act10" value="set_variable routebcytherea:yes"/>
     <property name="cond1" value="not variable_set routebcytherea:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -133,12 +133,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routeb_nephthys"/>
-    <property name="act3" value="translated_dialog spyder_routeb_nephthys1"/>
+    <property name="act3" value="char_talk spyder_routeb_nephthys,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster conifrost,45,spyder_routeb_nephthys,5,10"/>
     <property name="act6" value="add_monster djinnbo,45,spyder_routeb_nephthys,5,10"/>
     <property name="act7" value="start_battle player,spyder_routeb_nephthys"/>
-    <property name="act8" value="translated_dialog spyder_routeb_nephthys2"/>
+    <property name="act8" value="char_talk spyder_routeb_nephthys,post_battle_lose"/>
     <property name="act9" value="set_variable routebnephthys:yes"/>
     <property name="cond1" value="not variable_set routebnephthys:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -154,11 +154,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routeb_sedna"/>
-    <property name="act3" value="translated_dialog spyder_routeb_sedna1"/>
+    <property name="act3" value="char_talk spyder_routeb_sedna,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster squabbit,40,spyder_routeb_sedna,5,10"/>
     <property name="act6" value="start_battle player,spyder_routeb_sedna"/>
-    <property name="act7" value="translated_dialog spyder_routeb_sedna2"/>
+    <property name="act7" value="char_talk spyder_routeb_sedna,post_battle_lose"/>
     <property name="act8" value="set_variable routebsedna:yes"/>
     <property name="cond1" value="not variable_set routebsedna:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -175,13 +175,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_routeb_calypso"/>
-    <property name="act03" value="translated_dialog spyder_routeb_calypso1"/>
+    <property name="act03" value="char_talk spyder_routeb_calypso,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster ruption,40,spyder_routeb_calypso,5,10"/>
     <property name="act06" value="add_monster puparmor,35,spyder_routeb_calypso,5,10"/>
     <property name="act07" value="add_monster sumchon,40,spyder_routeb_calypso,5,10"/>
     <property name="act08" value="start_battle player,spyder_routeb_calypso"/>
-    <property name="act09" value="translated_dialog spyder_routeb_calypso2"/>
+    <property name="act09" value="char_talk spyder_routeb_calypso,post_battle_lose"/>
     <property name="act10" value="set_variable routebcalypso:yes"/>
     <property name="cond1" value="not variable_set routebcalypso:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -224,35 +224,35 @@
   </object>
   <object id="185" name="Post Talk Electra" type="event" x="240" y="560" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routeb_electra2"/>
+    <property name="act1" value="char_talk spyder_routeb_electra,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routeb_electra"/>
     <property name="cond1" value="is variable_set routebelectra:yes"/>
    </properties>
   </object>
   <object id="186" name="Post Talk Cytherea" type="event" x="240" y="416" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routeb_cytherea2"/>
+    <property name="act1" value="char_talk spyder_routeb_cytherea,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routeb_cytherea"/>
     <property name="cond1" value="is variable_set routebcytherea:yes"/>
    </properties>
   </object>
   <object id="187" name="Post Talk Nephthys" type="event" x="96" y="368" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routeb_nephthys2"/>
+    <property name="act1" value="char_talk spyder_routeb_nephthys,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routeb_nephthys"/>
     <property name="cond1" value="is variable_set routebnephthys:yes"/>
    </properties>
   </object>
   <object id="188" name="Post Talk Sedna" type="event" x="240" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routeb_sedna2"/>
+    <property name="act1" value="char_talk spyder_routeb_sedna,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routeb_sedna"/>
     <property name="cond1" value="is variable_set routebsedna:yes"/>
    </properties>
   </object>
   <object id="189" name="Post Talk Calypso" type="event" x="48" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routeb_calypso2"/>
+    <property name="act1" value="char_talk spyder_routeb_calypso,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routeb_calypso"/>
     <property name="cond1" value="is variable_set routebcalypso:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -59,10 +59,10 @@
   </object>
   <object id="202" name="Talk River" type="event" x="80" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_river1"/>
+    <property name="act1" value="char_talk spyder_searoutec_river,pre_battle"/>
     <property name="act2" value="add_monster manosting,24,spyder_searoutec_river,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_river"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_river2"/>
+    <property name="act4" value="char_talk spyder_searoutec_river,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecriver:yes"/>
     <property name="behav1" value="talk spyder_searoutec_river"/>
     <property name="cond1" value="not variable_set searoutecriver:yes"/>
@@ -76,7 +76,7 @@
   </object>
   <object id="204" name="Talk Wade" type="event" x="224" y="160" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_searoutec_wade1"/>
+    <property name="act01" value="char_talk spyder_searoutec_wade,pre_battle"/>
     <property name="act02" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
     <property name="act03" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
     <property name="act04" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
@@ -84,7 +84,7 @@
     <property name="act06" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
     <property name="act07" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
     <property name="act08" value="start_battle player,spyder_searoutec_wade"/>
-    <property name="act09" value="translated_dialog spyder_searoutec_wade2"/>
+    <property name="act09" value="char_talk spyder_searoutec_wade,post_battle_lose"/>
     <property name="act10" value="set_variable searoutecwade:yes"/>
     <property name="behav1" value="talk spyder_searoutec_wade"/>
     <property name="cond1" value="not variable_set searoutecwade:yes"/>
@@ -98,12 +98,12 @@
   </object>
   <object id="206" name="Talk Gil" type="event" x="384" y="224" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog spyder_searoutec_gil1"/>
+    <property name="act2" value="char_talk spyder_searoutec_gil,pre_battle"/>
     <property name="act3" value="add_monster nudiflot_female,22,spyder_searoutec_gil,5,10"/>
     <property name="act4" value="add_monster nudiflot_female,22,spyder_searoutec_gil,5,10"/>
     <property name="act5" value="add_monster nudimind,24,spyder_searoutec_gil,5,10"/>
     <property name="act6" value="start_battle player,spyder_searoutec_gil"/>
-    <property name="act7" value="translated_dialog spyder_searoutec_gil2"/>
+    <property name="act7" value="char_talk spyder_searoutec_gil,post_battle_lose"/>
     <property name="act8" value="set_variable searoutecgil:yes"/>
     <property name="behav1" value="talk spyder_searoutec_gil"/>
     <property name="cond1" value="not variable_set searoutecgil:yes"/>
@@ -118,10 +118,10 @@
   </object>
   <object id="208" name="Talk Leek" type="event" x="480" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_leek1"/>
+    <property name="act1" value="char_talk spyder_searoutec_leek,pre_battle"/>
     <property name="act2" value="add_monster nudikill,27,spyder_searoutec_leek,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_leek"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_leek2"/>
+    <property name="act4" value="char_talk spyder_searoutec_leek,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecleek:yes"/>
     <property name="behav1" value="talk spyder_searoutec_leek"/>
     <property name="cond1" value="not variable_set searoutecleek:yes"/>
@@ -136,10 +136,10 @@
   </object>
   <object id="210" name="Talk Beech" type="event" x="128" y="176" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_beech1"/>
+    <property name="act1" value="char_talk spyder_searoutec_beech,pre_battle"/>
     <property name="act2" value="add_monster nostray,26,spyder_searoutec_beech,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_beech"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_beech2"/>
+    <property name="act4" value="char_talk spyder_searoutec_beech,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecbeech:yes"/>
     <property name="behav1" value="talk spyder_searoutec_beech"/>
     <property name="cond1" value="not variable_set searoutecbeech:yes"/>
@@ -154,10 +154,10 @@
   </object>
   <object id="212" name="Talk Rutherford" type="event" x="528" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_rutherford1"/>
+    <property name="act1" value="char_talk spyder_searoutec_rutherford,pre_battle"/>
     <property name="act2" value="add_monster incandesfin,26,spyder_searoutec_rutherford,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_rutherford"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_rutherford2"/>
+    <property name="act4" value="char_talk spyder_searoutec_rutherford,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecrutherford:yes"/>
     <property name="behav1" value="talk spyder_searoutec_rutherford"/>
     <property name="cond1" value="not variable_set searoutecrutherford:yes"/>
@@ -172,10 +172,10 @@
   </object>
   <object id="214" name="Talk Carstair" type="event" x="400" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_carstair1"/>
+    <property name="act1" value="char_talk spyder_searoutec_carstair,pre_battle"/>
     <property name="act2" value="add_monster axolightl,24,spyder_searoutec_carstair,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_carstair"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_carstair2"/>
+    <property name="act4" value="char_talk spyder_searoutec_carstair,post_battle_lose"/>
     <property name="act6" value="set_variable searouteccarstair:yes"/>
     <property name="behav1" value="talk spyder_searoutec_carstair"/>
     <property name="cond1" value="not variable_set searouteccarstair:yes"/>
@@ -189,12 +189,12 @@
   </object>
   <object id="216" name="Talk Sandy" type="event" x="80" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_sandy1"/>
+    <property name="act1" value="char_talk spyder_searoutec_sandy,pre_battle"/>
     <property name="act2" value="add_monster sharpfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act3" value="add_monster sharpfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act4" value="add_monster bigfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act5" value="start_battle player,spyder_searoutec_sandy"/>
-    <property name="act6" value="translated_dialog spyder_searoutec_sandy2"/>
+    <property name="act6" value="char_talk spyder_searoutec_sandy,post_battle_lose"/>
     <property name="act7" value="set_variable searoutecsandy:yes"/>
     <property name="behav1" value="talk spyder_searoutec_sandy"/>
     <property name="cond1" value="not variable_set searoutecsandy:yes"/>
@@ -218,11 +218,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_searoutec_rutherford"/>
-    <property name="act3" value="translated_dialog spyder_searoutec_rutherford1"/>
+    <property name="act3" value="char_talk spyder_searoutec_rutherford,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster incandesfin,26,spyder_searoutec_rutherford,5,10"/>
     <property name="act6" value="start_battle player,spyder_searoutec_rutherford"/>
-    <property name="act7" value="translated_dialog spyder_searoutec_rutherford2"/>
+    <property name="act7" value="char_talk spyder_searoutec_rutherford,post_battle_lose"/>
     <property name="act8" value="set_variable searoutecrutherford:yes"/>
     <property name="cond1" value="not variable_set searoutecrutherford:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -232,13 +232,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_searoutec_gil"/>
-    <property name="act03" value="translated_dialog spyder_searoutec_gil1"/>
+    <property name="act03" value="char_talk spyder_searoutec_gil,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster nudiflot_female,22,spyder_searoutec_gil,5,10"/>
     <property name="act06" value="add_monster nudiflot_female,22,spyder_searoutec_gil,5,10"/>
     <property name="act07" value="add_monster nudimind,24,spyder_searoutec_gil,5,10"/>
     <property name="act08" value="start_battle player,spyder_searoutec_gil"/>
-    <property name="act09" value="translated_dialog spyder_searoutec_gil2"/>
+    <property name="act09" value="char_talk spyder_searoutec_gil,post_battle_lose"/>
     <property name="act10" value="set_variable searoutecgil:yes"/>
     <property name="cond1" value="not variable_set searoutecgil:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -248,13 +248,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_searoutec_sandy"/>
-    <property name="act03" value="translated_dialog spyder_searoutec_sandy1"/>
+    <property name="act03" value="char_talk spyder_searoutec_sandy,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster sharpfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act06" value="add_monster sharpfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act07" value="add_monster bigfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act08" value="start_battle player,spyder_searoutec_sandy"/>
-    <property name="act09" value="translated_dialog spyder_searoutec_sandy2"/>
+    <property name="act09" value="char_talk spyder_searoutec_sandy,post_battle_lose"/>
     <property name="act10" value="set_variable searoutecsandy:yes"/>
     <property name="cond1" value="not variable_set searoutecsandy:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -262,14 +262,14 @@
   </object>
   <object id="229" name="Talk More" type="event" x="528" y="464" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_more1"/>
+    <property name="act1" value="char_talk spyder_searoutec_more,pre_battle"/>
     <property name="act2" value="add_monster picc,26,spyder_searoutec_more,5,10"/>
     <property name="act3" value="add_monster incandesfin,25,spyder_searoutec_more,5,10"/>
     <property name="act4" value="add_monster nudimind,24,spyder_searoutec_more,5,10"/>
     <property name="act5" value="add_monster nudikill,23,spyder_searoutec_more,5,10"/>
     <property name="act6" value="add_monster bigfin,19,spyder_searoutec_more,5,10"/>
     <property name="act7" value="start_battle player,spyder_searoutec_more"/>
-    <property name="act8" value="translated_dialog spyder_searoutec_more2"/>
+    <property name="act8" value="char_talk spyder_searoutec_more,post_battle_lose"/>
     <property name="act9" value="set_variable searoutecmore:yes"/>
     <property name="behav1" value="talk spyder_searoutec_more"/>
     <property name="cond1" value="not variable_set searoutecmore:yes"/>
@@ -279,7 +279,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_searoutec_more"/>
-    <property name="act03" value="translated_dialog spyder_searoutec_more1"/>
+    <property name="act03" value="char_talk spyder_searoutec_more,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster picc,26,spyder_searoutec_more,5,10"/>
     <property name="act06" value="add_monster incandesfin,25,spyder_searoutec_more,5,10"/>
@@ -287,7 +287,7 @@
     <property name="act08" value="add_monster nudikill,23,spyder_searoutec_more,5,10"/>
     <property name="act09" value="add_monster bigfin,19,spyder_searoutec_more,5,10"/>
     <property name="act10" value="start_battle player,spyder_searoutec_more"/>
-    <property name="act11" value="translated_dialog spyder_searoutec_more2"/>
+    <property name="act11" value="char_talk spyder_searoutec_more,post_battle_lose"/>
     <property name="act12" value="set_variable searoutecmore:yes"/>
     <property name="cond1" value="not variable_set searoutecmore:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -317,10 +317,10 @@
   </object>
   <object id="244" name="Talk Nigel" type="event" x="192" y="384" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_nigel1"/>
+    <property name="act1" value="char_talk spyder_searoutec_nigel,pre_battle"/>
     <property name="act2" value="add_monster agnigon,36,spyder_searoutec_nigel,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_nigel"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_nigel2"/>
+    <property name="act4" value="char_talk spyder_searoutec_nigel,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecnigel:yes"/>
     <property name="behav1" value="talk spyder_searoutec_nigel"/>
     <property name="cond1" value="not variable_set searoutecnigel:yes"/>
@@ -377,10 +377,10 @@
   </object>
   <object id="263" name="Talk Stafford" type="event" x="416" y="528" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_stafford1"/>
+    <property name="act1" value="char_talk spyder_searoutec_stafford,pre_battle"/>
     <property name="act2" value="add_monster medushock,22,spyder_searoutec_stafford,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_stafford"/>
-    <property name="act4" value="translated_dialog spyder_searoutec_stafford2"/>
+    <property name="act4" value="char_talk spyder_searoutec_stafford,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecstafford:yes"/>
     <property name="behav1" value="talk spyder_searoutec_stafford"/>
     <property name="cond1" value="not variable_set searoutecstafford:yes"/>
@@ -395,11 +395,11 @@
   </object>
   <object id="265" name="Talk Maurice" type="event" x="80" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_maurice1"/>
+    <property name="act1" value="char_talk spyder_searoutec_maurice,pre_battle"/>
     <property name="act2" value="add_monster brewdin,22,spyder_searoutec_maurice,5,10"/>
     <property name="act3" value="add_monster fancair,22,spyder_searoutec_maurice,5,10"/>
     <property name="act4" value="start_battle player,spyder_searoutec_maurice"/>
-    <property name="act5" value="translated_dialog spyder_searoutec_maurice2"/>
+    <property name="act5" value="char_talk spyder_searoutec_maurice,post_battle_lose"/>
     <property name="act6" value="set_variable searoutecmaurice:yes"/>
     <property name="behav1" value="talk spyder_searoutec_maurice"/>
     <property name="cond1" value="not variable_set searoutecmaurice:yes"/>
@@ -463,14 +463,14 @@
   </object>
   <object id="282" name="Post Talk Maurice" type="event" x="112" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_maurice2"/>
+    <property name="act1" value="char_talk spyder_searoutec_maurice,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_maurice"/>
     <property name="cond1" value="is variable_set searoutecmaurice:yes"/>
    </properties>
   </object>
   <object id="283" name="Post Talk Nigel" type="event" x="176" y="384" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_nigel2"/>
+    <property name="act1" value="char_talk spyder_searoutec_nigel,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_nigel"/>
     <property name="cond1" value="is variable_set searoutecnigel:yes"/>
     <property name="cond2" value="is variable_set hospitalcure:yes"/>
@@ -478,70 +478,70 @@
   </object>
   <object id="284" name="Post Talk Sandy" type="event" x="112" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_sandy2"/>
+    <property name="act1" value="char_talk spyder_searoutec_sandy,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_sandy"/>
     <property name="cond1" value="is variable_set searoutecsandy:yes"/>
    </properties>
   </object>
   <object id="285" name="Post Talk Beech" type="event" x="128" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_beech2"/>
+    <property name="act1" value="char_talk spyder_searoutec_beech,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_beech"/>
     <property name="cond1" value="is variable_set searoutecbeech:yes"/>
    </properties>
   </object>
   <object id="286" name="Post Talk River" type="event" x="144" y="272" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_river2"/>
+    <property name="act1" value="char_talk spyder_searoutec_river,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_river"/>
     <property name="cond1" value="is variable_set searoutecriver:yes"/>
    </properties>
   </object>
   <object id="287" name="Post Talk Wade" type="event" x="160" y="272" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_searoutec_wade2"/>
+    <property name="act01" value="char_talk spyder_searoutec_wade,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_wade"/>
     <property name="cond1" value="is variable_set searoutecwade:yes"/>
    </properties>
   </object>
   <object id="288" name="Post Talk Stafford" type="event" x="416" y="544" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_stafford2"/>
+    <property name="act1" value="char_talk spyder_searoutec_stafford,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_stafford"/>
     <property name="cond1" value="is variable_set searoutecstafford:yes"/>
    </properties>
   </object>
   <object id="289" name="Post Talk Gil" type="event" x="128" y="288" width="16" height="16">
    <properties>
-    <property name="act2" value="translated_dialog spyder_searoutec_gil2"/>
+    <property name="act2" value="char_talk spyder_searoutec_gil,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_gil"/>
     <property name="cond1" value="is variable_set searoutecgil:yes"/>
    </properties>
   </object>
   <object id="290" name="Post Talk Carstair" type="event" x="144" y="288" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_carstair2"/>
+    <property name="act1" value="char_talk spyder_searoutec_carstair,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_carstair"/>
     <property name="cond1" value="is variable_set searouteccarstair:yes"/>
    </properties>
   </object>
   <object id="291" name="Post Talk Rutherford" type="event" x="432" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_rutherford2"/>
+    <property name="act1" value="char_talk spyder_searoutec_rutherford,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_rutherford"/>
     <property name="cond1" value="is variable_set searoutecrutherford:yes"/>
    </properties>
   </object>
   <object id="292" name="Post Talk Leek" type="event" x="416" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_leek2"/>
+    <property name="act1" value="char_talk spyder_searoutec_leek,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_leek"/>
     <property name="cond1" value="is variable_set searoutecleek:yes"/>
    </properties>
   </object>
   <object id="293" name="Post Talk More" type="event" x="512" y="480" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_searoutec_more2"/>
+    <property name="act1" value="char_talk spyder_searoutec_more,post_battle_lose"/>
     <property name="behav1" value="talk spyder_searoutec_more"/>
     <property name="cond1" value="is variable_set searoutecmore:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -116,12 +116,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routee_calliope,down"/>
-    <property name="act3" value="translated_dialog spyder_routee_calliope1"/>
+    <property name="act3" value="char_talk spyder_routee_calliope,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster tumblebee,40,spyder_routee_calliope,5,10"/>
     <property name="act6" value="add_monster windeye,35,spyder_routee_calliope,5,10"/>
     <property name="act7" value="start_battle player,spyder_routee_calliope"/>
-    <property name="act8" value="translated_dialog spyder_routee_calliope2"/>
+    <property name="act8" value="char_talk spyder_routee_calliope,post_battle_lose"/>
     <property name="act9" value="set_variable routeecalliope:yes"/>
     <property name="cond1" value="not variable_set routeecalliope:yes"/>
     <property name="cond2" value="is variable_set kernelquestbegin:yes"/>
@@ -154,12 +154,12 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_routee_aiolos"/>
-    <property name="act3" value="translated_dialog spyder_routee_aiolos1"/>
+    <property name="act3" value="char_talk spyder_routee_aiolos,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster dune_pincher,35,spyder_routee_aiolos,5,10"/>
     <property name="act6" value="add_monster dinoflop,40,spyder_routee_aiolos,5,10"/>
     <property name="act7" value="start_battle player,spyder_routee_aiolos"/>
-    <property name="act8" value="translated_dialog spyder_routee_aiolos2"/>
+    <property name="act8" value="char_talk spyder_routee_aiolos,post_battle_lose"/>
     <property name="act9" value="set_variable routeeaiolos:yes"/>
     <property name="cond1" value="not variable_set routeeaiolos:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -167,14 +167,14 @@
   </object>
   <object id="87" name="Post Talk Calliope" type="event" x="128" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routee_calliope2"/>
+    <property name="act1" value="char_talk spyder_routee_calliope,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routee_calliope"/>
     <property name="cond1" value="is variable_set routeecalliope:yes"/>
    </properties>
   </object>
   <object id="88" name="Post Talk Aiolos" type="event" x="128" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_routee_aiolos2"/>
+    <property name="act1" value="char_talk spyder_routee_aiolos,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routee_aiolos"/>
     <property name="cond1" value="is variable_set routeeaiolos:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -74,7 +74,7 @@
   </object>
   <object id="47" name="Talk Lanth" type="event" x="0" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_lanth1"/>
+    <property name="act1" value="char_talk spyder_scoop_lanth,pre_battle"/>
     <property name="act2" value="add_monster mrmoswitch,35,spyder_scoop_lanth,5,10"/>
     <property name="act3" value="add_monster picc,35,spyder_scoop_lanth,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_lanth"/>
@@ -92,7 +92,7 @@
   </object>
   <object id="50" name="Talk Paine" type="event" x="96" y="48" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_paine1"/>
+    <property name="act1" value="char_talk spyder_scoop_paine,pre_battle"/>
     <property name="act2" value="add_monster possessun,35,spyder_scoop_paine,5,10"/>
     <property name="act3" value="add_monster cairfrey,30,spyder_scoop_paine,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_paine"/>
@@ -111,7 +111,7 @@
   </object>
   <object id="52" name="Talk Rubid" type="event" x="224" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_rubid1"/>
+    <property name="act1" value="char_talk spyder_scoop_rubid,pre_battle"/>
     <property name="act2" value="add_monster birdling,35,spyder_scoop_rubid,5,10"/>
     <property name="act3" value="add_monster hatchling,30,spyder_scoop_rubid,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_rubid"/>
@@ -130,7 +130,7 @@
   </object>
   <object id="54" name="Talk Berys" type="event" x="304" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_berys1"/>
+    <property name="act1" value="char_talk spyder_scoop_berys,pre_battle"/>
     <property name="act2" value="add_monster propellercat,40,spyder_scoop_berys,5,10"/>
     <property name="act3" value="add_monster embazook,35,spyder_scoop_berys,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_berys"/>
@@ -148,7 +148,7 @@
   </object>
   <object id="56" name="Talk Turner" type="event" x="16" y="144" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_turner1"/>
+    <property name="act1" value="char_talk spyder_scoop_turner,pre_battle"/>
     <property name="act2" value="add_monster flacono,30,spyder_scoop_turner,5,10"/>
     <property name="act3" value="add_monster squabbit,30,spyder_scoop_turner,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_turner"/>
@@ -191,7 +191,7 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_scoop_lanth"/>
-    <property name="act3" value="translated_dialog spyder_scoop_lanth1"/>
+    <property name="act3" value="char_talk spyder_scoop_lanth,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster mrmoswitch,35,spyder_scoop_lanth,5,10"/>
     <property name="act6" value="add_monster picc,35,spyder_scoop_lanth,5,10"/>
@@ -206,7 +206,7 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_scoop_berys"/>
-    <property name="act3" value="translated_dialog spyder_scoop_berys1"/>
+    <property name="act3" value="char_talk spyder_scoop_berys,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster propellercat,40,spyder_scoop_berys,5,10"/>
     <property name="act6" value="add_monster embazook,35,spyder_scoop_berys,5,10"/>
@@ -221,7 +221,7 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_scoop_turner"/>
-    <property name="act3" value="translated_dialog spyder_scoop_turner1"/>
+    <property name="act3" value="char_talk spyder_scoop_turner,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster flacono,30,spyder_scoop_turner,5,10"/>
     <property name="act6" value="add_monster squabbit,30,spyder_scoop_turner,5,10"/>
@@ -236,7 +236,7 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_scoop_paine"/>
-    <property name="act3" value="translated_dialog spyder_scoop_paine1"/>
+    <property name="act3" value="char_talk spyder_scoop_paine,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster possessun,35,spyder_scoop_paine,5,10"/>
     <property name="act6" value="add_monster cairfrey,30,spyder_scoop_paine,5,10"/>
@@ -251,7 +251,7 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_scoop_rubid"/>
-    <property name="act3" value="translated_dialog spyder_scoop_rubid1"/>
+    <property name="act3" value="char_talk spyder_scoop_rubid,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster birdling,35,spyder_scoop_rubid,5,10"/>
     <property name="act6" value="add_monster hatchling,30,spyder_scoop_rubid,5,10"/>

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -118,7 +118,7 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_scoop_alyssa"/>
-    <property name="act3" value="translated_dialog spyder_scoop_alyssa1"/>
+    <property name="act3" value="char_talk spyder_scoop_alyssa,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster possessun,40,spyder_scoop_alyssa,5,10"/>
     <property name="act6" value="start_battle player,spyder_scoop_alyssa"/>
@@ -132,7 +132,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_scoop_taggart"/>
-    <property name="act03" value="translated_dialog spyder_scoop_taggart1"/>
+    <property name="act03" value="char_talk spyder_scoop_taggart,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster elofly,30,spyder_scoop_taggart,5,10"/>
     <property name="act06" value="add_monster elowind,35,spyder_scoop_taggart,5,10"/>
@@ -148,7 +148,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_scoop_donald"/>
-    <property name="act03" value="translated_dialog spyder_scoop_donald1"/>
+    <property name="act03" value="char_talk spyder_scoop_donald,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster birdling,35,spyder_scoop_donald,5,10"/>
     <property name="act06" value="add_monster pigabyte,35,spyder_scoop_donald,5,10"/>

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -86,7 +86,7 @@
   </object>
   <object id="31" name="Talk Orba" type="event" x="48" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_scoop_orba1"/>
+    <property name="act1" value="char_talk spyder_scoop_orba,pre_battle"/>
     <property name="act2" value="add_monster abesnaki,30,spyder_scoop_orba,5,10"/>
     <property name="act3" value="add_monster spighter,30,spyder_scoop_orba,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_orba"/>
@@ -297,7 +297,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_scoop_weaver"/>
-    <property name="act03" value="translated_dialog spyder_scoop_weaver1"/>
+    <property name="act03" value="char_talk spyder_scoop_weaver,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster cardiling,30,spyder_scoop_weaver,5,10"/>
     <property name="act06" value="add_monster spighter,30,spyder_scoop_weaver,5,10"/>

--- a/mods/tuxemon/maps/spyder_timber_walledgarden1.tmx
+++ b/mods/tuxemon/maps/spyder_timber_walledgarden1.tmx
@@ -119,13 +119,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_fugger"/>
-    <property name="act03" value="translated_dialog spyder_walled_fugger1"/>
+    <property name="act03" value="char_talk spyder_walled_fugger,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster polyrock,50,spyder_walled_fugger,5,10"/>
     <property name="act06" value="add_monster sampsage,50,spyder_walled_fugger,5,10"/>
     <property name="act07" value="add_monster sampsack,50,spyder_walled_fugger,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_fugger"/>
-    <property name="act09" value="translated_dialog spyder_walled_fugger2"/>
+    <property name="act09" value="char_talk spyder_walled_fugger,post_battle_lose"/>
     <property name="act10" value="set_variable walledfugger:yes"/>
     <property name="cond1" value="not variable_set walledfugger:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -142,12 +142,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_carnegie"/>
-    <property name="act03" value="translated_dialog spyder_walled_carnegie1"/>
+    <property name="act03" value="char_talk spyder_walled_carnegie,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster tetrchimp,45,spyder_walled_carnegie,5,10"/>
     <property name="act06" value="add_monster apeoro,55,spyder_walled_carnegie,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_carnegie"/>
-    <property name="act08" value="translated_dialog spyder_walled_carnegie2"/>
+    <property name="act08" value="char_talk spyder_walled_carnegie,post_battle_lose"/>
     <property name="act09" value="set_variable walledcarnegie:yes"/>
     <property name="cond1" value="not variable_set walledcarnegie:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -164,13 +164,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_ford"/>
-    <property name="act03" value="translated_dialog spyder_walled_ford1"/>
+    <property name="act03" value="char_talk spyder_walled_ford,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster drashimi,50,spyder_walled_ford,5,10"/>
     <property name="act06" value="add_monster mingdyn,50,spyder_walled_ford,5,10"/>
     <property name="act07" value="add_monster firomenis,50,spyder_walled_ford,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_ford"/>
-    <property name="act09" value="translated_dialog spyder_walled_ford2"/>
+    <property name="act09" value="char_talk spyder_walled_ford,post_battle_lose"/>
     <property name="act10" value="set_variable walledford:yes"/>
     <property name="cond1" value="not variable_set walledford:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -187,13 +187,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_girard"/>
-    <property name="act03" value="translated_dialog spyder_walled_girard1"/>
+    <property name="act03" value="char_talk spyder_walled_girard,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster tigrock,50,spyder_walled_girard,5,10"/>
     <property name="act06" value="add_monster anu,50,spyder_walled_girard,5,10"/>
     <property name="act07" value="add_monster komoduel,50,spyder_walled_girard,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_girard"/>
-    <property name="act09" value="translated_dialog spyder_walled_girard2"/>
+    <property name="act09" value="char_talk spyder_walled_girard,post_battle_lose"/>
     <property name="act10" value="set_variable walledgirard:yes"/>
     <property name="cond1" value="not variable_set walledgirard:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -210,13 +210,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_vanderbilt"/>
-    <property name="act03" value="translated_dialog spyder_walled_vanderbilt1"/>
+    <property name="act03" value="char_talk spyder_walled_vanderbilt,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster angesnow,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act06" value="add_monster cowpignon,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act07" value="add_monster narcileaf,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_vanderbilt"/>
-    <property name="act09" value="translated_dialog spyder_walled_vanderbilt2"/>
+    <property name="act09" value="char_talk spyder_walled_vanderbilt,post_battle_lose"/>
     <property name="act10" value="set_variable walledvanderbilt:yes"/>
     <property name="cond1" value="not variable_set walledvanderbilt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -226,13 +226,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_ford"/>
-    <property name="act03" value="translated_dialog spyder_walled_ford1"/>
+    <property name="act03" value="char_talk spyder_walled_ford,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster drashimi,50,spyder_walled_ford,5,10"/>
     <property name="act06" value="add_monster mingdyn,50,spyder_walled_ford,5,10"/>
     <property name="act07" value="add_monster firomenis,50,spyder_walled_ford,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_ford"/>
-    <property name="act09" value="translated_dialog spyder_walled_ford2"/>
+    <property name="act09" value="char_talk spyder_walled_ford,post_battle_lose"/>
     <property name="act10" value="set_variable walledford:yes"/>
     <property name="cond1" value="not variable_set walledford:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -242,13 +242,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_vanderbilt"/>
-    <property name="act03" value="translated_dialog spyder_walled_vanderbilt1"/>
+    <property name="act03" value="char_talk spyder_walled_vanderbilt,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster angesnow,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act06" value="add_monster cowpignon,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act07" value="add_monster narcileaf,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_vanderbilt"/>
-    <property name="act09" value="translated_dialog spyder_walled_vanderbilt2"/>
+    <property name="act09" value="char_talk spyder_walled_vanderbilt,post_battle_lose"/>
     <property name="act10" value="set_variable walledvanderbilt:yes"/>
     <property name="cond1" value="not variable_set walledvanderbilt:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -265,13 +265,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_astor"/>
-    <property name="act03" value="translated_dialog spyder_walled_astor1"/>
+    <property name="act03" value="char_talk spyder_walled_astor,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster araignee,50,spyder_walled_astor,5,10"/>
     <property name="act06" value="add_monster spighter,50,spyder_walled_astor,5,10"/>
     <property name="act07" value="add_monster selket,50,spyder_walled_astor,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_astor"/>
-    <property name="act09" value="translated_dialog spyder_walled_astor2"/>
+    <property name="act09" value="char_talk spyder_walled_astor,post_battle_lose"/>
     <property name="act10" value="set_variable walledastor:yes"/>
     <property name="cond1" value="not variable_set walledastor:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -279,42 +279,42 @@
   </object>
   <object id="72" name="Post Talk astor" type="event" x="176" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_astor2"/>
+    <property name="act1" value="char_talk spyder_walled_astor,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_astor"/>
     <property name="cond1" value="is variable_set walledastor:yes"/>
    </properties>
   </object>
   <object id="73" name="Post Talk girard" type="event" x="64" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_girard2"/>
+    <property name="act1" value="char_talk spyder_walled_girard,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_girard"/>
     <property name="cond1" value="is variable_set walledgirard:yes"/>
    </properties>
   </object>
   <object id="74" name="Post Talk ford" type="event" x="64" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_ford2"/>
+    <property name="act1" value="char_talk spyder_walled_ford,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_ford"/>
     <property name="cond1" value="is variable_set walledford:yes"/>
    </properties>
   </object>
   <object id="75" name="Post Talk vanderbilt" type="event" x="176" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_vanderbilt2"/>
+    <property name="act1" value="char_talk spyder_walled_vanderbilt,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_vanderbilt"/>
     <property name="cond1" value="is variable_set walledvanderbilt:yes"/>
    </properties>
   </object>
   <object id="76" name="Post Talk fugger" type="event" x="176" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_fugger2"/>
+    <property name="act1" value="char_talk spyder_walled_fugger,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_fugger"/>
     <property name="cond1" value="is variable_set walledfugger:yes"/>
    </properties>
   </object>
   <object id="77" name="Post Talk carnegie" type="event" x="48" y="32" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_carnegie2"/>
+    <property name="act1" value="char_talk spyder_walled_carnegie,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_carnegie"/>
     <property name="cond1" value="is variable_set walledcarnegie:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_timber_walledgarden2.tmx
+++ b/mods/tuxemon/maps/spyder_timber_walledgarden2.tmx
@@ -105,12 +105,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_osman"/>
-    <property name="act03" value="translated_dialog spyder_walled_osman1"/>
+    <property name="act03" value="char_talk spyder_walled_osman,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster miaownolith,50,spyder_walled_osman,5,10"/>
     <property name="act06" value="add_monster pyraminx,50,spyder_walled_osman,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_osman"/>
-    <property name="act08" value="translated_dialog spyder_walled_osman2"/>
+    <property name="act08" value="char_talk spyder_walled_osman,post_battle_lose"/>
     <property name="act09" value="set_variable walledosman:yes"/>
     <property name="cond1" value="not variable_set walledosman:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -127,12 +127,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_alexander"/>
-    <property name="act03" value="translated_dialog spyder_walled_alexander1"/>
+    <property name="act03" value="char_talk spyder_walled_alexander,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster embazook,50,spyder_walled_alexander,5,10"/>
     <property name="act06" value="add_monster eruptibus,50,spyder_walled_alexander,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_alexander"/>
-    <property name="act08" value="translated_dialog spyder_walled_alexander2"/>
+    <property name="act08" value="char_talk spyder_walled_alexander,post_battle_lose"/>
     <property name="act09" value="set_variable walledalexander:yes"/>
     <property name="cond1" value="not variable_set walledalexander:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -156,12 +156,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_musa"/>
-    <property name="act03" value="translated_dialog spyder_walled_musa1"/>
+    <property name="act03" value="char_talk spyder_walled_musa,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster grintrock,50,spyder_walled_musa,5,10"/>
     <property name="act06" value="add_monster grinflare,50,spyder_walled_musa,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_musa"/>
-    <property name="act08" value="translated_dialog spyder_walled_musa2"/>
+    <property name="act08" value="char_talk spyder_walled_musa,post_battle_lose"/>
     <property name="act09" value="set_variable walledmusa:yes"/>
     <property name="cond1" value="not variable_set walledmusa:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -171,12 +171,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_augustus"/>
-    <property name="act03" value="translated_dialog spyder_walled_augustus1"/>
+    <property name="act03" value="char_talk spyder_walled_augustus,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster statursus,50,spyder_walled_augustus,5,10"/>
     <property name="act06" value="add_monster spycozeus,50,spyder_walled_augustus,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_augustus"/>
-    <property name="act08" value="translated_dialog spyder_walled_augustus2"/>
+    <property name="act08" value="char_talk spyder_walled_augustus,post_battle_lose"/>
     <property name="act09" value="set_variable walledaugustus:yes"/>
     <property name="cond1" value="not variable_set walledaugustus:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -193,12 +193,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_rufus"/>
-    <property name="act03" value="translated_dialog spyder_walled_rufus1"/>
+    <property name="act03" value="char_talk spyder_walled_rufus,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster bamboon,50,spyder_walled_rufus,5,10"/>
     <property name="act06" value="add_monster frondly,50,spyder_walled_rufus,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_rufus"/>
-    <property name="act08" value="translated_dialog spyder_walled_rufus2"/>
+    <property name="act08" value="char_talk spyder_walled_rufus,post_battle_lose"/>
     <property name="act09" value="set_variable walledrufus:yes"/>
     <property name="cond1" value="not variable_set walledrufus:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -215,12 +215,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_walled_crassus"/>
-    <property name="act03" value="translated_dialog spyder_walled_crassus1"/>
+    <property name="act03" value="char_talk spyder_walled_crassus,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster bigfin,50,spyder_walled_crassus,5,10"/>
     <property name="act06" value="add_monster sharpfin,50,spyder_walled_crassus,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_crassus"/>
-    <property name="act08" value="translated_dialog spyder_walled_crassus2"/>
+    <property name="act08" value="char_talk spyder_walled_crassus,post_battle_lose"/>
     <property name="act09" value="set_variable walledcrassus:yes"/>
     <property name="cond1" value="not variable_set walledcrassus:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -233,12 +233,12 @@
     <property name="act03" value="create_npc spyder_walled_midas,9,19"/>
     <property name="act04" value="pathfind_to_char player,spyder_walled_midas,up"/>
     <property name="act05" value="unlock_controls"/>
-    <property name="act10" value="translated_dialog spyder_walled_midas1"/>
+    <property name="act10" value="char_talk spyder_walled_midas,pre_battle"/>
     <property name="act20" value="add_monster apeoro,55,spyder_walled_midas,5,10"/>
     <property name="act21" value="add_monster brewdin,55,spyder_walled_midas,5,10"/>
     <property name="act22" value="add_monster narcileaf,50,spyder_walled_midas,5,10"/>
     <property name="act30" value="start_battle player,spyder_walled_midas"/>
-    <property name="act40" value="translated_dialog spyder_walled_midas2"/>
+    <property name="act40" value="char_talk spyder_walled_midas,post_battle_lose"/>
     <property name="act50" value="pathfind spyder_walled_midas,9,19"/>
     <property name="act60" value="remove_npc spyder_walled_midas"/>
     <property name="act70" value="set_variable walledmidas:yes"/>
@@ -264,42 +264,42 @@
   </object>
   <object id="79" name="Post Talk rufus" type="event" x="144" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_rufus2"/>
+    <property name="act1" value="char_talk spyder_walled_rufus,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_rufus"/>
     <property name="cond1" value="is variable_set walledrufus:yes"/>
    </properties>
   </object>
   <object id="80" name="Post Talk crassus" type="event" x="144" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_crassus2"/>
+    <property name="act1" value="char_talk spyder_walled_crassus,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_crassus"/>
     <property name="cond1" value="is variable_set walledcrassus:yes"/>
    </properties>
   </object>
   <object id="81" name="Post Talk osman" type="event" x="144" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_osman2"/>
+    <property name="act1" value="char_talk spyder_walled_osman,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_osman"/>
     <property name="cond1" value="is variable_set walledosman:yes"/>
    </properties>
   </object>
   <object id="82" name="Post Talk Alexander" type="event" x="96" y="160" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_alexander2"/>
+    <property name="act1" value="char_talk spyder_walled_alexander,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_alexander"/>
     <property name="cond1" value="is variable_set walledalexander:yes"/>
    </properties>
   </object>
   <object id="83" name="Post Talk augustus" type="event" x="80" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_augustus2"/>
+    <property name="act1" value="char_talk spyder_walled_augustus,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_augustus"/>
     <property name="cond1" value="is variable_set walledaugustus:yes"/>
    </properties>
   </object>
   <object id="84" name="Post Talk musa" type="event" x="160" y="112" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_walled_musa2"/>
+    <property name="act1" value="char_talk spyder_walled_musa,post_battle_lose"/>
     <property name="behav1" value="talk spyder_walled_musa"/>
     <property name="cond1" value="is variable_set walledmusa:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -114,12 +114,12 @@
   </object>
   <object id="334" name="Talk Iris" type="event" x="160" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_tunnelb_iris1"/>
+    <property name="act1" value="char_talk spyder_tunnelb_iris,pre_battle"/>
     <property name="act2" value="add_monster tourbidi,18,spyder_tunnelb_iris,5,10"/>
     <property name="act3" value="add_monster tourbidi,18,spyder_tunnelb_iris,5,10"/>
     <property name="act4" value="add_monster tourbidi,18,spyder_tunnelb_iris,5,10"/>
     <property name="act5" value="start_battle player,spyder_tunnelb_iris"/>
-    <property name="act6" value="translated_dialog spyder_tunnelb_iris2"/>
+    <property name="act6" value="char_talk spyder_tunnelb_iris,post_battle_lose"/>
     <property name="act7" value="set_variable tunnelbiris:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_iris"/>
     <property name="cond1" value="not variable_set tunnelbiris:yes"/>
@@ -133,7 +133,7 @@
   </object>
   <object id="336" name="Talk Greta" type="event" x="208" y="544" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_tunnelb_greta1"/>
+    <property name="act01" value="char_talk spyder_tunnelb_greta,pre_battle"/>
     <property name="act02" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act03" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act04" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
@@ -141,7 +141,7 @@
     <property name="act06" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act07" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act08" value="start_battle player,spyder_tunnelb_greta"/>
-    <property name="act09" value="translated_dialog spyder_tunnelb_greta2"/>
+    <property name="act09" value="char_talk spyder_tunnelb_greta,post_battle_lose"/>
     <property name="act10" value="set_variable tunnelbgreta:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_greta"/>
     <property name="cond1" value="not variable_set tunnelbgreta:yes"/>
@@ -156,10 +156,10 @@
   </object>
   <object id="338" name="Talk Tommy" type="event" x="224" y="80" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_tunnelb_tommy1"/>
+    <property name="act1" value="char_talk spyder_tunnelb_tommy,pre_battle"/>
     <property name="act2" value="add_monster zunna,22,spyder_tunnelb_tommy,5,10"/>
     <property name="act3" value="start_battle player,spyder_tunnelb_tommy"/>
-    <property name="act4" value="translated_dialog spyder_tunnelb_tommy2"/>
+    <property name="act4" value="char_talk spyder_tunnelb_tommy,post_battle_lose"/>
     <property name="act6" value="set_variable tunnelbtommy:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_tommy"/>
     <property name="cond1" value="not variable_set tunnelbtommy:yes"/>
@@ -169,7 +169,7 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_tunnelb_greta"/>
-    <property name="act03" value="translated_dialog spyder_tunnelb_greta1"/>
+    <property name="act03" value="char_talk spyder_tunnelb_greta,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act06" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
@@ -178,7 +178,7 @@
     <property name="act09" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act10" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act11" value="start_battle player,spyder_tunnelb_greta"/>
-    <property name="act12" value="translated_dialog spyder_tunnelb_greta2"/>
+    <property name="act12" value="char_talk spyder_tunnelb_greta,post_battle_lose"/>
     <property name="act13" value="set_variable tunnelbgreta:yes"/>
     <property name="cond1" value="not variable_set tunnelbgreta:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -232,21 +232,21 @@
   </object>
   <object id="361" name="Post Talk Tommy" type="event" x="208" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_tunnelb_tommy2"/>
+    <property name="act1" value="char_talk spyder_tunnelb_tommy,post_battle_lose"/>
     <property name="behav1" value="talk spyder_tunnelb_tommy"/>
     <property name="cond1" value="is variable_set tunnelbtommy:yes"/>
    </properties>
   </object>
   <object id="362" name="Post Talk Iris" type="event" x="176" y="240" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_tunnelb_iris2"/>
+    <property name="act1" value="char_talk spyder_tunnelb_iris,post_battle_lose"/>
     <property name="behav1" value="talk spyder_tunnelb_iris"/>
     <property name="cond1" value="is variable_set tunnelbiris:yes"/>
    </properties>
   </object>
   <object id="363" name="Post Talk Greta" type="event" x="192" y="560" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_tunnelb_greta2"/>
+    <property name="act01" value="char_talk spyder_tunnelb_greta,post_battle_lose"/>
     <property name="behav1" value="talk spyder_tunnelb_greta"/>
     <property name="cond1" value="is variable_set tunnelbgreta:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -141,11 +141,11 @@
    <properties>
     <property name="act1" value="lock_controls"/>
     <property name="act2" value="pathfind_to_char player,spyder_tunnelb_meitner"/>
-    <property name="act3" value="translated_dialog spyder_tunnelb_meitner1"/>
+    <property name="act3" value="char_talk spyder_tunnelb_meitner,pre_battle"/>
     <property name="act4" value="unlock_controls"/>
     <property name="act5" value="add_monster masknake,22,spyder_tunnelb_meitner,5,10"/>
     <property name="act6" value="start_battle player,spyder_tunnelb_meitner"/>
-    <property name="act7" value="translated_dialog spyder_tunnelb_meitner2"/>
+    <property name="act7" value="char_talk spyder_tunnelb_meitner,post_battle_lose"/>
     <property name="act8" value="set_variable tunnelbmeitner:yes"/>
     <property name="cond1" value="not variable_set tunnelbmeitner:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -155,14 +155,14 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_tunnelb_lute"/>
-    <property name="act03" value="translated_dialog spyder_tunnelb_lute1"/>
+    <property name="act03" value="char_talk spyder_tunnelb_lute,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster noctula,16,spyder_tunnelb_lute,5,10"/>
     <property name="act06" value="add_monster noctalo,18,spyder_tunnelb_lute,5,10"/>
     <property name="act07" value="add_monster pipis,16,spyder_tunnelb_lute,5,10"/>
     <property name="act08" value="add_monster strella,20,spyder_tunnelb_lute,5,10"/>
     <property name="act09" value="start_battle player,spyder_tunnelb_lute"/>
-    <property name="act10" value="translated_dialog spyder_tunnelb_lute2"/>
+    <property name="act10" value="char_talk spyder_tunnelb_lute,post_battle_lose"/>
     <property name="act11" value="set_variable tunnelblute:yes"/>
     <property name="cond1" value="not variable_set tunnelblute:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -172,13 +172,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_tunnelb_beryll"/>
-    <property name="act03" value="translated_dialog spyder_tunnelb_beryll1"/>
+    <property name="act03" value="char_talk spyder_tunnelb_beryll,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster rockat,20,spyder_tunnelb_beryll,5,10"/>
     <property name="act06" value="add_monster ignibus,20,spyder_tunnelb_beryll,5,10"/>
     <property name="act07" value="add_monster grintot,20,spyder_tunnelb_beryll,5,10"/>
     <property name="act08" value="start_battle player,spyder_tunnelb_beryll"/>
-    <property name="act09" value="translated_dialog spyder_tunnelb_beryll2"/>
+    <property name="act09" value="char_talk spyder_tunnelb_beryll,post_battle_lose"/>
     <property name="act10" value="set_variable tunnelbberyll:yes"/>
     <property name="cond1" value="not variable_set tunnelbberyll:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -224,21 +224,21 @@
   </object>
   <object id="75" name="Talk Beryll" type="event" x="160" y="496" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_tunnelb_beryll2"/>
+    <property name="act1" value="char_talk spyder_tunnelb_beryll,post_battle_lose"/>
     <property name="behav1" value="talk spyder_tunnelb_beryll"/>
     <property name="cond1" value="is variable_set tunnelbberyll:yes"/>
    </properties>
   </object>
   <object id="76" name="Talk Lute" type="event" x="48" y="576" width="16" height="16">
    <properties>
-    <property name="act01" value="translated_dialog spyder_tunnelb_lute2"/>
+    <property name="act01" value="char_talk spyder_tunnelb_lute,post_battle_lose"/>
     <property name="behav1" value="talk spyder_tunnelb_lute"/>
     <property name="cond1" value="is variable_set tunnelblute:yes"/>
    </properties>
   </object>
   <object id="77" name="Talk Meitner" type="event" x="256" y="304" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_tunnelb_meitner2"/>
+    <property name="act1" value="char_talk spyder_tunnelb_meitner,post_battle_lose"/>
     <property name="behav1" value="talk spyder_tunnelb_meitner"/>
     <property name="cond1" value="is variable_set tunnelbmeitner:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -207,11 +207,11 @@
   </object>
   <object id="56" name="Talk Morton" type="event" x="64" y="96" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_morton1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_morton,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_morton"/>
     <property name="act12" value="add_monster mrmoswitch,14,spyder_wayfarer1_morton,5,10"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_morton"/>
-    <property name="act14" value="translated_dialog spyder_wayfarer1_morton2"/>
+    <property name="act14" value="char_talk spyder_wayfarer1_morton,post_battle_lose"/>
     <property name="act16" value="set_variable wayfarer1morton:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_morton"/>
     <property name="cond1" value="not variable_set wayfarer1morton:yes"/>
@@ -226,12 +226,12 @@
   </object>
   <object id="58" name="Talk Jessie" type="event" x="64" y="240" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_jessie1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_jessie,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_jessie"/>
     <property name="act12" value="add_monster lapinou,12,spyder_wayfarer1_jessie,5,10"/>
     <property name="act13" value="add_monster cairfrey,12,spyder_wayfarer1_jessie,5,10"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_jessie"/>
-    <property name="act15" value="translated_dialog spyder_wayfarer1_jessie2"/>
+    <property name="act15" value="char_talk spyder_wayfarer1_jessie,post_battle_lose"/>
     <property name="act16" value="set_variable wayfarer1jessie:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_jessie"/>
     <property name="cond1" value="not variable_set wayfarer1jessie:yes"/>
@@ -245,12 +245,12 @@
   </object>
   <object id="60" name="Talk Nightshade" type="event" x="48" y="208" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_nightshade1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_nightshade,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_nightshade"/>
     <property name="act12" value="add_monster lapinou,12,spyder_wayfarer1_nightshade,5,10"/>
     <property name="act13" value="add_monster elofly,12,spyder_wayfarer1_nightshade,5,10"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_nightshade"/>
-    <property name="act15" value="translated_dialog spyder_wayfarer1_nightshade2"/>
+    <property name="act15" value="char_talk spyder_wayfarer1_nightshade,post_battle_lose"/>
     <property name="act16" value="set_variable wayfarer1nightshade:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_nightshade"/>
     <property name="cond1" value="not variable_set wayfarer1nightshade:yes"/>
@@ -264,10 +264,10 @@
   </object>
   <object id="62" name="Talk Victor" type="event" x="208" y="48" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_victor1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_victor,pre_battle"/>
     <property name="act12" value="add_monster squabbit,14,spyder_wayfarer1_victor,5,10"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_victor"/>
-    <property name="act14" value="translated_dialog spyder_wayfarer1_victor2"/>
+    <property name="act14" value="char_talk spyder_wayfarer1_victor,post_battle_lose"/>
     <property name="act16" value="set_variable wayfarer1victor:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_victor"/>
     <property name="cond1" value="not variable_set wayfarer1victor:yes"/>
@@ -281,12 +281,12 @@
   </object>
   <object id="64" name="Talk Morningstar" type="event" x="16" y="32" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_morningstar1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_morningstar,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_morningstar"/>
     <property name="act12" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
     <property name="act13" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_morningstar"/>
-    <property name="act15" value="translated_dialog spyder_wayfarer1_morningstar2"/>
+    <property name="act15" value="char_talk spyder_wayfarer1_morningstar,post_battle_lose"/>
     <property name="act16" value="set_variable wayfarer1morningstar:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_morningstar"/>
     <property name="cond1" value="not variable_set wayfarer1morningstar:yes"/>
@@ -296,13 +296,13 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_wayfarer1_morningstar"/>
-    <property name="act03" value="translated_dialog spyder_wayfarer1_morningstar1"/>
+    <property name="act03" value="char_talk spyder_wayfarer1_morningstar,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="char_plague spyderbite,infected,spyder_wayfarer1_morningstar"/>
     <property name="act06" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
     <property name="act07" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
     <property name="act08" value="start_battle player,spyder_wayfarer1_morningstar"/>
-    <property name="act09" value="translated_dialog spyder_wayfarer1_morningstar2"/>
+    <property name="act09" value="char_talk spyder_wayfarer1_morningstar,post_battle_lose"/>
     <property name="act10" value="set_variable wayfarer1morningstar:yes"/>
     <property name="cond1" value="not variable_set wayfarer1morningstar:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -312,12 +312,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_wayfarer1_victor"/>
-    <property name="act03" value="translated_dialog spyder_wayfarer1_victor1"/>
+    <property name="act03" value="char_talk spyder_wayfarer1_victor,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="char_plague spyderbite,infected,spyder_wayfarer1_victor"/>
     <property name="act06" value="add_monster squabbit,14,spyder_wayfarer1_victor,5,10"/>
     <property name="act07" value="start_battle player,spyder_wayfarer1_victor"/>
-    <property name="act08" value="translated_dialog spyder_wayfarer1_victor2"/>
+    <property name="act08" value="char_talk spyder_wayfarer1_victor,post_battle_lose"/>
     <property name="act09" value="set_variable wayfarer1victor:yes"/>
     <property name="cond1" value="not variable_set wayfarer1victor:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -338,11 +338,11 @@
   </object>
   <object id="77" name="Talk Ratcher" type="event" x="80" y="112" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_ratcher1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_ratcher,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_ratcher"/>
     <property name="act12" value="add_monster lapinou,14,spyder_wayfarer1_ratcher,5,10"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_ratcher"/>
-    <property name="act14" value="translated_dialog spyder_wayfarer1_ratcher2"/>
+    <property name="act14" value="char_talk spyder_wayfarer1_ratcher,post_battle_lose"/>
     <property name="act15" value="set_variable wayfarer1ratcher:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_ratcher"/>
     <property name="cond1" value="not variable_set wayfarer1ratcher:yes"/>
@@ -357,11 +357,11 @@
   </object>
   <object id="79" name="Talk Bismuth" type="event" x="16" y="224" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_bismuth1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_bismuth,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_bismuth"/>
     <property name="act12" value="add_monster hydrone,14,spyder_wayfarer1_bismuth,5,10"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_bismuth"/>
-    <property name="act14" value="translated_dialog spyder_wayfarer1_bismuth2"/>
+    <property name="act14" value="char_talk spyder_wayfarer1_bismuth,post_battle_lose"/>
     <property name="act15" value="set_variable wayfarer1bismuth:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_bismuth"/>
     <property name="cond1" value="not variable_set wayfarer1bismuth:yes"/>
@@ -369,49 +369,49 @@
   </object>
   <object id="82" name="Post Talk Jessie" type="event" x="112" y="224" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_jessie2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_jessie,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_jessie"/>
     <property name="cond1" value="is variable_set wayfarer1jessie:yes"/>
    </properties>
   </object>
   <object id="83" name="Post Talk Nightshade" type="event" x="112" y="208" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_nightshade2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_nightshade,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_nightshade"/>
     <property name="cond1" value="is variable_set wayfarer1nightshade:yes"/>
    </properties>
   </object>
   <object id="84" name="Post Talk Bismuth" type="event" x="112" y="192" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_bismuth2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_bismuth,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_bismuth"/>
     <property name="cond1" value="is variable_set wayfarer1bismuth:yes"/>
    </properties>
   </object>
   <object id="85" name="Post Talk Morton" type="event" x="32" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_morton2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_morton,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_morton"/>
     <property name="cond1" value="is variable_set wayfarer1morton:yes"/>
    </properties>
   </object>
   <object id="86" name="Post Talk Ratcher" type="event" x="48" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_ratcher2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_ratcher,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_ratcher"/>
     <property name="cond1" value="is variable_set wayfarer1ratcher:yes"/>
    </properties>
   </object>
   <object id="87" name="Post Talk Morningstar" type="event" x="64" y="64" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_morningstar2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_morningstar,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_morningstar"/>
     <property name="cond1" value="is variable_set wayfarer1morningstar:yes"/>
    </properties>
   </object>
   <object id="88" name="Post Talk Victor" type="event" x="208" y="16" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_victor2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_victor,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_victor"/>
     <property name="cond1" value="is variable_set wayfarer1victor:yes"/>
    </properties>

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -120,12 +120,12 @@
   </object>
   <object id="40" name="Talk Bravo" type="event" x="192" y="32" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_bravo1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_bravo,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_bravo"/>
     <property name="act12" value="add_monster elofly,12,spyder_wayfarer1_bravo,5,10"/>
     <property name="act13" value="add_monster flacono,12,spyder_wayfarer1_bravo,5,10"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_bravo"/>
-    <property name="act15" value="translated_dialog spyder_wayfarer1_bravo2"/>
+    <property name="act15" value="char_talk spyder_wayfarer1_bravo,post_battle_lose"/>
     <property name="act16" value="set_variable wayfarer1bravo:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_bravo"/>
     <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
@@ -139,13 +139,13 @@
   </object>
   <object id="42" name="Talk James" type="event" x="128" y="112" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_james1"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_james,pre_battle"/>
     <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_james"/>
     <property name="act12" value="add_monster botbot,12,spyder_wayfarer1_james,5,10"/>
     <property name="act13" value="add_monster picc,12,spyder_wayfarer1_james,5,10"/>
     <property name="act14" value="add_monster b_ver_1,12,spyder_wayfarer1_james,5,10"/>
     <property name="act15" value="start_battle player,spyder_wayfarer1_james"/>
-    <property name="act16" value="translated_dialog spyder_wayfarer1_james2"/>
+    <property name="act16" value="char_talk spyder_wayfarer1_james,post_battle_lose"/>
     <property name="act17" value="set_variable wayfarer1james:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_james"/>
     <property name="cond1" value="not variable_set wayfarer1james:yes"/>
@@ -168,12 +168,12 @@
    <properties>
     <property name="act01" value="lock_controls"/>
     <property name="act02" value="pathfind_to_char player,spyder_wayfarer1_bravo"/>
-    <property name="act03" value="translated_dialog spyder_wayfarer1_bravo1"/>
+    <property name="act03" value="char_talk spyder_wayfarer1_bravo,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
     <property name="act05" value="add_monster elofly,12,spyder_wayfarer1_bravo,5,10"/>
     <property name="act06" value="add_monster flacono,12,spyder_wayfarer1_bravo,5,10"/>
     <property name="act07" value="start_battle player,spyder_wayfarer1_bravo"/>
-    <property name="act08" value="translated_dialog spyder_wayfarer1_bravo2"/>
+    <property name="act08" value="char_talk spyder_wayfarer1_bravo,post_battle_lose"/>
     <property name="act09" value="set_variable wayfarer1bravo:yes"/>
     <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
     <property name="cond2" value="is char_at player"/>
@@ -181,14 +181,14 @@
   </object>
   <object id="51" name="Post Talk James" type="event" x="128" y="128" width="16" height="16">
    <properties>
-    <property name="act1" value="translated_dialog spyder_wayfarer1_james2"/>
+    <property name="act1" value="char_talk spyder_wayfarer1_james,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_james"/>
     <property name="cond1" value="is variable_set wayfarer1james:yes"/>
    </properties>
   </object>
   <object id="52" name="Post Talk Bravo" type="event" x="192" y="16" width="16" height="16">
    <properties>
-    <property name="act10" value="translated_dialog spyder_wayfarer1_bravo2"/>
+    <property name="act10" value="char_talk spyder_wayfarer1_bravo,post_battle_lose"/>
     <property name="behav1" value="talk spyder_wayfarer1_bravo"/>
     <property name="cond1" value="is variable_set wayfarer1bravo:yes"/>
    </properties>


### PR DESCRIPTION
PR refactors the pre/post-battle dialog system by replacing the use of `translated_dialog` with the more context-aware `char_talk` structure. This change enhances character-specific interactions and improves localization flexibility.