### PR TITLE
Improve Error Handling and Logging in `PluginManager`

### DIFF
--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -179,9 +179,19 @@ class PluginFilter:
 
     def is_valid_plugin(self, class_name: str, class_obj: type) -> bool:
         """Check if a plugin should be included."""
-        return not self.is_excluded(class_name) and self.matches_patterns(
-            class_obj
-        )
+        if self.is_excluded(class_name):
+            logger.debug(
+                f"Skipping class '{class_name}' because it's in the exclusion list."
+            )
+            return False
+
+        if not self.matches_patterns(class_obj):
+            logger.debug(
+                f"Skipping class '{class_name}' because its name does not match an include pattern."
+            )
+            return False
+
+        return True
 
 
 class PluginManager:
@@ -220,7 +230,7 @@ class PluginManager:
                 )
             except ImportError as e:
                 logger.error(
-                    f"Skipping module {module_name} due to import error: {e}"
+                    f"Skipping module '{module_name}' due to import error: {e}"
                 )
         return imported_plugins
 


### PR DESCRIPTION
PR refines the error handling and logging strategy in  to make plugin discovery and command collection more transparent and easier to debug. By replacing broad exception catches with more targeted ones and enhancing log messages, we gain better visibility into plugin behavior and potential issues.

Key changes:
- improved logging in `get_all_plugins` to distinguish between different types of import failures
- ensured that exclusion logic logs the plugin name and reason for skipping