### PR TITLE
Fix Inconsistent Placeholders in `combat_state_recover_failure` and Prevent KeyError

### DIFF
--- a/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/de_DE/LC_MESSAGES/base.po
@@ -176,7 +176,7 @@ msgid "combat_state_recover_success"
 msgstr "{user} hat sie geheilt!"
 
 msgid "combat_state_recover_failure"
-msgstr "{link} kann nicht weiter geheilt werden."
+msgstr "{target} kann nicht weiter geheilt werden."
 
 msgid "combat_status_damage"
 msgstr "{name} erleidet Schaden durch {status}!"

--- a/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_ES/LC_MESSAGES/base.po
@@ -166,7 +166,7 @@ msgid "combat_state_recover_success"
 msgstr "¡{user} recuperó salud!"
 
 msgid "combat_state_recover_failure"
-msgstr "{user} no puede curarse más."
+msgstr "{target} no puede curarse más."
 
 msgid "combat_status_damage"
 msgstr "¡{name} sufrió {status} de daño!"

--- a/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/es_MX/LC_MESSAGES/base.po
@@ -1509,7 +1509,7 @@ msgid "combat_state_recover_success"
 msgstr "¡{user} recuperó la salud!"
 
 msgid "combat_state_recover_failure"
-msgstr "{user} no puede sanar más."
+msgstr "{target} no puede sanar más."
 
 msgid "combat_state_lifeleech_success"
 msgstr "¡{user} perdió salud por absorbe-vidas!"

--- a/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fi/LC_MESSAGES/base.po
@@ -65,7 +65,7 @@ msgid "combat_amnesia_get"
 msgstr "{user} kärsii muistinmenetyksestä."
 
 msgid "combat_state_recover_failure"
-msgstr "{user} enempää ei voida parantaa."
+msgstr "{target} enempää ei voida parantaa."
 
 msgid "combat_defeat"
 msgstr "Sinut päihitettiin!"

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -1552,7 +1552,7 @@ msgid "combat_trainer_appeared"
 msgstr "{name} veut se battre !"
 
 msgid "combat_state_recover_failure"
-msgstr "{user} ne peut pas se soigner davantage."
+msgstr "{target} ne peut pas se soigner davantage."
 
 msgid "combat_state_recover_get"
 msgstr "{target} commence à regagner ses PV."

--- a/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/it_IT/LC_MESSAGES/base.po
@@ -122,7 +122,7 @@ msgid "combat_state_recover_success"
 msgstr "{user} ha recuperato vita!"
 
 msgid "combat_state_recover_failure"
-msgstr "{user} non può guarire maggiormente."
+msgstr "{target} non può guarire maggiormente."
 
 msgid "combat_status_damage"
 msgstr "{name} ha subito danno da {status}!"

--- a/mods/tuxemon/l18n/nb_NO/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/nb_NO/LC_MESSAGES/base.po
@@ -39,7 +39,7 @@ msgid "combat_state_lifeleech_failure"
 msgstr "{link} kan ikke heles ytterligere."
 
 msgid "combat_state_recover_failure"
-msgstr "{user} kan ikke heles ytterligere."
+msgstr "{target} kan ikke heles ytterligere."
 
 msgid "super_potion_description"
 msgstr "Heler et monster med 100 HP."

--- a/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pl/LC_MESSAGES/base.po
@@ -279,7 +279,7 @@ msgid "combat_trainer_appeared"
 msgstr "{name} chce walczyć!"
 
 msgid "combat_state_recover_failure"
-msgstr "{user} nie może się dalej uleczyć."
+msgstr "{target} nie może się dalej uleczyć."
 
 msgid "combat_state_recover_success"
 msgstr "{user} odzyskał zdrowie!"

--- a/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/pt_BR/LC_MESSAGES/base.po
@@ -1037,7 +1037,7 @@ msgid "combat_state_overfeed_get"
 msgstr "{user} Sobrealimentou {target}."
 
 msgid "combat_state_recover_failure"
-msgstr "{user} não pode sarar mais que isso."
+msgstr "{target} não pode sarar mais que isso."
 
 msgid "combat_status_damage"
 msgstr "{name} levou dano de {status}!"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -188,7 +188,7 @@ msgid "combat_state_recover_success"
 msgstr "{user}恢复健康了!"
 
 msgid "combat_state_recover_failure"
-msgstr "{user}不能再愈合了."
+msgstr "{target}不能再愈合了."
 
 msgid "combat_status_damage"
 msgstr "{name}的{status}造成了伤害!"

--- a/tuxemon/locale_dir/translator.py
+++ b/tuxemon/locale_dir/translator.py
@@ -13,6 +13,19 @@ logger = logging.getLogger(__name__)
 FALLBACK_LOCALE = "en_US"
 
 
+class SafeDict(dict[str, str]):
+    _msgid: str
+
+    def __missing__(self, key: str) -> str:
+        logger.warning(
+            f"Missing parameter '{key}' in translation for msgid: '{self._msgid}'"
+        )
+        return f"<{key}>"
+
+    def set_msgid(self, msgid: str) -> None:
+        self._msgid = msgid
+
+
 class TranslatorPo:
     """
     A class used to translate text using a specific gettext translation
@@ -134,10 +147,20 @@ class TranslatorPo:
             The formatted string.
         """
         text = text.replace(r"\n", "\n")
-        text = self.translate(text)
+        translated_text = self.translate(text)
+
         if parameters:
-            text = text.format(**parameters)
-        return text
+            safe_params = SafeDict(parameters)
+            safe_params.set_msgid(text)  # original msgid before translation
+            try:
+                translated_text = translated_text.format_map(safe_params)
+            except Exception as e:
+                logger.error(
+                    f"Unexpected formatting error for msgid '{text}': {e}"
+                )
+                raise
+
+        return translated_text
 
     def maybe_translate(self, text: Optional[str]) -> str:
         """


### PR DESCRIPTION
PR fixes #3066 and resolves KeyError from inconsistent Localization placeholders and align all the wrong translations with English format to prevent KeyError.

To resolve `KeyError` exceptions caused by mismatched or incomplete localization placeholders, I have introduced a `SafeDict` mechanism that gracefully handles missing formatting parameters. Instead of crashing when a translation string contains variables not present in the provided parameters, the system now logs a warning and substitutes missing values with visible placeholders (e.g., `<user>`).

This ensures robust formatting across all locales and aligns non-English translations with the English source format.