### PR TITLE
Fix Slot Icon Positioning in NPC vs NPC Battles

### DIFF
--- a/tests/tuxemon/test_combat_layout.py
+++ b/tests/tuxemon/test_combat_layout.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock
+
+from pygame.rect import Rect
+
+from tuxemon.ui.combat_hud import CombatLayoutManager, MonsterUI, Side
+
+
+class TestCombatLayoutManager(unittest.TestCase):
+    def setUp(self):
+        self.npc1 = MagicMock()
+        self.npc1.name = "NPC1"
+        self.npc1.is_player = False
+
+        self.npc2 = MagicMock()
+        self.npc2.name = "NPC2"
+        self.npc2.is_player = False
+
+        self.player_npc = MagicMock()
+        self.player_npc.name = "Player"
+        self.player_npc.is_player = True
+
+        self.monster1 = MagicMock()
+        self.monster1.name = "Monster1"
+
+        self.monster2 = MagicMock()
+        self.monster2.name = "Monster2"
+
+        self.layouts = {
+            self.npc1: {
+                "home": [Rect(0, 0, 10, 10)],
+                "monster_box_home": [Rect(5, 5, 10, 10)],
+                "home0": [Rect(0, 0, 10, 10)],
+                "monster_box_home0": [Rect(5, 5, 10, 10)],
+                "home1": [Rect(10, 0, 10, 10)],
+                "monster_box_home1": [Rect(15, 5, 10, 10)],
+            },
+            self.npc2: {
+                "home": [Rect(20, 0, 10, 10)],
+                "monster_box_home": [Rect(25, 5, 10, 10)],
+                "home0": [Rect(20, 0, 10, 10)],
+                "monster_box_home0": [Rect(25, 5, 10, 10)],
+                "home1": [Rect(30, 0, 10, 10)],
+                "monster_box_home1": [Rect(35, 5, 10, 10)],
+            },
+            self.player_npc: {
+                "home": [Rect(40, 0, 10, 10)],
+                "monster_box_home": [Rect(45, 5, 10, 10)],
+                "home0": [Rect(40, 0, 10, 10)],
+                "monster_box_home0": [Rect(45, 5, 10, 10)],
+                "home1": [Rect(50, 0, 10, 10)],
+                "monster_box_home1": [Rect(55, 5, 10, 10)],
+            },
+        }
+
+        self.manager = CombatLayoutManager(self.layouts)
+
+    def test_assign_player_vs_npc(self):
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=False,
+        )
+        ui = self.manager._monster_ui[self.monster1]
+        self.assertEqual(ui.slot_index, 1)
+        self.assertEqual(ui.layout_key, "home")
+        self.assertEqual(
+            self.manager._positions[self.monster1][0], Side.PLAYER
+        )
+
+    def test_assign_npc_vs_npc(self):
+        self.manager.assign(
+            nr_players=2, npc=self.npc1, monster=self.monster1, is_double=False
+        )
+        self.manager.assign(
+            nr_players=2, npc=self.npc2, monster=self.monster2, is_double=False
+        )
+
+        ui1 = self.manager._monster_ui[self.monster1]
+        ui2 = self.manager._monster_ui[self.monster2]
+
+        self.assertEqual(ui1.slot_index, 1)
+        self.assertEqual(ui2.slot_index, 0)
+
+        self.assertEqual(
+            self.manager._positions[self.monster1][0], Side.PLAYER
+        )
+        self.assertEqual(
+            self.manager._positions[self.monster2][0], Side.OPPONENT
+        )
+
+    def test_get_open_slot(self):
+        slot = self.manager.get_open_slot(self.player_npc)
+        self.assertEqual(slot, 0)
+
+        self.manager._layout_keys[(self.player_npc, self.monster1)] = "home0"
+        slot = self.manager.get_open_slot(self.player_npc)
+        self.assertEqual(slot, 1)
+
+    def test_get_rect_valid(self):
+        rect = self.manager.get_rect(self.player_npc, "home")
+        self.assertEqual(rect.topleft, (40, 0))
+
+    def test_get_rect_missing_key(self):
+        with self.assertRaises(ValueError):
+            self.manager.get_rect(self.player_npc, "invalid_key")
+
+    def test_assign_hud_and_get_hud(self):
+        sprite = MagicMock()
+        self.manager.assign_hud(self.monster1, sprite)
+        self.assertIs(self.manager.get_hud(self.monster1), sprite)
+
+    def test_delete_hud(self):
+        sprite = MagicMock()
+        sprite.kill = MagicMock()
+        self.manager.assign_hud(self.monster1, sprite)
+        self.manager.delete_hud(self.monster1)
+        sprite.kill.assert_called_once()
+        self.assertIsNone(self.manager.get_hud(self.monster1))
+
+    def test_unassign(self):
+        sprite = MagicMock()
+        sprite.kill = MagicMock()
+        icon = MagicMock()
+        icon.kill = MagicMock()
+
+        self.manager._monster_ui[self.monster1] = MonsterUI(
+            slot_index=0,
+            layout_key="home",
+            hud_sprite=sprite,
+            status_icons=[icon],
+            feet_pos=(0, 0),
+        )
+        self.manager._positions[self.monster1] = (Side.PLAYER, 0)
+        self.manager._layout_keys[(self.player_npc, self.monster1)] = "home"
+
+        self.manager.unassign(self.player_npc, self.monster1)
+
+        sprite.kill.assert_called_once()
+        icon.kill.assert_called_once()
+        self.assertNotIn(self.monster1, self.manager._monster_ui)
+        self.assertNotIn(self.monster1, self.manager._positions)
+        self.assertNotIn(
+            (self.player_npc, self.monster1), self.manager._layout_keys
+        )
+
+    def test_reassign_monster_skips(self):
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=False,
+        )
+        original_ui = self.manager._monster_ui[self.monster1]
+
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=False,
+        )
+        reassigned_ui = self.manager._monster_ui[self.monster1]
+
+        self.assertIs(original_ui, reassigned_ui)
+
+    def test_get_index_default(self):
+        index = self.manager.get_index(self.monster1)
+        self.assertEqual(index, 0)
+
+    def test_get_key_default(self):
+        key = self.manager.get_key(self.player_npc, self.monster1)
+        self.assertEqual(key, "home")
+
+    def test_get_feet_position(self):
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=False,
+        )
+        feet = self.manager.get_feet_position(self.player_npc, self.monster1)
+        self.assertEqual(feet, (45, 5))
+
+    def test_unassign_twice_safe(self):
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=False,
+        )
+        self.manager.unassign(self.player_npc, self.monster1)
+        self.manager.unassign(self.player_npc, self.monster1)
+
+    def test_multiple_monsters_same_npc(self):
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=False,
+        )
+        self.manager.assign(
+            nr_players=1,
+            npc=self.player_npc,
+            monster=self.monster2,
+            is_double=False,
+        )
+
+        index1 = self.manager.get_index(self.monster1)
+        index2 = self.manager.get_index(self.monster2)
+
+        self.assertEqual(index1, 1)
+        self.assertEqual(index2, 1)
+
+    def test_double_battle_layout_key(self):
+        self.manager.assign(
+            nr_players=2,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=True,
+        )
+        key = self.manager.get_key(self.player_npc, self.monster1)
+        self.assertIn("home", key)
+
+    def test_double_battle_slot_assignment(self):
+        self.manager.assign(
+            nr_players=2,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=True,
+        )
+        self.manager.assign(
+            nr_players=2,
+            npc=self.player_npc,
+            monster=self.monster2,
+            is_double=True,
+        )
+
+        ui1 = self.manager._monster_ui[self.monster1]
+        ui2 = self.manager._monster_ui[self.monster2]
+
+        self.assertIn(ui1.layout_key, ["home0", "home1"])
+        self.assertIn(ui2.layout_key, ["home0", "home1"])
+        self.assertNotEqual(ui1.slot_index, ui2.slot_index)
+
+    def test_double_battle_feet_position(self):
+        self.manager.assign(
+            nr_players=2,
+            npc=self.player_npc,
+            monster=self.monster1,
+            is_double=True,
+        )
+        feet = self.manager.get_feet_position(self.player_npc, self.monster1)
+
+        self.assertIn(feet, [(45, 5), (55, 5)])
+
+    def test_double_battle_npc_vs_npc(self):
+        self.manager.assign(
+            nr_players=2, npc=self.npc1, monster=self.monster1, is_double=True
+        )
+        self.manager.assign(
+            nr_players=2, npc=self.npc2, monster=self.monster2, is_double=True
+        )
+
+        ui1 = self.manager._monster_ui[self.monster1]
+        ui2 = self.manager._monster_ui[self.monster2]
+
+        self.assertIn(ui1.layout_key, ["home0", "home1"])
+        self.assertIn(ui2.layout_key, ["home0", "home1"])
+        self.assertNotEqual(ui1.slot_index, ui2.slot_index)

--- a/tuxemon/ui/combat_hud.py
+++ b/tuxemon/ui/combat_hud.py
@@ -9,13 +9,13 @@ from typing import TYPE_CHECKING, Optional
 
 from pygame.rect import Rect
 
-from tuxemon.sprite import Sprite
-
-logger = logging.getLogger(__name__)
-
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC
+    from tuxemon.sprite import Sprite
+
+
+logger = logging.getLogger(__name__)
 
 
 class Side(Enum):
@@ -58,15 +58,11 @@ class CombatLayoutManager:
         if monster in self._monster_ui:
             logger.debug(f"{monster.name} already assigned, skipping.")
             return
-        side = Side.PLAYER if npc.is_player else Side.OPPONENT
-        slot_index = self.get_open_slot(npc)
 
-        if not is_double and nr_players == 2 and side == Side.PLAYER:
-            slot_index = 1
-
-        if not is_double and nr_players == 2 and side == Side.OPPONENT:
-            slot_index = 0
-
+        side = self.determine_side(npc, nr_players, is_double)
+        slot_index = self.determine_slot_index(
+            npc, side, nr_players, is_double
+        )
         key = f"home{slot_index}" if is_double else "home"
         feet = self.get_feet_position(npc, monster)
 
@@ -134,3 +130,38 @@ class CombatLayoutManager:
                 icon.kill()
 
         logger.debug(f"[unassign] {monster.name} removed from layout and HUD")
+
+    def determine_side(
+        self, npc: NPC, nr_players: int, is_double: bool
+    ) -> Side:
+        if npc.is_player:
+            return Side.PLAYER
+
+        # Special case: NPC vs NPC
+        if nr_players == 2 and not is_double:
+            # Assign PLAYER to the first NPC, OPPONENT to the second
+            npc_list = list(self._layouts.keys())
+            return Side.PLAYER if npc == npc_list[0] else Side.OPPONENT
+
+        return Side.OPPONENT
+
+    def determine_slot_index(
+        self, npc: NPC, side: Side, nr_players: int, is_double: bool
+    ) -> int:
+        if is_double:
+            # Double battle: assign slot based on side-local usage
+            used_slots = {
+                index
+                for monster, (s, index) in self._positions.items()
+                if s == side
+            }
+
+            for i in range(2):  # supports up to 2 monsters per side
+                if i not in used_slots:
+                    return i
+
+            return 0  # fallback
+
+        else:
+            # Single battle: opponent on left (slot 0), player on right (slot 1)
+            return 1 if side == Side.PLAYER else 0

--- a/tuxemon/ui/combat_status.py
+++ b/tuxemon/ui/combat_status.py
@@ -42,6 +42,7 @@ class StatusIconManager:
         for monster in active_monsters:
             ui = self._tracker._monster_ui.get(monster)
             if not ui:
+                logger.warning(f"No UI found for monster '{monster}'")
                 continue
 
             index = ui.slot_index
@@ -53,12 +54,19 @@ class StatusIconManager:
                     key = (status.icon, position)
 
                     if key not in self._status_icon_cache:
+                        logger.debug(
+                            f"Loading new icon '{status.icon}' at {position}"
+                        )
                         sprite = self._state.load_sprite(
                             status.icon,
                             layer=self._layer,
                             center=position,
                         )
                         self._status_icon_cache[key] = sprite
+                    else:
+                        logger.debug(
+                            f"Using cached icon '{status.icon}' at {position}"
+                        )
 
                     ui.status_icons.append(self._status_icon_cache[key])
 
@@ -118,8 +126,21 @@ class StatusIconManager:
     ) -> tuple[float, float]:
         owner = monster.get_owner()
         layout_data = self._layouts.get(owner, {})
-        rects = layout_data.get(f"monster_status_icon_slot_{index}", [])
-        return rects[0].topleft if rects else (0, 0)
+        key = f"monster_status_icon_slot_{index}"
+        rects = layout_data.get(key, [])
+
+        if not rects:
+            logger.warning(
+                f"No layout rects found for key '{key}' (owner: {owner})"
+            )
+            return (0, 0)
+
+        position = rects[0].topleft
+        logger.debug(
+            f"Icon position for monster '{monster}' (owner: {owner}, index: {index}) "
+            f"resolved to {position} using key '{key}'"
+        )
+        return position
 
     def recalculate_icon_positions(self) -> None:
         for monster, ui in self._tracker._monster_ui.items():


### PR DESCRIPTION
PR resolves a layout issue where the `slot_icon` was incorrectly positioned during NPC vs NPC battles. The bug stemmed from slot assignment logic that reused the same layout as 2v2 battles, even in single battle scenarios.