### PR TITLE
Enhance Translation System with Domain Discovery and Plural Support

### DIFF
--- a/tests/tuxemon/test_translator_po.py
+++ b/tests/tuxemon/test_translator_po.py
@@ -9,7 +9,7 @@ from tuxemon.locale_dir.translator import TranslatorPo
 
 class TestTranslatorPo(unittest.TestCase):
 
-    @patch("gettext.translation")
+    @patch("tuxemon.locale_dir.translator.translation")
     def test_translation_success(self, mock_translation):
         mock_trans = MagicMock()
         mock_trans.gettext.return_value = "Bonjour"
@@ -24,7 +24,10 @@ class TestTranslatorPo(unittest.TestCase):
         result = po.translate("Hello")
         self.assertEqual(result, "Bonjour")
 
-    @patch("gettext.translation", side_effect=FileNotFoundError)
+    @patch(
+        "tuxemon.locale_dir.translator.translation",
+        side_effect=FileNotFoundError,
+    )
     def test_fallback_to_null_translations(self, mock_translation):
         po = TranslatorPo(
             locale_name="xx",
@@ -34,18 +37,6 @@ class TestTranslatorPo(unittest.TestCase):
         )
         result = po.translate("Hello")
         self.assertEqual(result, "Hello")  # Should be untranslated
-
-    def test_translate_with_cache(self):
-        po = TranslatorPo(
-            locale_name="xx",
-            domain="base",
-            localedir=Path("."),
-            fallback_locale="en",
-        )
-        po._real_translate = MagicMock(return_value="Hi")
-        result = po.translate("Hello")
-        self.assertEqual(result, "Hi")
-        self.assertIn("Hello", po._translation_cache)
 
     def test_format_translation(self):
         po = TranslatorPo(
@@ -62,3 +53,80 @@ class TestTranslatorPo(unittest.TestCase):
         po = TranslatorPo("en", "base", Path("."), "en")
         result = po.maybe_translate(None)
         self.assertEqual(result, "")
+
+    @patch("tuxemon.locale_dir.translator.translation")
+    def test_plural_translation_success(self, mock_translation):
+        mock_trans = MagicMock()
+        mock_trans.ngettext.side_effect = lambda singular, plural, n: (
+            f"{n} apple" if n == 1 else f"{n} apples"
+        )
+
+        mock_fallback = MagicMock()
+        mock_fallback.ngettext.side_effect = lambda s, p, n: f"{n} fallback"
+
+        mock_translation.side_effect = [mock_trans, mock_fallback]
+
+        po = TranslatorPo(
+            locale_name="en",
+            domain="base",
+            localedir=Path("."),
+            fallback_locale="en",
+        )
+
+        singular = "apple"
+        plural = "apples"
+
+        result_one = po.translate_plural(singular, plural, 1)
+        result_many = po.translate_plural(singular, plural, 3)
+
+        self.assertEqual(result_one, "1 apple")
+        self.assertEqual(result_many, "3 apples")
+
+    @patch("tuxemon.locale_dir.translator.translation")
+    def test_has_translation(self, mock_translation):
+        mock_trans = MagicMock()
+        mock_trans.gettext.side_effect = lambda msg: (
+            "Bonjour" if msg == "Hello" else msg
+        )
+        mock_fallback = MagicMock()
+        mock_fallback.gettext.side_effect = lambda msg: msg
+
+        mock_translation.side_effect = [mock_trans, mock_fallback]
+
+        po = TranslatorPo("fr", "base", Path("."), "en")
+        self.assertTrue(po.has_translation("Hello"))
+        self.assertFalse(po.has_translation("Goodbye"))
+
+    @patch("tuxemon.locale_dir.translator.translation")
+    def test_has_plural_translation(self, mock_translation):
+        mock_trans = MagicMock()
+        mock_trans.ngettext.side_effect = lambda s, p, n: s if n == 1 else p
+        mock_fallback = MagicMock()
+        mock_fallback.ngettext.side_effect = lambda s, p, n: s if n == 1 else p
+
+        mock_translation.side_effect = [mock_trans, mock_fallback]
+
+        po = TranslatorPo("en", "base", Path("."), "en")
+        self.assertFalse(po.has_plural_translation("apple", "apples", 0))
+
+    @patch(
+        "tuxemon.locale_dir.translator.translation",
+        side_effect=FileNotFoundError,
+    )
+    def test_missing_all_translations(self, mock_translation):
+        po = TranslatorPo("xx", "base", Path("."), "yy")
+        result = po.translate("Hello")
+        self.assertEqual(result, "Hello")
+
+    def test_get_current_language(self):
+        po = TranslatorPo("it", "base", Path("."), "en")
+        self.assertEqual(po.get_current_language(), "it")
+
+    def test_maybe_translate_string(self):
+        po = TranslatorPo("en", "base", Path("."), "en")
+        po.translate = MagicMock(return_value="Hi")
+        self.assertEqual(po.maybe_translate("Hello"), "Hi")
+
+    def test_maybe_translate_none(self):
+        po = TranslatorPo("en", "base", Path("."), "en")
+        self.assertEqual(po.maybe_translate(None), "")

--- a/tuxemon/locale.py
+++ b/tuxemon/locale.py
@@ -422,6 +422,26 @@ class TranslatorManager:
                     f"Configured locale mode '{_locale_mode}' doesn't exist as a supported language."
                 )
 
+    def discover_and_load_all_domains(self, locale_name: str) -> None:
+        """
+        Discovers all available translation domains and loads a translator for each.
+
+        Parameters:
+            locale_name: The locale to use when loading translators.
+        """
+        logger.info(
+            "Discovering and loading all available translation domains..."
+        )
+
+        all_domains = {
+            info.domain for info in self.locale_finder.search_locales()
+        }
+
+        for domain in sorted(all_domains):
+            self.load_translator_for_domain(domain, locale_name)
+
+        logger.info(f"Loaded translators for domains: {sorted(all_domains)}")
+
     def initialize_translations(
         self,
         locale_name: str = LOCALE_CONFIG.slug,
@@ -450,3 +470,4 @@ locale_finder = LocaleFinder(all_l18n_mod_paths)
 gettext_compiler = GettextCompiler(paths.CACHE_DIR)
 T = TranslatorManager(locale_finder, gettext_compiler)
 T.initialize_translations()
+T.discover_and_load_all_domains(locale_name=LOCALE_CONFIG.slug)

--- a/tuxemon/locale_dir/translator.py
+++ b/tuxemon/locale_dir/translator.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import gettext
 import logging
 from collections.abc import Callable, Mapping
+from gettext import GNUTranslations, NullTranslations, translation
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -31,20 +31,24 @@ class TranslatorPo:
         self.domain = domain
         self.localedir = localedir
         self.fallback_locale = fallback_locale
-        self._translation_cache: dict[str, str] = {}
-        self._real_translate: Callable[[str], str] = (
+        self._real_translate: Union[GNUTranslations, NullTranslations] = (
             self._load_gettext_translation()
         )
-        self.translate: Callable[[str], str] = self._translate_with_cache
+        self.translate: Callable[[str], str] = self._real_translate.gettext
+        self.translate_plural: Callable[[str, str, int], str] = (
+            self._real_translate.ngettext
+        )
 
-    def _load_gettext_translation(self) -> Callable[[str], str]:
+    def _load_gettext_translation(
+        self,
+    ) -> Union[GNUTranslations, NullTranslations]:
         """
         Loads and returns the gettext translation function for this translator.
         Handles fallback if the specific translation is not found.
         """
-        trans: Union[gettext.GNUTranslations, gettext.NullTranslations]
+        trans: Union[GNUTranslations, NullTranslations]
         try:
-            trans = gettext.translation(
+            trans = translation(
                 self.domain, self.localedir, [self.locale_name]
             )
             logger.debug(
@@ -57,7 +61,7 @@ class TranslatorPo:
                 f"Attempting to use fallback '{self.fallback_locale}'."
             )
             try:
-                trans = gettext.translation(
+                trans = translation(
                     self.domain, self.localedir, [self.fallback_locale]
                 )
                 logger.debug(
@@ -69,10 +73,10 @@ class TranslatorPo:
                     f"No translation found for domain '{self.domain}' in any locale."
                     " Using NullTranslations."
                 )
-                trans = gettext.NullTranslations()
+                trans = NullTranslations()
 
         try:
-            fallback_base_trans = gettext.translation(
+            fallback_base_trans = translation(
                 "base", self.localedir, [self.fallback_locale]
             )
             trans.add_fallback(fallback_base_trans)
@@ -85,16 +89,7 @@ class TranslatorPo:
                 "Translations might be very incomplete."
             )
 
-        return trans.gettext
-
-    def _translate_with_cache(self, message: str) -> str:
-        """Translates a message, caching the result."""
-        if message in self._translation_cache:
-            return self._translation_cache[message]
-
-        translated_message = self._real_translate(message)
-        self._translation_cache[message] = translated_message
-        return translated_message
+        return trans
 
     def get_current_language(self) -> str:
         """
@@ -116,7 +111,24 @@ class TranslatorPo:
         Returns:
             True if the translation exists, False otherwise.
         """
-        return self._real_translate(msgid) != msgid
+        return self.translate(msgid) != msgid
+
+    def has_plural_translation(
+        self, singular_msgid: str, plural_msgid: str, n: int
+    ) -> bool:
+        """
+        Checks if a plural translation exists for the given message IDs.
+
+        Parameters:
+            singular_msgid: The singular msgid.
+            plural_msgid: The plural msgid.
+            n: The number used to determine the plural form.
+
+        Returns:
+            True if a plural translation exists, False otherwise.
+        """
+        translated = self.translate_plural(singular_msgid, plural_msgid, n)
+        return translated != singular_msgid and translated != plural_msgid
 
     def format(
         self,


### PR DESCRIPTION
PR introduces two key improvements to the translation infrastructure, making it more dynamic, scalable, and capable of handling plural forms.

Added `discover_and_load_all_domains()` to `TranslatorManager`:
- scans all available `.po` files using `LocaleFinder`
- loads a translator for each discovered domain using the specified locale
- ensures that all translation domains, including those introduced by mods or external content—are initialized without manual intervention
- this single change allows the system to automatically handle any new `.po` file added (e.g., `monster.po`, `items.po`) without requiring further code modification
- `TranslatorManager` object (`T`) will now be aware of all available translation domains
- developers can use `T.translate("message", domain="...")` throughout the codebase to retrieve translations from the appropriate domain

Updated `TranslatorPo` to Support Plural Translations:
- replaced the cached translation logic with direct access to `gettext.gettext` and `gettext.ngettext`
- introduced `translate_plural()` for handling singular/plural forms based on quantity
- added `has_plural_translation()` to check for the existence of plural translations
- ensures fallback logic still applies, including fallback to the `"base"` domain if needed