### PR TITLE
Refactor `get_exits` with Utility Methods for Traversability Checks

### DIFF
--- a/tests/tuxemon/test_body.py
+++ b/tests/tuxemon/test_body.py
@@ -62,21 +62,29 @@ class TestBody(unittest.TestCase):
         self.assertEqual(self.body.velocity, Vector3(0, 0, 0))
 
     def test_move_with_valid_direction(self):
-        self.mover.move(Vector3(0, -1, 0), speed=5)
+        self.mover.base_moverate = 5
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(0, -1, 0))
         self.assertEqual(self.body.velocity, Vector3(0, -5, 0))
         self.assertEqual(self.mover.facing, Direction.up)
 
     def test_move_with_invalid_direction(self):
+        self.mover.base_moverate = 10
+        self.mover.moverate_modifier = 1.0
         with self.assertRaises(ValueError):
-            self.mover.move(Vector3(1, 1, 1), speed=10)
+            self.mover.move(Vector3(1, 1, 1))
 
     def test_move_boundary_case(self):
-        self.mover.move(Vector3(0, 1, 0), speed=0.0001)
+        self.mover.base_moverate = 0.0001
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(0, 1, 0))
         self.assertEqual(self.body.velocity, Vector3(0, 0.0001, 0))
         self.assertEqual(self.mover.facing, Direction.down)
 
     def test_no_change_in_facing_when_stopping(self):
-        self.mover.move(Vector3(1, 0, 0), speed=5)
+        self.mover.base_moverate = 5
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(1, 0, 0))
         self.mover.stop()
 
         self.assertEqual(self.body.velocity, Vector3(0, 0, 0))
@@ -114,36 +122,50 @@ class TestMover(unittest.TestCase):
         self.mover = Mover(self.body)
 
     def test_move_with_valid_direction(self):
-        self.mover.move(Vector3(1, 0, 0), speed=5)
+        self.mover.base_moverate = 5
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(1, 0, 0))
         self.assertEqual(self.body.velocity, Vector3(5, 0, 0))
         self.assertEqual(self.mover.facing, Direction.right)
 
     def test_move_with_invalid_direction(self):
+        self.mover.base_moverate = 5
+        self.mover.moverate_modifier = 1.0
         with self.assertRaises(ValueError):
-            self.mover.move(Vector3(0.5, 0.5, 0.5), speed=5)
+            self.mover.move(Vector3(0.5, 0.5, 0.5))
 
     def test_stop(self):
-        self.mover.move(Vector3(1, 0, 0), speed=5)
+        self.mover.base_moverate = 5
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(1, 0, 0))
         self.mover.stop()
         self.assertEqual(self.body.velocity, Vector3(0, 0, 0))
 
     def test_move_with_zero_speed(self):
-        self.mover.move(Vector3(0, 1, 0), speed=0)
+        self.mover.base_moverate = 0
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(0, 1, 0))
         self.assertEqual(self.body.velocity, Vector3(0, 0, 0))
         self.assertEqual(self.mover.facing, Direction.down)
 
     def test_move_with_negative_speed(self):
-        self.mover.move(Vector3(0, 1, 0), speed=-5)
+        self.mover.base_moverate = -5
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(0, 1, 0))
         self.assertEqual(self.body.velocity, Vector3(0, -5, 0))
         self.assertEqual(self.mover.facing, Direction.down)
 
     def test_move_extreme_speed(self):
-        self.mover.move(Vector3(1, 0, 0), speed=999999)
+        self.mover.base_moverate = 999999
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(1, 0, 0))
         self.assertEqual(self.body.velocity, Vector3(999999, 0, 0))
         self.assertEqual(self.mover.facing, Direction.right)
 
     def test_facing_consistency_after_stop(self):
-        self.mover.move(Vector3(0, -1, 0), speed=5)
+        self.mover.base_moverate = 5
+        self.mover.moverate_modifier = 1.0
+        self.mover.move(Vector3(0, -1, 0))
         self.mover.stop()
         self.assertEqual(self.mover.facing, Direction.up)
 

--- a/tests/tuxemon/test_pathfinder.py
+++ b/tests/tuxemon/test_pathfinder.py
@@ -37,21 +37,13 @@ class TestPathfinder(unittest.TestCase):
         self.client.collision_manager.get_collision_map.return_value = {}
         self.client.npc_manager.get_entity_pos.return_value = None
 
-        node1 = MagicMock(spec=PathfindNode)
-        node1.get_value.return_value = start
-        node1.get_parent.return_value = None
-        node1.reconstruct_path.return_value = [start]
-
-        node2 = MagicMock(spec=PathfindNode)
-        node2.get_value.return_value = dest
-        node2.get_parent.return_value = node1
-        node2.reconstruct_path.return_value = [start, dest]
-
-        self.pathfinder.pathfind_r = MagicMock(return_value=node2)
+        # No exits from start
+        self.pathfinder.get_exits = MagicMock(return_value=[])
 
         path = self.pathfinder.pathfind(start, dest, Direction.down)
 
-        self.assertEqual(path, [start, dest])
+        self.assertIsNone(path)
+        self.client.npc_manager.get_entity_pos.assert_called_once_with(start)
 
     def test_pathfind_failure(self):
         start = (0, 0)
@@ -59,7 +51,7 @@ class TestPathfinder(unittest.TestCase):
         self.client.collision_manager.get_collision_map.return_value = {}
         self.client.npc_manager.get_entity_pos.return_value = None
 
-        self.pathfinder.pathfind_r = MagicMock(return_value=None)
+        self.pathfinder.get_exits = MagicMock(return_value=[])
 
         path = self.pathfinder.pathfind(start, dest, Direction.down)
 
@@ -85,87 +77,58 @@ class TestPathfinder(unittest.TestCase):
         self.assertFalse(self.pathfinder.is_valid_position((2, 2), skip_nodes))
 
     def test_is_tile_traversable(self):
-        npc = MagicMock(spec=NPC)
-        npc.tile_pos = (1, 1)
-        npc.ignore_collisions = False
-        npc.facing = Direction.down
         tile = (1, 2)
 
         self.pathfinder.get_exits = MagicMock(return_value=[tile])
         self.client.npc_manager.get_entity_pos = MagicMock(return_value=None)
 
-        self.assertTrue(self.pathfinder.is_tile_traversable(npc, tile))
+        result = self.pathfinder.is_tile_traversable(
+            (1, 1), Direction.down, tile, False
+        )
+        self.assertTrue(result)
 
         other_npc = MagicMock()
         other_npc.moving = True
         other_npc.moverate = CONFIG.player_walkrate
         other_npc.facing = Direction.up
         self.client.npc_manager.get_entity_pos.return_value = other_npc
-        self.assertFalse(self.pathfinder.is_tile_traversable(npc, tile))
+        result = self.pathfinder.is_tile_traversable(
+            (1, 1), Direction.down, tile, False
+        )
+        self.assertFalse(result)
 
-        npc.ignore_collisions = True
-        self.assertTrue(self.pathfinder.is_tile_traversable(npc, tile))
+        result = self.pathfinder.is_tile_traversable(
+            (1, 1), Direction.down, tile, True
+        )
+        self.assertTrue(result)
 
     def test_get_tile_moverate(self):
-        npc = MagicMock(spec=NPC)
         destination = (1, 1)
 
         self.client.map_manager.surface_map = {
             destination: {"speed_modifier": 0.5}
         }
-        npc.moverate = 2.0
+        npc_moverate = 2.0
 
         moverate = get_tile_moverate(
-            self.client.map_manager.surface_map, npc, destination
+            self.client.map_manager.surface_map, destination
         )
 
-        expected_moverate = npc.moverate * 0.5  # 2.0 * 0.5
-        self.assertEqual(moverate, expected_moverate)
+        expected_moverate = npc_moverate * 0.5  # 2.0 * 0.5
+        self.assertEqual(moverate * npc_moverate, expected_moverate)
 
     def test_get_tile_moverate_no_properties(self):
-        npc = MagicMock(spec=NPC)
         destination = (1, 1)
 
         self.client.map_manager.surface_map = {destination: {}}
-        npc.moverate = 2.0
+        npc_moverate = 2.0
 
         moverate = get_tile_moverate(
-            self.client.map_manager.surface_map, npc, destination
+            self.client.map_manager.surface_map, destination
         )
 
-        expected_moverate = npc.moverate * 1.0  # 2.0 * 1.0
-        self.assertEqual(moverate, expected_moverate)
-
-    def test_pathfind_r_with_no_nodes(self):
-        dest = (1, 1)
-        queue = []
-        known_nodes = set()
-
-        result = self.pathfinder.pathfind_r(
-            dest, queue, known_nodes, Direction.down
-        )
-
-        self.assertIsNone(result)
-
-    def test_pathfind_r_reaches_destination(self):
-        start = (0, 0)
-        dest = (1, 1)
-        node1 = MagicMock(spec=PathfindNode)
-        node1.get_value.return_value = start
-        node1.get_parent.return_value = None
-
-        node2 = MagicMock(spec=PathfindNode)
-        node2.get_value.return_value = dest
-        node2.get_parent.return_value = node1
-
-        self.pathfinder.get_exits = MagicMock(return_value=[dest])
-        self.pathfinder.pathfind_r = MagicMock(return_value=node2)
-
-        result = self.pathfinder.pathfind_r(
-            dest, [node1], set(), Direction.down
-        )
-
-        self.assertEqual(result, node2)
+        expected_moverate = npc_moverate * 1.0  # 2.0 * 1.0
+        self.assertEqual(moverate * npc_moverate, expected_moverate)
 
     def test_pathfind_with_same_start_and_dest(self):
         start = (1, 1)
@@ -184,50 +147,23 @@ class TestPathfinder(unittest.TestCase):
         )
 
     def test_is_tile_traversable_with_no_npcs(self):
-        npc = MagicMock(spec=NPC)
-        npc.tile_pos = (1, 1)
-        npc.ignore_collisions = False
-        npc.facing = Direction.down
         tile = (1, 2)
         self.pathfinder.get_exits = MagicMock(return_value=[tile])
         self.client.npc_manager.get_entity_pos = MagicMock(return_value=None)
-        self.assertTrue(self.pathfinder.is_tile_traversable(npc, tile))
+        result = self.pathfinder.is_tile_traversable(
+            (1, 1), Direction.down, tile, False
+        )
+        self.assertTrue(result)
 
     def test_get_tile_moverate_with_no_surface_data(self):
-        npc = MagicMock(spec=NPC)
         destination = (1, 1)
         self.client.map_manager.surface_map = {}
-        npc.moverate = 2.0
+        npc_moverate = 2.0
         moverate = get_tile_moverate(
-            self.client.map_manager.surface_map, npc, destination
+            self.client.map_manager.surface_map, destination
         )
-        expected_moverate = npc.moverate * 1.0
-        self.assertEqual(moverate, expected_moverate)
-
-    def test_pathfind_r_with_multiple_exits(self):
-        start = (0, 0)
-        dest = (1, 1)
-        node1 = MagicMock(spec=PathfindNode)
-        node1.get_value.return_value = start
-        node2 = MagicMock(spec=PathfindNode)
-        node2.get_value.return_value = dest
-        self.pathfinder.get_exits = MagicMock(return_value=[(1, 1), (0, 1)])
-        self.pathfinder.pathfind_r = MagicMock(return_value=node2)
-        result = self.pathfinder.pathfind_r(
-            dest, [node1], set(), Direction.down
-        )
-        self.assertEqual(result, node2)
-
-    def test_pathfind_r_no_adjacent_nodes(self):
-        start = (0, 0)
-        dest = (1, 1)
-        node1 = MagicMock(spec=PathfindNode)
-        node1.get_value.return_value = start
-        self.pathfinder.get_exits = MagicMock(return_value=[])
-        result = self.pathfinder.pathfind_r(
-            dest, [node1], set(), Direction.down
-        )
-        self.assertIsNone(result)
+        expected_moverate = npc_moverate * 1.0
+        self.assertEqual(moverate * npc_moverate, expected_moverate)
 
     def test_get_exits_with_tile_data(self):
         position = (1, 1)
@@ -361,3 +297,99 @@ class TestPathfinder(unittest.TestCase):
         exits = self.pathfinder.get_exits(position, Direction.down)
 
         self.assertEqual(exits, [])
+
+    def test_pathfind_multi_step_success(self):
+        start = (0, 0)
+        dest = (2, 0)
+        self.client.collision_manager.get_collision_map.return_value = {}
+        self.client.npc_manager.get_entity_pos.return_value = None
+
+        self.pathfinder.get_exits = MagicMock(
+            side_effect=[
+                [(1, 0)],  # from (0, 0)
+                [(2, 0)],  # from (1, 0)
+                [],  # from (2, 0)
+            ]
+        )
+
+        path = self.pathfinder.pathfind(start, dest, Direction.right)
+        self.assertEqual(path, [(2, 0), (1, 0)])
+
+    def test_pathfind_avoids_cycles(self):
+        start = (0, 0)
+        dest = (1, 1)
+        self.client.collision_manager.get_collision_map.return_value = {}
+        self.client.npc_manager.get_entity_pos.return_value = None
+
+        self.pathfinder.get_exits = MagicMock(
+            side_effect=[
+                [(0, 1)],  # from (0, 0)
+                [(0, 0), (1, 1)],  # from (0, 1)
+                [],  # from (1, 1)
+            ]
+        )
+
+        path = self.pathfinder.pathfind(start, dest, Direction.down)
+
+        self.assertEqual(path, [(1, 1), (0, 1)])
+
+    def test_pathfind_skips_blocked_tile(self):
+        start = (0, 0)
+        dest = (1, 1)
+        self.client.collision_manager.get_collision_map.return_value = {}
+
+        # Simulate that no exits are available from (0, 0)
+        self.pathfinder.get_exits = MagicMock(return_value=[])
+        self.client.npc_manager.get_entity_pos.return_value = None
+
+        path = self.pathfinder.pathfind(start, dest, Direction.down)
+
+        self.assertIsNone(path)
+
+    def test_get_exits_respects_facing(self):
+        position = (1, 1)
+        collision_map = {
+            position: RegionProperties(
+                enter_from=[],
+                exit_from=["up"],  # Only allow exit upward
+                endure=[],
+                entity=None,
+                key=None,
+            ),
+            (1, 0): RegionProperties(
+                enter_from=["down"],
+                exit_from=[],
+                endure=[],
+                entity=None,
+                key=None,
+            ),
+        }
+        self.client.collision_manager.get_collision_map.return_value = (
+            collision_map
+        )
+        self.client.boundary.is_within_boundaries.return_value = True
+
+        exits = self.pathfinder.get_exits(position, Direction.up)
+        self.assertEqual(exits, [(1, 0)])
+
+    def test_is_tile_traversable_blocked_by_npc(self):
+        npc = MagicMock(spec=NPC)
+
+        tile = (1, 2)
+        self.pathfinder.get_exits = MagicMock(return_value=[tile])
+
+        # Simulate a blocking NPC on a neighboring tile
+        blocking_npc = MagicMock()
+        blocking_npc.moving = True
+        blocking_npc.moverate = CONFIG.player_walkrate
+        blocking_npc.facing = Direction.up  # Opposite direction
+
+        self.client.npc_manager.get_entity_pos = MagicMock(
+            return_value=blocking_npc
+        )
+        self.client.map_manager.map_size = (10, 10)
+
+        result = self.pathfinder.is_tile_traversable(
+            (1, 1), Direction.down, tile, False
+        )
+        self.assertFalse(result)

--- a/tuxemon/entity.py
+++ b/tuxemon/entity.py
@@ -82,12 +82,14 @@ class Mover:
         self,
         body: Body,
         facing: Direction = Direction.down,
-        moverate: float = 0.0,
+        base_moverate: float = CONFIG.player_walkrate,
+        moverate_modifier: float = 1.0,
     ) -> None:
         self.state = EntityState.IDLE
         self.body = body
         self.facing = facing
-        self.moverate = moverate  # walk by default
+        self.base_moverate = base_moverate
+        self.moverate_modifier = moverate_modifier
         self.direction_map = {tuple(v.normalized): k for k, v in dirs3.items()}
         self.move_direction: Optional[Direction] = None
 
@@ -95,15 +97,23 @@ class Mover:
     def current_direction(self) -> Vector3:
         return dirs3[self.facing]
 
-    def move(self, direction: Vector3, speed: float) -> None:
+    @property
+    def effective_moverate(self) -> float:
+        return self.moverate * self.moverate_modifier
+
+    @property
+    def moverate(self) -> float:
+        return self.base_moverate * self.moverate_modifier
+
+    def move(self, direction: Vector3) -> None:
         """Applies movement in a given direction."""
         normalized_direction = tuple(direction.normalized)
         if normalized_direction in self.direction_map:
-            self.body.velocity = Vector3(*normalized_direction) * speed
+            self.body.velocity = Vector3(*normalized_direction) * self.moverate
             self.facing = self.direction_map[normalized_direction]
             self.state = (
                 EntityState.RUNNING
-                if speed > CONFIG.player_walkrate
+                if self.base_moverate == CONFIG.player_runrate
                 else EntityState.WALKING
             )
         else:
@@ -113,18 +123,18 @@ class Mover:
         """Stops movement without affecting acceleration."""
         self.body.velocity = Vector3(0, 0, 0)
         self.state = EntityState.IDLE
-        self.moverate = CONFIG.player_walkrate
+        self.base_moverate = CONFIG.player_walkrate
 
     def running(self) -> None:
         """Boosts moverate to running speed."""
         if self.body.is_moving:
-            self.moverate = CONFIG.player_runrate
+            self.base_moverate = CONFIG.player_runrate
             self.state = EntityState.RUNNING
 
     def walking(self) -> None:
         """Resets moverate back to walking speed."""
         if self.body.is_moving:
-            self.moverate = CONFIG.player_walkrate
+            self.base_moverate = CONFIG.player_walkrate
             self.state = EntityState.WALKING
 
     def update_movement_state(self, running: bool) -> None:
@@ -163,7 +173,7 @@ class Entity(Generic[SaveDict]):
         self.world = session.world
         self.instance_id: UUID = uuid4()
         self.body = Body(position=Point3(0, 0, 0))
-        self.mover = Mover(self.body, moverate=CONFIG.player_walkrate)
+        self.mover = Mover(self.body)
         self.tile_pos: tuple[int, int] = (0, 0)
         self.update_location: bool = False
         self.is_player: bool = False
@@ -206,7 +216,15 @@ class Entity(Generic[SaveDict]):
         Parameters:
             moverate: The new movement rate to be applied.
         """
-        self.mover.moverate = moverate
+        self.mover.base_moverate = moverate
+
+    def set_moverate_modifier(self, modifier: float) -> None:
+        """Sets a new moverate modifier.
+
+        Parameters:
+            modifier: The new modifier to be applied.
+        """
+        self.mover.moverate_modifier = max(0.0, modifier)
 
     def set_facing(self, direction: Direction) -> None:
         """

--- a/tuxemon/movement.py
+++ b/tuxemon/movement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from collections.abc import MutableMapping, Sequence
 from typing import TYPE_CHECKING, Optional
 
@@ -157,57 +158,21 @@ class Pathfinder:
             A sequence of positions representing the path if found, or None if no path
                 exists.
         """
-        pathnode = self.pathfind_r(
-            dest=dest,
-            queue=[PathfindNode(start)],
-            known_nodes=set(),
-            facing=facing,
-        )
         logger.info(f"Pathfinding from {start} to {dest}.")
-        if pathnode:
-            path = pathnode.reconstruct_path()
-            return path
-        else:
-            character = self.npc_manager.get_entity_pos(start)
-            if character and self.map_manager.current_map:
-                filename = self.map_manager.current_map.filename
-                logger.error(
-                    f"{character.name}'s pathfinding failed in {filename}."
-                )
-            else:
-                logger.error(f"No character found at start position {start}.")
-            return None
 
-    def pathfind_r(
-        self,
-        dest: tuple[int, int],
-        queue: list[PathfindNode],
-        known_nodes: set[tuple[int, int]],
-        facing: Direction,
-    ) -> Optional[PathfindNode]:
-        """
-        A recursive helper method that explores possible paths to the destination.
-
-        Parameters:
-            dest: The destination position as a tuple of (x, y) coordinates.
-            queue: A deque of PathfindNode objects representing the current nodes to
-                explore.
-            known_nodes: A set of positions that have already been explored.
-            facing: The direction the character is currently facing, which guides path
-                exploration.
-
-        Returns:
-            The PathfindNode representing the destination if found, or None if no path exists.
-        """
-        if not queue:
-            return None
+        queue = deque([PathfindNode(start)])
+        known_nodes: set[tuple[int, int]] = set()
         collision_map = self.collision_manager.get_collision_map()
+
         while queue:
-            node = queue.pop(0)
+            node = queue.popleft()
             logger.debug(f"Checking node {node.get_value()}.")
+
             if node.get_value() == dest:
                 logger.info(f"Destination {dest} reached.")
-                return node
+                path = node.reconstruct_path()
+                return path
+
             for adj_pos in self.get_exits(
                 position=node.get_value(),
                 facing=facing,
@@ -216,12 +181,20 @@ class Pathfinder:
             ):
                 if adj_pos not in known_nodes:
                     known_nodes.add(adj_pos)
-                    new_node = PathfindNode(adj_pos)
-                    new_node.set_parent(node)
+                    new_node = PathfindNode(adj_pos, node)
                     queue.append(new_node)
                     logger.debug(
                         f"Added adjacent position {adj_pos} to the queue."
                     )
+
+        character = self.npc_manager.get_entity_pos(start)
+        if character and self.map_manager.current_map:
+            filename = self.map_manager.current_map.filename
+            logger.error(
+                f"{character.name}'s pathfinding failed in {filename}."
+            )
+        else:
+            logger.error(f"No character found at start position {start}.")
         logger.warning(f"No path found to destination {dest}.")
         return None
 
@@ -254,93 +227,154 @@ class Pathfinder:
         skip_nodes: Optional[set[tuple[int, int]]] = None,
     ) -> Sequence[tuple[int, int]]:
         """
-        Retrieves a list of adjacent tiles that can be moved into from the given position.
+        Determines all adjacent tiles that can be traversed from the given position.
 
         Parameters:
-            position: The original position as a tuple of (x, y) coordinates.
-            facing: The direction the character is currently facing, used to determine
-                valid exits.
-            collision_map: An optional mapping of collisions with entities and terrain.
-            skip_nodes: A set of nodes to skip during the exit check.
+            position: The current tile coordinates (x, y).
+            facing: The direction the character is currently facing.
+            collision_map: Optional preloaded collision map; defaults to current map's
+                collision data.
+            skip_nodes: Optional set of positions to exclude from traversal.
 
         Returns:
-            A sequence of adjacent and traversable tile positions.
+            A list of adjacent tile positions that are valid for movement.
         """
-        # get tile-level and npc/entity blockers
         collision_map = (
             collision_map or self.collision_manager.get_collision_map()
         )
         skip_nodes = skip_nodes or set()
-        logger.debug(f"Getting exits for position {position}.")
+        logger.debug(f"[get_exits] Position: {position}, Facing: {facing}")
+        logger.debug(f"[get_exits] Skip nodes: {skip_nodes}")
 
-        # Get explicit 'continue' and 'exits' based on tile data if it exists
-        exits = []
         tile_data = collision_map.get(position)
-        if tile_data is not None:
-            exits = get_explicit_tile_exits(
-                position, tile_data, facing, skip_nodes
-            )
-            logger.debug(f"Found explicit exits: {exits}.")
-        else:
-            logger.debug(
-                f"No tile data found for position {position}. "
-                "No explicit exits can be determined."
-            )
+        exits = (
+            get_explicit_tile_exits(position, tile_data, facing, skip_nodes)
+            if tile_data
+            else []
+        )
+        logger.debug(f"[get_exits] Found explicit exits: {exits}")
 
         adjacent_tiles = set()
-        # Loop through all directions dynamically using dirs2
+
         for direction, vector in dirs2.items():
             neighbor = get_adjacent_position(position, direction)
-            # If we have specific exits defined, make sure the neighbor is one of them
-            # Also, skip this neighbor if it's in the list of nodes we want to avoid
-            # We only need to check the edges since we can't go out of bounds
-            if (exits and neighbor not in exits) or not self.is_valid_position(
-                neighbor, skip_nodes
+            logger.debug(
+                f"[get_exits] Checking direction: {direction}, Neighbor: {neighbor}"
+            )
+
+            if self.is_tile_traversable_from(
+                position, neighbor, direction, exits, collision_map, skip_nodes
             ):
-                logger.debug(
-                    f"Skipping neighbor {neighbor} (not valid or not an exit)."
-                )
-                continue
+                adjacent_tiles.add(neighbor)
 
-            if (
-                position,
-                direction,
-            ) in self.map_manager.collision_lines_map:
-                logger.debug(
-                    f"Wall detected between {position} and {neighbor}."
-                )
-                continue
-
-            # test if this tile has special movement handling
-            # NOTE: Do not refact. into a dict.get(xxxxx, None) style check
-            # NOTE: None has special meaning in this check
-            try:
-                tile_data = collision_map[neighbor]
-            except KeyError:
-                pass
-            else:
-                # None means tile is blocked with no specific data
-                if tile_data is None:
-                    continue
-
-                try:
-                    if pairs(direction) not in tile_data.enter_from:
-                        continue
-                except KeyError:
-                    continue
-
-            logger.debug(f"Neighbor {neighbor} is free to move into.")
-            adjacent_tiles.add(neighbor)
-
-        logger.debug(f"Adjacent tiles found: {adjacent_tiles}.")
+        logger.debug(f"[get_exits] Final adjacent tiles: {adjacent_tiles}")
         return list(adjacent_tiles)
 
-    def is_tile_traversable(self, npc: NPC, tile: tuple[int, int]) -> bool:
+    def is_explicitly_allowed(
+        self,
+        neighbor: tuple[int, int],
+        exits: list[tuple[float, ...]],
+    ) -> bool:
+        """
+        Checks whether a neighbor tile is explicitly allowed based on exit rules.
+
+        Parameters:
+            neighbor: The adjacent tile to evaluate.
+            exits: A list of explicitly allowed exit positions.
+
+        Returns:
+            True if no explicit exits are defined or if the neighbor is in the list;
+            False otherwise.
+        """
+        return not exits or neighbor in exits
+
+    def is_tile_enterable(
+        self,
+        neighbor: tuple[int, int],
+        direction: Direction,
+        collision_map: CollisionMap,
+    ) -> bool:
+        """
+        Determines whether a tile can be entered from a given direction.
+
+        Parameters:
+            neighbor: The tile to enter.
+            direction: The direction from which entry is attempted.
+            collision_map: The map containing tile data and entry rules.
+
+        Returns:
+            True if the tile allows entry from the given direction; False otherwise.
+        """
+        try:
+            tile_data = collision_map[neighbor]
+        except KeyError:
+            return True  # Missing tile data is treated as traversable
+
+        if tile_data is None:
+            return False
+
+        try:
+            return pairs(direction) in tile_data.enter_from
+        except KeyError:
+            return False
+
+    def is_tile_traversable_from(
+        self,
+        position: tuple[int, int],
+        neighbor: tuple[int, int],
+        direction: Direction,
+        exits: list[tuple[float, ...]],
+        collision_map: CollisionMap,
+        skip_nodes: set[tuple[int, int]],
+    ) -> bool:
+        """
+        Evaluates whether a neighboring tile is traversable from the current position.
+
+        Parameters:
+            position: The current tile position.
+            neighbor: The adjacent tile to evaluate.
+            direction: The direction of movement toward the neighbor.
+            exits: A list of explicitly allowed exit positions.
+            collision_map: The map containing tile data and entry rules.
+            skip_nodes: A set of positions to exclude from traversal.
+
+        Returns:
+            True if the neighbor tile is traversable; False otherwise.
+        """
+        if not self.is_explicitly_allowed(neighbor, exits):
+            logger.debug(f"[traversable] {neighbor} not in explicit exits")
+            return False
+        if not self.is_valid_position(neighbor, skip_nodes):
+            logger.debug(
+                f"[traversable] {neighbor} is invalid (boundary or skipped)"
+            )
+            return False
+        if (position, direction) in self.map_manager.collision_lines_map:
+            logger.debug(
+                f"[traversable] Wall between {position} and {neighbor}"
+            )
+            return False
+        if not self.is_tile_enterable(neighbor, direction, collision_map):
+            logger.debug(
+                f"[traversable] Cannot enter {neighbor} from {direction}"
+            )
+            return False
+
+        logger.debug(f"[traversable] {neighbor} is traversable")
+        return True
+
+    def is_tile_traversable(
+        self,
+        tile_pos: tuple[int, int],
+        facing: Direction,
+        tile: tuple[int, int],
+        ignore_collisions: bool,
+    ) -> bool:
         """Checks if a tile is traversable for the given NPC."""
-        if npc.ignore_collisions:
+        if ignore_collisions:
             return True
 
-        if tile not in self.get_exits(npc.tile_pos, npc.facing):
+        if tile not in self.get_exits(tile_pos, facing):
             return False
 
         # Check for collisions with moving entities
@@ -351,7 +385,7 @@ class Pathfinder:
                 char
                 and char.moving
                 and char.moverate == CONFIG.player_walkrate
-                and npc.facing != char.facing
+                and facing != char.facing
             ):
                 return False
 
@@ -360,12 +394,9 @@ class Pathfinder:
 
 def get_tile_moverate(
     surface_map: MutableMapping[tuple[int, int], dict[str, float]],
-    npc: NPC,
     destination: tuple[int, int],
 ) -> float:
     """Gets the movement speed modifier for the given tile."""
     tile_properties = surface_map.get(destination, {})
     rate = next(iter(tile_properties.values()), 1.0)
-    # Convert rate to a numeric type if necessary
-    _moverate = npc.moverate * float(rate)
-    return _moverate
+    return rate

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -412,8 +412,11 @@ class NPC(Entity[NPCState]):
         direction = get_direction(proj(self.position), target)
         self.set_facing(direction)
         try:
-            if self.client.pathfinder.is_tile_traversable(self, target):
-                moverate = get_tile_moverate(surface_map, self, target)
+            if self.client.pathfinder.is_tile_traversable(
+                self.tile_pos, self.facing, target, self.ignore_collisions
+            ):
+                tile_rate = get_tile_moverate(surface_map, target)
+                self.set_moverate_modifier(tile_rate)
                 # Surfanim suffers from significant clock drift, causing
                 # timing inconsistencies. Even after completing one animation
                 # cycle, the timing can become inaccurate. This drift results
@@ -427,7 +430,7 @@ class NPC(Entity[NPCState]):
                 # visual glitches and ensure frame accuracy.
                 self.sprite_controller.play_animation()
                 self.path_origin = self.tile_pos
-                self.mover.move(self.mover.current_direction, moverate)
+                self.mover.move(self.mover.current_direction)
                 self.remove_collision()
             else:
                 self.stop_moving()


### PR DESCRIPTION
waiting
- [x] #3082

PR refactors the `get_exits` method to improve readability, maintainability, and testability by introducing two utility methods: `is_explicitly_allowed` and `is_tile_enterable`.

Key changes:
- extracted the logic for checking whether a tile is explicitly allowed into a separate method `is_explicitly_allowed`, it isolates the exit filtering logic and makes it reusable
- moved the logic for determining whether a tile can be entered from a given direction into `is_tile_enterable`, it encapsulates the tile data and directional entry rules
- introduced a higher-level method `is_tile_traversable_from` that combines all traversal checks (exit rules, boundary validation, wall collisions, and entry permissions) into a single decision point
- replaced inline conditionals in `get_exits` with calls to these utility methods
- preserved the original behavior for handling missing tile data and entry rules

This refactor makes it easier to extend or modify traversal logic in the future, such as adding terrain costs, NPC-specific movement rules or debugging tile access patterns