### PR TITLE
Introduce `TradeManager` for Centralized Trade Handling

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4082,6 +4082,9 @@ msgstr "{name} is trying to evolve into {evolve}. Allow evolution?"
 msgid "evolution_ended"
 msgstr "{name} evolves into {evolve}!"
 
+msgid "trade_completed"
+msgstr "You traded {sent} and received {received}!"
+
 msgid "no_signal"
 msgstr "No Signal"
 

--- a/tests/tuxemon/test_trade_manager.py
+++ b/tests/tuxemon/test_trade_manager.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from tuxemon.trade_manager import TradeManager, TradeRecord, TradeResult
+
+
+class MockPlayer:
+    def __init__(self, name):
+        self.name = name
+        self.instance_id = uuid4()
+        self.party = MagicMock()
+        self.tuxepedia = MagicMock()
+
+
+class MockMonster:
+    def __init__(self, name, slug, owner):
+        self.name = name
+        self.slug = slug
+        self.instance_id = uuid4()
+        self.level = 5
+        self._owner = owner
+
+    def get_owner(self):
+        return self._owner
+
+    def set_owner(self, new_owner):
+        self._owner = new_owner
+
+    def set_acquisition(self, acquisition):
+        self.acquisition = acquisition
+
+
+class TradeManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.manager = TradeManager()
+
+        self.player_a = MockPlayer("Better")
+        self.player_b = MockPlayer("Call")
+
+        self.monster_a = MockMonster("Flamey", "flamey_slug", self.player_a)
+        self.monster_b = MockMonster("Splashy", "splashy_slug", self.player_b)
+
+        self.player_a.party.monsters = [self.monster_a]
+        self.player_b.party.monsters = [self.monster_b]
+
+    def test_execute_trade_success(self):
+        result = self.manager.execute_trade(self.monster_a, self.monster_b)
+        self.assertEqual(result, TradeResult.SUCCESS)
+        self.assertEqual(len(self.manager.global_trade_log), 2)
+
+    def test_execute_trade_same_owner(self):
+        self.monster_b._owner = self.player_a
+        result = self.manager.execute_trade(self.monster_a, self.monster_b)
+        self.assertEqual(result, TradeResult.SAME_OWNER)
+
+    def test_execute_trade_monster_not_found(self):
+        self.player_a.party.monsters = []
+        result = self.manager.execute_trade(self.monster_a, self.monster_b)
+        self.assertEqual(result, TradeResult.NOT_FOUND)
+
+    def test_was_traded_with_player(self):
+        record = TradeRecord(
+            from_player="Better",
+            to_player="Call",
+            from_player_id=self.player_a.instance_id,
+            to_player_id=self.player_b.instance_id,
+            monster_given="flamey_slug",
+            monster_received="splashy_slug",
+            monster_given_id=self.monster_a.instance_id,
+            monster_received_id=self.monster_b.instance_id,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.manager.global_trade_log.append(record)
+        self.assertTrue(self.manager.was_traded_with_player("Better"))
+        self.assertTrue(self.manager.was_traded_with_player("Call"))
+        self.assertFalse(self.manager.was_traded_with_player("Saul"))
+
+    def test_was_traded_for_monster(self):
+        record = TradeRecord(
+            from_player="Better",
+            to_player="Call",
+            from_player_id=self.player_a.instance_id,
+            to_player_id=self.player_b.instance_id,
+            monster_given="flamey_slug",
+            monster_received="splashy_slug",
+            monster_given_id=self.monster_a.instance_id,
+            monster_received_id=self.monster_b.instance_id,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.manager.global_trade_log.append(record)
+        self.assertTrue(self.manager.was_traded_for_monster("flamey_slug"))
+        self.assertTrue(self.manager.was_traded_for_monster("splashy_slug"))
+        self.assertFalse(self.manager.was_traded_for_monster("leafy_slug"))
+
+    def test_get_trade_history(self):
+        record = TradeRecord(
+            from_player="Better",
+            to_player="Call",
+            from_player_id=self.player_a.instance_id,
+            to_player_id=self.player_b.instance_id,
+            monster_given="flamey_slug",
+            monster_received="splashy_slug",
+            monster_given_id=self.monster_a.instance_id,
+            monster_received_id=self.monster_b.instance_id,
+            timestamp=datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+        self.manager.global_trade_log.append(record)
+        lineage = self.manager.get_trade_history()
+        self.assertEqual(len(lineage), 1)
+        self.assertIn("Better traded flamey_slug for splashy_slug", lineage[0])
+
+    def test_save_and_load_log(self):
+        original_record = TradeRecord(
+            from_player="Better",
+            to_player="Call",
+            from_player_id=self.player_a.instance_id,
+            to_player_id=self.player_b.instance_id,
+            monster_given="flamey_slug",
+            monster_received="splashy_slug",
+            monster_given_id=self.monster_a.instance_id,
+            monster_received_id=self.monster_b.instance_id,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.manager.global_trade_log.append(original_record)
+        saved = self.manager.save_log()
+
+        new_manager = TradeManager()
+        new_manager.event_bus = MagicMock()
+        new_manager.load_log(saved)
+
+        self.assertEqual(len(new_manager.global_trade_log), 1)
+        self.assertEqual(new_manager.global_trade_log[0].from_player, "Better")
+
+    def test_accept_trade_expired_offer(self):
+        self.manager.propose_trade(self.monster_a, self.monster_b)
+        offer = self.manager.pending_offers[0]
+
+        offer.expires_at = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
+        result = self.manager.accept_trade(MagicMock(), offer.offer_id)
+        self.assertEqual(result, TradeResult.EXPIRED)
+        self.assertNotIn(offer, self.manager.pending_offers)
+
+    def test_accept_trade_nonexistent_offer(self):
+        fake_id = uuid4()
+        result = self.manager.accept_trade(MagicMock(), fake_id)
+        self.assertEqual(result, TradeResult.NOT_FOUND)
+
+    def test_accept_trade_missing_monster(self):
+        self.manager.propose_trade(self.monster_a, self.monster_b)
+        offer = self.manager.pending_offers[0]
+
+        self.player_a.party.monsters = []
+        self.player_b.party.monsters = []
+
+        result = self.manager.accept_trade(MagicMock(), offer.offer_id)
+        self.assertEqual(result, TradeResult.NOT_FOUND)
+
+    def test_get_trade_history_filtered(self):
+        record = TradeRecord(
+            from_player="Better",
+            to_player="Call",
+            from_player_id=self.player_a.instance_id,
+            to_player_id=self.player_b.instance_id,
+            monster_given="flamey_slug",
+            monster_received="splashy_slug",
+            monster_given_id=self.monster_a.instance_id,
+            monster_received_id=self.monster_b.instance_id,
+            timestamp=datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+        self.manager.global_trade_log.append(record)
+        lineage = self.manager.get_trade_history(player_name="Better")
+        self.assertEqual(len(lineage), 1)
+        self.assertIn("Better traded flamey_slug", lineage[0])

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -7,11 +7,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, final
 from uuid import UUID
 
-from tuxemon.db import Acquisition, SeenStatus, db
+from tuxemon.db import db
 from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
-from tuxemon.monster import Monster
-from tuxemon.time_handler import today_ordinal
+from tuxemon.trade_manager import TradeManager, TradeResult
 
 if TYPE_CHECKING:
     from tuxemon.session import Session
@@ -45,57 +44,63 @@ class TradingAction(EventAction):
     added: str
 
     def start(self, session: Session) -> None:
+        trade_manager = TradeManager()
         player = session.player
-        _monster_id = UUID(player.game_variables.get(self.variable))
-        monster_id = get_monster_by_iid(session, _monster_id)
-        if monster_id is None:
-            logger.error("Monster not found")
+        try:
+            player_monster_id = UUID(
+                player.game_variables.get(self.variable, "")
+            )
+            player_monster = get_monster_by_iid(session, player_monster_id)
+        except (ValueError, KeyError):
+            logger.error("Invalid monster ID or variable not found.")
+            return
+
+        if player_monster is None:
+            logger.error("Player's monster not found.")
             return
 
         if self.added in db.database["monster"]:
-            new = _create_traded_monster(monster_id, self.added)
-            owner = monster_id.get_owner()
-            slot = owner.monsters.index(monster_id)
-            owner.party.remove_monster(monster_id)
-            owner.party.add_monster(new, slot)
-            owner.tuxepedia.add_entry(new.slug, SeenStatus.caught)
+            # Trade for a new monster from the database
+            result = trade_manager.execute_scripted_trade(
+                player_monster, self.added
+            )
+
+            if result == TradeResult.SUCCESS:
+                logger.info("Scripted trade completed successfully.")
+                session.client.push_state(
+                    "TradingTransition",
+                    sent_monster=player_monster.slug,
+                    received_monster=self.added,
+                )
+            elif result == TradeResult.NOT_FOUND:
+                logger.error("Player's monster not found in party.")
         else:
-            _added_id = UUID(player.game_variables.get(self.added))
-            added_id = get_monster_by_iid(session, _added_id)
-            if added_id is None:
-                logger.error("Monster not found")
+            # Trade for an existing monster from another party
+            try:
+                other_monster_id = UUID(
+                    player.game_variables.get(self.added, "")
+                )
+                other_monster = get_monster_by_iid(session, other_monster_id)
+            except (ValueError, KeyError):
+                logger.error(
+                    "Invalid monster ID or variable not found for the added monster."
+                )
                 return
-            _switch_monsters(monster_id, added_id)
 
+            if other_monster is None:
+                logger.error("Other monster not found.")
+                return
 
-def _create_traded_monster(removed: Monster, added: str) -> Monster:
-    """Create a new monster with the same level and moves as the removed monster."""
-    new = Monster.spawn_base(added, removed.level)
-    new.set_capture(today_ordinal())
-    new.set_acquisition(Acquisition.TRADED)
-    return new
+            result = trade_manager.execute_trade(player_monster, other_monster)
 
-
-def _switch_monsters(removed: Monster, added: Monster) -> None:
-    """Switch two monsters between their owners."""
-    receiver = removed.get_owner()
-    giver = added.get_owner()
-
-    slot_removed = receiver.monsters.index(removed)
-    slot_added = giver.monsters.index(added)
-
-    removed.set_acquisition(Acquisition.TRADED)
-    added.set_acquisition(Acquisition.TRADED)
-
-    logger.info(f"{removed.name} traded for {added.name}!")
-    logger.info(f"{added.name} traded for {removed.name}!")
-    logger.info(f"{receiver.name} welcomes {added.name}!")
-    logger.info(f"{giver.name} welcomes {removed.name}!")
-
-    giver.party.remove_monster(removed)
-    receiver.party.add_monster(added, slot_removed)
-    receiver.tuxepedia.add_entry(added.slug, SeenStatus.caught)
-
-    receiver.party.remove_monster(added)
-    giver.party.add_monster(removed, slot_added)
-    giver.tuxepedia.add_entry(removed.slug, SeenStatus.caught)
+            if result == TradeResult.SUCCESS:
+                logger.info("Trade completed successfully!")
+                session.client.push_state(
+                    "TradingTransition",
+                    sent_monster=player_monster.slug,
+                    received_monster=other_monster.slug,
+                )
+            elif result == TradeResult.SAME_OWNER:
+                logger.error("You can't trade with yourself.")
+            elif result == TradeResult.NOT_FOUND:
+                logger.error("One of the monsters wasn't found in the party.")

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -42,7 +42,7 @@ class JournalInfoState(PygameMenuState):
     ) -> None:
         fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
         fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
-        menu._width = fxw((248 / 256))
+        menu._width = fxw(248 / 256)
 
         # evolutions
         evo = T.translate("no_evolution")
@@ -76,7 +76,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fxw((126 / 256)), fxh((19.8 / 144)))
+        lab1.translate(fxw(126 / 256), fxh(19.8 / 144))
         # weight
         _weight = f"{mon_weight} {unit_weight}"
         lab2: Any = menu.add.label(
@@ -86,7 +86,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fxw((158 / 256)), fxh((39 / 144)))
+        lab2.translate(fxw(158 / 256), fxh(39 / 144))
         # height
         _height = f"{mon_height} {unit_height}"
         lab3: Any = menu.add.label(
@@ -96,7 +96,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fxw((126 / 256)), fxh((39 / 144)))
+        lab3.translate(fxw(126 / 256), fxh(39 / 144))
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
@@ -106,14 +106,14 @@ class JournalInfoState(PygameMenuState):
             type_image_2 = self._create_image(path2)
             type_image_2.scale(prepare.SCALE, prepare.SCALE)
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
             menu.add.image(type_image_2, float=True).translate(
-                fxw((25.4 / 256)), fxh((47.8 / 144))
+                fxw(25.4 / 256), fxh(47.8 / 144)
             )
         else:
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
 
         # Shift amount for two types
@@ -127,7 +127,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fxw((141.4 / 256) + type_shift), fxh((56 / 144)))
+        lab5.translate(fxw((141.4 / 256) + type_shift), fxh(56 / 144))
 
         _type = T.translate("monster_menu_type")
         lab4: Any = menu.add.label(
@@ -137,7 +137,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fxw((141 / 256) + type_shift), fxh((49 / 144)))
+        lab4.translate(fxw((141 / 256) + type_shift), fxh(49 / 144))
         # shape
         menu_shape = T.translate("monster_menu_shape")
         _shape = T.translate(monster.shape)
@@ -149,7 +149,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab6.translate(fxw((126 / 256)), fxh((66 / 144)))
+        lab6.translate(fxw(126 / 256), fxh(66 / 144))
         # species
         spec = T.translate(f"cat_{monster.species}")
         spec = self._safe_display(spec)
@@ -161,7 +161,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fxw((126 / 256)), fxh((29 / 144)))
+        lab7.translate(fxw(126 / 256), fxh(29 / 144))
         # txmn_id
         _txmn_id = f"ID: {monster.txmn_id}"
         lab8: Any = menu.add.label(
@@ -171,7 +171,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fxw((124.6 / 256)), fxh((10 / 144)))
+        lab8.translate(fxw(124.6 / 256), fxh(10 / 144))
 
         # description
         desc = T.translate(f"{monster.slug}_description")
@@ -186,7 +186,7 @@ class JournalInfoState(PygameMenuState):
             float=True,
         )
 
-        lab9.translate(fxw((2 / 256)), fxh((82 / 144)))
+        lab9.translate(fxw(2 / 256), fxh(82 / 144))
 
         # evolution
         evo = self._safe_display(evo)
@@ -198,17 +198,17 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab10.translate(fxw((2 / 256)), fxh((109 / 144)))
+        lab10.translate(fxw(2 / 256), fxh(109 / 144))
 
         # evolution monsters
         if self.is_visible:
             f = menu.add.frame_h(
                 float=True,
-                width=fxw((243 / 256)),
-                height=fxw((7 / 144)),
+                width=fxw(243 / 256),
+                height=fxw(7 / 144),
                 frame_id="histories",
             )
-            f.translate(fxw((5 / 256)), fxh((115 / 144)))
+            f.translate(fxw(5 / 256), fxh(115 / 144))
             f._relax = True
             slugs = [ele.monster_slug for ele in monster.evolutions]
             elements = list(dict.fromkeys(slugs))
@@ -229,7 +229,7 @@ class JournalInfoState(PygameMenuState):
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(fxw((53.6 / 256)), fxh((10 / 144)))
+        image_widget.translate(fxw(53.6 / 256), fxh(10 / 144))
 
     def __init__(
         self,

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+import pygame
+from pygame.surface import Surface
+
+from tuxemon import prepare, tools
+from tuxemon.graphics import load_sprite
+from tuxemon.locale import T
+from tuxemon.platform.const import buttons
+from tuxemon.state.state import State
+
+if TYPE_CHECKING:
+    from tuxemon.platform.events import PlayerInput
+    from tuxemon.sprite import Sprite
+
+logger = logging.getLogger(__name__)
+
+TOTAL_SECONDS: int = 8
+INTERVAL_MULTIPLIER: int = 2
+ITERATION_TIME: float = 0.25
+
+PHASE_1_END = 12.5
+PHASE_2_END = 37.5
+PHASE_3_END = 75.0
+
+
+class TradingTransition(State):
+    """The state responsible for the trading transition."""
+
+    name: ClassVar[str] = "TradingTransition"
+    force_draw = True
+
+    def __init__(self, sent_monster: str, received_monster: str) -> None:
+        super().__init__()
+
+        self.sent_monster = sent_monster
+        self.received_monster = received_monster
+
+        if not self.sent_monster or not self.received_monster:
+            logger.error("A monster object was not provided.")
+            return
+
+        self.sent_sprite = self._load_sprite(self.sent_monster)
+        self.received_sprite = self._load_sprite(self.received_monster)
+
+        self.transition_start_time = pygame.time.get_ticks()
+        self.dialog_opened = False
+        self.elapsed_time = 0.0
+        self.percentage = 0.0
+        self.total_seconds = TOTAL_SECONDS
+
+        self.sent_sprite_copy = self.sent_sprite.image.copy()
+        self.received_sprite_copy = self.received_sprite.image.copy()
+        self.sent_sprite_white = self._white_image(
+            self.sent_sprite.image.copy()
+        )
+        self.received_sprite_white = self._white_image(
+            self.received_sprite.image.copy()
+        )
+
+        self.phase_sprites = {
+            1: self.sent_sprite,
+            2: self.sent_sprite,
+            3: self._get_phase_3_sprite(),
+            4: self.received_sprite,
+        }
+
+        screen_width, screen_height = prepare.SCREEN_SIZE
+        sprite_width, sprite_height = self.sent_sprite.image.get_size()
+        self.sent_x = (screen_width // 4) - (sprite_width // 2)
+        self.received_x = (3 * screen_width // 4) - (sprite_width // 2)
+        self.sprite_y = (screen_height - sprite_height) // 2
+
+    def update(self, time_delta: float) -> None:
+        current_time = pygame.time.get_ticks()
+        self.elapsed_time = (current_time - self.transition_start_time) / 1000
+        self.percentage = (self.elapsed_time / self.total_seconds) * 100
+
+        self.phase = 0
+        if self.percentage < PHASE_1_END:
+            self.phase = 1
+        elif self.percentage < PHASE_2_END:
+            self.phase = 2
+        elif self.percentage < PHASE_3_END:
+            self.phase = 3
+        else:
+            self.phase = 4
+
+        phase_actions = {
+            1: self._phase1,
+            2: self._phase2,
+            3: self._phase3,
+            4: self._phase4,
+        }
+
+        phase_actions[self.phase]()
+
+    def _phase1(self) -> None:
+        self.client.current_music.pause()
+        self.sent_sprite.image = self.sent_sprite_copy
+
+    def _phase2(self) -> None:
+        fade_amount = (self.elapsed_time - 1) / 2
+        self.sent_sprite.image.blit(self.sent_sprite_copy, (0, 0))
+        self.sent_sprite_white.set_alpha(int(255 * fade_amount))
+        self.sent_sprite.image.blit(self.sent_sprite_white, (0, 0))
+
+    def _phase3(self) -> None:
+        iteration = int(
+            (self.elapsed_time - 3) / (ITERATION_TIME / INTERVAL_MULTIPLIER)
+        )
+        if iteration % (2 * INTERVAL_MULTIPLIER) < INTERVAL_MULTIPLIER:
+            self.sent_sprite.image = self.sent_sprite_white.copy()
+            self.sent_sprite.image.set_alpha(255)
+            self.received_sprite.image = self.received_sprite_white.copy()
+            self.received_sprite.image.set_alpha(0)
+        else:
+            self.sent_sprite.image = self.sent_sprite_white.copy()
+            self.sent_sprite.image.set_alpha(0)
+            self.received_sprite.image = self.received_sprite_white.copy()
+            self.received_sprite.image.set_alpha(255)
+
+    def _phase4(self) -> None:
+        fade_amount = (self.elapsed_time - 6) / (self.total_seconds - 6)
+        self.received_sprite_white.set_alpha(int(255 * (1 - fade_amount)))
+
+        self.received_sprite.image.blit(self.received_sprite_copy, (0, 0))
+        self.received_sprite.image.blit(self.received_sprite_white, (0, 0))
+
+        if self.elapsed_time > self.total_seconds and not self.dialog_opened:
+            self.client.sound_manager.play_sound("sound_confirm")
+            self.on_animation_complete()
+
+    def draw(self, surface: Surface) -> None:
+        surface.fill(prepare.BLACK_COLOR)
+
+        # In phases 1 and 2, only the sent monster is displayed, centered
+        if self.phase in (1, 2):
+            sprite_image = self.sent_sprite.image
+            center_x = (prepare.SCREEN_SIZE[0] - sprite_image.get_width()) // 2
+            surface.blit(sprite_image, (center_x, self.sprite_y))
+        # In phases 3 and 4, both sprites are displayed at their respective positions
+        elif self.phase in (3, 4):
+            surface.blit(self.sent_sprite.image, (self.sent_x, self.sprite_y))
+            surface.blit(
+                self.received_sprite.image, (self.received_x, self.sprite_y)
+            )
+
+    def _load_sprite(self, slug: str) -> Sprite:
+        path = tools.transform_resource_filename(
+            f"gfx/sprites/battle/{slug}-front.png"
+        )
+        return load_sprite(path)
+
+    def _white_image(self, sprite: Surface) -> Surface:
+        for x in range(sprite.get_width()):
+            for y in range(sprite.get_height()):
+                if sprite.get_at((x, y)).a != 0:
+                    sprite.set_at((x, y), prepare.WHITE_COLOR)
+        return sprite
+
+    def on_animation_complete(self) -> None:
+        if self.sent_sprite.image:
+            self.sent_sprite.image.set_alpha(255)
+        self.sent_sprite.image = None
+
+        self.received_sprite.image = self.received_sprite_copy
+        self.received_sprite.image.set_alpha(255)
+
+        param = {
+            "sent": T.format(self.sent_monster),
+            "received": T.format(self.received_monster),
+        }
+        msg = T.format("trade_completed", param)
+        tools.open_dialog(self.client, [msg])
+        self.dialog_opened = True
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        if (
+            event.button in (buttons.BACK, buttons.B, buttons.A)
+            and event.pressed
+        ):
+            if self.percentage < 100:
+                self.transition_start_time = pygame.time.get_ticks() - (
+                    self.total_seconds * 1000
+                )
+            else:
+                self.client.current_music.unpause()
+                self.client.pop_state()
+        return None
+
+    def _get_phase_3_sprite(self) -> Sprite:
+        iteration = int(
+            (self.elapsed_time - 3) / (ITERATION_TIME / INTERVAL_MULTIPLIER)
+        )
+        return (
+            self.sent_sprite
+            if iteration % (2 * INTERVAL_MULTIPLIER) < INTERVAL_MULTIPLIER
+            else self.received_sprite
+        )

--- a/tuxemon/trade_manager.py
+++ b/tuxemon/trade_manager.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional
+from uuid import UUID, uuid4
+
+from tuxemon.db import Acquisition, SeenStatus
+from tuxemon.event import get_event_bus, get_monster_by_iid
+from tuxemon.monster import Monster
+from tuxemon.time_handler import today_ordinal
+
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+    from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+class TradeResult(Enum):
+    SUCCESS = "success"
+    SAME_OWNER = "same_owner"
+    NOT_FOUND = "not_found"
+    EXPIRED = "expired"
+
+
+@dataclass
+class TradeOffer:
+    proposing_player_id: UUID
+    proposing_monster_id: UUID
+    receiving_player_id: UUID
+    requested_monster_id: UUID
+    offer_id: UUID = field(default_factory=uuid4)
+    timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    expires_at: Optional[datetime] = None
+
+
+@dataclass
+class TradeRecord:
+    from_player: str
+    to_player: str
+    from_player_id: UUID
+    to_player_id: UUID
+    monster_given: str
+    monster_received: str
+    monster_given_id: UUID
+    monster_received_id: UUID
+    timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "from_player": self.from_player,
+            "to_player": self.to_player,
+            "from_player_id": str(self.from_player_id),
+            "to_player_id": str(self.to_player_id),
+            "monster_given": self.monster_given,
+            "monster_received": self.monster_received,
+            "monster_given_id": str(self.monster_given_id),
+            "monster_received_id": str(self.monster_received_id),
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> TradeRecord:
+        return cls(
+            from_player=data["from_player"],
+            to_player=data["to_player"],
+            from_player_id=UUID(data["from_player_id"]),
+            to_player_id=UUID(data["to_player_id"]),
+            monster_given=data["monster_given"],
+            monster_received=data["monster_received"],
+            monster_given_id=UUID(data["monster_given_id"]),
+            monster_received_id=UUID(data["monster_received_id"]),
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+        )
+
+
+class TradeManager:
+    def __init__(self) -> None:
+        self.global_trade_log: list[TradeRecord] = []
+        self.pending_offers: list[TradeOffer] = []
+        self.event_bus = get_event_bus()
+
+    def execute_trade(
+        self, monster_a: Monster, monster_b: Monster
+    ) -> TradeResult:
+        player_a = monster_a.get_owner()
+        player_b = monster_b.get_owner()
+
+        if player_a == player_b:
+            logger.warning(
+                "Attempted to trade two monsters from the same owner."
+            )
+            return TradeResult.SAME_OWNER
+
+        try:
+            slot_a = player_a.party.monsters.index(monster_a)
+            slot_b = player_b.party.monsters.index(monster_b)
+        except ValueError:
+            logger.error(
+                "One of the monsters was not found in its owner's party during trade."
+            )
+            return TradeResult.NOT_FOUND
+
+        player_a.party.remove_monster(monster_a)
+        player_b.party.remove_monster(monster_b)
+
+        player_a.party.add_monster(monster_b, slot_a)
+        player_b.party.add_monster(monster_a, slot_b)
+
+        monster_a.set_owner(player_b)
+        monster_b.set_owner(player_a)
+
+        monster_a.set_acquisition(Acquisition.TRADED)
+        monster_b.set_acquisition(Acquisition.TRADED)
+
+        player_a.tuxepedia.add_entry(monster_b.slug, SeenStatus.caught)
+        player_b.tuxepedia.add_entry(monster_a.slug, SeenStatus.caught)
+
+        record_a = self._create_trade_record(
+            from_player=player_a,
+            to_player=player_b,
+            given_monster=monster_a,
+            received_monster=monster_b,
+        )
+        record_b = self._create_trade_record(
+            from_player=player_b,
+            to_player=player_a,
+            given_monster=monster_b,
+            received_monster=monster_a,
+        )
+
+        self.event_bus.publish("trade_completed", [record_a, record_b])
+
+        self.global_trade_log.extend([record_a, record_b])
+
+        logger.info(f"{player_a.name} welcomes {monster_b.name}!")
+        logger.info(f"{player_b.name} welcomes {monster_a.name}!")
+
+        return TradeResult.SUCCESS
+
+    def _create_trade_record(
+        self,
+        from_player: NPC,
+        to_player: NPC,
+        given_monster: Monster,
+        received_monster: Monster,
+    ) -> TradeRecord:
+        return TradeRecord(
+            from_player=from_player.name,
+            to_player=to_player.name,
+            from_player_id=from_player.instance_id,
+            to_player_id=to_player.instance_id,
+            monster_given=given_monster.slug,
+            monster_received=received_monster.slug,
+            monster_given_id=given_monster.instance_id,
+            monster_received_id=received_monster.instance_id,
+        )
+
+    def execute_scripted_trade(
+        self, player_monster: Monster, added_slug: str
+    ) -> TradeResult:
+        player = player_monster.get_owner()
+
+        new_monster = Monster.spawn_base(added_slug, player_monster.level)
+        new_monster.set_capture(today_ordinal())
+        new_monster.set_acquisition(Acquisition.TRADED)
+
+        try:
+            slot = player.party.monsters.index(player_monster)
+        except ValueError:
+            logger.error("Player's monster not found in party.")
+            return TradeResult.NOT_FOUND
+
+        player.party.remove_monster(player_monster)
+        player.party.add_monster(new_monster, slot)
+
+        player.tuxepedia.add_entry(new_monster.slug, SeenStatus.caught)
+
+        record = TradeRecord(
+            from_player=player.name,
+            to_player="NPC",
+            from_player_id=player.instance_id,
+            to_player_id=UUID(int=0),
+            monster_given=player_monster.slug,
+            monster_received=added_slug,
+            monster_given_id=player_monster.instance_id,
+            monster_received_id=new_monster.instance_id,
+        )
+
+        self.global_trade_log.append(record)
+        self.event_bus.publish("trade_completed", [record])
+
+        logger.info(
+            f"{player.name} traded {player_monster.name} for {new_monster.name} (scripted trade)."
+        )
+        return TradeResult.SUCCESS
+
+    def propose_trade(
+        self, proposing_monster: Monster, requested_monster: Monster
+    ) -> TradeResult:
+        """Creates a trade offer for a monster and adds it to the list of pending offers."""
+        proposing_player = proposing_monster.get_owner()
+        receiving_player = requested_monster.get_owner()
+
+        if proposing_player == receiving_player:
+            logger.warning(
+                f"Attempted to propose a trade with a monster from the same owner: {proposing_player.name}."
+            )
+            return TradeResult.SAME_OWNER
+
+        try:
+            proposing_player.party.monsters.index(proposing_monster)
+            receiving_player.party.monsters.index(requested_monster)
+        except ValueError:
+            logger.error(
+                "One of the monsters was not found in its owner's party during trade proposal."
+            )
+            return TradeResult.NOT_FOUND
+
+        new_offer = TradeOffer(
+            proposing_player_id=proposing_player.instance_id,
+            proposing_monster_id=proposing_monster.instance_id,
+            receiving_player_id=receiving_player.instance_id,
+            requested_monster_id=requested_monster.instance_id,
+        )
+
+        self.pending_offers.append(new_offer)
+        logger.info(
+            f"Trade offer from {proposing_player.name} to {receiving_player.name} proposed."
+        )
+        self.event_bus.publish("trade_offer_proposed", new_offer)
+        return TradeResult.SUCCESS
+
+    def accept_trade(self, session: Session, offer_id: UUID) -> TradeResult:
+        """Accepts a pending trade offer, executing the trade if valid."""
+        offer: Optional[TradeOffer] = None
+        try:
+            offer = next(
+                o for o in self.pending_offers if o.offer_id == offer_id
+            )
+        except StopIteration:
+            logger.error(f"Trade offer with ID {offer_id} not found.")
+            return TradeResult.NOT_FOUND
+
+        if offer.expires_at and datetime.now(timezone.utc) > offer.expires_at:
+            logger.warning(f"Trade offer {offer_id} has expired.")
+            self.pending_offers.remove(offer)
+            return TradeResult.EXPIRED
+
+        proposing_monster = get_monster_by_iid(
+            session, offer.proposing_monster_id
+        )
+        requested_monster = get_monster_by_iid(
+            session, offer.requested_monster_id
+        )
+
+        if not proposing_monster or not requested_monster:
+            logger.error(
+                "One or both monsters in the trade offer no longer exist."
+            )
+            self.pending_offers.remove(offer)
+            return TradeResult.NOT_FOUND
+
+        if (
+            proposing_monster.get_owner().instance_id
+            != offer.proposing_player_id
+            or requested_monster.get_owner().instance_id
+            != offer.receiving_player_id
+        ):
+            logger.error("Trade offer invalid: monster ownership has changed.")
+            self.pending_offers.remove(offer)
+            return TradeResult.NOT_FOUND
+
+        result = self.execute_trade(proposing_monster, requested_monster)
+
+        if result == TradeResult.SUCCESS:
+            self.pending_offers.remove(offer)
+            logger.info(f"Trade offer {offer_id} accepted and completed.")
+        else:
+            logger.error(
+                f"Trade offer {offer_id} failed to complete with result: {result.value}."
+            )
+
+        return result
+
+    def was_traded_with_player(self, player_name: str) -> bool:
+        return any(
+            record.from_player == player_name
+            or record.to_player == player_name
+            for record in self.global_trade_log
+        )
+
+    def was_traded_for_monster(self, monster_slug: str) -> bool:
+        return any(
+            record.monster_given == monster_slug
+            or record.monster_received == monster_slug
+            for record in self.global_trade_log
+        )
+
+    def get_trade_history(
+        self, player_name: Optional[str] = None
+    ) -> list[str]:
+        records = self.global_trade_log
+        if player_name:
+            records = [
+                r
+                for r in records
+                if r.from_player == player_name or r.to_player == player_name
+            ]
+        return [
+            f"{r.timestamp.strftime('%Y-%m-%d %H:%M')} — {r.from_player} traded {r.monster_given} for {r.monster_received} with {r.to_player}"
+            for r in records
+        ]
+
+    def save_log(self) -> Mapping[str, Any]:
+        return {
+            "trade_history": [
+                record.to_dict() for record in self.global_trade_log
+            ]
+        }
+
+    def load_log(self, data: Mapping[str, Any]) -> None:
+        trade_data = data.get("trade_history", [])
+        self.global_trade_log = [TradeRecord.from_dict(r) for r in trade_data]
+
+
+def on_trade_completed(records: list[TradeRecord]) -> None:
+    for record in records:
+        logger.info(
+            f"{record.from_player} traded {record.monster_given} for {record.monster_received} with {record.to_player}"
+        )
+
+
+# trade_manager = TradeManager()
+# trade_manager.event_bus.subscribe("trade_completed", on_trade_completed)


### PR DESCRIPTION
PR introduces a new `TradeManager` class to centralize and streamline the handling of monster trades between players. This replaces the previous approach and lays the foundation for more scalable and maintainable trade logic.

Key changes:
- added the `TradeManager` class, which manages trade execution and maintains a global trade registry
- refactored the `TradingAction` event to delegate trade logic to `TradeManager`, improving separation of concerns
- introduced a `TradeRecord` dataclass to capture detailed trade information, including player names, monster slugs and timestamps
- implemented basic trade validation to prevent trades between monsters owned by the same player
- added support for querying trade history, including methods to check if a player or monster was involved in a trade and to retrieve a readable trade lineage

Note: The global trade registry is not yet persisted. Save/load support will be added in a future update.

https://github.com/user-attachments/assets/9f25b90b-d1ed-4056-91fa-b514afa4d434
