### PR TITLE
Centralized Tuxepedia Updates & Party Swap Support

### DIFF
--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -468,6 +468,10 @@ class CombatSession:
                     "monster_needed", player=player, ask=ask
                 )
 
+            on_the_field = self.field_monsters.get_monsters(player)
+            for monster in on_the_field:
+                self.update_tuxepedia(player, monster)
+
     def add_monster_into_play(
         self,
         session: Session,

--- a/tuxemon/entity_dir/party.py
+++ b/tuxemon/entity_dir/party.py
@@ -258,6 +258,32 @@ class PartyHandler:
         dominant_type, _ = type_counter.most_common(1)[0]
         return dominant_type
 
+    def replace_party(
+        self, new_monsters: list[Monster], add_overflow_to_box: bool = True
+    ) -> None:
+        """
+        Replaces the entire party with a new list of monsters.
+
+        Parameters:
+            new_monsters: The new monsters to set as the party.
+            add_overflow_to_box:
+                If True, overflow monsters are added to the box.
+                If False, overflow monsters are discarded.
+        """
+        self.clear_party()
+
+        for monster in new_monsters[: self._party_limit]:
+            monster.set_owner(self._owner)
+            self._monsters.append(monster)
+
+        if add_overflow_to_box:
+            overflow = new_monsters[self._party_limit :]
+            for monster in overflow:
+                monster.set_owner(self._owner)
+                self._monster_boxes.add_monster(prepare.KENNEL, monster)
+                if self._monster_boxes.is_box_full(prepare.KENNEL):
+                    self._monster_boxes.create_and_merge_box(prepare.KENNEL)
+
     def encode_party(self) -> Sequence[Mapping[str, Any]]:
         return encode_monsters(self._monsters)
 

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -103,8 +103,6 @@ class RandomEncounterAction(EventAction):
         env = player.game_variables.get("environment", "grass")
         environment = EnvironmentModel.lookup(env, db)
 
-        player.tuxepedia.add_entry(current_monster.slug)
-
         context = CombatContext(
             session=session,
             teams=[player, npc],

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -95,8 +95,6 @@ class WildEncounterAction(EventAction):
         env = env_var if self.env is None else self.env
         environment = EnvironmentModel.lookup(env, db)
 
-        player.tuxepedia.add_entry(current_monster.slug)
-
         context = CombatContext(
             session=session,
             teams=[player, npc],

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -1005,7 +1005,6 @@ class CombatState(CombatAnimations):
                 session.add_monster_into_play(
                     self.session, player, replacement
                 )
-                session.update_tuxepedia(player, replacement)
 
     def _on_update_sprite_position(
         self, player: NPC, monster: Monster

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -42,7 +42,7 @@ class JournalInfoState(PygameMenuState):
     ) -> None:
         fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
         fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
-        menu._width = fxw((248 / 256))
+        menu._width = fxw(248 / 256)
 
         # evolutions
         evo = T.translate("no_evolution")
@@ -76,7 +76,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fxw((126 / 256)), fxh((19.8 / 144)))
+        lab1.translate(fxw(126 / 256), fxh(19.8 / 144))
         # weight
         _weight = f"{mon_weight} {unit_weight}"
         lab2: Any = menu.add.label(
@@ -86,7 +86,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fxw((158 / 256)), fxh((39 / 144)))
+        lab2.translate(fxw(158 / 256), fxh(39 / 144))
         # height
         _height = f"{mon_height} {unit_height}"
         lab3: Any = menu.add.label(
@@ -96,7 +96,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fxw((126 / 256)), fxh((39 / 144)))
+        lab3.translate(fxw(126 / 256), fxh(39 / 144))
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
@@ -106,14 +106,14 @@ class JournalInfoState(PygameMenuState):
             type_image_2 = self._create_image(path2)
             type_image_2.scale(prepare.SCALE, prepare.SCALE)
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
             menu.add.image(type_image_2, float=True).translate(
-                fxw((25.4 / 256)), fxh((47.8 / 144))
+                fxw(25.4 / 256), fxh(47.8 / 144)
             )
         else:
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
 
         # Shift amount for two types
@@ -127,7 +127,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fxw((141.4 / 256) + type_shift), fxh((56 / 144)))
+        lab5.translate(fxw((141.4 / 256) + type_shift), fxh(56 / 144))
 
         _type = T.translate("monster_menu_type")
         lab4: Any = menu.add.label(
@@ -137,7 +137,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fxw((141 / 256) + type_shift), fxh((49 / 144)))
+        lab4.translate(fxw((141 / 256) + type_shift), fxh(49 / 144))
         # shape
         menu_shape = T.translate("monster_menu_shape")
         _shape = T.translate(monster.shape)
@@ -149,7 +149,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab6.translate(fxw((126 / 256)), fxh((66 / 144)))
+        lab6.translate(fxw(126 / 256), fxh(66 / 144))
         # species
         spec = T.translate(f"cat_{monster.species}")
         spec = self._safe_display(spec)
@@ -161,7 +161,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fxw((126 / 256)), fxh((29 / 144)))
+        lab7.translate(fxw(126 / 256), fxh(29 / 144))
         # txmn_id
         _txmn_id = f"ID: {monster.txmn_id}"
         lab8: Any = menu.add.label(
@@ -171,7 +171,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fxw((124.6 / 256)), fxh((10 / 144)))
+        lab8.translate(fxw(124.6 / 256), fxh(10 / 144))
 
         # description
         desc = T.translate(f"{monster.slug}_description")
@@ -186,7 +186,7 @@ class JournalInfoState(PygameMenuState):
             float=True,
         )
 
-        lab9.translate(fxw((2 / 256)), fxh((82 / 144)))
+        lab9.translate(fxw(2 / 256), fxh(82 / 144))
 
         # evolution
         evo = self._safe_display(evo)
@@ -198,17 +198,17 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab10.translate(fxw((2 / 256)), fxh((109 / 144)))
+        lab10.translate(fxw(2 / 256), fxh(109 / 144))
 
         # evolution monsters
         if self.is_visible:
             f = menu.add.frame_h(
                 float=True,
-                width=fxw((243 / 256)),
-                height=fxw((7 / 144)),
+                width=fxw(243 / 256),
+                height=fxw(7 / 144),
                 frame_id="histories",
             )
-            f.translate(fxw((5 / 256)), fxh((115 / 144)))
+            f.translate(fxw(5 / 256), fxh(115 / 144))
             f._relax = True
             slugs = [ele.monster_slug for ele in monster.evolutions]
             elements = list(dict.fromkeys(slugs))
@@ -229,7 +229,7 @@ class JournalInfoState(PygameMenuState):
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(fxw((53.6 / 256)), fxh((10 / 144)))
+        image_widget.translate(fxw(53.6 / 256), fxh(10 / 144))
 
     def __init__(
         self,


### PR DESCRIPTION
PR tidies up the way Tuxepedia entries are handled during combat. Instead of having `add_entry` scattered across places like `random_encounter` and `wild_encounter`, everything now flows through `CombatSession`so updates are centralized and easier to manage.

Also added a handy new method to `PartyHandler` (for NPCs) that lets you swap out the entire party in one go by passing a full list of monsters. No more fiddling with individual slots, just plug in the new crew and you're good to go.