### PR TITLE
`EventState` Enum for Improved Event Lifecycle Management

### DIFF
--- a/tests/tuxemon/test_running_event.py
+++ b/tests/tuxemon/test_running_event.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import Mock
 
-from tuxemon.event.eventengine import RunningEvent
+from tuxemon.event.eventengine import EventState, RunningEvent
 
 
 class TestRunningEvent(unittest.TestCase):
@@ -15,7 +15,7 @@ class TestRunningEvent(unittest.TestCase):
         self.assertEqual(0, event.action_index)
         self.assertIsNone(event.current_action)
         self.assertIsNone(event.current_map_action)
-        self.assertFalse(event.cancelled)
+        self.assertEqual(EventState.WAITING, event.state)
 
     def test_get_next_action(self):
         map_event = Mock(acts=[1, 2])
@@ -38,10 +38,54 @@ class TestRunningEvent(unittest.TestCase):
         map_event = Mock(acts=[1, 2])
         event = RunningEvent(map_event)
         event.cancel()
-        self.assertTrue(event.cancelled)
+        self.assertEqual(EventState.CANCELLED, event.state)
+        self.assertTrue(event.is_cancelled())
 
     def test_context(self):
         map_event = Mock(acts=[1, 2])
         event = RunningEvent(map_event)
         event.context["a"] = 1
         self.assertEqual({"a": 1}, event.context)
+
+    def test_state_transitions(self):
+        map_event = Mock(acts=[1])
+        event = RunningEvent(map_event)
+        self.assertEqual(event.state, EventState.WAITING)
+
+        event.running()
+        self.assertEqual(event.state, EventState.RUNNING)
+        self.assertTrue(event.is_running())
+
+        event.cancel()
+        self.assertEqual(event.state, EventState.CANCELLED)
+        self.assertTrue(event.is_cancelled())
+
+    def test_get_next_action_exhausted(self):
+        map_event = Mock(acts=[1])
+        event = RunningEvent(map_event)
+        event.advance()
+        self.assertIsNone(event.get_next_action())
+
+    def test_cancel_all_events(self):
+        map_event = Mock(acts=[1])
+        event1 = RunningEvent(map_event)
+        event2 = RunningEvent(map_event)
+        event1.running()
+        event2.running()
+
+        manager = Mock()
+        manager.running_events = {1: event1, 2: event2}
+        manager.cancel_all_events = lambda: [
+            e.cancel() for e in manager.running_events.values()
+        ]
+
+        manager.cancel_all_events()
+        self.assertEqual(event1.state, EventState.CANCELLED)
+        self.assertEqual(event2.state, EventState.CANCELLED)
+
+    def test_context_persistence(self):
+        map_event = Mock(acts=[1])
+        event = RunningEvent(map_event)
+        event.context["score"] = 42
+        event.context["score"] += 8
+        self.assertEqual(event.context["score"], 50)

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
+from enum import Enum, auto
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -19,6 +20,13 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+class EventState(Enum):
+    WAITING = auto()
+    RUNNING = auto()
+    COMPLETED = auto()
+    CANCELLED = auto()
 
 
 class RunningEvent:
@@ -48,7 +56,7 @@ class RunningEvent:
         "action_index",
         "current_action",
         "current_map_action",
-        "cancelled",
+        "state",
     )
 
     def __init__(self, map_event: EventObject) -> None:
@@ -57,7 +65,7 @@ class RunningEvent:
         self.action_index = 0
         self.current_action: Optional[EventAction] = None
         self.current_map_action = None
-        self.cancelled = False
+        self.state = EventState.WAITING
 
     def get_next_action(self) -> Optional[MapAction]:
         """
@@ -85,8 +93,19 @@ class RunningEvent:
         self.action_index += 1
 
     def cancel(self) -> None:
-        """Cancels the event."""
-        self.cancelled = True
+        self.state = EventState.CANCELLED
+
+    def complete(self) -> None:
+        self.state = EventState.COMPLETED
+
+    def running(self) -> None:
+        self.state = EventState.RUNNING
+
+    def is_cancelled(self) -> bool:
+        return self.state == EventState.CANCELLED
+
+    def is_running(self) -> bool:
+        return self.state == EventState.RUNNING
 
 
 class EventEngine:
@@ -220,6 +239,7 @@ class EventEngine:
             logger.debug(map_event)
 
             token = RunningEvent(map_event)
+            token.running()
             self.running_events[map_event.id] = token
 
             if map_event in self.session.client.map_manager.inits:
@@ -304,11 +324,15 @@ class EventEngine:
         Parameters:
             dt: Amount of time passed in seconds since last frame.
         """
-        to_remove = set()
         current_map = self.current_map
 
-        # Loop through the list of actions and update them
-        for event_id, running_event in self.running_events.items():
+        running_events_to_process = [
+            (event_id, event)
+            for event_id, event in self.running_events.items()
+            if event.is_running()
+        ]
+
+        for event_id, running_event in running_events_to_process:
             # If the current map has changed, then `reset` has also been
             # called, which replaced self.running_events with an empty dict.
             # We need to stop processing the running_events, as they may not
@@ -320,16 +344,17 @@ class EventEngine:
                 assert not self.running_events
                 return
 
-            # Check for cancellation
-            if running_event.cancelled:
-                to_remove.add(event_id)
-                continue
-
             if not self.process_running_event(running_event):
-                # Event is complete or failed; mark it for removal
-                to_remove.add(event_id)
+                # Event is complete or failed; mark it as completed
+                running_event.complete()
 
-        # Clean up completed or cancelled events
+        # Clean up completed or cancelled events outside the loop
+        to_remove = [
+            event_id
+            for event_id, event in self.running_events.items()
+            if event.state in (EventState.COMPLETED, EventState.CANCELLED)
+        ]
+
         for event_id in to_remove:
             self.running_events.pop(event_id, None)
 
@@ -363,6 +388,11 @@ class EventEngine:
             check another RunningEvent, but the position in the action list
             is remembered and will be restored.
             """
+            # Check if the event was cancelled during processing
+            if running_event.is_cancelled():
+                logger.debug("Running event was cancelled.")
+                return False
+
             current_action = running_event.current_action
 
             # Handle initialization of the next action if none is active
@@ -407,6 +437,7 @@ class EventEngine:
 
         if next_action_data is None:
             # No more actions; event is complete
+            running_event.complete()
             return False
 
         action = self.action_manager.get_action(
@@ -442,50 +473,38 @@ def add_error_context(
     """
     try:
         yield
-    except Exception:
+    except Exception as original_exc:
         from lxml import etree
 
         file_name = session.client.map_manager.get_map_filepath()
-        tree = etree.parse(file_name)
-        event_node = tree.find("//object[@id='%s']" % event.id)
-        msg = None
-        if event_node:
-            if item.name is None:
-                # It's an "interact" event, so no condition defined in the map
-                msg = """
-                    Error in {file_name}
-                    {event}
-                    Line {line_number}
-                """.format(
-                    file_name=file_name,
-                    event=etree.tostring(event_node)
-                    .decode()
-                    .split("\n")[0]
-                    .strip(),
-                    line_number=event_node.sourceline,
-                )
-            else:
-                # This is either a condition or an action
-                child_node = event_node.find(
-                    ".//property[@name='%s']" % (item.name)
-                )
-                if child_node:
-                    msg = """
-                        Error in {file_name}
-                        {event}
-                            ...
-                            {line}
-                        Line {line_number}
-                    """.format(
-                        file_name=file_name,
-                        event=etree.tostring(event_node)
-                        .decode()
-                        .split("\n")[0]
-                        .strip(),
-                        line=etree.tostring(child_node).decode().strip(),
-                        line_number=child_node.sourceline,
-                    )
-        if msg:
-            print(dedent(msg))
+        try:
+            tree = etree.parse(file_name)
+            event_node = tree.find(f"//object[@id='{event.id}']")
+        except Exception as parse_exc:
+            logger.error(
+                f"Failed to parse map file '{file_name}': {parse_exc}"
+            )
+            raise original_exc
 
-        raise
+        msg_lines = [f"\nError in map file: {file_name}"]
+
+        if event_node is not None:
+            event_summary = (
+                etree.tostring(event_node).decode().split("\n")[0].strip()
+            )
+            msg_lines.append(f"Event: {event_summary}")
+            msg_lines.append(f"Line: {event_node.sourceline}")
+
+            if item.name:
+                child_node = event_node.find(
+                    f".//property[@name='{item.name}']"
+                )
+                if child_node is not None:
+                    child_summary = etree.tostring(child_node).decode().strip()
+                    msg_lines.append(f"Property: {child_summary}")
+                    msg_lines.append(f"Line: {child_node.sourceline}")
+        else:
+            msg_lines.append(f"Event with ID '{event.id}' not found in XML.")
+
+        print(dedent("\n".join(msg_lines)))
+        raise original_exc

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -42,7 +42,7 @@ class JournalInfoState(PygameMenuState):
     ) -> None:
         fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
         fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
-        menu._width = fxw((248 / 256))
+        menu._width = fxw(248 / 256)
 
         # evolutions
         evo = T.translate("no_evolution")
@@ -76,7 +76,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fxw((126 / 256)), fxh((19.8 / 144)))
+        lab1.translate(fxw(126 / 256), fxh(19.8 / 144))
         # weight
         _weight = f"{mon_weight} {unit_weight}"
         lab2: Any = menu.add.label(
@@ -86,7 +86,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fxw((158 / 256)), fxh((39 / 144)))
+        lab2.translate(fxw(158 / 256), fxh(39 / 144))
         # height
         _height = f"{mon_height} {unit_height}"
         lab3: Any = menu.add.label(
@@ -96,7 +96,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fxw((126 / 256)), fxh((39 / 144)))
+        lab3.translate(fxw(126 / 256), fxh(39 / 144))
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
@@ -106,14 +106,14 @@ class JournalInfoState(PygameMenuState):
             type_image_2 = self._create_image(path2)
             type_image_2.scale(prepare.SCALE, prepare.SCALE)
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
             menu.add.image(type_image_2, float=True).translate(
-                fxw((25.4 / 256)), fxh((47.8 / 144))
+                fxw(25.4 / 256), fxh(47.8 / 144)
             )
         else:
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
 
         # Shift amount for two types
@@ -127,7 +127,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fxw((141.4 / 256) + type_shift), fxh((56 / 144)))
+        lab5.translate(fxw((141.4 / 256) + type_shift), fxh(56 / 144))
 
         _type = T.translate("monster_menu_type")
         lab4: Any = menu.add.label(
@@ -137,7 +137,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fxw((141 / 256) + type_shift), fxh((49 / 144)))
+        lab4.translate(fxw((141 / 256) + type_shift), fxh(49 / 144))
         # shape
         menu_shape = T.translate("monster_menu_shape")
         _shape = T.translate(monster.shape)
@@ -149,7 +149,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab6.translate(fxw((126 / 256)), fxh((66 / 144)))
+        lab6.translate(fxw(126 / 256), fxh(66 / 144))
         # species
         spec = T.translate(f"cat_{monster.species}")
         spec = self._safe_display(spec)
@@ -161,7 +161,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fxw((126 / 256)), fxh((29 / 144)))
+        lab7.translate(fxw(126 / 256), fxh(29 / 144))
         # txmn_id
         _txmn_id = f"ID: {monster.txmn_id}"
         lab8: Any = menu.add.label(
@@ -171,7 +171,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fxw((124.6 / 256)), fxh((10 / 144)))
+        lab8.translate(fxw(124.6 / 256), fxh(10 / 144))
 
         # description
         desc = T.translate(f"{monster.slug}_description")
@@ -186,7 +186,7 @@ class JournalInfoState(PygameMenuState):
             float=True,
         )
 
-        lab9.translate(fxw((2 / 256)), fxh((82 / 144)))
+        lab9.translate(fxw(2 / 256), fxh(82 / 144))
 
         # evolution
         evo = self._safe_display(evo)
@@ -198,17 +198,17 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab10.translate(fxw((2 / 256)), fxh((109 / 144)))
+        lab10.translate(fxw(2 / 256), fxh(109 / 144))
 
         # evolution monsters
         if self.is_visible:
             f = menu.add.frame_h(
                 float=True,
-                width=fxw((243 / 256)),
-                height=fxw((7 / 144)),
+                width=fxw(243 / 256),
+                height=fxw(7 / 144),
                 frame_id="histories",
             )
-            f.translate(fxw((5 / 256)), fxh((115 / 144)))
+            f.translate(fxw(5 / 256), fxh(115 / 144))
             f._relax = True
             slugs = [ele.monster_slug for ele in monster.evolutions]
             elements = list(dict.fromkeys(slugs))
@@ -229,7 +229,7 @@ class JournalInfoState(PygameMenuState):
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(fxw((53.6 / 256)), fxh((10 / 144)))
+        image_widget.translate(fxw(53.6 / 256), fxh(10 / 144))
 
     def __init__(
         self,


### PR DESCRIPTION
PR refactors the event system by replacing the previous boolean-based cancellation logic with a more expressive `EventState` enum.

Here's a summary of the differences and improvements:
- introduced a new `EventState` enum with four states: `WAITING`, `RUNNING`, `COMPLETED`, and `CANCELLED`
- replaced the `cancelled` boolean flag in `RunningEvent` with a `state` attribute using the new enum
- updated `start_event()` to explicitly set the event state to `RUNNING` when an event begins
- modified `update_running_events()` to process only events in the `RUNNING` state and clean up those marked as `COMPLETED` or `CANCELLED`
- enhanced `handle_next_action()` to mark events as `COMPLETED` when no further actions are available
- improved readability and maintainability by making event progression and termination more explicit
- refactored `add_error_context()` to fix broken `.format()` calls, improve error diagnostics, and handle XML parsing failures

 It also lays the groundwork for future enhancements, such as pausing or retrying events based on state.