### PR TITLE
Refactor Client Architecture: Introduce BaseClient ABC for Shared Logic Between LocalPygameClient and HeadlessClient

### DIFF
--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from pathlib import Path
+from threading import Thread
+from typing import Any, Optional, TypeVar, Union, overload
+
+from tuxemon.audio import MusicPlayerState, SoundManager
+from tuxemon.boundary import BoundaryChecker
+from tuxemon.camera.camera import CameraManager
+from tuxemon.cli.processor import CommandProcessor
+from tuxemon.collision_manager import CollisionManager
+from tuxemon.combat.session import CombatSession
+from tuxemon.config import TuxemonConfig
+from tuxemon.constants import paths
+from tuxemon.event import get_event_bus
+from tuxemon.event.eventaction import ActionManager
+from tuxemon.event.eventcondition import ConditionManager
+from tuxemon.event.eventengine import EventEngine
+from tuxemon.event.eventmanager import EventManager
+from tuxemon.event.eventpersist import EventPersist
+from tuxemon.map_loader import MapLoader
+from tuxemon.map_manager import MapManager
+from tuxemon.map_transition import MapTransition
+from tuxemon.movement import MovementManager, Pathfinder
+from tuxemon.networking import NetworkManager
+from tuxemon.npc_manager import NPCManager
+from tuxemon.park_tracker import ParkSession
+from tuxemon.platform.events import PlayerInput
+from tuxemon.platform.input_manager import InputManager
+from tuxemon.rumble import RumbleManager
+from tuxemon.session import local_session
+from tuxemon.state.loader import StateLoader
+from tuxemon.state.manager import StateManager
+from tuxemon.state.repository import StateRepository
+from tuxemon.state.state import State
+from tuxemon.ui.cipher_processor import CipherProcessor
+
+StateType = TypeVar("StateType", bound=State)
+
+logger = logging.getLogger(__name__)
+
+
+class ClientState(Enum):
+    RUNNING = "running"
+    EXITING = "exiting"
+    DONE = "done"
+
+
+class BaseClient(ABC):
+    """
+    Abstract base class for Tuxemon clients.
+
+    Handles shared setup and lifecycle management for both graphical and headless clients.
+    """
+
+    def __init__(self, config: TuxemonConfig) -> None:
+        self.config = config
+
+        self.event_bus = get_event_bus()
+        self.state_repository = StateRepository()
+        loader = StateLoader(
+            base_package="tuxemon.states", lib_dir=paths.LIBDIR
+        )
+        loader.auto_state_discovery(self.state_repository)
+        self.state_manager = StateManager(
+            package="tuxemon.states",
+            event=self.event_bus,
+            repository=self.state_repository,
+            on_state_change=self.on_state_change,
+        )
+        self.state = ClientState.RUNNING
+        self.current_time = 0.0
+
+        # setup controls
+        self.input_manager = InputManager(config)
+
+        # Set up our networking for multiplayer.
+        self.network_manager = NetworkManager(self)
+        self.network_manager.initialize()
+
+        # Set up our game's event engine which executes actions based on
+        # conditions defined in map files.
+        self.event_manager = EventManager(self.state_manager)
+        self.action_manager = ActionManager()
+        self.condition_manager = ConditionManager()
+        self.event_engine = EventEngine(
+            local_session, self.action_manager, self.condition_manager
+        )
+        self.event_persist = EventPersist()
+
+        self.npc_manager = NPCManager()
+        self.map_loader = MapLoader()
+        self.map_manager = MapManager()
+        self.boundary = BoundaryChecker()
+        self.camera_manager = CameraManager()
+
+        # Set up a variable that will keep track of currently playing music.
+        self.current_music = MusicPlayerState()
+        self.sound_manager = SoundManager()
+
+        if self.config.cli:
+            self.cli = CommandProcessor(local_session)
+            thread = Thread(target=self.cli.run)
+            thread.daemon = True
+            thread.start()
+
+        # Set up rumble support for gamepads
+        self.rumble_manager = RumbleManager()
+        self.rumble = self.rumble_manager.rumbler
+
+        # TODO: phase these out
+        self.key_events: Sequence[PlayerInput] = []
+        self.event_data: dict[str, Any] = {}
+
+        # Set up our combat engine and router.
+        self.combat_session = CombatSession()
+        # self.combat_engine = CombatEngine(self, self.combat_session)
+        # self.combat_router = CombatRouter(self, self.combat_engine)
+
+        self.movement_manager = MovementManager(
+            self.event_manager, self.input_manager
+        )
+        self.collision_manager = CollisionManager(
+            self.map_manager, self.npc_manager
+        )
+        self.pathfinder = Pathfinder(
+            self.npc_manager,
+            self.map_manager,
+            self.collision_manager,
+            self.boundary,
+        )
+        self.map_transition = MapTransition(
+            self.map_loader,
+            self.npc_manager,
+            self.map_manager,
+            self.boundary,
+            self.event_engine,
+        )
+
+        # Various Sessions
+        self.park_session = ParkSession()
+        self.cipher_processor: Optional[CipherProcessor] = None
+
+    @property
+    def is_running(self) -> bool:
+        return self.state == ClientState.RUNNING
+
+    def on_state_change(self) -> None:
+        logger.debug("State change detected. Resetting controls.")
+        self.event_manager.release_controls(self.input_manager)
+
+    def quit(self) -> None:
+        """Handles quitting the game."""
+        self.state = ClientState.EXITING
+
+    def perform_cleanup(self) -> None:
+        """Handles necessary cleanup before shutting down."""
+        self.current_music.stop()
+        local_session.reset()
+        logger.info("Performing cleanup before exiting...")
+
+    def update_states(self, time_delta: float) -> None:
+        """
+        Checks if a state is done or has called for a game quit.
+
+        Parameters:
+            time_delta: Amount of time passed since last frame.
+        """
+        self.state_manager.update(time_delta)
+        if self.state_manager.current_state is None:
+            self.state = ClientState.EXITING
+
+    def get_map_name(self) -> str:
+        """
+        Gets the name of the current map.
+
+        Returns:
+            Name of the current map.
+        """
+        map_path = self.map_manager.get_map_filepath()
+        if map_path is None:
+            raise ValueError("Name of the map requested when no map is active")
+        return Path(map_path).name
+
+    @abstractmethod
+    def main(self) -> None:
+        """
+        Initiates the main game loop.
+
+        Must be implemented by subclasses to define how the game loop is executed.
+        """
+
+    @abstractmethod
+    def update(self, time_delta: float) -> None:
+        """
+        Main loop for entire game.
+
+        Must be implemented by subclasses to define how the game state is updated.
+
+        Parameters:
+            time_delta: Elapsed time since last frame.
+        """
+
+    """
+    The following methods provide an interface to the state stack
+    """
+
+    @overload
+    def get_state_by_name(self, state_name: str) -> State:
+        pass
+
+    @overload
+    def get_state_by_name(
+        self,
+        state_name: type[StateType],
+    ) -> StateType:
+        pass
+
+    def get_state_by_name(
+        self,
+        state_name: Union[str, type[State]],
+    ) -> State:
+        """
+        Query the state stack for a state by the name supplied.
+        """
+        return self.state_manager.get_state_by_name(state_name)
+
+    def get_queued_state_by_name(
+        self,
+        state_name: str,
+    ) -> tuple[str, Mapping[str, Any]]:
+        """
+        Query the state stack for a state by the name supplied.
+        """
+        return self.state_manager.get_queued_state_by_name(state_name)
+
+    def queue_state(self, state_name: str, **kwargs: Any) -> None:
+        """Queue a state"""
+        self.state_manager.queue_state(state_name, **kwargs)
+
+    def pop_state(self, state: Optional[State] = None) -> None:
+        """Pop current state, or another"""
+        self.state_manager.pop_state(state)
+
+    def remove_state_by_name(self, state: str) -> None:
+        """Remove a state by name"""
+        self.state_manager.remove_state_by_name(state)
+
+    @overload
+    def push_state(self, state_name: str, **kwargs: Any) -> State:
+        pass
+
+    @overload
+    def push_state(
+        self,
+        state_name: StateType,
+        **kwargs: Any,
+    ) -> StateType:
+        pass
+
+    def push_state(
+        self,
+        state_name: Union[str, StateType],
+        **kwargs: Any,
+    ) -> State:
+        """Push new state, by name"""
+        return self.state_manager.push_state(state_name, **kwargs)
+
+    @overload
+    def replace_state(self, state_name: str, **kwargs: Any) -> State:
+        pass
+
+    @overload
+    def replace_state(
+        self,
+        state_name: StateType,
+        **kwargs: Any,
+    ) -> StateType:
+        pass
+
+    def replace_state(
+        self,
+        state_name: Union[str, State],
+        **kwargs: Any,
+    ) -> State:
+        """Replace current state with new one"""
+        return self.state_manager.replace_state(state_name, **kwargs)
+
+    def push_state_with_timeout(
+        self,
+        state_name: Union[str, StateType],
+        updates: int = 1,
+    ) -> None:
+        """Push new state, by name, by with timeout"""
+        self.state_manager.push_state_with_timeout(state_name, updates)
+
+    @property
+    def active_states(self) -> Sequence[State]:
+        """List of active states"""
+        return self.state_manager.active_states
+
+    @property
+    def current_state(self) -> Optional[State]:
+        """Current State object, or None"""
+        return self.state_manager.current_state
+
+    @property
+    def active_state_names(self) -> Sequence[str]:
+        """List of names of active states"""
+        return self.state_manager.get_active_state_names()

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -4,59 +4,19 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Mapping, Sequence
-from enum import Enum
-from pathlib import Path
-from threading import Thread
-from typing import Any, Optional, TypeVar, Union, overload
 
 import pygame
 from pygame.surface import Surface
 
-from tuxemon.audio import MusicPlayerState, SoundManager
-from tuxemon.boundary import BoundaryChecker
-from tuxemon.camera.camera import CameraManager
-from tuxemon.cli.processor import CommandProcessor
-from tuxemon.collision_manager import CollisionManager
-from tuxemon.combat.session import CombatSession
+from tuxemon.base_client import BaseClient, ClientState
 from tuxemon.config import TuxemonConfig
-from tuxemon.constants import paths
-from tuxemon.event import get_event_bus
-from tuxemon.event.eventaction import ActionManager
-from tuxemon.event.eventcondition import ConditionManager
-from tuxemon.event.eventengine import EventEngine
-from tuxemon.event.eventmanager import EventManager
-from tuxemon.event.eventpersist import EventPersist
-from tuxemon.map_loader import MapLoader
-from tuxemon.map_manager import MapManager
-from tuxemon.map_transition import MapTransition
-from tuxemon.movement import MovementManager, Pathfinder
-from tuxemon.networking import NetworkManager
-from tuxemon.npc_manager import NPCManager
-from tuxemon.park_tracker import ParkSession
-from tuxemon.platform.events import PlayerInput
-from tuxemon.platform.input_manager import InputManager
-from tuxemon.rumble import RumbleManager
 from tuxemon.session import local_session
 from tuxemon.state.draw import EventDebugDrawer, Renderer, StateDrawer
-from tuxemon.state.loader import StateLoader
-from tuxemon.state.manager import StateManager
-from tuxemon.state.repository import StateRepository
-from tuxemon.state.state import State
-from tuxemon.ui.cipher_processor import CipherProcessor
-
-StateType = TypeVar("StateType", bound=State)
 
 logger = logging.getLogger(__name__)
 
 
-class ClientState(Enum):
-    RUNNING = "running"
-    EXITING = "exiting"
-    DONE = "done"
-
-
-class LocalPygameClient:
+class LocalPygameClient(BaseClient):
     """
     Client class for the entire project.
 
@@ -89,26 +49,8 @@ class LocalPygameClient:
         return client
 
     def __init__(self, config: TuxemonConfig, screen: Surface) -> None:
-        self.config = config
-
-        self.event_bus = get_event_bus()
-        self.state_repository = StateRepository()
-        loader = StateLoader(
-            base_package="tuxemon.states", lib_dir=paths.LIBDIR
-        )
-        loader.auto_state_discovery(self.state_repository)
-        self.state_manager = StateManager(
-            package="tuxemon.states",
-            event=self.event_bus,
-            repository=self.state_repository,
-            on_state_change=self.on_state_change,
-        )
+        super().__init__(config)
         self.screen = screen
-        self.state = ClientState.RUNNING
-        self.current_time = 0.0
-
-        # setup controls
-        self.input_manager = InputManager(config)
 
         # movie creation
         self.frame_number = 0
@@ -119,91 +61,10 @@ class LocalPygameClient:
             self.screen, self.state_manager, config
         )
         self.event_debug_drawer = EventDebugDrawer(self.screen)
-        self.renderer = Renderer(
-            self.screen,
-            self.state_drawer,
-            self.config,
-        )
-
-        # Set up our networking for multiplayer.
-        self.network_manager = NetworkManager(self)
-        self.network_manager.initialize()
-
-        # Set up our combat engine and router.
-        self.combat_session = CombatSession()
-        # self.combat_engine = CombatEngine(self, self.combat_session)
-        # self.combat_router = CombatRouter(self, self.combat_engine)
-
-        # Set up our game's event engine which executes actions based on
-        # conditions defined in map files.
-        self.event_manager = EventManager(self.state_manager)
-        self.action_manager = ActionManager()
-        self.condition_manager = ConditionManager()
-        self.event_engine = EventEngine(
-            local_session, self.action_manager, self.condition_manager
-        )
-        self.event_persist = EventPersist()
-
-        self.movement_manager = MovementManager(
-            self.event_manager, self.input_manager
-        )
-        self.npc_manager = NPCManager()
-        self.map_loader = MapLoader()
-        self.map_manager = MapManager()
-        self.collision_manager = CollisionManager(
-            self.map_manager, self.npc_manager
-        )
-        self.boundary = BoundaryChecker()
-        self.pathfinder = Pathfinder(
-            self.npc_manager,
-            self.map_manager,
-            self.collision_manager,
-            self.boundary,
-        )
-        self.map_transition = MapTransition(
-            self.map_loader,
-            self.npc_manager,
-            self.map_manager,
-            self.boundary,
-            self.event_engine,
-        )
-        self.camera_manager = CameraManager()
-
-        # Set up a variable that will keep track of currently playing music.
-        self.current_music = MusicPlayerState()
-        self.sound_manager = SoundManager()
+        self.renderer = Renderer(self.screen, self.state_drawer, self.config)
 
         if self.config.cli:
-            # TODO: There is no protection for the main thread from the cli
-            # actions that execute in this thread may have undefined
-            # behavior for the game.  at some point, a lock should be
-            # implemented so that actions executed here have exclusive
-            # control of the game loop and state.
             local_session.set_client(self)
-            self.cli = CommandProcessor(local_session)
-            thread = Thread(target=self.cli.run)
-            thread.daemon = True
-            thread.start()
-
-        # Set up rumble support for gamepads
-        self.rumble_manager = RumbleManager()
-        self.rumble = self.rumble_manager.rumbler
-
-        # TODO: phase these out
-        self.key_events: Sequence[PlayerInput] = []
-        self.event_data: dict[str, Any] = {}
-
-        # Various Sessions
-        self.park_session = ParkSession()
-        self.cipher_processor: Optional[CipherProcessor] = None
-
-    @property
-    def is_running(self) -> bool:
-        return self.state == ClientState.RUNNING
-
-    def on_state_change(self) -> None:
-        logger.debug("State change detected. Resetting controls.")
-        self.event_manager.release_controls(self.input_manager)
 
     def main(self) -> None:
         """
@@ -254,47 +115,16 @@ class LocalPygameClient:
         Parameters:
             time_delta: Elapsed time since last frame.
         """
-        # Update our networking
         self.network_manager.update(time_delta)
-
-        # get all the input waiting for use
         events = self.input_manager.process_events()
-
-        # process the events and collect the unused ones
         self.key_events = list(self.event_manager.process_events(events))
-
-        # Run our event engine which will check to see if game conditions
-        # are met and run an action associated with that condition.
         self.event_data = {}
-
         self.event_engine.update(time_delta)
 
         if self.event_data:
             logger.debug("Event Data:" + str(self.event_data))
 
-        # Update the game engine
         self.update_states(time_delta)
-
-    def quit(self) -> None:
-        """Handles quitting the game."""
-        self.state = ClientState.EXITING
-
-    def perform_cleanup(self) -> None:
-        """Handles necessary cleanup before shutting down."""
-        self.current_music.stop()
-        local_session.reset()
-        logger.info("Performing cleanup before exiting...")
-
-    def update_states(self, time_delta: float) -> None:
-        """
-        Checks if a state is done or has called for a game quit.
-
-        Parameters:
-            time_delta: Amount of time passed since last frame.
-        """
-        self.state_manager.update(time_delta)
-        if self.state_manager.current_state is None:
-            self.state = ClientState.EXITING
 
     def draw(self) -> None:
         """Centralized draw logic."""
@@ -306,123 +136,3 @@ class LocalPygameClient:
             partial_events=self.event_engine.partial_events,
         )
         self.frame_number += 1
-
-    def get_map_name(self) -> str:
-        """
-        Gets the name of the current map.
-
-        Returns:
-            Name of the current map.
-        """
-        map_path = self.map_manager.get_map_filepath()
-        if map_path is None:
-            raise ValueError("Name of the map requested when no map is active")
-        return Path(map_path).name
-
-    """
-    The following methods provide an interface to the state stack
-    """
-
-    @overload
-    def get_state_by_name(self, state_name: str) -> State:
-        pass
-
-    @overload
-    def get_state_by_name(
-        self,
-        state_name: type[StateType],
-    ) -> StateType:
-        pass
-
-    def get_state_by_name(
-        self,
-        state_name: Union[str, type[State]],
-    ) -> State:
-        """
-        Query the state stack for a state by the name supplied.
-        """
-        return self.state_manager.get_state_by_name(state_name)
-
-    def get_queued_state_by_name(
-        self,
-        state_name: str,
-    ) -> tuple[str, Mapping[str, Any]]:
-        """
-        Query the state stack for a state by the name supplied.
-        """
-        return self.state_manager.get_queued_state_by_name(state_name)
-
-    def queue_state(self, state_name: str, **kwargs: Any) -> None:
-        """Queue a state"""
-        self.state_manager.queue_state(state_name, **kwargs)
-
-    def pop_state(self, state: Optional[State] = None) -> None:
-        """Pop current state, or another"""
-        self.state_manager.pop_state(state)
-
-    def remove_state_by_name(self, state: str) -> None:
-        """Remove a state by name"""
-        self.state_manager.remove_state_by_name(state)
-
-    @overload
-    def push_state(self, state_name: str, **kwargs: Any) -> State:
-        pass
-
-    @overload
-    def push_state(
-        self,
-        state_name: StateType,
-        **kwargs: Any,
-    ) -> StateType:
-        pass
-
-    def push_state(
-        self,
-        state_name: Union[str, StateType],
-        **kwargs: Any,
-    ) -> State:
-        """Push new state, by name"""
-        return self.state_manager.push_state(state_name, **kwargs)
-
-    @overload
-    def replace_state(self, state_name: str, **kwargs: Any) -> State:
-        pass
-
-    @overload
-    def replace_state(
-        self,
-        state_name: StateType,
-        **kwargs: Any,
-    ) -> StateType:
-        pass
-
-    def replace_state(
-        self,
-        state_name: Union[str, State],
-        **kwargs: Any,
-    ) -> State:
-        """Replace current state with new one"""
-        return self.state_manager.replace_state(state_name, **kwargs)
-
-    def push_state_with_timeout(
-        self,
-        state_name: Union[str, StateType],
-        updates: int = 1,
-    ) -> None:
-        """Push new state, by name, by with timeout"""
-        self.state_manager.push_state_with_timeout(state_name, updates)
-
-    @property
-    def active_states(self) -> Sequence[State]:
-        """List of active states"""
-        return self.state_manager.active_states
-
-    @property
-    def current_state(self) -> Optional[State]:
-        """Current State object, or None"""
-        return self.state_manager.current_state
-
-    @property
-    def active_state_names(self) -> Sequence[str]:
-        """List of names of active states"""
-        return self.state_manager.get_active_state_names()

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -4,48 +4,14 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Mapping, Sequence
-from enum import Enum
-from pathlib import Path
-from threading import Thread
-from typing import Any, Optional, TypeVar, Union, overload
 
-from tuxemon.audio import MusicPlayerState, SoundManager
-from tuxemon.boundary import BoundaryChecker
-from tuxemon.camera.camera import CameraManager
-from tuxemon.cli.processor import CommandProcessor
+from tuxemon.base_client import BaseClient, ClientState
 from tuxemon.config import TuxemonConfig
-from tuxemon.constants import paths
-from tuxemon.event import get_event_bus
-from tuxemon.event.eventaction import ActionManager
-from tuxemon.event.eventcondition import ConditionManager
-from tuxemon.event.eventengine import EventEngine
-from tuxemon.event.eventmanager import EventManager
-from tuxemon.event.eventpersist import EventPersist
-from tuxemon.map_loader import MapLoader
-from tuxemon.map_manager import MapManager
-from tuxemon.npc_manager import NPCManager
-from tuxemon.platform.events import PlayerInput
-from tuxemon.platform.input_manager import InputManager
-from tuxemon.rumble import RumbleManager
-from tuxemon.session import local_session
-from tuxemon.state.loader import StateLoader
-from tuxemon.state.manager import StateManager
-from tuxemon.state.repository import StateRepository
-from tuxemon.state.state import State
-
-StateType = TypeVar("StateType", bound=State)
 
 logger = logging.getLogger(__name__)
 
 
-class ClientState(Enum):
-    RUNNING = "running"
-    EXITING = "exiting"
-    DONE = "done"
-
-
-class HeadlessClient:
+class HeadlessClient(BaseClient):
     """
     Headless client for server-side processing of game logic.
     This client runs without graphics, only handling events and
@@ -56,71 +22,7 @@ class HeadlessClient:
     """
 
     def __init__(self, config: TuxemonConfig) -> None:
-        self.config = config
-
-        self.event_bus = get_event_bus()
-        self.state_repository = StateRepository()
-        loader = StateLoader(
-            base_package="tuxemon.states", lib_dir=paths.LIBDIR
-        )
-        loader.auto_state_discovery(self.state_repository)
-        self.state_manager = StateManager(
-            package="tuxemon.states",
-            event=self.event_bus,
-            repository=self.state_repository,
-            on_state_change=self.on_state_change,
-        )
-        self.state = ClientState.RUNNING
-        self.current_time = 0.0
-
-        # setup controls
-        self.input_manager = InputManager(config)
-
-        # Set up our networking for multiplayer.
-        # self.network_manager = NetworkManager(self)
-        # self.network_manager.initialize()
-
-        # Set up our game's event engine which executes actions based on
-        # conditions defined in map files.
-        self.event_manager = EventManager(self.state_manager)
-        self.action_manager = ActionManager()
-        self.condition_manager = ConditionManager()
-        self.event_engine = EventEngine(
-            local_session, self.action_manager, self.condition_manager
-        )
-        self.event_persist = EventPersist()
-
-        self.npc_manager = NPCManager()
-        self.map_loader = MapLoader()
-        self.map_manager = MapManager()
-        self.boundary = BoundaryChecker()
-        self.camera_manager = CameraManager()
-
-        # Set up a variable that will keep track of currently playing music.
-        self.current_music = MusicPlayerState()
-        self.sound_manager = SoundManager()
-
-        if self.config.cli:
-            self.cli = CommandProcessor(local_session)
-            thread = Thread(target=self.cli.run)
-            thread.daemon = True
-            thread.start()
-
-        # Set up rumble support for gamepads
-        self.rumble_manager = RumbleManager()
-        self.rumble = self.rumble_manager.rumbler
-
-        # TODO: phase these out
-        self.key_events: Sequence[PlayerInput] = []
-        self.event_data: dict[str, Any] = {}
-
-    @property
-    def is_running(self) -> bool:
-        return self.state == ClientState.RUNNING
-
-    def on_state_change(self) -> None:
-        logger.debug("State change detected. Resetting controls.")
-        self.event_manager.release_controls(self.input_manager)
+        super().__init__(config)
 
     def main(self) -> None:
         """
@@ -159,164 +61,13 @@ class HeadlessClient:
         Parameters:
             time_delta: Elapsed time since last frame.
         """
-        # Update our networking
         # self.network_manager.update(time_delta)
-
-        # get all the input waiting for use
         events = self.input_manager.process_events()
-
-        # process the events and collect the unused ones
         self.key_events = list(self.event_manager.process_events(events))
-
-        # Run our event engine which will check to see if game conditions
-        # are met and run an action associated with that condition.
         self.event_data = {}
-
         self.event_engine.update(time_delta)
 
         if self.event_data:
             logger.debug("Event Data:" + str(self.event_data))
 
-        # Update the game engine
         self.update_states(time_delta)
-
-    def quit(self) -> None:
-        """Handles quitting the game."""
-        self.state = ClientState.EXITING
-
-    def perform_cleanup(self) -> None:
-        """Handles necessary cleanup before shutting down."""
-        self.current_music.stop()
-        local_session.reset()
-        logger.info("Performing cleanup before exiting...")
-
-    def update_states(self, time_delta: float) -> None:
-        """
-        Checks if a state is done or has called for a game quit.
-
-        Parameters:
-            time_delta: Amount of time passed since last frame.
-        """
-        self.state_manager.update(time_delta)
-        if self.state_manager.current_state is None:
-            self.state = ClientState.EXITING
-
-    def get_map_name(self) -> str:
-        """
-        Gets the name of the current map.
-
-        Returns:
-            Name of the current map.
-        """
-        map_path = self.map_manager.get_map_filepath()
-        if map_path is None:
-            raise ValueError("Name of the map requested when no map is active")
-        return Path(map_path).name
-
-    """
-    The following methods provide an interface to the state stack
-    """
-
-    @overload
-    def get_state_by_name(self, state_name: str) -> State:
-        pass
-
-    @overload
-    def get_state_by_name(
-        self,
-        state_name: type[StateType],
-    ) -> StateType:
-        pass
-
-    def get_state_by_name(
-        self,
-        state_name: Union[str, type[State]],
-    ) -> State:
-        """
-        Query the state stack for a state by the name supplied.
-        """
-        return self.state_manager.get_state_by_name(state_name)
-
-    def get_queued_state_by_name(
-        self,
-        state_name: str,
-    ) -> tuple[str, Mapping[str, Any]]:
-        """
-        Query the state stack for a state by the name supplied.
-        """
-        return self.state_manager.get_queued_state_by_name(state_name)
-
-    def queue_state(self, state_name: str, **kwargs: Any) -> None:
-        """Queue a state"""
-        self.state_manager.queue_state(state_name, **kwargs)
-
-    def pop_state(self, state: Optional[State] = None) -> None:
-        """Pop current state, or another"""
-        self.state_manager.pop_state(state)
-
-    def remove_state_by_name(self, state: str) -> None:
-        """Remove a state by name"""
-        self.state_manager.remove_state_by_name(state)
-
-    @overload
-    def push_state(self, state_name: str, **kwargs: Any) -> State:
-        pass
-
-    @overload
-    def push_state(
-        self,
-        state_name: StateType,
-        **kwargs: Any,
-    ) -> StateType:
-        pass
-
-    def push_state(
-        self,
-        state_name: Union[str, StateType],
-        **kwargs: Any,
-    ) -> State:
-        """Push new state, by name"""
-        return self.state_manager.push_state(state_name, **kwargs)
-
-    @overload
-    def replace_state(self, state_name: str, **kwargs: Any) -> State:
-        pass
-
-    @overload
-    def replace_state(
-        self,
-        state_name: StateType,
-        **kwargs: Any,
-    ) -> StateType:
-        pass
-
-    def replace_state(
-        self,
-        state_name: Union[str, State],
-        **kwargs: Any,
-    ) -> State:
-        """Replace current state with new one"""
-        return self.state_manager.replace_state(state_name, **kwargs)
-
-    def push_state_with_timeout(
-        self,
-        state_name: Union[str, StateType],
-        updates: int = 1,
-    ) -> None:
-        """Push new state, by name, by with timeout"""
-        self.state_manager.push_state_with_timeout(state_name, updates)
-
-    @property
-    def active_states(self) -> Sequence[State]:
-        """List of active states"""
-        return self.state_manager.active_states
-
-    @property
-    def current_state(self) -> Optional[State]:
-        """Current State object, or None"""
-        return self.state_manager.current_state
-
-    @property
-    def active_state_names(self) -> Sequence[str]:
-        """List of names of active states"""
-        return self.state_manager.get_active_state_names()

--- a/tuxemon/networking.py
+++ b/tuxemon/networking.py
@@ -33,7 +33,7 @@ except ImportError:
     networking = False
 
 if TYPE_CHECKING:
-    from tuxemon.client import LocalPygameClient
+    from tuxemon.base_client import BaseClient
     from tuxemon.platform.events import PlayerInput
 
 
@@ -61,7 +61,7 @@ class EventData(TypedDict, total=False):
 
 
 class NetworkManager:
-    def __init__(self, parent: LocalPygameClient) -> None:
+    def __init__(self, parent: BaseClient) -> None:
         self.parent = parent
         self.server: Optional[TuxemonServer] = None
         self.client: Optional[TuxemonClient] = None
@@ -131,7 +131,7 @@ class TuxemonServer:
 
     def __init__(
         self,
-        game: LocalPygameClient,
+        game: BaseClient,
         server_name: Optional[str] = SERVER_NAME,
         server_port: int = 40081,
         timeout: int = 15,
@@ -382,7 +382,7 @@ class ControllerServer:
     to the local game for processing.
     """
 
-    def __init__(self, game: LocalPygameClient) -> None:
+    def __init__(self, game: BaseClient) -> None:
         """
         Initializes the ControllerServer instance.
 
@@ -453,7 +453,7 @@ class TuxemonClient:
 
     def __init__(
         self,
-        game: LocalPygameClient,
+        game: BaseClient,
         server_port: int = 40081,
         wait_delay: float = 0.25,
         ping_time: float = 2.0,
@@ -951,7 +951,7 @@ class DummyNetworking:
 
 # Universal functions
 def populate_client(
-    cuuid: Any, event_data: Any, game: LocalPygameClient, registry: Any
+    cuuid: Any, event_data: Any, game: BaseClient, registry: Any
 ) -> Any:
     """
     Creates an NPC to represent the client character and adds the information
@@ -997,9 +997,7 @@ def populate_client(
     return sprite
 
 
-def update_client(
-    sprite: Any, char_dict: Any, game: LocalPygameClient
-) -> None:
+def update_client(sprite: Any, char_dict: Any, game: BaseClient) -> None:
     """Corrects character location when it changes map or loses sync.
 
     Updates a client's character information, correcting its location and

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -42,7 +42,7 @@ class JournalInfoState(PygameMenuState):
     ) -> None:
         fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
         fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
-        menu._width = fxw((248 / 256))
+        menu._width = fxw(248 / 256)
 
         # evolutions
         evo = T.translate("no_evolution")
@@ -76,7 +76,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab1.translate(fxw((126 / 256)), fxh((19.8 / 144)))
+        lab1.translate(fxw(126 / 256), fxh(19.8 / 144))
         # weight
         _weight = f"{mon_weight} {unit_weight}"
         lab2: Any = menu.add.label(
@@ -86,7 +86,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab2.translate(fxw((158 / 256)), fxh((39 / 144)))
+        lab2.translate(fxw(158 / 256), fxh(39 / 144))
         # height
         _height = f"{mon_height} {unit_height}"
         lab3: Any = menu.add.label(
@@ -96,7 +96,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab3.translate(fxw((126 / 256)), fxh((39 / 144)))
+        lab3.translate(fxw(126 / 256), fxh(39 / 144))
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
@@ -106,14 +106,14 @@ class JournalInfoState(PygameMenuState):
             type_image_2 = self._create_image(path2)
             type_image_2.scale(prepare.SCALE, prepare.SCALE)
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
             menu.add.image(type_image_2, float=True).translate(
-                fxw((25.4 / 256)), fxh((47.8 / 144))
+                fxw(25.4 / 256), fxh(47.8 / 144)
             )
         else:
             menu.add.image(type_image_1, float=True).translate(
-                fxw((11.4 / 256)), fxh((47.8 / 144))
+                fxw(11.4 / 256), fxh(47.8 / 144)
             )
 
         # Shift amount for two types
@@ -127,7 +127,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab5.translate(fxw((141.4 / 256) + type_shift), fxh((56 / 144)))
+        lab5.translate(fxw((141.4 / 256) + type_shift), fxh(56 / 144))
 
         _type = T.translate("monster_menu_type")
         lab4: Any = menu.add.label(
@@ -137,7 +137,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab4.translate(fxw((141 / 256) + type_shift), fxh((49 / 144)))
+        lab4.translate(fxw((141 / 256) + type_shift), fxh(49 / 144))
         # shape
         menu_shape = T.translate("monster_menu_shape")
         _shape = T.translate(monster.shape)
@@ -149,7 +149,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab6.translate(fxw((126 / 256)), fxh((66 / 144)))
+        lab6.translate(fxw(126 / 256), fxh(66 / 144))
         # species
         spec = T.translate(f"cat_{monster.species}")
         spec = self._safe_display(spec)
@@ -161,7 +161,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab7.translate(fxw((126 / 256)), fxh((29 / 144)))
+        lab7.translate(fxw(126 / 256), fxh(29 / 144))
         # txmn_id
         _txmn_id = f"ID: {monster.txmn_id}"
         lab8: Any = menu.add.label(
@@ -171,7 +171,7 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab8.translate(fxw((124.6 / 256)), fxh((10 / 144)))
+        lab8.translate(fxw(124.6 / 256), fxh(10 / 144))
 
         # description
         desc = T.translate(f"{monster.slug}_description")
@@ -186,7 +186,7 @@ class JournalInfoState(PygameMenuState):
             float=True,
         )
 
-        lab9.translate(fxw((2 / 256)), fxh((82 / 144)))
+        lab9.translate(fxw(2 / 256), fxh(82 / 144))
 
         # evolution
         evo = self._safe_display(evo)
@@ -198,17 +198,17 @@ class JournalInfoState(PygameMenuState):
             align=locals.ALIGN_LEFT,
             float=True,
         )
-        lab10.translate(fxw((2 / 256)), fxh((109 / 144)))
+        lab10.translate(fxw(2 / 256), fxh(109 / 144))
 
         # evolution monsters
         if self.is_visible:
             f = menu.add.frame_h(
                 float=True,
-                width=fxw((243 / 256)),
-                height=fxw((7 / 144)),
+                width=fxw(243 / 256),
+                height=fxw(7 / 144),
                 frame_id="histories",
             )
-            f.translate(fxw((5 / 256)), fxh((115 / 144)))
+            f.translate(fxw(5 / 256), fxh(115 / 144))
             f._relax = True
             slugs = [ele.monster_slug for ele in monster.evolutions]
             elements = list(dict.fromkeys(slugs))
@@ -229,7 +229,7 @@ class JournalInfoState(PygameMenuState):
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(fxw((53.6 / 256)), fxh((10 / 144)))
+        image_widget.translate(fxw(53.6 / 256), fxh(10 / 144))
 
     def __init__(
         self,


### PR DESCRIPTION
PR introduces a new abstract base class called `BaseClient` to unify shared logic between `LocalPygameClient` and `HeadlessClient`.

Key changes included in this pull request:
- created `BaseClient` using Python’s `abc` module to define a common structure for all client types
- moved shared attributes and setup logic (e.g. state manager, event engine, input manager, music player, etc.) from both `LocalPygameClient` and `HeadlessClient` into `BaseClient`
- preserved original comments and docstrings to maintain clarity and documentation continuity
- defined `main()` and `update()` as abstract methods in `BaseClient`, requiring subclasses to implement their own game loop and update logic
- refactored `LocalPygameClient` and `HeadlessClient` to inherit from `BaseClient`, removing duplicated code and keeping only their unique behavior (e.g. rendering logic in `LocalPygameClient`)
- retained the `create()` class method in `LocalPygameClient` for centralized error handling and logging during initialization, as it is actively used in the launcher


Right now, the `Session` still uses `LocalPygameClient`, but we might switch it over to `BaseClient` later on. Before we do that, though, we need to clean up a few things, mainly making sure all the Pygame-specific stuff is properly separated. The `State` is a bit of a hybrid at the moment, and it's not super clear what's being handled by Pygame (like what's drawn or cleared), so that needs to be sorted out first.