### PR TITLE
`BaseClient` Detox - No More Peeking into StateManager (1)

### DIFF
--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from enum import Enum
 from pathlib import Path
 from threading import Thread
@@ -231,19 +231,6 @@ class BaseClient(ABC):
         """
         return self.state_manager.get_state_by_name(state_name)
 
-    def get_queued_state_by_name(
-        self,
-        state_name: str,
-    ) -> tuple[str, Mapping[str, Any]]:
-        """
-        Query the state stack for a state by the name supplied.
-        """
-        return self.state_manager.get_queued_state_by_name(state_name)
-
-    def queue_state(self, state_name: str, **kwargs: Any) -> None:
-        """Queue a state"""
-        self.state_manager.queue_state(state_name, **kwargs)
-
     def pop_state(self, state: Optional[State] = None) -> None:
         """Pop current state, or another"""
         self.state_manager.pop_state(state)
@@ -271,46 +258,3 @@ class BaseClient(ABC):
     ) -> State:
         """Push new state, by name"""
         return self.state_manager.push_state(state_name, **kwargs)
-
-    @overload
-    def replace_state(self, state_name: str, **kwargs: Any) -> State:
-        pass
-
-    @overload
-    def replace_state(
-        self,
-        state_name: StateType,
-        **kwargs: Any,
-    ) -> StateType:
-        pass
-
-    def replace_state(
-        self,
-        state_name: Union[str, State],
-        **kwargs: Any,
-    ) -> State:
-        """Replace current state with new one"""
-        return self.state_manager.replace_state(state_name, **kwargs)
-
-    def push_state_with_timeout(
-        self,
-        state_name: Union[str, StateType],
-        updates: int = 1,
-    ) -> None:
-        """Push new state, by name, by with timeout"""
-        self.state_manager.push_state_with_timeout(state_name, updates)
-
-    @property
-    def active_states(self) -> Sequence[State]:
-        """List of active states"""
-        return self.state_manager.active_states
-
-    @property
-    def current_state(self) -> Optional[State]:
-        """Current State object, or None"""
-        return self.state_manager.current_state
-
-    @property
-    def active_state_names(self) -> Sequence[str]:
-        """List of names of active states"""
-        return self.state_manager.get_active_state_names()

--- a/tuxemon/event/actions/access_pc.py
+++ b/tuxemon/event/actions/access_pc.py
@@ -39,10 +39,10 @@ class AccessPCAction(EventAction):
         self.session = session
         self.client = session.client
 
-        if self.client.current_state is None:
+        if self.client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
-        if self.client.current_state.name == "PCState":
+        if self.client.state_manager.current_state.name == "PCState":
             logger.error(
                 f"The state 'PCState' is already active. No action taken."
             )

--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -62,7 +62,7 @@ class ChangeBgAction(EventAction):
     def start(self, session: Session) -> None:
         # don't override previous state if we are still in the state.
         client = session.client
-        if client.current_state is None:
+        if client.state_manager.current_state is None:
             # obligatory "should not happen"
             raise RuntimeError
 
@@ -88,7 +88,7 @@ class ChangeBgAction(EventAction):
                 )
                 return
 
-        if client.current_state.name != "ImageState":
+        if client.state_manager.current_state.name != "ImageState":
             if self.background is None:
                 if len(client.state_manager.active_states) > 2:
                     client.pop_state()

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -37,10 +37,10 @@ class ChangeStateAction(EventAction):
         self.session = session
         self.client = session.client
 
-        if self.client.current_state is None:
+        if self.client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
-        if self.client.current_state.name == self.state_name:
+        if self.client.state_manager.current_state.name == self.state_name:
             logger.error(
                 f"The state '{self.state_name}' is already active. No action taken."
             )

--- a/tuxemon/event/actions/char_look.py
+++ b/tuxemon/event/actions/char_look.py
@@ -64,7 +64,7 @@ class CharLookAction(EventAction):
             # Suspend looking around if a dialog window is open
             if any(
                 state_name in ("WorldMenuState", "DialogState", "ChoiceState")
-                for state_name in session.client.active_state_names
+                for state_name in session.client.state_manager.get_active_state_names()
             ):
                 return
 

--- a/tuxemon/event/actions/char_wander.py
+++ b/tuxemon/event/actions/char_wander.py
@@ -84,7 +84,7 @@ class CharWanderAction(EventAction):
             # Suspend wandering if a dialog window is open
             if any(
                 state_name in ("WorldMenuState", "DialogState", "ChoiceState")
-                for state_name in session.client.active_state_names
+                for state_name in session.client.state_manager.get_active_state_names()
             ):
                 return
 

--- a/tuxemon/event/actions/crafting_station.py
+++ b/tuxemon/event/actions/crafting_station.py
@@ -39,10 +39,10 @@ class CraftingStationAction(EventAction):
     def start(self, session: Session) -> None:
         self.client = session.client
 
-        if self.client.current_state is None:
+        if self.client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
-        if self.client.current_state.name == "CraftMenuState":
+        if self.client.state_manager.current_state.name == "CraftMenuState":
             logger.error(
                 f"The state 'CraftMenuState' is already active. No action taken."
             )

--- a/tuxemon/event/actions/open_journal.py
+++ b/tuxemon/event/actions/open_journal.py
@@ -39,10 +39,10 @@ class OpenJournalAction(EventAction):
         self.client = session.client
         self.action = self.client.event_engine
 
-        if self.client.current_state is None:
+        if self.client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
-        if self.client.current_state.name == "JournalInfoState":
+        if self.client.state_manager.current_state.name == "JournalInfoState":
             logger.error(
                 f"The state 'JournalInfoState' is already active. No action taken."
             )

--- a/tuxemon/event/actions/park_experience.py
+++ b/tuxemon/event/actions/park_experience.py
@@ -43,7 +43,7 @@ class ParkExperienceAction(EventAction):
         self.client = session.client
         session.player.game_variables.remove("park_out")
 
-        if self.client.current_state is None:
+        if self.client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
         self.client.push_state("ParkState", session=session)

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -110,7 +110,9 @@ class RandomEncounterAction(EventAction):
             graphics=environment.battle_graphics,
             battle_mode=BattleMode.SINGLE,
         )
-        session.client.queue_state("CombatState", context=context)
+        session.client.state_manager.queue_state(
+            "CombatState", context=context
+        )
 
         session.client.movement_manager.lock_controls(player)
         session.client.movement_manager.stop_char(player)
@@ -127,7 +129,9 @@ class RandomEncounterAction(EventAction):
 
     def update(self, session: Session) -> None:
         try:
-            session.client.get_queued_state_by_name("CombatState")
+            session.client.state_manager.get_queued_state_by_name(
+                "CombatState"
+            )
         except ValueError:
             try:
                 session.client.get_state_by_name("CombatState")

--- a/tuxemon/event/actions/remove_state.py
+++ b/tuxemon/event/actions/remove_state.py
@@ -41,18 +41,20 @@ class RemoveStateAction(EventAction):
         client = session.client
         state_name = self.state_name
 
-        if client.current_state is None:
+        if client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
         if state_name is None:
-            if client.current_state.name not in [
+            if client.state_manager.current_state.name not in [
                 "WorldState",
                 "BackgroundState",
             ]:
-                logger.info(f"{client.current_state.name} is removed.")
+                logger.info(
+                    f"{client.state_manager.current_state.name} is removed."
+                )
                 client.pop_state()
         else:
-            if state_name not in client.active_state_names:
+            if state_name not in client.state_manager.get_active_state_names():
                 logger.error(f"{state_name} isn't active.")
                 return
             client.remove_state_by_name(state_name)

--- a/tuxemon/event/actions/show_monster.py
+++ b/tuxemon/event/actions/show_monster.py
@@ -40,10 +40,10 @@ class ShowMonsterAction(EventAction):
         self.session = session
         self.client = session.client
 
-        if self.client.current_state is None:
+        if self.client.state_manager.current_state is None:
             raise RuntimeError("No current state active. This is unexpected.")
 
-        if self.client.current_state.name == "MonsterInfoState":
+        if self.client.state_manager.current_state.name == "MonsterInfoState":
             logger.error(
                 f"The state 'MonsterInfoState' is already active. No action taken."
             )

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -48,7 +48,7 @@ class TeleportFaintAction(EventAction):
             return
 
         client = session.client
-        current_state = client.current_state
+        current_state = client.state_manager.current_state
         if current_state and current_state.name == "DialogState":
             client.remove_state_by_name("DialogState")
 

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -102,7 +102,9 @@ class WildEncounterAction(EventAction):
             graphics=environment.battle_graphics,
             battle_mode=BattleMode.SINGLE,
         )
-        session.client.queue_state("CombatState", context=context)
+        session.client.state_manager.queue_state(
+            "CombatState", context=context
+        )
 
         session.client.movement_manager.lock_controls(player)
         session.client.movement_manager.stop_char(player)
@@ -118,7 +120,9 @@ class WildEncounterAction(EventAction):
 
     def update(self, session: Session) -> None:
         try:
-            session.client.get_queued_state_by_name("CombatState")
+            session.client.state_manager.get_queued_state_by_name(
+                "CombatState"
+            )
         except ValueError:
             try:
                 session.client.get_state_by_name("CombatState")

--- a/tuxemon/event/conditions/current_state.py
+++ b/tuxemon/event/conditions/current_state.py
@@ -31,7 +31,7 @@ class CurrentStateCondition(EventCondition):
     name = "current_state"
 
     def test(self, session: Session, condition: MapCondition) -> bool:
-        current_state = session.client.current_state
+        current_state = session.client.state_manager.current_state
         assert current_state
         states = condition.parameters[0].split(":")
         return current_state.name in states

--- a/tuxemon/event/conditions/music_playing.py
+++ b/tuxemon/event/conditions/music_playing.py
@@ -32,7 +32,7 @@ class MusicPlayingCondition(EventCondition):
         combat_states = {"FlashTransition", "CombatState"}
         if any(
             state in combat_states
-            for state in session.client.active_state_names
+            for state in session.client.state_manager.get_active_state_names()
         ):
             return True
 

--- a/tuxemon/networking.py
+++ b/tuxemon/networking.py
@@ -408,8 +408,10 @@ class ControllerServer:
             key_events_buffer = list(self.game.key_events)
             for controller_event in controller_events:
                 key_events_buffer.append(controller_event)
-                if self.game.current_state:
-                    self.game.current_state.process_event(controller_event)
+                if self.game.state_manager.current_state:
+                    self.game.state_manager.current_state.process_event(
+                        controller_event
+                    )
             self.game.key_events = tuple(key_events_buffer)
 
     def net_controller_loop(self) -> Sequence[PlayerInput]:
@@ -771,8 +773,9 @@ class TuxemonClient:
 
         :type event: Dictionary
         """
-        if self.game.current_state != self.game.get_state_by_name(
-            world.WorldState
+        if (
+            self.game.state_manager.current_state
+            != self.game.get_state_by_name(world.WorldState)
         ):
             return
 

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -216,7 +216,9 @@ class StateManager:
 
     @overload
     def push_state(
-        self, state_name: str, **kwargs: Optional[dict[str, Any]]
+        self,
+        state_name: str,
+        **kwargs: Any,
     ) -> State:
         pass
 
@@ -224,14 +226,14 @@ class StateManager:
     def push_state(
         self,
         state_name: StateType,
-        **kwargs: Optional[dict[str, Any]],
+        **kwargs: Any,
     ) -> StateType:
         pass
 
     def push_state(
         self,
         state_name: Union[str, StateType],
-        **kwargs: Optional[dict[str, Any]],
+        **kwargs: Any,
     ) -> State:
         """
         Pause currently running state and start new one.
@@ -269,23 +271,21 @@ class StateManager:
         return instance
 
     @overload
-    def replace_state(
-        self, state_name: str, **kwargs: Optional[dict[str, Any]]
-    ) -> State:
+    def replace_state(self, state_name: str, **kwargs: Any) -> State:
         pass
 
     @overload
     def replace_state(
         self,
         state_name: StateType,
-        **kwargs: Optional[dict[str, Any]],
+        **kwargs: Any,
     ) -> StateType:
         pass
 
     def replace_state(
         self,
         state_name: Union[str, State],
-        **kwargs: Optional[dict[str, Any]],
+        **kwargs: Any,
     ) -> State:
         """
         Replace the currently running state with a new one.

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -233,7 +233,9 @@ class CharacterState(PygameMenuState):
         party = self.char.monsters
         if event.button == buttons.RIGHT and event.pressed and party:
             params = {"party": party}
-            self.client.replace_state("PartyState", kwargs=params)
+            self.client.state_manager.replace_state(
+                "PartyState", kwargs=params
+            )
         if (
             event.button in (buttons.BACK, buttons.B, buttons.A)
             and event.pressed

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -158,8 +158,11 @@ class CombatState(CombatAnimations):
         """
         Update the combat phase.
         """
-        if self.client.current_state:
-            if self.client.current_state.name == "WaitForInputState":
+        if self.client.state_manager.current_state:
+            if (
+                self.client.state_manager.current_state.name
+                == "WaitForInputState"
+            ):
                 return
         time_left = self.text_anim.get_text_animation_time_left()
         if time_left <= 0 and all(map(self.is_task_finished, self.animations)):
@@ -912,7 +915,9 @@ class CombatState(CombatAnimations):
         """
         Removes any states stacked on top of the combat state
         """
-        while not isinstance(self.client.current_state, CombatState):
+        while not isinstance(
+            self.client.state_manager.current_state, CombatState
+        ):
             self.client.pop_state()
 
     def end_combat(self) -> None:

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -144,7 +144,8 @@ class ItemMenuState(Menu[Item]):
             open_dialog(self.client, [error_message])
         # Check if the item can be used in the current state
         elif not any(
-            s.name in self.client.active_state_names for s in item.usable_in
+            s.name in self.client.state_manager.get_active_state_names()
+            for s in item.usable_in
         ):
             error_message = T.format(
                 "item_cannot_use_here", {"name": item.name}

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -284,7 +284,7 @@ class JournalInfoState(PygameMenuState):
                 if event.button == buttons.RIGHT
                 else (current_monster_index - 1) % len(monster_models)
             )
-            client.replace_state(
+            client.state_manager.replace_state(
                 "JournalInfoState",
                 character=self.char,
                 monster=monster_models[new_index],

--- a/tuxemon/states/journal_state.py
+++ b/tuxemon/states/journal_state.py
@@ -150,7 +150,7 @@ class JournalState(PygameMenuState):
             self._page = (
                 self._page + (1 if event.button == buttons.RIGHT else -1)
             ) % max_page
-            client.replace_state(
+            client.state_manager.replace_state(
                 "JournalState",
                 character=self.char,
                 monsters=box,

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -70,7 +70,9 @@ class DifficultySelectState(PygameMenuState):
         """
         Transitions to the minigame with the selected difficulty.
         """
-        self.client.replace_state("MinigameState", difficulty=difficulty)
+        self.client.state_manager.replace_state(
+            "MinigameState", difficulty=difficulty
+        )
 
 
 class MinigameState(PygameMenuState):
@@ -190,7 +192,7 @@ class MinigameState(PygameMenuState):
                 "normal": 2,
                 "hard": 3,
             }[self.difficulty]
-            self.client.replace_state(
+            self.client.state_manager.replace_state(
                 "MinigameState",
                 difficulty=self.difficulty,
                 streak=self.streak,

--- a/tuxemon/states/mission.py
+++ b/tuxemon/states/mission.py
@@ -194,7 +194,7 @@ class SingleMissionState(PygameMenuState):
                 if event.button == buttons.RIGHT
                 else (current_index - 1) % len(missions)
             )
-            client.replace_state(
+            client.state_manager.replace_state(
                 "SingleMissionState",
                 mission=missions[new_index],
                 character=self.character,

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -322,11 +322,15 @@ class MonsterInfoState(PygameMenuState):
             if event.button == buttons.RIGHT and event.pressed:
                 slot = (slot + 1) % len(monsters)
                 param["monster"] = monsters[slot]
-                client.replace_state("MonsterInfoState", kwargs=param)
+                client.state_manager.replace_state(
+                    "MonsterInfoState", kwargs=param
+                )
             elif event.button == buttons.LEFT and event.pressed:
                 slot = (slot - 1) % len(monsters)
                 param["monster"] = monsters[slot]
-                client.replace_state("MonsterInfoState", kwargs=param)
+                client.state_manager.replace_state(
+                    "MonsterInfoState", kwargs=param
+                )
 
         if (
             event.button in (buttons.BACK, buttons.B, buttons.A)

--- a/tuxemon/states/monster_item.py
+++ b/tuxemon/states/monster_item.py
@@ -134,11 +134,15 @@ class MonsterItemState(PygameMenuState):
             if event.button == buttons.RIGHT and event.pressed:
                 slot = (slot + 1) % len(monsters)
                 param["monster"] = monsters[slot]
-                client.replace_state("MonsterItemState", kwargs=param)
+                client.state_manager.replace_state(
+                    "MonsterItemState", kwargs=param
+                )
             elif event.button == buttons.LEFT and event.pressed:
                 slot = (slot - 1) % len(monsters)
                 param["monster"] = monsters[slot]
-                client.replace_state("MonsterItemState", kwargs=param)
+                client.state_manager.replace_state(
+                    "MonsterItemState", kwargs=param
+                )
 
         if event.button in (buttons.BACK, buttons.B) and event.pressed:
             client.remove_state_by_name("MonsterItemState")

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -393,11 +393,15 @@ class MonsterMovesState(PygameMenuState):
             if event.button == buttons.RIGHT and event.pressed:
                 slot = (slot + 1) % len(monsters)
                 param["monster"] = monsters[slot]
-                client.replace_state("MonsterMovesState", kwargs=param)
+                client.state_manager.replace_state(
+                    "MonsterMovesState", kwargs=param
+                )
             elif event.button == buttons.LEFT and event.pressed:
                 slot = (slot - 1) % len(monsters)
                 param["monster"] = monsters[slot]
-                client.replace_state("MonsterMovesState", kwargs=param)
+                client.state_manager.replace_state(
+                    "MonsterMovesState", kwargs=param
+                )
             else:
                 self.update_selected_widget()
                 menu = self.menu.get_current()

--- a/tuxemon/states/party.py
+++ b/tuxemon/states/party.py
@@ -162,7 +162,9 @@ class PartyState(PygameMenuState):
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         params = {"character": self.char}
         if event.button == buttons.LEFT and event.pressed:
-            self.client.replace_state("CharacterState", kwargs=params)
+            self.client.state_manager.replace_state(
+                "CharacterState", kwargs=params
+            )
         if (
             event.button in (buttons.BACK, buttons.B, buttons.A)
             and event.pressed

--- a/tuxemon/states/pc.py
+++ b/tuxemon/states/pc.py
@@ -54,7 +54,9 @@ class PCMenuBuilder:
         )
 
     def _change_state(self, state: str, **kwargs: Any) -> partial[State]:
-        return partial(self.client.replace_state, state, **kwargs)
+        return partial(
+            self.client.state_manager.replace_state, state, **kwargs
+        )
 
     def _not_implemented_dialog(self) -> None:
         open_dialog(self.client, [T.translate("not_implemented")])

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -335,7 +335,9 @@ class MonsterBoxState(PygameMenuState):
         return []
 
     def change_state(self, state: str, **kwargs: Any) -> partial[State]:
-        return partial(self.client.replace_state, state, **kwargs)
+        return partial(
+            self.client.state_manager.replace_state, state, **kwargs
+        )
 
     def update_animation_position(self) -> None:
         self.menu.translate(-self.animation_offset, 0)

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -307,7 +307,9 @@ class ItemBoxState(PygameMenuState):
         return []
 
     def change_state(self, state: str, **kwargs: Any) -> partial[State]:
-        return partial(self.client.replace_state, state, **kwargs)
+        return partial(
+            self.client.state_manager.replace_state, state, **kwargs
+        )
 
     def update_animation_position(self) -> None:
         self.menu.translate(-self.animation_offset, 0)

--- a/tuxemon/states/set_language.py
+++ b/tuxemon/states/set_language.py
@@ -41,10 +41,10 @@ class SetLanguage(PygameMenuState):
         self.client.remove_state_by_name("SetLanguage")
         if self.main_menu:
             self.client.remove_state_by_name("ControlState")
-            self.client.replace_state("StartState")
+            self.client.state_manager.replace_state("StartState")
         else:
             self.client.remove_state_by_name("ControlState")
-            self.client.replace_state(
+            self.client.state_manager.replace_state(
                 "WorldMenuState",
                 menu_manager=local_session.world.menu_manager,
                 character=local_session.player,

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -335,7 +335,7 @@ class WorldState(State):
             else:
                 if self.wants_duel:
                     if event_data["response"] == "Accept":
-                        world = self.client.current_state
+                        world = self.client.state_manager.current_state
                         pd = self.player.__dict__
                         event_data = {
                             "type": "CLIENT_INTERACTION",

--- a/tuxemon/teleporter.py
+++ b/tuxemon/teleporter.py
@@ -153,7 +153,7 @@ class Teleporter:
         self.movement_manager.stop_char(character)
 
         if len(self.state_manager.active_states) == 2:
-            self.client.push_state_with_timeout("TeleporterState", 15)
+            self.state_manager.push_state_with_timeout("TeleporterState", 15)
 
         self.movement_manager.lock_controls(character)
         logger.info(f"{character.slug} is prepared for teleportation.")


### PR DESCRIPTION
PR begins cleaning up the `BaseClient` by removing some methods that expose the state stack (via the state manager). The goal is to keep the client lean and avoid breaking encapsulation, Demeter says no 👀.

Gone:
- get_queued_state_by_name
- queue_state
- replace_state
- push_state_with_timeout
- active_states
- current_state
- active_state_names

to be addressed:
- get_state_by_name
- pop_state
- remove_state_by_name
- push_state