### PR TITLE
Optimize Type Hint Resolution in Dataclass Casting

### DIFF
--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -14,6 +14,7 @@ import typing
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import fields
 from enum import Enum
+from functools import lru_cache
 from operator import add, eq, floordiv, ge, gt, le, lt, mul, ne, sub
 from pathlib import Path
 from typing import (
@@ -379,21 +380,29 @@ def get_types_tuple(
         return (param_type,)
 
 
+@lru_cache(maxsize=None)
+def get_cached_type_info(cls: type) -> dict[str, tuple[type, ...]]:
+    type_hints = typing.get_type_hints(cls)
+    return {
+        field.name: tuple(
+            t
+            for t in get_types_tuple(type_hints[field.name])
+            if isinstance(t, type)
+        )
+        for field in fields(cls)
+        if field.init
+    }
+
+
 def cast_dataclass_parameters(self: Any) -> None:
     """
     Takes a dataclass object and casts its __init__ values to the correct type
     """
-    type_hints = typing.get_type_hints(self.__class__)
-    for field in fields(self):
-        if field.init:
-            field_name = field.name  # e.g "map_name"
-            type_hint = type_hints[field_name]  # e.g. Optional[str]
-            constructors = get_types_tuple(
-                type_hint
-            )  # e.g. (<class 'str'>, <class 'NoneType'>)
-            old_value = getattr(self, field_name)
-            new_value = cast_value(((constructors, field_name), old_value))
-            setattr(self, field_name, new_value)
+    field_info = get_cached_type_info(self.__class__)
+    for field_name, constructors in field_info.items():
+        old_value = getattr(self, field_name)
+        new_value = cast_value(((constructors, field_name), old_value))
+        setattr(self, field_name, new_value)
 
 
 def show_result_as_dialog(


### PR DESCRIPTION
PR  improves the performance and readability of the `cast_dataclass_parameters` method by introducing a caching mechanism for type hints and constructor resolution.

Here's a plain explanation of the changes:
- the original implementation recalculated type hints and constructor tuples every time the method was called, even for instances of the same dataclass
- this PR introduces a helper function called `get_cached_type_info`, which uses Python’s built-in `@lru_cache` decorator to store type information per class
- the cached function extracts type hints and constructor types only once per dataclass type, reducing redundant computation
- the main method now simply retrieves the cached field information and performs casting, making the logic cleaner and more efficient
- this change is especially beneficial in scenarios where many instances of the same dataclass are created, such as in batch processing or repeated testing