### PR TITLE
Add `probability` and `held_item` Conditions to Monster Evolution Logic

### DIFF
--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -26,23 +26,23 @@
   "evolutions": [
     {
       "monster_slug": "av8r",
-      "item": "booster_tech"
+      "item": { "booster_tech": 0.2 }
     },
     {
       "monster_slug": "picc",
-      "item": "booster_tech"
+      "item": { "booster_tech": 0.2 }
     },
     {
       "monster_slug": "mrmoswitch",
-      "item": "booster_tech"
+      "item": { "booster_tech": 0.2 }
     },
     {
       "monster_slug": "k9",
-      "item": "booster_tech"
+      "item": { "booster_tech": 0.2 }
     },
     {
       "monster_slug": "b_ver_1",
-      "item": "booster_tech"
+      "item": { "booster_tech": 0.2 }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -42,19 +42,17 @@
   "evolutions": [
     {
       "monster_slug": "bamboon",
-      "item": "wood_booster"
-    },
-    {
-      "monster_slug": "bamboon",
-      "item": "lucky_bamboo"
-    },
-    {
-      "monster_slug": "frondly",
-      "item": "water_booster"
+      "item": {
+        "wood_booster": 0.5,
+        "lucky_bamboo": 0.5
+      }
     },
     {
       "monster_slug": "frondly",
-      "item": "peace_lily"
+      "item": {
+        "water_booster": 0.5,
+        "peace_lily": 0.5
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/claymorior.json
+++ b/mods/tuxemon/db/monster/claymorior.json
@@ -59,7 +59,9 @@
     {
       "at_level": 32,
       "monster_slug": "regalance",
-      "taste_warm": "hearty"
+      "tastes": {
+        "warm": "hearty"
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/doctsky.json
+++ b/mods/tuxemon/db/monster/doctsky.json
@@ -54,11 +54,15 @@
   "evolutions": [
     {
       "monster_slug": "askylpaws",
-      "item": "ox_stick"
+      "item": {
+        "ox_stick": 1.0
+      }
     },
     {
       "monster_slug": "erythroskyte",
-      "item": "peace_lily"
+      "item": {
+        "peace_lily": 1.0
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -26,23 +26,24 @@
   "evolutions": [
     {
       "monster_slug": "bigfin",
-      "item": "water_booster"
-    },
-    {
-      "monster_slug": "bigfin",
-      "item": "sweet_sand"
-    },
-    {
-      "monster_slug": "sharpfin",
-      "item": "metal_booster"
+      "item": {
+        "water_booster": 0.5,
+        "sweet_sand": 0.5
+      }
     },
     {
       "monster_slug": "sharpfin",
-      "item": "sea_girdle"
+      "item": {
+        "metal_booster": 0.5,
+        "sea_girdle": 0.5
+      }
     },
     {
       "monster_slug": "delfeco",
-      "bond": "equals:100"
+      "bond": {
+        "comparison": "equals",
+        "value": 100
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/duggot.json
+++ b/mods/tuxemon/db/monster/duggot.json
@@ -22,9 +22,11 @@
   "evolutions": [
     {
       "monster_slug": "breem",
-      "party": [
-        "tumbleworm"
-      ]
+      "party_conditions": {
+        "monster_slugs": {
+          "tumbleworm": 1
+        }
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/flummby.json
+++ b/mods/tuxemon/db/monster/flummby.json
@@ -53,9 +53,11 @@
   ],
   "evolutions": [
     {
-      "at_level": 32,
       "monster_slug": "flummack",
-      "item": "lima_pie"
+      "at_level": 32,
+      "item": {
+        "lima_pie": 1.0
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -53,8 +53,11 @@
   ],
   "evolutions": [
     {
-      "at_level": 32,
-      "monster_slug": "fuzzina"
+      "monster_slug": "fuzzina",
+      "bond": {
+        "comparison": "greater_than",
+        "value": 80
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -26,19 +26,17 @@
   "evolutions": [
     {
       "monster_slug": "grinflare",
-      "item": "earth_booster"
-    },
-    {
-      "monster_slug": "grinflare",
-      "item": "flintstone"
-    },
-    {
-      "monster_slug": "grintrock",
-      "item": "metal_booster"
+      "item": {
+        "earth_booster": 0.5,
+        "flintstone": 0.5
+      }
     },
     {
       "monster_slug": "grintrock",
-      "item": "thunderstone"
+      "item": {
+        "metal_booster": 0.5,
+        "thunderstone": 0.5
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -26,19 +26,17 @@
   "evolutions": [
     {
       "monster_slug": "eruptibus",
-      "item": "earth_booster"
-    },
-    {
-      "monster_slug": "eruptibus",
-      "item": "tectonic_drill"
-    },
-    {
-      "monster_slug": "embazook",
-      "item": "metal_booster"
+      "item": {
+        "earth_booster": 0.5,
+        "tectonic_drill": 0.5
+      }
     },
     {
       "monster_slug": "embazook",
-      "item": "stovepipe"
+      "item": {
+        "metal_booster": 0.5,
+        "stovepipe": 0.5
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -31,17 +31,29 @@
     {
       "at_level": 12,
       "monster_slug": "bugnin",
-      "stats": "dodge:greater_than:speed"
+      "stats": {
+        "stat_type": "dodge",
+        "comparison": "greater_than",
+        "target_stat": "speed"
+      }
     },
     {
       "at_level": 12,
       "monster_slug": "sumchon",
-      "stats": "speed:greater_than:dodge"
+      "stats": {
+        "stat_type": "speed",
+        "comparison": "greater_than",
+        "target_stat": "dodge"
+      }
     },
     {
       "at_level": 12,
       "monster_slug": "gladiatorbug",
-      "stats": "speed:equals:dodge"
+      "stats": {
+        "stat_type": "speed",
+        "comparison": "equals",
+        "target_stat": "dodge"
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -26,27 +26,24 @@
   "evolutions": [
     {
       "monster_slug": "miaownolith",
-      "item": "earth_booster"
-    },
-    {
-      "monster_slug": "miaownolith",
-      "item": "miaow_milk"
-    },
-    {
-      "monster_slug": "pyraminx",
-      "item": "metal_booster"
+      "item": {
+        "earth_booster": 0.5,
+        "miaow_milk": 0.5
+      }
     },
     {
       "monster_slug": "pyraminx",
-      "item": "pyramidion"
+      "item": {
+        "metal_booster": 0.5,
+        "pyramidion": 0.5
+      }
     },
     {
       "monster_slug": "mauai",
-      "item": "fire_booster"
-    },
-    {
-      "monster_slug": "mauai",
-      "item": "pyramidion"
+      "item": {
+        "fire_booster": 0.5,
+        "pyramidion": 0.5
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/pawsand.json
+++ b/mods/tuxemon/db/monster/pawsand.json
@@ -46,15 +46,21 @@
   "evolutions": [
     {
       "monster_slug": "knightsand",
-      "item": "sweet_sand"
+      "item": {
+        "sweet_sand": 1.0
+      }
     },
     {
       "monster_slug": "bishosand",
-      "item": "earth_booster"
+      "item": {
+        "earth_booster": 1.0
+      }
     },
     {
       "monster_slug": "rooksand",
-      "item": "pyramidion"
+      "item": {
+        "pyramidion": 1.0
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -26,11 +26,15 @@
   "evolutions": [
     {
       "monster_slug": "ouroboutlet",
-      "item": "fire_booster"
+      "item": {
+        "fire_booster": 1.0
+      }
     },
     {
       "monster_slug": "sockeserp",
-      "item": "metal_booster"
+      "item": {
+        "metal_booster": 1.0
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -42,11 +42,13 @@
   "evolutions": [
     {
       "monster_slug": "loliferno",
-      "item": "flintstone"
+      "item": {
+        "flintstone": 1.0
+      }
     },
     {
-      "at_level": 20,
-      "monster_slug": "spirain"
+      "monster_slug": "spirain",
+      "at_level": 20
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/sheye.json
+++ b/mods/tuxemon/db/monster/sheye.json
@@ -30,7 +30,10 @@
   "evolutions": [
     {
       "monster_slug": "shrab",
-      "bond": "greater_than:40"
+      "bond": {
+        "comparison": "greater_than",
+        "value": 40
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/virware.json
+++ b/mods/tuxemon/db/monster/virware.json
@@ -58,7 +58,9 @@
   "evolutions": [
     {
       "monster_slug": "trojerror",
-      "item": "metal_booster"
+      "item": {
+        "metal_booster": 1.0
+      }
     }
   ],
   "history": [

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -33,8 +33,8 @@
       "element": "wood"
     },
     {
-      "at_level": 24,
       "monster_slug": "viviteel",
+      "at_level": 24,
       "gender": "female"
     },
     {
@@ -42,24 +42,20 @@
       "inside": true
     },
     {
-      "at_level": 26,
-      "monster_slug": "vivitron"
+      "monster_slug": "vivitron",
+      "at_level": 26
     },
     {
       "monster_slug": "vividactil",
-      "item": "petrified_dung"
+      "item": {
+        "petrified_dung": 0.333,
+        "shammer_fossil": 0.333,
+        "rhincus_fossil": 0.334
+      }
     },
     {
-      "monster_slug": "vividactil",
-      "item": "shammer_fossil"
-    },
-    {
-      "monster_slug": "vividactil",
-      "item": "rhincus_fossil"
-    },
-    {
-      "at_level": 24,
       "monster_slug": "vivisource",
+      "at_level": 24,
       "gender": "male"
     }
   ],

--- a/mods/tuxemon/db/monster/weedsea.json
+++ b/mods/tuxemon/db/monster/weedsea.json
@@ -50,15 +50,19 @@
   "evolutions": [
     {
       "monster_slug": "weedlantis",
-      "party": [
-        "shrab"
-      ]
+      "party_conditions": {
+        "monster_slugs": {
+          "shrab": 1
+        }
+      }
     },
     {
       "monster_slug": "weedlantis",
-      "party": [
-        "lesmagu"
-      ]
+      "party_conditions": {
+        "monster_slugs": {
+          "lesmagu": 1
+        }
+      }
     }
   ],
   "history": [

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -3,8 +3,16 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tuxemon.db import Acquisition, MonsterEvolutionItemModel
-from tuxemon.element import Element
+from tuxemon.db import (
+    Acquisition,
+    BondComparison,
+    Comparison,
+    GenderType,
+    MonsterEvolutionItemModel,
+    PartyConditionsModel,
+    StatsComparison,
+    StatType,
+)
 from tuxemon.game_variables import GameVariablesManager
 from tuxemon.monster import Monster
 from tuxemon.npc import PartyHandler
@@ -109,61 +117,81 @@ class TestCanEvolve(unittest.TestCase):
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_party_match(self):
-        evo = MonsterEvolutionItemModel(monster_slug="rockat", party=["nut"])
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(monster_slugs={"nut": 1}),
+        )
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_party_match_double(self):
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", party=["nut", "rockitten"]
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(
+                monster_slugs={"nut": 1, "rockitten": 1}
+            ),
         )
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_party_mismatch(self):
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", party=["agnidon"]
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(
+                monster_slugs={"agnidon": 1}
+            ),
         )
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
-    def test_taste_cold_match(self):
+    def test_taste_match(self):
         self.mon.taste_cold = "flakey"
-        evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_cold="flakey"
+        evo_cold = MonsterEvolutionItemModel(
+            monster_slug="rockat", tastes={"cold": "flakey"}
         )
         context = {"map_inside": True}
-        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
+        self.assertTrue(
+            self.mon.evolution_handler.can_evolve(evo_cold, context)
+        )
 
-    def test_taste_cold_mismatch(self):
+        self.mon.taste_warm = "peppy"
+        evo_warm = MonsterEvolutionItemModel(
+            monster_slug="rockat", tastes={"warm": "peppy"}
+        )
+        context = {"map_inside": True}
+        self.assertTrue(
+            self.mon.evolution_handler.can_evolve(evo_warm, context)
+        )
+
+    def test_taste_mismatch(self):
         self.mon.taste_cold = "mild"
-        evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_cold="flakey"
+        evo_cold = MonsterEvolutionItemModel(
+            monster_slug="rockat", tastes={"cold": "flakey"}
         )
         context = {"map_inside": True}
-        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+        self.assertFalse(
+            self.mon.evolution_handler.can_evolve(evo_cold, context)
+        )
 
-    def test_taste_warm_match(self):
         self.mon.taste_warm = "peppy"
-        evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_warm="peppy"
+        evo_warm = MonsterEvolutionItemModel(
+            monster_slug="rockat", tastes={"warm": "salty"}
         )
         context = {"map_inside": True}
-        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
-
-    def test_taste_warm_mismatch(self):
-        self.mon.taste_warm = "peppy"
-        evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", taste_warm="salty"
+        self.assertFalse(
+            self.mon.evolution_handler.can_evolve(evo_warm, context)
         )
-        context = {"map_inside": True}
-        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_stats_match(self):
         self.mon.base_stats.hp = 30
         self.mon.base_stats.melee = 20
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", stats="hp:greater_or_equal:melee"
+            monster_slug="rockat",
+            stats=StatsComparison(
+                stat_type=StatType.hp,
+                comparison=Comparison.greater_or_equal,
+                target_stat=StatType.melee,
+            ),
         )
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
@@ -172,7 +200,12 @@ class TestCanEvolve(unittest.TestCase):
         self.mon.base_stats.speed = 5
         self.mon.base_stats.armour = 10
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", stats="speed:greater_or_equal:armour"
+            monster_slug="rockat",
+            stats=StatsComparison(
+                stat_type=StatType.speed,
+                comparison=Comparison.greater_or_equal,
+                target_stat=StatType.armour,
+            ),
         )
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
@@ -227,7 +260,10 @@ class TestCanEvolve(unittest.TestCase):
     def test_bond_match(self):
         self.mon.bond = 10
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", bond="greater_or_equal:10"
+            monster_slug="rockat",
+            bond=BondComparison(
+                comparison=Comparison.greater_or_equal, value=10
+            ),
         )
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
@@ -235,33 +271,38 @@ class TestCanEvolve(unittest.TestCase):
     def test_bond_mismatch(self):
         self.mon.bond = 5
         evo = MonsterEvolutionItemModel(
-            monster_slug="rockat", bond="greater_or_equal:10"
+            monster_slug="rockat",
+            bond=BondComparison(
+                comparison=Comparison.greater_or_equal, value=10
+            ),
         )
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_item_match(self):
         evo = MonsterEvolutionItemModel(
-            monster_slug="botbot", item="booster_tech"
+            monster_slug="botbot", item={"booster_tech": 1.0}
         )
         context = {"map_inside": True, "use_item": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_item_mismatch(self):
         evo = MonsterEvolutionItemModel(
-            monster_slug="botbot", item="booster_tech"
+            monster_slug="botbot", item={"booster_tech": 1.0}
         )
         context = {"map_inside": True, "use_item": False}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_element_match(self):
-        self.mon.types.set_types([Element("metal")])
+        element = MagicMock(slug="metal")
+        self.mon.types.set_types([element])
         evo = MonsterEvolutionItemModel(monster_slug="botbot", element="metal")
         context = {"map_inside": True}
         self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
 
     def test_element_mismatch(self):
-        self.mon.types.set_types([Element("metal")])
+        element = MagicMock(slug="metal")
+        self.mon.types.set_types([element])
         evo = MonsterEvolutionItemModel(monster_slug="botbot", element="water")
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
@@ -278,6 +319,150 @@ class TestCanEvolve(unittest.TestCase):
         self.mon.moves.moves = [tech]
         evo = MonsterEvolutionItemModel(
             monster_slug="rockat", moves=["strike"]
+        )
+        context = {"map_inside": True}
+        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+
+    @patch("random.random", return_value=0.05)
+    def test_probability_success(self, mock_random):
+        self.mon.level = 20
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", at_level=20, probability=0.1  # 10% chance
+        )
+        context = {"map_inside": True}
+        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
+
+    @patch("random.random", return_value=0.15)
+    def test_probability_failure(self, mock_random):
+        self.mon.level = 20
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", at_level=20, probability=0.1  # 10% chance
+        )
+        context = {"map_inside": True}
+        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+
+    @patch("random.random", return_value=0.05)
+    def test_evolution_probability_only_success(self, mock_random):
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", probability=0.1  # 10% chance
+        )
+        context = {"map_inside": True}
+        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
+
+    @patch("random.random", return_value=0.15)
+    def test_evolution_probability_only_failure(self, mock_random):
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", probability=0.1  # 10% chance
+        )
+        context = {"map_inside": True}
+        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_evolution_with_correct_held_item(self):
+        item = MagicMock(slug="potion")
+        self.mon.held_item = MagicMock()
+        self.mon.held_item.get_item = MagicMock(return_value=item)
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", held_item="potion"
+        )
+        context = {"map_inside": True}
+        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_evolution_with_wrong_held_item(self):
+        item = MagicMock(slug="tea")
+        self.mon.held_item = MagicMock()
+        self.mon.held_item.get_item = MagicMock(return_value=item)
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", held_item="potion"
+        )
+        context = {"map_inside": True}
+        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_evolution_with_no_item_held(self):
+        self.mon.held_item = MagicMock()
+        self.mon.held_item.get_item = MagicMock(return_value=None)
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat", held_item="potion"
+        )
+        context = {"map_inside": True}
+        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_can_evolve_party_alignment_matches(self):
+        with patch.object(
+            self.player.party, "get_alignment", return_value="fire"
+        ):
+            evolution_item = MonsterEvolutionItemModel(
+                monster_slug="nut",
+                party_conditions=PartyConditionsModel(alignment="fire"),
+            )
+            context = {"map_inside": True}
+            result = self.mon.evolution_handler.can_evolve(
+                evolution_item, context
+            )
+            self.assertTrue(result)
+
+    def test_can_evolve_party_alignment_mismatch(self):
+        with patch.object(
+            self.player.party, "get_alignment", return_value="water"
+        ):
+            evolution_item = MonsterEvolutionItemModel(
+                monster_slug="nut",
+                party_conditions=PartyConditionsModel(alignment="fire"),
+            )
+            context = {"map_inside": True}
+            result = self.mon.evolution_handler.can_evolve(
+                evolution_item, context
+            )
+            self.assertFalse(result)
+
+    def test_can_evolve_gender_match(self):
+        for mon in self.player.party._monsters:
+            mon.gender = GenderType.male
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(
+                genders={GenderType.male: 1}
+            ),
+        )
+        context = {"map_inside": True}
+        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_can_evolve_gender_mismatch(self):
+        for mon in self.player.party._monsters:
+            mon.gender = GenderType.female
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(
+                genders={GenderType.male: 1}
+            ),
+        )
+        context = {"map_inside": True}
+        self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_can_evolve_type_match(self):
+        element = MagicMock(slug="earth")
+        for mon in self.player.party._monsters:
+            mon.types.set_types([element])
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(monster_types={"earth": 1}),
+        )
+        context = {"map_inside": True}
+        self.assertTrue(self.mon.evolution_handler.can_evolve(evo, context))
+
+    def test_can_evolve_type_mismatch(self):
+        element = MagicMock(slug="water")
+        for mon in self.player.party._monsters:
+            mon.types.set_types([element])
+
+        evo = MonsterEvolutionItemModel(
+            monster_slug="rockat",
+            party_conditions=PartyConditionsModel(monster_types={"fire": 1}),
         )
         context = {"map_inside": True}
         self.assertFalse(self.mon.evolution_handler.can_evolve(evo, context))

--- a/tuxemon/core/conditions/has_path.py
+++ b/tuxemon/core/conditions/has_path.py
@@ -15,14 +15,14 @@ if TYPE_CHECKING:
 @dataclass
 class HasPathCondition(CoreCondition):
     """
-    Checks against the creature's evolution paths.
-
-    Accepts a single parameter and returns whether it is applied.
-
+    Checks whether the creature has an evolution path that includes the specified
+    item slug.
     """
 
     name = "has_path"
     expected: str
 
     def test_with_monster(self, session: Session, target: Monster) -> bool:
-        return any(t.item == self.expected for t in target.evolutions)
+        return any(
+            self.expected in (evo.item or {}) for evo in target.evolutions
+        )

--- a/tuxemon/core/effects/evolve.py
+++ b/tuxemon/core/effects/evolve.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
+from tuxemon.db import MonsterEvolutionItemModel
 from tuxemon.monster import Monster
 
 if TYPE_CHECKING:
@@ -25,13 +26,28 @@ class EvolveEffect(CoreEffect):
     ) -> ItemEffectResult:
         if not target.evolutions:
             return ItemEffectResult(name=item.name)
-        choices = [d for d in target.evolutions if d.item == item.slug]
-        if len(choices) == 1:
-            evolution = choices[0].monster_slug
-        else:
-            evolution = random.choice(choices).monster_slug
 
-        new_monster = Monster.create(evolution)
+        possible_evolutions: list[tuple[MonsterEvolutionItemModel, float]] = []
+        for evolution_model in target.evolutions:
+            item_weights = evolution_model.item
+            if isinstance(item_weights, dict) and item.slug in item_weights:
+                weight = item_weights[item.slug]
+                if weight > 0.0:
+                    possible_evolutions.append((evolution_model, weight))
+
+        if not possible_evolutions:
+            return ItemEffectResult(name=item.name)
+
+        if len(possible_evolutions) == 1:
+            selected_evolution_model = possible_evolutions[0][0]
+        else:
+            evolution_choices, weights = zip(*possible_evolutions)
+            selected_evolution_model = random.choices(
+                evolution_choices, weights=weights, k=1
+            )[0]
+
+        evolution_slug = selected_evolution_model.monster_slug
+        new_monster = Monster.create(evolution_slug)
         target.evolution_handler.evolve_monster(new_monster)
 
         session.client.push_state(
@@ -39,4 +55,5 @@ class EvolveEffect(CoreEffect):
             original=target.slug,
             evolved=new_monster.slug,
         )
+
         return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -234,6 +234,96 @@ class CommonEffect(BaseModel):
     )
 
 
+class BaseComparison(BaseModel):
+    comparison: Comparison = Field(
+        ...,
+        description="The type of comparison to perform (e.g., greater_than, equal_to).",
+    )
+    target_value: Optional[int] = Field(
+        None,
+        description="An optional fixed numeric value to compare against (e.g., stat must be greater than 50).",
+    )
+
+
+class StatsComparison(BaseComparison):
+    stat_type: StatType = Field(
+        ...,
+        description="The primary stat being evaluated for the evolution condition (e.g., speed, defense).",
+    )
+    target_stat: Optional[StatType] = Field(
+        None,
+        description="An optional secondary stat to compare against the primary stat (e.g., compare speed to defense).",
+    )
+
+
+class BondComparison(BaseComparison):
+    value: int = Field(
+        ...,
+        description="The bond value to compare against.",
+        ge=config_monster.bond_range[0],
+        le=config_monster.bond_range[1],
+    )
+
+
+class PartyConditionsModel(BaseModel):
+    monster_slugs: Optional[dict[str, int]] = Field(
+        None,
+        description="A dictionary specifying required monsters and their minimum counts by slug.",
+    )
+    monster_types: Optional[dict[str, int]] = Field(
+        None,
+        description="A dictionary specifying required monster types and their minimum counts.",
+    )
+    genders: Optional[dict[GenderType, int]] = Field(
+        None,
+        description="A dictionary specifying required genders and their minimum counts.",
+    )
+    alignment: Optional[str] = Field(
+        None,
+        description="The elemental alignment the party must lean toward for evolution to occur.",
+    )
+
+    @field_validator("monster_slugs")
+    def validate_monster_slugs(
+        cls, v: Optional[dict[str, int]]
+    ) -> Optional[dict[str, int]]:
+        if v:
+            for slug, count in v.items():
+                if not has.db_entry("monster", slug):
+                    raise ValueError(
+                        f"Monster slug '{slug}' does not exist in the database."
+                    )
+                if not (0 <= count < prepare.PARTY_LIMIT):
+                    raise ValueError(
+                        f"Count for monster slug '{slug}' must be between 0 and {prepare.PARTY_LIMIT - 1}."
+                    )
+        return v
+
+    @field_validator("monster_types")
+    def validate_monster_types(
+        cls, v: Optional[dict[str, int]]
+    ) -> Optional[dict[str, int]]:
+        if v:
+            for type_, count in v.items():
+                if not (0 <= count < prepare.PARTY_LIMIT):
+                    raise ValueError(
+                        f"Count for monster type '{type_}' must be between 0 and {prepare.PARTY_LIMIT - 1}."
+                    )
+        return v
+
+    @field_validator("genders")
+    def validate_genders(
+        cls, v: Optional[dict[GenderType, int]]
+    ) -> Optional[dict[GenderType, int]]:
+        if v:
+            for gender, count in v.items():
+                if not (0 <= count < prepare.PARTY_LIMIT):
+                    raise ValueError(
+                        f"Count for gender '{gender}' must be between 0 and {prepare.PARTY_LIMIT - 1}."
+                    )
+        return v
+
+
 class ItemBehaviors(BaseModel):
     consumable: bool = Field(
         True, description="Whether or not this item is consumable."
@@ -497,9 +587,13 @@ class MonsterEvolutionItemModel(BaseModel):
         None,
         description="The required gender of the monster for evolution.",
     )
-    item: Optional[str] = Field(
+    item: Optional[dict[str, float]] = Field(
         None,
-        description="The item that the monster must have to evolve.",
+        description=(
+            "A dictionary of item slugs and their associated evolution weights. "
+            "Weights are relative and will be normalized to sum to 1.0. "
+            "Each item must exist in the database and have a non-negative weight."
+        ),
     )
     inside: Optional[bool] = Field(
         None,
@@ -514,9 +608,14 @@ class MonsterEvolutionItemModel(BaseModel):
         description="The game variables that must exist and match a specific value for the monster to evolve.",
         min_length=1,
     )
-    stats: Optional[str] = Field(
+    stats: Optional[StatsComparison] = Field(
         None,
-        description="The statistic comparison required for the monster to evolve (e.g., greater_than, less_than, etc.).",
+        description=(
+            "Defines a condition where one monster stat must compare to another stat or value "
+            "for evolution to occur. For example, 'speed must be greater than defense'. "
+            "Includes the stat being evaluated, the type of comparison (e.g., greater_than, equal_to), "
+            "and the target stat or value."
+        ),
     )
     steps: Optional[int] = Field(
         None,
@@ -532,23 +631,28 @@ class MonsterEvolutionItemModel(BaseModel):
         min_length=1,
         max_length=prepare.MAX_MOVES,
     )
-    bond: Optional[str] = Field(
+    bond: Optional[BondComparison] = Field(
         None,
-        description="The bond value comparison required for the monster to evolve (e.g., greater_than, less_than, etc.).",
+        description=(
+            "Defines a condition where the monster's bond must meet a specific comparison to evolve. "
+            "Includes the comparison type (e.g., greater_than, equals) and the target bond value. "
+            "For example, 'bond must be greater than 50'."
+        ),
     )
-    party: Sequence[str] = Field(
-        [],
-        description="The slug of the monsters that must be in the party for the evolution to occur.",
-        min_length=1,
-        max_length=prepare.PARTY_LIMIT - 1,
-    )
-    taste_cold: Optional[str] = Field(
+    tastes: Optional[dict[str, str]] = Field(
         None,
-        description="The required taste cold value for the monster to evolve.",
+        description="A dictionary of taste values required for the monster to evolve (e.g., {'cold': 'value', 'warm': 'value'}).",
     )
-    taste_warm: Optional[str] = Field(
+    probability: Optional[float] = Field(
         None,
-        description="The required taste warm value for the monster to evolve.",
+        description="Chance (0.0 to 1.0) that this evolution occurs when conditions are met.",
+    )
+    held_item: Optional[str] = Field(
+        None, description="Item slug the monster must be holding to evolve."
+    )
+    party_conditions: Optional[PartyConditionsModel] = Field(
+        None,
+        description="Complex conditions based on the player's party required for evolution.",
     )
 
     @field_validator("moves")
@@ -571,13 +675,17 @@ class MonsterEvolutionItemModel(BaseModel):
             return v
         raise ValueError(f"the technique {v} doesn't exist in the db")
 
-    @field_validator("taste_cold", "taste_warm")
-    def taste_exists(
-        cls: MonsterEvolutionItemModel, v: Optional[str]
-    ) -> Optional[str]:
-        if not v or has.db_entry("taste", v):
-            return v
-        raise ValueError(f"the taste {v} doesn't exist in the db")
+    @field_validator("tastes")
+    def validate_tastes(
+        cls, v: Optional[dict[str, str]]
+    ) -> Optional[dict[str, str]]:
+        if v:  # Only proceed if the tastes dictionary is not None
+            for taste_value in v.values():
+                if not has.db_entry("taste", taste_value):
+                    raise ValueError(
+                        f"The taste '{taste_value}' does not exist in the database."
+                    )
+        return v
 
     @field_validator("element")
     def element_exists(
@@ -593,69 +701,42 @@ class MonsterEvolutionItemModel(BaseModel):
             return v
         raise ValueError(f"the monster {v} doesn't exist in the db")
 
-    @field_validator("party")
-    def party_exists(
-        cls: MonsterEvolutionItemModel, v: Sequence[str]
-    ) -> Sequence[str]:
-        if v:
-            for element in v:
-                if not has.db_entry("monster", element):
-                    raise ValueError(
-                        f"A monster {element} doesn't exist in the db"
-                    )
-        return v
-
     @field_validator("item")
-    def item_exists(
+    def validate_item_and_weights(
+        cls: MonsterEvolutionItemModel, v: Optional[dict[str, float]]
+    ) -> Optional[dict[str, float]]:
+        if v is None:
+            return v
+
+        total_weight = 0.0
+        for item_slug, weight in v.items():
+            if not has.db_entry("item", item_slug):
+                raise ValueError(
+                    f"The item '{item_slug}' doesn't exist in the database."
+                )
+            if weight < 0.0:
+                raise ValueError(
+                    f"Weight for item '{item_slug}' must be non-negative."
+                )
+            total_weight += weight
+
+        if total_weight == 0.0:
+            raise ValueError(
+                "Total weight must be greater than 0.0 to normalize."
+            )
+
+        normalized = {
+            slug: weight / total_weight for slug, weight in v.items()
+        }
+        return normalized
+
+    @field_validator("held_item")
+    def held_item_exists(
         cls: MonsterEvolutionItemModel, v: Optional[str]
     ) -> Optional[str]:
         if not v or has.db_entry("item", v):
             return v
-        raise ValueError(f"the item {v} doesn't exist in the db")
-
-    @field_validator("stats")
-    def stats_exists(
-        cls: MonsterEvolutionItemModel, v: Optional[str]
-    ) -> Optional[str]:
-        stats = list(StatType)
-        comparison = list(Comparison)
-        param = v.split(":") if v else []
-        if not v or len(param) == 3:
-            if param[1] not in comparison:
-                raise ValueError(
-                    f"the comparison {param[1]} doesn't exist among {comparison}"
-                )
-            if param[0] not in stats:
-                raise ValueError(
-                    f"the stat {param[0]} doesn't exist among {stats}"
-                )
-            if param[2] not in stats:
-                raise ValueError(
-                    f"the stat {param[2]} doesn't exist among {stats}"
-                )
-            return v
-        raise ValueError(f"the stats {v} isn't formatted correctly")
-
-    @field_validator("bond")
-    def bond_exists(
-        cls: MonsterEvolutionItemModel, v: Optional[str]
-    ) -> Optional[str]:
-        comparison = list(Comparison)
-        param = v.split(":") if v else []
-        if not v or len(param) == 2:
-            if param[0] not in comparison:
-                raise ValueError(
-                    f"the comparison {param[0]} doesn't exist among {comparison}"
-                )
-            if not param[1].isdigit():
-                raise ValueError(f"{param[1]} isn't a number (int)")
-            lower, upper = config_monster.bond_range
-            if int(param[1]) < lower or int(param[1]) > upper:
-                raise ValueError(
-                    f"the bond is between {lower} and {upper} ({v})"
-                )
-            return v
-        raise ValueError(f"the stats {v} isn't formatted correctly")
+        raise ValueError(f"the held item {v} doesn't exist in the db")
 
 
 class MonsterFlairItemModel(BaseModel):

--- a/tuxemon/monster_dir/evolution.py
+++ b/tuxemon/monster_dir/evolution.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 import logging
+import random
 from typing import TYPE_CHECKING
 
 from tuxemon.db import (
+    GenderType,
     LearningMethod,
     MonsterEvolutionItemModel,
+    PartyConditionsModel,
     SeenStatus,
-    StatType,
 )
 from tuxemon.locale import T
 from tuxemon.tools import compare
 
 if TYPE_CHECKING:
+    from tuxemon.entity_dir.party import PartyHandler
     from tuxemon.monster import Monster
 
 logger = logging.getLogger(__name__)
@@ -70,7 +73,10 @@ class Evolution:
         new_monster.moves = self.monster.moves
         new_monster.status = self.monster.status
         new_monster.instance_id = self.monster.instance_id
-        new_monster.gender = self.monster.gender
+        if self.monster.gender in new_monster.possible_genders:
+            new_monster.gender = self.monster.gender
+        else:
+            new_monster.gender = random.choice(new_monster.possible_genders)
         new_monster.capture = self.monster.capture
         new_monster.capture_device = self.monster.capture_device
         new_monster.taste_cold = self.monster.taste_cold
@@ -144,27 +150,31 @@ class Evolution:
             conditions.extend(
                 monster in moves_slugs for monster in evolution_item.moves
             )
-        if evolution_item.party:
-            monster_slugs = {mon.slug for mon in owner.monsters}
-            conditions.extend(
-                monster in monster_slugs for monster in evolution_item.party
-            )
-        if evolution_item.taste_cold is not None:
-            conditions.append(
-                self.monster.taste_cold == evolution_item.taste_cold
-            )
-        if evolution_item.taste_warm is not None:
-            conditions.append(
-                self.monster.taste_warm == evolution_item.taste_warm
-            )
+
+        if evolution_item.tastes:
+            for taste_type, required_value in evolution_item.tastes.items():
+                monster_taste = getattr(
+                    self.monster, f"taste_{taste_type}", None
+                )
+                conditions.append(monster_taste == required_value)
 
         # Check if the monster's stats meet the evolution conditions
         if evolution_item.stats is not None:
-            params = evolution_item.stats.split(":")
-            operator = params[1]
-            stat1 = self.monster.return_stat(StatType(params[0]))
-            stat2 = self.monster.return_stat(StatType(params[2]))
-            conditions.append(compare(operator, stat1, stat2))
+            stat1 = self.monster.return_stat(evolution_item.stats.stat_type)
+            operator = evolution_item.stats.comparison
+
+            if evolution_item.stats.target_stat is not None:
+                stat2 = self.monster.return_stat(
+                    evolution_item.stats.target_stat
+                )
+            elif evolution_item.stats.target_value is not None:
+                stat2 = evolution_item.stats.target_value
+            else:
+                raise ValueError(
+                    "StatsComparison must have either target_stat or target_value."
+                )
+
+            conditions.append(compare(operator.value, stat1, stat2))
 
         # Check if the monster's game variables meet the evolution conditions
         if evolution_item.variables:
@@ -183,15 +193,93 @@ class Evolution:
             self.monster.levelling_up = True
             self.monster.got_experience = True
 
+        # Check if the party conditions
+        if evolution_item.party_conditions is not None:
+            conditions.append(
+                check_party_conditions(
+                    owner.party, evolution_item.party_conditions
+                )
+            )
+
         # Check if the monster's bond meets the evolution conditions
         if evolution_item.bond is not None:
-            parts = evolution_item.bond.split(":")
-            operator, value = parts[:2]
+            _operator = evolution_item.bond.comparison
+            _value = evolution_item.bond.value
             _bond = self.monster.bond
-            conditions.append(compare(operator, _bond, int(value)))
+            conditions.append(compare(_operator.value, _bond, _value))
 
-        # If the evolution requires an item, do not evolve
-        if evolution_item.item is not None:
-            return context.get("use_item", False)
+        # Check if the monster is holding the required item for evolution
+        if evolution_item.held_item is not None:
+            held_item = self.monster.held_item.get_item()
+            conditions.append(
+                held_item is not None
+                and held_item.slug == evolution_item.held_item
+            )
 
-        return all(conditions)
+        # If the evolution requires an item, do not evolve unless it's being used
+        if evolution_item.item is not None and not context.get(
+            "use_item", False
+        ):
+            return False
+
+        # No conditions, only probability
+        if not conditions and evolution_item.probability is not None:
+            return random.random() <= evolution_item.probability
+
+        # Conditions must all be met
+        if all(conditions):
+            # If probability is set, roll for it
+            if evolution_item.probability is not None:
+                return random.random() <= evolution_item.probability
+            # Otherwise, guaranteed evolution
+            return True
+
+        # Conditions not met
+        return False
+
+
+def check_party_conditions(
+    party_handler: PartyHandler, conditions_model: PartyConditionsModel
+) -> bool:
+    """
+    Evaluates whether the player's party meets the specified evolution conditions.
+    """
+    conditions = []
+
+    # Check party alignment
+    if conditions_model.alignment is not None:
+        alignment = party_handler.get_alignment()
+        conditions.append(alignment == conditions_model.alignment)
+
+    # Check required monster slugs
+    if conditions_model.monster_slugs is not None:
+        slug_counts: dict[str, int] = {}
+        for mon in party_handler.monsters:
+            slug_counts[mon.slug] = slug_counts.get(mon.slug, 0) + 1
+
+        for slug, required_count in conditions_model.monster_slugs.items():
+            conditions.append(slug_counts.get(slug, 0) >= required_count)
+
+    # Check required monster types
+    if conditions_model.monster_types is not None:
+        type_counts: dict[str, int] = {}
+        for mon in party_handler.monsters:
+            types = mon.types.current
+            for t in types:
+                slug = t.slug
+                type_counts[slug] = type_counts.get(slug, 0) + 1
+
+        for type_, required_count in conditions_model.monster_types.items():
+            conditions.append(type_counts.get(type_, 0) >= required_count)
+
+    # Check required genders
+    if conditions_model.genders is not None:
+        gender_counts: dict[GenderType, int] = {}
+        for mon in party_handler.monsters:
+            gender = mon.gender
+            gender_counts[gender] = gender_counts.get(gender, 0) + 1
+
+        for gender, required_count in conditions_model.genders.items():
+            conditions.append(gender_counts.get(gender, 0) >= required_count)
+
+    return all(conditions)


### PR DESCRIPTION
PR introduces two new optional fields to the `MonsterEvolutionItemModel`.

- `probability`: allows evolution to be chance-based. If set, the monster will only evolve when all other conditions are met *and* a random check passes. This enables rare or unpredictable evolutions, adding variety and surprise to gameplay.

- `held_item`: specifies a required item that the monster must be holding to evolve. It supports item-based evolution triggers, such as needing to hold an item. The system checks the monster’s held item and compares it to the required slug.

Both fields are optional and integrate cleanly with existing evolution logic. Unit tests have been added to verify behavior for both successful and failed evolution attempts based on these new conditions.

**Also included is a fix for a subtle gender mismatch issue during evolution.**

Normally, when a monster evolves, it keeps the same gender, male stays male, neuter stays neuter, and so on. But some evolved forms only allow specific genders (like only female or only neuter), which can cause problems if the original monster doesn’t match. Previously, the system would blindly copy the old gender over, even if it wasn’t valid for the new form.

This PR adds a check: if the original gender is allowed by the evolved form’s `possible_genders`, it’s kept. If not, the system randomly picks one of the valid options for the new monster. This avoids invalid states and makes sure the evolved monster always has a gender that fits its design.

It’s a small but important fix that keeps evolution logic clean and avoids weird edge cases where a monster ends up with a gender it shouldn’t have.

This PR also refactors the `stats` field in `MonsterEvolutionItemModel`, replacing the previous string-based format with a structured `StatsComparison`. This change improves clarity, validation and flexibility. It eliminates parsing logic and enables more robust evolution conditions, paving the way for future extensions like stat thresholds or dynamic comparisons.

This update also refactors the `bond` field in `MonsterEvolutionItemModel`, replacing the previous string-based format with a structured `BondComparison` model. By explicitly separating the comparison type and target bond value, it eliminates parsing logic and improves validation. This change aligns with the new `StatsComparison` model, creating a consistent and extensible framework for condition-based evolution triggers.

The evolution schema has transitioned from using a single optional string (`item: Optional[str]`) to a more expressive and extensible dictionary format (`item: dict[str, float]`). This change allows each evolution entry to support multiple item triggers with associated weights, enabling probabilistic evolution logic and greater flexibility for modders. Instead of hardcoding one item per evolution, designers can now define several valid items with relative chances, all while maintaining a consistent structure that simplifies validation, introspection and future expansion.