### PR TITLE
Replace client-based screen size and rect with prepare constants

### DIFF
--- a/tests/tuxemon/test_world_transition.py
+++ b/tests/tuxemon/test_world_transition.py
@@ -3,8 +3,6 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from pygame.surface import Surface
-
 from tuxemon.client import LocalPygameClient
 from tuxemon.movement import MovementManager
 from tuxemon.world.transition import WorldTransition
@@ -14,8 +12,6 @@ class TestTransition(TestCase):
     def setUp(self):
         self.mock_world = MagicMock()
         self.mock_world.client = MagicMock(spec=LocalPygameClient)
-        self.mock_world.client.screen = MagicMock(spec=Surface)
-        self.mock_world.client.screen.get_size.return_value = (800, 600)
         self.mock_world.client.movement_manager = MagicMock(
             spec=MovementManager
         )
@@ -30,6 +26,7 @@ class TestTransition(TestCase):
         self.assertEqual(self.transition.transition_alpha, 0)
         self.assertFalse(self.transition.in_transition)
 
+    @patch("tuxemon.prepare.SCREEN_SIZE", (800, 600))
     def test_set_transition_surface_size(self):
         color = (0, 0, 0, 255)
         self.transition.set_transition_surface(color)
@@ -53,6 +50,7 @@ class TestTransition(TestCase):
         self.transition.set_transition_state(False)
         self.assertFalse(self.transition.in_transition)
 
+    @patch("tuxemon.prepare.SCREEN_SIZE", (800, 600))
     def test_set_transition_surface(self):
         mock_color = (255, 0, 0)
         self.transition.set_transition_surface(mock_color)

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -12,7 +12,7 @@ import logging
 import re
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
+from typing import Any, Optional, Protocol, Union
 
 from pygame.color import Color
 from pygame.image import load
@@ -28,9 +28,6 @@ from tuxemon.session import Session
 from tuxemon.sprite import Sprite
 from tuxemon.surfanim import SurfaceAnimation
 from tuxemon.tools import scale_sequence, transform_resource_filename
-
-if TYPE_CHECKING:
-    from tuxemon.client import LocalPygameClient
 
 logger = logging.getLogger(__name__)
 
@@ -382,24 +379,6 @@ def scaled_image_loader(
         return tile
 
     return load_image
-
-
-def capture_screenshot(game: LocalPygameClient) -> Surface:
-    """
-    Capture a screenshot of the current map.
-
-    Parameters:
-        game: The game object.
-
-    Returns:
-        The captured screenshot.
-    """
-    from tuxemon.states.world_state import WorldState
-
-    screenshot = Surface(game.screen.get_size())
-    world = game.get_state_by_name(WorldState)
-    world.draw(screenshot)
-    return screenshot
 
 
 def get_avatar(session: Session, avatar: str) -> Optional[Sprite]:

--- a/tuxemon/map/map_view.py
+++ b/tuxemon/map/map_view.py
@@ -289,9 +289,8 @@ class MapRenderer:
     def __init__(self, client: LocalPygameClient):
         """Initializes the MapRenderer."""
         self.client = client
-        self.screen = client.screen
         self.camera_manager = client.camera_manager
-        self.layer = Surface(self.screen.get_size(), pygame.SRCALPHA)
+        self.layer = Surface(prepare.SCREEN_SIZE, pygame.SRCALPHA)
         self.layer_color: Optional[ColorLike] = None
         self.cinema_x_ratio: Optional[float] = None
         self.cinema_y_ratio: Optional[float] = None

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -932,7 +932,7 @@ class PopUpMenu(Menu[T]):
     def animate_open(self) -> Animation:
         # anchor the center of the popup
         final_rect = self.calc_final_rect()
-        self.anchor("center", self.client.screen.get_rect().center)
+        self.anchor("center", prepare.SCREEN_RECT.center)
 
         # set rect to a small size for the initial values of the animation
         self.rect = self._calculate_initial_rect(final_rect)

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -73,7 +73,7 @@ def capture_screenshot(client: LocalPygameClient) -> Surface:
     Returns:
         Captured image.
     """
-    screenshot = Surface(client.screen.get_size())
+    screenshot = Surface(prepare.SCREEN_SIZE)
     world = client.get_state_by_name(WorldState)
     world.draw(screenshot)
     return screenshot

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -96,7 +96,7 @@ class CombatAnimations(Menu[None], ABC):
     def show_combat_dialog(self) -> None:
         """Create and show the area where battle messages are displayed."""
         # make the border and area at the bottom of the screen for messages
-        rect_screen = self.client.screen.get_rect()
+        rect_screen = prepare.SCREEN_RECT.copy()
         rect = Rect(0, 0, rect_screen.w, rect_screen.h // 4)
         rect.bottomright = rect_screen.w, rect_screen.h
         border = graphics.load_and_scale(self.borders_filename)
@@ -206,7 +206,7 @@ class CombatAnimations(Menu[None], ABC):
         self.sprite_map.add_sprite(monster, monster_sprite)
 
         # Position monster sprite off screen and animate it to final spot
-        monster_sprite.rect.top = self.client.screen.get_height()
+        monster_sprite.rect.top = prepare.SCREEN.get_height()
         self.animate(
             monster_sprite.rect,
             bottom=feet[1],

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -78,7 +78,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         self.combat.dialog.alert(message)
 
     def calculate_menu_rectangle(self) -> Rect:
-        rect_screen = self.client.screen.get_rect()
+        rect_screen = prepare.SCREEN_RECT.copy()
         menu_width = rect_screen.w // 2.5
         menu_height = rect_screen.h // 4
         rect = Rect(0, 0, menu_width, menu_height)
@@ -182,7 +182,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         menu.on_menu_selection = swap_it  # type: ignore[assignment]
         menu.is_valid_entry = validate  # type: ignore[assignment]
         menu.anchor("bottom", self.rect.top)
-        menu.anchor("right", self.client.screen.get_rect().right)
+        menu.anchor("right", prepare.SCREEN_RECT.right)
 
         if all(not validate_monster(mon) for mon in self.character.monsters):
             party_unselectable = T.translate("combat_party_unselectable")
@@ -303,7 +303,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
             # position the new menu
             menu.anchor("bottom", self.rect.top)
-            menu.anchor("right", self.client.screen.get_rect().right)
+            menu.anchor("right", prepare.SCREEN_RECT.right)
 
             # set next menu after the selection is made
             menu.on_menu_selection = choose_target  # type: ignore[assignment]
@@ -464,7 +464,7 @@ class CombatTargetMenuState(Menu[Monster]):
 
     def _create_menu(self) -> None:
         """Sets up the menu UI."""
-        rect_screen = self.client.screen.get_rect()
+        rect_screen = prepare.SCREEN_RECT.copy()
         rect = Rect(0, 0, rect_screen.w // 2, rect_screen.h // 4)
         rect.bottomright = rect_screen.w, rect_screen.h
 

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -99,7 +99,7 @@ class ItemMenuState(Menu[Item]):
         self.inventory = self.filter_controller.get_filtered_inventory()
 
         # this is the area where the item description is displayed
-        rect = self.client.screen.get_rect()
+        rect = prepare.SCREEN_RECT.copy()
         rect.top = scale(106)
         rect.left = scale(3)
         rect.width = scale(250)

--- a/tuxemon/states/load_menu.py
+++ b/tuxemon/states/load_menu.py
@@ -7,6 +7,7 @@ from typing import ClassVar, Optional
 
 from pygame.rect import Rect
 
+from tuxemon import prepare
 from tuxemon.menu.interface import MenuItem
 
 from .save_menu import SLOT_HEIGHT_RATIO, SLOT_WIDTH_RATIO, SaveMenuState
@@ -24,7 +25,7 @@ class LoadMenuState(SaveMenuState):
             self.on_menu_selection(None)
 
     def initialize_items(self) -> None:
-        rect = self.client.screen.get_rect()
+        rect = prepare.SCREEN_RECT.copy()
         slot_rect = Rect(
             0,
             0,

--- a/tuxemon/states/park_menu.py
+++ b/tuxemon/states/park_menu.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional
 
 from pygame.rect import Rect
 
+from tuxemon import prepare
 from tuxemon.db import ItemCategory
 from tuxemon.item.filter import ItemFilter
 from tuxemon.item.item import Item
@@ -69,7 +70,7 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
         self.combat.dialog.alert(message)
 
     def calculate_menu_rectangle(self) -> Rect:
-        rect_screen = self.client.screen.get_rect()
+        rect_screen = prepare.SCREEN_RECT.copy()
         menu_width = rect_screen.w // 2.5
         menu_height = rect_screen.h // 4
         rect = Rect(0, 0, menu_width, menu_height)

--- a/tuxemon/states/save_menu.py
+++ b/tuxemon/states/save_menu.py
@@ -58,7 +58,7 @@ class SaveMenuState(PopUpMenu[None]):
             )
 
     def initialize_items(self) -> None:
-        rect = self.client.screen.get_rect()
+        rect = prepare.SCREEN_RECT.copy()
         slot_rect = Rect(
             0,
             0,

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -54,7 +54,7 @@ class TechniqueMenuState(Menu[Technique]):
         self.menu_items.line_spacing = scale(7)
 
         # this is the area where the technique description is displayed
-        rect = self.client.screen.get_rect()
+        rect = prepare.SCREEN_RECT.copy()
         rect.top = scale(106)
         rect.left = scale(3)
         rect.width = scale(250)

--- a/tuxemon/states/transition_fade.py
+++ b/tuxemon/states/transition_fade.py
@@ -53,8 +53,7 @@ class FadeTransitionBase(State):
             self.fade_duration = fade_duration
 
         self.caller = caller
-        size = self.client.screen.get_size()
-        self.transition_surface = Surface(size, SRCALPHA)
+        self.transition_surface = Surface(prepare.SCREEN_SIZE, SRCALPHA)
         self.transition_surface.fill(color)
         self.task(self.client.pop_state, interval=self.state_duration)
         self.create_fade_animation()

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -60,7 +60,6 @@ class WorldState(State):
         self.mod_name = extract_mod_name(map_name)
         self.session = session
         self.session.set_world(self)
-        self.screen = self.client.screen
         self.tile_size = prepare.TILE_SIZE
         self.menu_manager = WorldMenuManager(self.client)
         self.teleporter = Teleporter(self.client)
@@ -149,7 +148,6 @@ class WorldState(State):
         Parameters:
             surface: Surface to draw into.
         """
-        self.screen = surface
         if self.client.map_manager.current_map is None:
             raise ValueError("Unable to draw the game world.")
         self.map_renderer.draw(surface, self.client.map_manager.current_map)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -231,7 +231,7 @@ def open_dialog(
         dialog_rect = custom_rect
     else:
         dialog_rect = calc_dialog_rect(
-            client.screen.get_rect(), position, target_coords=target_coords
+            prepare.SCREEN_RECT, position, target_coords=target_coords
         )
 
     return client.push_state(

--- a/tuxemon/world/transition.py
+++ b/tuxemon/world/transition.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional
 from pygame import SRCALPHA
 from pygame.surface import Surface
 
+from tuxemon import prepare
 from tuxemon.graphics import ColorLike
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ class WorldTransition:
         ):
             return
 
-        new_surface = Surface(self.world.client.screen.get_size(), SRCALPHA)
+        new_surface = Surface(prepare.SCREEN_SIZE, SRCALPHA)
         new_surface.fill(color)
         self.transition_surface = new_surface
 


### PR DESCRIPTION
waiting:
- [x] #3101

PR updates screen size and rectangle references to use `prepare.SCREEN_SIZE` and `prepare.SCREEN_RECT` instead of accessing them through `self.client.screen.get_size()` and `get_rect()`.

Changes:
- replaced all instances of `self.client.screen.get_size()` with `prepare.SCREEN_SIZE`
- replaced all instances of `self.client.screen.get_rect()` with `prepare.SCREEN_RECT`
- this avoids passing screen-related values through the client object
- helps distinguish between headless and pygame-based clients more cleanly
- reduces coupling between menu logic and client implementation
- removed `capture_screenshot` method from graphics.py (exactly the same in save.py)