### PR TITLE
Temporary Relocation of `CommandProcessor` Initialization

### DIFF
--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -7,13 +7,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from enum import Enum
 from pathlib import Path
-from threading import Thread
 from typing import Any, Optional, TypeVar, Union, overload
 
 from tuxemon.audio import MusicPlayerState, SoundManager
 from tuxemon.boundary import BoundaryChecker
 from tuxemon.camera.camera import CameraManager
-from tuxemon.cli.processor import CommandProcessor
 from tuxemon.combat.session import CombatSession
 from tuxemon.config import TuxemonConfig
 from tuxemon.constants import paths
@@ -103,12 +101,6 @@ class BaseClient(ABC):
         # Set up a variable that will keep track of currently playing music.
         self.current_music = MusicPlayerState()
         self.sound_manager = SoundManager()
-
-        if self.config.cli:
-            self.cli = CommandProcessor(local_session)
-            thread = Thread(target=self.cli.run)
-            thread.daemon = True
-            thread.start()
 
         # Set up rumble support for gamepads
         self.rumble_manager = RumbleManager()

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 import time
+from threading import Thread
 
 import pygame
 from pygame.surface import Surface
 
 from tuxemon.base_client import BaseClient, ClientState
+from tuxemon.cli.processor import CommandProcessor
 from tuxemon.config import TuxemonConfig
 from tuxemon.session import local_session
 from tuxemon.state.draw import EventDebugDrawer, Renderer, StateDrawer
@@ -65,6 +67,10 @@ class LocalPygameClient(BaseClient):
 
         if self.config.cli:
             local_session.set_client(self)
+            self.cli = CommandProcessor(local_session)
+            thread = Thread(target=self.cli.run)
+            thread.daemon = True
+            thread.start()
 
     def main(self) -> None:
         """


### PR DESCRIPTION
PR temporarily moves the initialization of `CommandProcessor` from `BaseClient` to `LocalPygameClient`. Although `CommandProcessor` logically belongs in `BaseClient`. The root cause is the following error during client startup:
```
[2025-09-09 12:11:30,792] tuxemon.client - ERROR - Failed to initialize client: Client is not initialized
An error occurred: Client is not initialized
```
To properly restore the initialization to `BaseClient` and ensures functionality.