### PR TITLE
Refactor Status Stat Fields into Unified Dictionary Format

### DIFF
--- a/mods/tuxemon/db/status/blinded.json
+++ b/mods/tuxemon/db/status/blinded.json
@@ -14,13 +14,15 @@
   "sfx": "sfx_pulse",
   "slug": "blinded",
   "sort": "meta",
-  "statdodge": {
-    "value": 0.5,
-    "operation": "*"
-  },
-  "statspeed": {
-    "value": 0.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "speed": {
+      "value": 0.5,
+      "operation": "*"
+    },
+    "dodge": {
+      "value": 0.5,
+      "operation": "*"
+    }
   },
   "cond_id": 17,
   "use_failure": null,

--- a/mods/tuxemon/db/status/chargedup.json
+++ b/mods/tuxemon/db/status/chargedup.json
@@ -17,25 +17,27 @@
   "sfx": "sfx_pulse",
   "slug": "chargedup",
   "sort": "meta",
-  "statarmour": {
-    "value": 2,
-    "operation": "*"
-  },
-  "statdodge": {
-    "value": 2,
-    "operation": "*"
-  },
-  "statmelee": {
-    "value": 2,
-    "operation": "*"
-  },
-  "statranged": {
-    "value": 2,
-    "operation": "*"
-  },
-  "statspeed": {
-    "value": 2,
-    "operation": "*"
+  "stat_modifiers": {
+    "armour": {
+      "value": 2,
+      "operation": "*"
+    },
+    "dodge": {
+      "value": 2,
+      "operation": "*"
+    },
+    "melee": {
+      "value": 2,
+      "operation": "*"
+    },
+    "ranged": {
+      "value": 2,
+      "operation": "*"
+    },
+    "speed": {
+      "value": 2,
+      "operation": "*"
+    }
   },
   "cond_id": 9,
   "use_failure": null,

--- a/mods/tuxemon/db/status/enraged.json
+++ b/mods/tuxemon/db/status/enraged.json
@@ -14,13 +14,15 @@
   "sfx": "sfx_pulse",
   "slug": "enraged",
   "sort": "meta",
-  "statmelee": {
-    "value": 2,
-    "operation": "*"
-  },
-  "statranged": {
-    "value": 0.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "melee": {
+      "value": 2,
+      "operation": "*"
+    },
+    "ranged": {
+      "value": 0.5,
+      "operation": "*"
+    }
   },
   "cond_id": 12,
   "use_failure": null,

--- a/mods/tuxemon/db/status/exhausted.json
+++ b/mods/tuxemon/db/status/exhausted.json
@@ -17,13 +17,15 @@
   "sfx": "sfx_pulse",
   "slug": "exhausted",
   "sort": "meta",
-  "statmelee": {
-    "value": 0.5,
-    "operation": "*"
-  },
-  "statranged": {
-    "value": 0.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "melee": {
+      "value": 0.5,
+      "operation": "*"
+    },
+    "ranged": {
+      "value": 0.5,
+      "operation": "*"
+    }
   },
   "cond_id": 11,
   "use_failure": null,

--- a/mods/tuxemon/db/status/focused.json
+++ b/mods/tuxemon/db/status/focused.json
@@ -14,9 +14,11 @@
   "sfx": "sfx_pulse",
   "slug": "focused",
   "sort": "meta",
-  "statdodge": {
-    "value": 1.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "dodge": {
+      "value": 1.5,
+      "operation": "*"
+    }
   },
   "cond_id": 14,
   "use_failure": null,

--- a/mods/tuxemon/db/status/hardshell.json
+++ b/mods/tuxemon/db/status/hardshell.json
@@ -14,9 +14,11 @@
   "sfx": "sfx_bite",
   "slug": "hardshell",
   "sort": "meta",
-  "statarmour": {
-    "value": 1.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "armour": {
+      "value": 1.5,
+      "operation": "*"
+    }
   },
   "cond_id": 1,
   "use_failure": null,

--- a/mods/tuxemon/db/status/slow.json
+++ b/mods/tuxemon/db/status/slow.json
@@ -14,9 +14,11 @@
   "sfx": "sfx_pulse",
   "slug": "slow",
   "sort": "meta",
-  "statspeed": {
-    "value": 0.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "speed": {
+      "value": 0.5,
+      "operation": "*"
+    }
   },
   "cond_id": 21,
   "use_failure": null,

--- a/mods/tuxemon/db/status/sniping.json
+++ b/mods/tuxemon/db/status/sniping.json
@@ -14,13 +14,15 @@
   "sfx": "sfx_pulse",
   "slug": "sniping",
   "sort": "meta",
-  "statmelee": {
-    "value": 0.5,
-    "operation": "*"
-  },
-  "statranged": {
-    "value": 2,
-    "operation": "*"
+  "stat_modifiers": {
+    "melee": {
+      "value": 0.5,
+      "operation": "*"
+    },
+    "ranged": {
+      "value": 2,
+      "operation": "*"
+    }
   },
   "cond_id": 13,
   "use_failure": null,

--- a/mods/tuxemon/db/status/softened.json
+++ b/mods/tuxemon/db/status/softened.json
@@ -14,13 +14,15 @@
   "sfx": "sfx_pulse",
   "slug": "softened",
   "sort": "meta",
-  "statarmour": {
-    "value": 0.5,
-    "operation": "*"
-  },
-  "statspeed": {
-    "value": 0.5,
-    "operation": "*"
+  "stat_modifiers": {
+    "armour": {
+      "value": 0.5,
+      "operation": "*"
+    },
+    "speed": {
+      "value": 0.5,
+      "operation": "*"
+    }
   },
   "cond_id": 16,
   "use_failure": null,

--- a/tuxemon/core/effects/statchange.py
+++ b/tuxemon/core/effects/statchange.py
@@ -30,7 +30,7 @@ class StatChangeEffect(CoreEffect):
     adjustments relative to a stat's base value, with clamping via `max_step_limit`
     to ensure balance.
 
-    Stats are pulled from the status's stat components (e.g. `status.statmelee`, etc.),
+    Stats are pulled from the status's stat components (e.g. `melee`, etc.),
     and can impact either permanent base stats or runtime health values.
 
     This class supports:
@@ -74,29 +74,13 @@ class StatChangeEffect(CoreEffect):
     def apply_status_target(
         self, session: Session, status: Status, target: Monster
     ) -> StatusEffectResult:
-        statsmaster = [
-            status.statspeed,
-            status.stathp,
-            status.statarmour,
-            status.statmelee,
-            status.statranged,
-            status.statdodge,
-        ]
-        slugs = [
-            "speed",
-            "current_hp",  # special case for current HP
-            "armour",
-            "melee",
-            "ranged",
-            "dodge",
-        ]
-
         if (
             status.has_phase(EffectPhase.PERFORM_STATUS)
             and self.name not in status._effect_applied
         ):
             status._effect_applied.add("statchange")
-            for stat_model, slug in zip(statsmaster, slugs):
+
+            for stat_slug, stat_model in status.stat_modifiers.items():
                 if not stat_model:
                     continue
 
@@ -107,7 +91,7 @@ class StatChangeEffect(CoreEffect):
                 operation = stat_model.operation
 
                 # Handle HP override
-                if slug == "current_hp" and override:
+                if stat_slug == "current_hp" and override:
                     target.current_hp = target.hp
                     logger.info(
                         f"[{status.name}] Overriding current HP > {target.name}: {target.hp}"
@@ -133,12 +117,12 @@ class StatChangeEffect(CoreEffect):
                         max(-max_step, min(max_step, actual_step))
                     )
 
-                    if slug == "current_hp":
+                    if stat_slug == "current_hp":
                         base = target.hp
                     else:
-                        base = getattr(target.base_stats, slug)
+                        base = getattr(target.base_stats, stat_slug)
 
-                    current = target.return_stat(StatType(slug))
+                    current = target.return_stat(StatType(stat_slug))
                     old_step = (current - base) / base
                     total_step = max(
                         -max_step,
@@ -159,7 +143,7 @@ class StatChangeEffect(CoreEffect):
                             )
 
                     logger.debug(
-                        f"[{status.name}] {slug} changed via {scaling_mode} step on {target.name}: "
+                        f"[{status.name}] {stat_slug} changed via {scaling_mode} step on {target.name}: "
                         f"step {old_step:.3f} > {total_step:.3f}, value {current:.2f} > {new_value:.2f}"
                     )
 
@@ -174,30 +158,36 @@ class StatChangeEffect(CoreEffect):
                     )
 
                     stat_base = (
-                        getattr(target, slug)
-                        if slug == "current_hp"
-                        else getattr(target.base_stats, slug, None)
+                        getattr(target, stat_slug)
+                        if stat_slug == "current_hp"
+                        else getattr(target.base_stats, stat_slug, None)
                     )
                     if stat_base is None:
                         continue
 
+                    if operation not in ops_dict:
+                        logger.warning(
+                            f"Unknown operation '{operation}' in status '{status.name}'"
+                        )
+                        continue
+
                     op_func = ops_dict.get(operation, lambda a, b: a)
-                    new_value = int(op_func(stat_base, applied_value))
+                    new_value = round(op_func(stat_base, applied_value))
 
                     logger.debug(
-                        f"[{status.name}] {slug} changed via value on {target.name}: "
+                        f"[{status.name}] {stat_slug} changed via value on {target.name}: "
                         f"{stat_base} > {new_value}"
                     )
 
                 # Safety: Clamp stat values
-                if new_value <= 0 and slug != "current_hp":
+                if new_value <= 0 and stat_slug != "current_hp":
                     new_value = 1
 
                 # Assignment
-                if slug == "current_hp":
+                if stat_slug == "current_hp":
                     target.current_hp = min(new_value, target.hp)
-                elif slug in StatType.__members__:
-                    setattr(target.base_stats, slug, int(new_value))
+                elif stat_slug in StatType.__members__:
+                    setattr(target.base_stats, stat_slug, int(new_value))
 
         elif status.has_phase(EffectPhase.ON_END):
             target.set_stats()

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1200,12 +1200,10 @@ class StatusModel(BaseModel, BaseLookupModel):
         description="Slug of what string to display when status fails",
     )
     cond_id: int = Field(..., description="The id of this status")
-    statspeed: Optional[StatModel] = Field(None)
-    stathp: Optional[StatModel] = Field(None)
-    statarmour: Optional[StatModel] = Field(None)
-    statdodge: Optional[StatModel] = Field(None)
-    statmelee: Optional[StatModel] = Field(None)
-    statranged: Optional[StatModel] = Field(None)
+    stat_modifiers: dict[str, StatModel] = Field(
+        default_factory=dict,
+        description="Dictionary of stat modifiers keyed by stat name (e.g., 'speed', 'hp')",
+    )
 
     @classmethod
     def lookup(cls, slug: str, db: ModData) -> StatusModel:

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -17,6 +17,7 @@ from tuxemon.db import (
     EffectPhase,
     Range,
     ResponseStatus,
+    StatModel,
     StatusModel,
     db,
 )
@@ -86,6 +87,7 @@ class Status:
         self.use_success: str = ""
         self.use_failure: str = ""
         self.modifiers: ModifiersHandler = ModifiersHandler()
+        self.stat_modifiers: dict[str, StatModel] = {}
 
         if Status.effect_manager is None:
             Status.effect_manager = EffectManager(
@@ -137,12 +139,8 @@ class Status:
 
         self.modifiers = ModifiersHandler(results.modifiers)
         # monster stats
-        self.statspeed = results.statspeed
-        self.stathp = results.stathp
-        self.statarmour = results.statarmour
-        self.statmelee = results.statmelee
-        self.statranged = results.statranged
-        self.statdodge = results.statdodge
+        self.stat_modifiers = results.stat_modifiers
+
         # status fields
         self.duration = results.duration
         self.bond = results.bond


### PR DESCRIPTION
PR introduces a structural refactor to how stat-related data is handled in the `StatusModel` and its associated effect logic.

Key changes:
- replaces individual stat fields (`statspeed`, `statarmour`, `statdodge`, `statmelee`, `statranged`, etc.) with a single `stat_modifiers` dictionary keyed by stat slug
- simplifies the model by consolidating all stat modifiers under one field, improving scalability and reducing redundancy
- updates the `StatChangeEffect` method to iterate over `stat_modifiers` instead of accessing each stat field manually
- ensures consistent handling of stat changes, including value-based and step-based operations, within the new dictionary structure
- preserves all existing functionality, including HP overrides, deviation logic and clamping safeguards
- prepares the system for future expansion of stat types without requiring model changes