### PR TITLE
Refactoring Player Initialization for Mod Flexibility

### DIFF
--- a/mods/tuxemon/mod.yaml
+++ b/mods/tuxemon/mod.yaml
@@ -7,6 +7,9 @@ authors:
   - beta
   - gamma
 
+# The player's initial slugs
+starting_players: ["npc_red"]
+
 # The map file (.tmx) where the player begins when starting this mod
 starting_map: "start_tuxemon.tmx"
 

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -129,7 +129,6 @@ class TuxemonConfig:
         # [player]
         player = self.config["player"]
         self.player_animation_speed: float = player["animation_speed"]
-        self.player_npc: str = player["player_npc"]
         self.player_walkrate: float = player["player_walkrate"]
         self.player_runrate: float = player["player_runrate"]
 
@@ -335,7 +334,6 @@ def generate_default_config() -> dict[str, Any]:
         },
         "player": {
             "animation_speed": 0.15,
-            "player_npc": "npc_red",
             "player_walkrate": 3.75,
             "player_runrate": 7.35,
         },

--- a/tuxemon/entity.py
+++ b/tuxemon/entity.py
@@ -169,8 +169,8 @@ class Entity(Generic[SaveDict]):
         session: Session,
     ) -> None:
         self.slug = slug
+        self.session = session
         self.client = session.client
-        self.world = session.world
         self.instance_id: UUID = uuid4()
         self.body = Body(position=Point3(0, 0, 0))
         self.mover = Mover(self.body)
@@ -250,13 +250,13 @@ class Entity(Generic[SaveDict]):
         """
         Set the entity's wandering position in the collision zone.
         """
-        self.world.add_collision(self, pos)
+        self.client.collision_manager.add_collision(self, pos)
 
     def remove_collision(self) -> None:
         """
         Remove the entity's wandering position from the collision zone.
         """
-        self.world.remove_collision(self.tile_pos)
+        self.client.collision_manager.remove_collision(self.tile_pos)
 
     # === PHYSICS END =========================================================
 

--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -10,6 +10,8 @@ from tuxemon import save
 from tuxemon.constants.asset_loader import fetch_asset
 from tuxemon.event.eventaction import EventAction
 from tuxemon.npc import NPCState
+from tuxemon.player import Player
+from tuxemon.prepare import PLAYER_NPC
 from tuxemon.session import Session
 from tuxemon.states.world_state import WorldSave, WorldState
 
@@ -63,6 +65,10 @@ class LoadGameAction(EventAction):
                 # avoid crash save and load same action
                 if self.index is not None:
                     client.remove_state_by_name("StartState")
+
+            slug = save_data["npc_state"].get("player_slug", PLAYER_NPC)
+            save_data["npc_state"]["player_slug"] = slug
+            Player.create(session, slug=slug)
 
             map_path = fetch_asset(
                 "maps", save_data["npc_state"]["current_map"]

--- a/tuxemon/launcher.py
+++ b/tuxemon/launcher.py
@@ -6,6 +6,7 @@ import random
 from typing import TYPE_CHECKING, Optional
 
 from tuxemon.constants.asset_loader import fetch_asset
+from tuxemon.player import Player
 from tuxemon.time_handler import today_ordinal
 
 if TYPE_CHECKING:
@@ -39,13 +40,20 @@ class GameLauncher:
         Starts the game session from a mod's metadata.
 
         Parameters:
-            mod_name: The name (folder) of the mod to launch.
             session: The active game session object.
+            mod_name: The name (folder) of the mod to launch.
             remove_states: Optional list of state names to remove after launch.
         """
         destination = self.db.require_mod_attribute(mod_name, "starting_map")
         tile_pos = self.db.require_mod_attribute(mod_name, "starting_position")
         map_path = fetch_asset("maps", destination)
+
+        player_slugs: list[str] = self.db.require_mod_attribute(
+            mod_name, "starting_players"
+        )
+        player_slug = random.choice(player_slugs)
+
+        Player.create(session, slug=player_slug)
 
         self.client.push_state(
             "WorldState", session=session, map_name=map_path

--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -76,7 +76,10 @@ def configure_game_states(
     if config.skip_titlescreen and config.mods:
         if len(config.mods) == 1:
             launcher = GameLauncher(client, db)
-            launcher.launch(mod_name=config.mods[0], session=local_session)
+            launcher.launch(
+                mod_name=config.mods[0],
+                session=local_session,
+            )
         else:
             client.push_state("ModsChoice", mods=config.mods)
 

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -56,6 +56,7 @@ class NPCState(TypedDict, total=False):
     missions: Sequence[Mapping[str, Any]]
     items: Sequence[Mapping[str, Any]]
     monsters: Sequence[Mapping[str, Any]]
+    player_slug: str
     player_name: str
     player_steps: float
     monster_boxes: dict[str, Sequence[Mapping[str, Any]]]
@@ -177,6 +178,7 @@ class NPC(Entity[NPCState]):
             "template": self.template.model_dump(),
             "missions": self.mission_controller.encode_missions(),
             "monsters": self.party.encode_party(),
+            "player_slug": self.slug,
             "player_name": self.name,
             "player_steps": self.steps,
             "monster_boxes": self.monster_boxes.get_state(),
@@ -206,6 +208,7 @@ class NPC(Entity[NPCState]):
         self.items.decode_items(save_data)
         self.party.decode_party(save_data)
         self.mission_controller.decode_missions(save_data.get("missions"))
+        self.slug = save_data["player_slug"]
         self.name = save_data["player_name"]
         self.steps = save_data["player_steps"]
         self.money_controller.load(save_data)
@@ -245,7 +248,9 @@ class NPC(Entity[NPCState]):
             destination: Desired final position.
         """
         self.pathfinding = destination
-        path = self.world.pathfind(self.tile_pos, destination, self.facing)
+        path = self.client.pathfinder.pathfind(
+            self.tile_pos, destination, self.facing
+        )
         if path:
             self.path = list(path)
             self.next_waypoint()

--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from tuxemon.map.map import proj
 from tuxemon.npc import NPC
-from tuxemon.prepare import PLAYER_NPC
 
 if TYPE_CHECKING:
     from tuxemon.session import Session
@@ -28,7 +27,7 @@ class Player(NPC):
         self.is_player = True
 
     @classmethod
-    def create(cls, session: Session, slug: str = PLAYER_NPC) -> Player:
+    def create(cls, session: Session, slug: str) -> Player:
         """Creates a player instance only if one doesn't already exist."""
         if not session.has_player():
             session.set_player(cls(slug, session))

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -218,7 +218,7 @@ COEFF_FEET: float = 0.032808399
 COEFF_POUNDS: float = 2.2046
 
 # Players
-PLAYER_NPC = CONFIG.player_npc
+PLAYER_NPC = "npc_red"
 PLAYER_NAME_LIMIT: int = 15  # The character limit for a player name.
 PARTY_LIMIT: int = 6  # The maximum number of tuxemon this npc can hold
 #  Moverate limits to avoid losing sprites

--- a/tuxemon/save_state.py
+++ b/tuxemon/save_state.py
@@ -34,6 +34,7 @@ class NPCState(TypedDict, total=False):
     items: Sequence[Mapping[str, Any]]
     monsters: Sequence[Mapping[str, Any]]
     player_name: str
+    player_slug: str
     player_steps: float
     monster_boxes: dict[str, Sequence[Mapping[str, Any]]]
     item_boxes: dict[str, Sequence[Mapping[str, Any]]]

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,7 +23,6 @@ from tuxemon.map.map_view import MapRenderer
 from tuxemon.platform.const import intentions
 from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.tools import translate_input_event
-from tuxemon.player import Player
 from tuxemon.session import Session
 from tuxemon.state.state import State
 from tuxemon.teleporter import Teleporter
@@ -32,7 +31,6 @@ from tuxemon.world.manager import WorldMenuManager
 from tuxemon.world.transition import WorldTransition
 
 if TYPE_CHECKING:
-    from tuxemon.entity import Entity
     from tuxemon.networking import EventData
 
 logger = logging.getLogger(__name__)
@@ -67,7 +65,7 @@ class WorldState(State):
         self.transition_manager = WorldTransition(
             self, self.client.movement_manager
         )
-        self.player = Player.create(self.session)
+        self.player = self.session.player
         self.camera = Camera(self.player, self.client.boundary)
         self.client.camera_manager.add_camera(self.camera)
         self.map_renderer = MapRenderer(self.client)
@@ -243,23 +241,6 @@ class WorldState(State):
 
         # Return event for others to process
         return event
-
-    def add_collision(self, entity: Entity[Any], pos: Sequence[float]) -> None:
-        """
-        Registers the given entity's position within the collision zone.
-        """
-        self.client.collision_manager.add_collision(entity, pos)
-
-    def remove_collision(self, tile_pos: tuple[int, int]) -> None:
-        """
-        Removes the specified tile position from the collision zone.
-        """
-        self.client.collision_manager.remove_collision(tile_pos)
-
-    def pathfind(
-        self, start: tuple[int, int], dest: tuple[int, int], facing: Direction
-    ) -> Optional[Sequence[tuple[int, int]]]:
-        return self.client.pathfinder.pathfind(start, dest, facing)
 
     @no_type_check  # only used by multiplayer which is disabled
     def check_interactable_space(self) -> bool:


### PR DESCRIPTION
PR relocates player creation logic out of `WorldState` and into the points where `WorldState` is actually instantiated, specifically within the `GameLauncher` (for new games) and the `LoadGame` event action (for loading saved games).  

In new game scenarios, the player character is now selected randomly from a list defined in each mod’s `mod.yaml` file. This allows individual mods to specify different NPCs as potential starting players, offering greater flexibility and customization.  

To support persistence across sessions, the selected `player_slug` is now saved into the game state. For the time being, if no slug is provided, a default `PLAYER_NPC` is automatically assigned. This fallback mechanism ensures backward compatibility with older save files and simplifies the transition. It will be removed once the majority of savegames have migrated to the new system, which will rely on explicit player selection and slug storage.