### PR TITLE
Refactoring the Monster History Model for Evolution Consistency

### DIFF
--- a/mods/tuxemon/db/monster/aardart.json
+++ b/mods/tuxemon/db/monster/aardart.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "aardorn",
-      "evo_stage": "basic"
+      "slug": "aardart",
+      "stage": "stage1",
+      "evolves_from": [
+        "aardorn"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "aardorn",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "aardart"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/aardorn.json
+++ b/mods/tuxemon/db/monster/aardorn.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "aardart",
-      "evo_stage": "stage1"
+      "slug": "aardorn",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "aardart"
+      ]
+    },
+    {
+      "slug": "aardart",
+      "stage": "stage1",
+      "evolves_from": [
+        "aardorn"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/abesnaki.json
+++ b/mods/tuxemon/db/monster/abesnaki.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "abesnaki",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "desert",
     "grassland",

--- a/mods/tuxemon/db/monster/agnidon.json
+++ b/mods/tuxemon/db/monster/agnidon.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "agnite",
-      "evo_stage": "basic"
+      "slug": "agnidon",
+      "stage": "stage1",
+      "evolves_from": [
+        "agnite"
+      ],
+      "evolves_into": [
+        "agnigon"
+      ]
     },
     {
-      "mon_slug": "agnigon",
-      "evo_stage": "stage2"
+      "slug": "agnite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "agnidon"
+      ]
+    },
+    {
+      "slug": "agnigon",
+      "stage": "stage2",
+      "evolves_from": [
+        "agnidon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/agnigon.json
+++ b/mods/tuxemon/db/monster/agnigon.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "agnite",
-      "evo_stage": "basic"
+      "slug": "agnigon",
+      "stage": "stage2",
+      "evolves_from": [
+        "agnidon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "agnidon",
-      "evo_stage": "stage1"
+      "slug": "agnite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "agnidon"
+      ]
+    },
+    {
+      "slug": "agnidon",
+      "stage": "stage1",
+      "evolves_from": [
+        "agnite"
+      ],
+      "evolves_into": [
+        "agnigon"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/agnite.json
+++ b/mods/tuxemon/db/monster/agnite.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "agnidon",
-      "evo_stage": "stage1"
+      "slug": "agnite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "agnidon"
+      ]
     },
     {
-      "mon_slug": "agnigon",
-      "evo_stage": "stage2"
+      "slug": "agnidon",
+      "stage": "stage1",
+      "evolves_from": [
+        "agnite"
+      ],
+      "evolves_into": [
+        "agnigon"
+      ]
+    },
+    {
+      "slug": "agnigon",
+      "stage": "stage2",
+      "evolves_from": [
+        "agnidon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/agnsher.json
+++ b/mods/tuxemon/db/monster/agnsher.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "agnsher",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "flier",

--- a/mods/tuxemon/db/monster/allagon.json
+++ b/mods/tuxemon/db/monster/allagon.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "wrougon",
-      "evo_stage": "basic"
+      "slug": "allagon",
+      "stage": "stage1",
+      "evolves_from": [
+        "wrougon"
+      ],
+      "evolves_into": [
+        "ferricran"
+      ]
     },
     {
-      "mon_slug": "ferricran",
-      "evo_stage": "stage2"
+      "slug": "wrougon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "allagon"
+      ]
+    },
+    {
+      "slug": "ferricran",
+      "stage": "stage2",
+      "evolves_from": [
+        "allagon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "altie",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraterrestrial",
     "ruins"

--- a/mods/tuxemon/db/monster/ambuwl.json
+++ b/mods/tuxemon/db/monster/ambuwl.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "ambuwl",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "desert",
     "woodland"

--- a/mods/tuxemon/db/monster/ampystoma.json
+++ b/mods/tuxemon/db/monster/ampystoma.json
@@ -58,8 +58,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "axolightl",
-      "evo_stage": "basic"
+      "slug": "ampystoma",
+      "stage": "stage1",
+      "evolves_from": [
+        "axolightl"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "axolightl",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ampystoma"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -51,12 +51,31 @@
   ],
   "history": [
     {
-      "mon_slug": "waysprite",
-      "evo_stage": "basic"
+      "slug": "angesnow",
+      "stage": "stage1",
+      "evolves_from": [
+        "waysprite"
+      ],
+      "evolves_into": [
+        "seraphice"
+      ]
     },
     {
-      "mon_slug": "seraphice",
-      "evo_stage": "stage2"
+      "slug": "waysprite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angesnow",
+        "demosnow"
+      ]
+    },
+    {
+      "slug": "seraphice",
+      "stage": "stage2",
+      "evolves_from": [
+        "angesnow"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -38,8 +38,23 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chromeye",
-      "evo_stage": "basic"
+      "slug": "angrito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chromeye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angrito",
+        "happito",
+        "neutrito",
+        "sadito"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/anoleaf.json
+++ b/mods/tuxemon/db/monster/anoleaf.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "gectile",
-      "evo_stage": "stage1"
+      "slug": "anoleaf",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gectile"
+      ]
     },
     {
-      "mon_slug": "velocitile",
-      "evo_stage": "stage2"
+      "slug": "gectile",
+      "stage": "stage1",
+      "evolves_from": [
+        "anoleaf"
+      ],
+      "evolves_into": [
+        "velocitile"
+      ]
+    },
+    {
+      "slug": "velocitile",
+      "stage": "stage2",
+      "evolves_from": [
+        "gectile"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/anu.json
+++ b/mods/tuxemon/db/monster/anu.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "anu",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "desert",
     "extraplanar"

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tetrchimp",
-      "evo_stage": "basic"
+      "slug": "apeoro",
+      "stage": "stage1",
+      "evolves_from": [
+        "tetrchimp"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "tetrchimp",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "apeoro"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/araignee.json
+++ b/mods/tuxemon/db/monster/araignee.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "araignee",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "jungle",
     "ruins",

--- a/mods/tuxemon/db/monster/arthrobolt.json
+++ b/mods/tuxemon/db/monster/arthrobolt.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "nut",
-      "evo_stage": "basic"
+      "slug": "arthrobolt",
+      "stage": "stage2",
+      "evolves_from": [
+        "bolt"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "bolt",
-      "evo_stage": "stage1"
+      "slug": "nut",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bolt"
+      ]
+    },
+    {
+      "slug": "bolt",
+      "stage": "stage1",
+      "evolves_from": [
+        "nut"
+      ],
+      "evolves_into": [
+        "arthrobolt"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/askylpaws.json
+++ b/mods/tuxemon/db/monster/askylpaws.json
@@ -62,12 +62,31 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "medipup",
-      "evo_stage": "basic"
+      "slug": "askylpaws",
+      "stage": "stage2",
+      "evolves_from": [
+        "doctsky"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "doctsky",
-      "evo_stage": "stage1"
+      "slug": "medipup",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "doctsky"
+      ]
+    },
+    {
+      "slug": "doctsky",
+      "stage": "stage1",
+      "evolves_from": [
+        "medipup"
+      ],
+      "evolves_into": [
+        "askylpaws",
+        "erythroskyte"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/asudopt.json
+++ b/mods/tuxemon/db/monster/asudopt.json
@@ -44,7 +44,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "asudopt",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "other"
   ],

--- a/mods/tuxemon/db/monster/av8r.json
+++ b/mods/tuxemon/db/monster/av8r.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "botbot",
-      "evo_stage": "basic"
+      "slug": "av8r",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "botbot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "av8r",
+        "picc",
+        "mrmoswitch",
+        "k9",
+        "b_ver_1"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/axolightl.json
+++ b/mods/tuxemon/db/monster/axolightl.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "ampystoma",
-      "evo_stage": "stage1"
+      "slug": "axolightl",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ampystoma"
+      ]
+    },
+    {
+      "slug": "ampystoma",
+      "stage": "stage1",
+      "evolves_from": [
+        "axolightl"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/b_ver_1.json
+++ b/mods/tuxemon/db/monster/b_ver_1.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "botbot",
-      "evo_stage": "basic"
+      "slug": "b_ver_1",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "botbot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "av8r",
+        "picc",
+        "mrmoswitch",
+        "k9",
+        "b_ver_1"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/babysnitch.json
+++ b/mods/tuxemon/db/monster/babysnitch.json
@@ -39,8 +39,20 @@
   ],
   "history": [
     {
-      "mon_slug": "baddrscratch",
-      "evo_stage": "stage1"
+      "slug": "babysnitch",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "baddrscratch"
+      ]
+    },
+    {
+      "slug": "baddrscratch",
+      "stage": "stage1",
+      "evolves_from": [
+        "babysnitch"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/baddrscratch.json
+++ b/mods/tuxemon/db/monster/baddrscratch.json
@@ -34,8 +34,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "babysnitch",
-      "evo_stage": "basic"
+      "slug": "baddrscratch",
+      "stage": "stage1",
+      "evolves_from": [
+        "babysnitch"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "babysnitch",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "baddrscratch"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bamboon.json
+++ b/mods/tuxemon/db/monster/bamboon.json
@@ -46,8 +46,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "budaye",
-      "evo_stage": "basic"
+      "slug": "bamboon",
+      "stage": "stage1",
+      "evolves_from": [
+        "budaye",
+        "budaye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "budaye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bamboon",
+        "bamboon",
+        "frondly",
+        "frondly"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -63,12 +63,30 @@
   ],
   "history": [
     {
-      "mon_slug": "bansaken",
-      "evo_stage": "stage1"
+      "slug": "banling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bansaken"
+      ]
     },
     {
-      "mon_slug": "banvengeance",
-      "evo_stage": "stage2"
+      "slug": "bansaken",
+      "stage": "stage1",
+      "evolves_from": [
+        "banling"
+      ],
+      "evolves_into": [
+        "banvengeance"
+      ]
+    },
+    {
+      "slug": "banvengeance",
+      "stage": "stage2",
+      "evolves_from": [
+        "bansaken"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bansaken.json
+++ b/mods/tuxemon/db/monster/bansaken.json
@@ -63,12 +63,30 @@
   ],
   "history": [
     {
-      "mon_slug": "banling",
-      "evo_stage": "basic"
+      "slug": "bansaken",
+      "stage": "stage1",
+      "evolves_from": [
+        "banling"
+      ],
+      "evolves_into": [
+        "banvengeance"
+      ]
     },
     {
-      "mon_slug": "banvengeance",
-      "evo_stage": "stage2"
+      "slug": "banling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bansaken"
+      ]
+    },
+    {
+      "slug": "banvengeance",
+      "stage": "stage2",
+      "evolves_from": [
+        "bansaken"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/banvengeance.json
+++ b/mods/tuxemon/db/monster/banvengeance.json
@@ -58,12 +58,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "banling",
-      "evo_stage": "basic"
+      "slug": "banvengeance",
+      "stage": "stage2",
+      "evolves_from": [
+        "bansaken"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "bansaken",
-      "evo_stage": "stage1"
+      "slug": "banling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bansaken"
+      ]
+    },
+    {
+      "slug": "bansaken",
+      "stage": "stage1",
+      "evolves_from": [
+        "banling"
+      ],
+      "evolves_into": [
+        "banvengeance"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "baoby",
-      "evo_stage": "basic"
+      "slug": "baobaraffe",
+      "stage": "stage1",
+      "evolves_from": [
+        "baoby"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "baoby",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "baobaraffe"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "baobaraffe",
-      "evo_stage": "stage1"
+      "slug": "baoby",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "baobaraffe"
+      ]
+    },
+    {
+      "slug": "baobaraffe",
+      "stage": "stage1",
+      "evolves_from": [
+        "baoby"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/bearloch.json
+++ b/mods/tuxemon/db/monster/bearloch.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "bearloch",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "brute",

--- a/mods/tuxemon/db/monster/bedoo.json
+++ b/mods/tuxemon/db/monster/bedoo.json
@@ -58,8 +58,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "jelillow",
-      "evo_stage": "basic"
+      "slug": "bedoo",
+      "stage": "stage1",
+      "evolves_from": [
+        "jelillow"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "jelillow",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bedoo"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -47,12 +47,30 @@
   ],
   "history": [
     {
-      "mon_slug": "turnipper",
-      "evo_stage": "basic"
+      "slug": "beenstalker",
+      "stage": "stage1",
+      "evolves_from": [
+        "turnipper"
+      ],
+      "evolves_into": [
+        "wendigger"
+      ]
     },
     {
-      "mon_slug": "wendigger",
-      "evo_stage": "stage2"
+      "slug": "turnipper",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "beenstalker"
+      ]
+    },
+    {
+      "slug": "wendigger",
+      "stage": "stage2",
+      "evolves_from": [
+        "beenstalker"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bewhich.json
+++ b/mods/tuxemon/db/monster/bewhich.json
@@ -34,12 +34,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "cackleen",
-      "evo_stage": "basic"
+      "slug": "bewhich",
+      "stage": "stage2",
+      "evolves_from": [
+        "brumi"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "brumi",
-      "evo_stage": "stage1"
+      "slug": "cackleen",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "brumi"
+      ]
+    },
+    {
+      "slug": "brumi",
+      "stage": "stage1",
+      "evolves_from": [
+        "cackleen"
+      ],
+      "evolves_into": [
+        "bewhich"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bigfin.json
+++ b/mods/tuxemon/db/monster/bigfin.json
@@ -46,8 +46,25 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "dollfin",
-      "evo_stage": "basic"
+      "slug": "bigfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "dollfin",
+        "dollfin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "dollfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bigfin",
+        "bigfin",
+        "sharpfin",
+        "sharpfin",
+        "delfeco"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/birdee.json
+++ b/mods/tuxemon/db/monster/birdee.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chickadee",
-      "evo_stage": "basic"
+      "slug": "birdee",
+      "stage": "stage1",
+      "evolves_from": [
+        "chickadee"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chickadee",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "birdee"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/birdling.json
+++ b/mods/tuxemon/db/monster/birdling.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "hatchling",
-      "evo_stage": "basic"
+      "slug": "birdling",
+      "stage": "stage1",
+      "evolves_from": [
+        "hatchling"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "hatchling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "birdling"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bishosand.json
+++ b/mods/tuxemon/db/monster/bishosand.json
@@ -46,8 +46,22 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pawsand",
-      "evo_stage": "basic"
+      "slug": "bishosand",
+      "stage": "stage1",
+      "evolves_from": [
+        "pawsand"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pawsand",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "knightsand",
+        "bishosand",
+        "rooksand"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/blasdoor.json
+++ b/mods/tuxemon/db/monster/blasdoor.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "woodoor",
-      "evo_stage": "basic"
+      "slug": "blasdoor",
+      "stage": "stage1",
+      "evolves_from": [
+        "woodoor"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "woodoor",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "blasdoor"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bolt.json
+++ b/mods/tuxemon/db/monster/bolt.json
@@ -47,12 +47,30 @@
   ],
   "history": [
     {
-      "mon_slug": "nut",
-      "evo_stage": "basic"
+      "slug": "bolt",
+      "stage": "stage1",
+      "evolves_from": [
+        "nut"
+      ],
+      "evolves_into": [
+        "arthrobolt"
+      ]
     },
     {
-      "mon_slug": "arthrobolt",
-      "evo_stage": "stage2"
+      "slug": "nut",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bolt"
+      ]
+    },
+    {
+      "slug": "arthrobolt",
+      "stage": "stage2",
+      "evolves_from": [
+        "bolt"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "exclawvate",
-      "evo_stage": "stage1"
+      "slug": "boltnu",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "exclawvate"
+      ]
+    },
+    {
+      "slug": "exclawvate",
+      "stage": "stage1",
+      "evolves_from": [
+        "boltnu"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/botbot.json
+++ b/mods/tuxemon/db/monster/botbot.json
@@ -47,24 +47,56 @@
   ],
   "history": [
     {
-      "mon_slug": "b_ver_1",
-      "evo_stage": "stage1"
+      "slug": "botbot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "av8r",
+        "picc",
+        "mrmoswitch",
+        "k9",
+        "b_ver_1"
+      ]
     },
     {
-      "mon_slug": "k9",
-      "evo_stage": "stage1"
+      "slug": "b_ver_1",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "mrmoswitch",
-      "evo_stage": "stage1"
+      "slug": "k9",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "picc",
-      "evo_stage": "stage1"
+      "slug": "mrmoswitch",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "av8r",
-      "evo_stage": "stage1"
+      "slug": "picc",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "av8r",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "boxali",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "desert",
     "grassland"

--- a/mods/tuxemon/db/monster/boxorox.json
+++ b/mods/tuxemon/db/monster/boxorox.json
@@ -28,7 +28,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "boxorox",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "rock",

--- a/mods/tuxemon/db/monster/brachifor.json
+++ b/mods/tuxemon/db/monster/brachifor.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "fordin",
-      "evo_stage": "basic"
+      "slug": "brachifor",
+      "stage": "stage2",
+      "evolves_from": [
+        "stegofor"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "stegofor",
-      "evo_stage": "stage1"
+      "slug": "fordin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "stegofor"
+      ]
+    },
+    {
+      "slug": "stegofor",
+      "stage": "stage1",
+      "evolves_from": [
+        "fordin"
+      ],
+      "evolves_into": [
+        "brachifor"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/breem.json
+++ b/mods/tuxemon/db/monster/breem.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "duggot",
-      "evo_stage": "basic"
+      "slug": "breem",
+      "stage": "stage1",
+      "evolves_from": [
+        "duggot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "duggot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "breem"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "brewdin",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "ruins",
     "urban"

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "imbrickcile",
-      "evo_stage": "basic"
+      "slug": "bricgard",
+      "stage": "stage1",
+      "evolves_from": [
+        "imbrickcile"
+      ],
+      "evolves_into": [
+        "brickhemoth"
+      ]
     },
     {
-      "mon_slug": "brickhemoth",
-      "evo_stage": "stage2"
+      "slug": "imbrickcile",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bricgard"
+      ]
+    },
+    {
+      "slug": "brickhemoth",
+      "stage": "stage2",
+      "evolves_from": [
+        "bricgard"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/brickhemoth.json
+++ b/mods/tuxemon/db/monster/brickhemoth.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "imbrickcile",
-      "evo_stage": "basic"
+      "slug": "brickhemoth",
+      "stage": "stage2",
+      "evolves_from": [
+        "bricgard"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "bricgard",
-      "evo_stage": "stage1"
+      "slug": "imbrickcile",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bricgard"
+      ]
+    },
+    {
+      "slug": "bricgard",
+      "stage": "stage1",
+      "evolves_from": [
+        "imbrickcile"
+      ],
+      "evolves_into": [
+        "brickhemoth"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/brumi.json
+++ b/mods/tuxemon/db/monster/brumi.json
@@ -44,12 +44,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cackleen",
-      "evo_stage": "basic"
+      "slug": "brumi",
+      "stage": "stage1",
+      "evolves_from": [
+        "cackleen"
+      ],
+      "evolves_into": [
+        "bewhich"
+      ]
     },
     {
-      "mon_slug": "bewhich",
-      "evo_stage": "stage2"
+      "slug": "cackleen",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "brumi"
+      ]
+    },
+    {
+      "slug": "bewhich",
+      "stage": "stage2",
+      "evolves_from": [
+        "brumi"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/budaye.json
+++ b/mods/tuxemon/db/monster/budaye.json
@@ -59,12 +59,33 @@
   ],
   "history": [
     {
-      "mon_slug": "bamboon",
-      "evo_stage": "stage1"
+      "slug": "budaye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bamboon",
+        "bamboon",
+        "frondly",
+        "frondly"
+      ]
     },
     {
-      "mon_slug": "frondly",
-      "evo_stage": "stage1"
+      "slug": "bamboon",
+      "stage": "stage1",
+      "evolves_from": [
+        "budaye",
+        "budaye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "frondly",
+      "stage": "stage1",
+      "evolves_from": [
+        "budaye",
+        "budaye"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bugnin.json
+++ b/mods/tuxemon/db/monster/bugnin.json
@@ -50,12 +50,32 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "katapill",
-      "evo_stage": "basic"
+      "slug": "bugnin",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "katacoon",
-      "evo_stage": "stage1"
+      "slug": "katapill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "katacoon"
+      ]
+    },
+    {
+      "slug": "katacoon",
+      "stage": "stage1",
+      "evolves_from": [
+        "katapill"
+      ],
+      "evolves_into": [
+        "bugnin",
+        "sumchon",
+        "gladiatorbug"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "nimbulex",
-      "evo_stage": "stage1"
+      "slug": "bumbulus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "nimbulex"
+      ]
+    },
+    {
+      "slug": "nimbulex",
+      "stage": "stage1",
+      "evolves_from": [
+        "bumbulus"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/burrlock.json
+++ b/mods/tuxemon/db/monster/burrlock.json
@@ -39,8 +39,20 @@
   ],
   "history": [
     {
-      "mon_slug": "cacaburr",
-      "evo_stage": "stage1"
+      "slug": "burrlock",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cacaburr"
+      ]
+    },
+    {
+      "slug": "cacaburr",
+      "stage": "stage1",
+      "evolves_from": [
+        "burrlock"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/bursa.json
+++ b/mods/tuxemon/db/monster/bursa.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "flambear",
-      "evo_stage": "stage1"
+      "slug": "bursa",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "flambear"
+      ]
+    },
+    {
+      "slug": "flambear",
+      "stage": "stage1",
+      "evolves_from": [
+        "bursa"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cacaburr.json
+++ b/mods/tuxemon/db/monster/cacaburr.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "burrlock",
-      "evo_stage": "basic"
+      "slug": "cacaburr",
+      "stage": "stage1",
+      "evolves_from": [
+        "burrlock"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "burrlock",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cacaburr"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/cackleen.json
+++ b/mods/tuxemon/db/monster/cackleen.json
@@ -44,12 +44,30 @@
   ],
   "history": [
     {
-      "mon_slug": "brumi",
-      "evo_stage": "stage1"
+      "slug": "cackleen",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "brumi"
+      ]
     },
     {
-      "mon_slug": "bewhich",
-      "evo_stage": "stage2"
+      "slug": "brumi",
+      "stage": "stage1",
+      "evolves_from": [
+        "cackleen"
+      ],
+      "evolves_into": [
+        "bewhich"
+      ]
+    },
+    {
+      "slug": "bewhich",
+      "stage": "stage2",
+      "evolves_from": [
+        "brumi"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cairfrey.json
+++ b/mods/tuxemon/db/monster/cairfrey.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "possessun",
-      "evo_stage": "stage1"
+      "slug": "cairfrey",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "possessun"
+      ]
+    },
+    {
+      "slug": "possessun",
+      "stage": "stage1",
+      "evolves_from": [
+        "cairfrey"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/caper.json
+++ b/mods/tuxemon/db/monster/caper.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "crankus",
-      "evo_stage": "stage1"
+      "slug": "caper",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "crankus"
+      ]
+    },
+    {
+      "slug": "crankus",
+      "stage": "stage1",
+      "evolves_from": [
+        "caper"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/capinyah.json
+++ b/mods/tuxemon/db/monster/capinyah.json
@@ -66,8 +66,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "capiti",
-      "evo_stage": "basic"
+      "slug": "capinyah",
+      "stage": "stage1",
+      "evolves_from": [
+        "capiti"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "capiti",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "capinyah"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/capiti.json
+++ b/mods/tuxemon/db/monster/capiti.json
@@ -71,8 +71,20 @@
   ],
   "history": [
     {
-      "mon_slug": "capinyah",
-      "evo_stage": "stage1"
+      "slug": "capiti",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "capinyah"
+      ]
+    },
+    {
+      "slug": "capinyah",
+      "stage": "stage1",
+      "evolves_from": [
+        "capiti"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/carcharock.json
+++ b/mods/tuxemon/db/monster/carcharock.json
@@ -48,7 +48,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "carcharock",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "jungle"

--- a/mods/tuxemon/db/monster/cardiling.json
+++ b/mods/tuxemon/db/monster/cardiling.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cardiwing",
-      "evo_stage": "stage1"
+      "slug": "cardiling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cardiwing"
+      ]
     },
     {
-      "mon_slug": "cardinale",
-      "evo_stage": "stage2"
+      "slug": "cardiwing",
+      "stage": "stage1",
+      "evolves_from": [
+        "cardiling"
+      ],
+      "evolves_into": [
+        "cardinale"
+      ]
+    },
+    {
+      "slug": "cardinale",
+      "stage": "stage2",
+      "evolves_from": [
+        "cardiwing"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cardinale.json
+++ b/mods/tuxemon/db/monster/cardinale.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "cardiling",
-      "evo_stage": "basic"
+      "slug": "cardinale",
+      "stage": "stage2",
+      "evolves_from": [
+        "cardiwing"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "cardiwing",
-      "evo_stage": "stage1"
+      "slug": "cardiling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cardiwing"
+      ]
+    },
+    {
+      "slug": "cardiwing",
+      "stage": "stage1",
+      "evolves_from": [
+        "cardiling"
+      ],
+      "evolves_into": [
+        "cardinale"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cardiwing.json
+++ b/mods/tuxemon/db/monster/cardiwing.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cardiling",
-      "evo_stage": "basic"
+      "slug": "cardiwing",
+      "stage": "stage1",
+      "evolves_from": [
+        "cardiling"
+      ],
+      "evolves_into": [
+        "cardinale"
+      ]
     },
     {
-      "mon_slug": "cardinale",
-      "evo_stage": "stage2"
+      "slug": "cardiling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cardiwing"
+      ]
+    },
+    {
+      "slug": "cardinale",
+      "stage": "stage2",
+      "evolves_from": [
+        "cardiwing"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cataspike.json
+++ b/mods/tuxemon/db/monster/cataspike.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "puparmor",
-      "evo_stage": "stage1"
+      "slug": "cataspike",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "puparmor"
+      ]
     },
     {
-      "mon_slug": "weavifly",
-      "evo_stage": "stage2"
+      "slug": "puparmor",
+      "stage": "stage1",
+      "evolves_from": [
+        "cataspike"
+      ],
+      "evolves_into": [
+        "weavifly"
+      ]
+    },
+    {
+      "slug": "weavifly",
+      "stage": "stage2",
+      "evolves_from": [
+        "puparmor"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/cateye.json
+++ b/mods/tuxemon/db/monster/cateye.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "cateye",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "gaze",

--- a/mods/tuxemon/db/monster/chenipode.json
+++ b/mods/tuxemon/db/monster/chenipode.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "exapode",
-      "evo_stage": "stage1"
+      "slug": "chenipode",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "exapode"
+      ]
+    },
+    {
+      "slug": "exapode",
+      "stage": "stage1",
+      "evolves_from": [
+        "chenipode"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/cherubat.json
+++ b/mods/tuxemon/db/monster/cherubat.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "cherubat",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "urban",
     "woodland"

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "chibiro",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant",

--- a/mods/tuxemon/db/monster/chickadee.json
+++ b/mods/tuxemon/db/monster/chickadee.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "birdee",
-      "evo_stage": "stage1"
+      "slug": "chickadee",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "birdee"
+      ]
+    },
+    {
+      "slug": "birdee",
+      "stage": "stage1",
+      "evolves_from": [
+        "chickadee"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/chillimp.json
+++ b/mods/tuxemon/db/monster/chillimp.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "snowrilla",
-      "evo_stage": "stage1"
+      "slug": "chillimp",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "snowrilla"
+      ]
+    },
+    {
+      "slug": "snowrilla",
+      "stage": "stage1",
+      "evolves_from": [
+        "chillimp"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/chloragon.json
+++ b/mods/tuxemon/db/monster/chloragon.json
@@ -63,12 +63,30 @@
   ],
   "history": [
     {
-      "mon_slug": "sapragon",
-      "evo_stage": "stage1"
+      "slug": "chloragon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sapragon"
+      ]
     },
     {
-      "mon_slug": "dragarbor",
-      "evo_stage": "stage2"
+      "slug": "sapragon",
+      "stage": "stage1",
+      "evolves_from": [
+        "chloragon"
+      ],
+      "evolves_into": [
+        "dragarbor"
+      ]
+    },
+    {
+      "slug": "dragarbor",
+      "stage": "stage2",
+      "evolves_from": [
+        "sapragon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "chrome_robo",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "humanoid",

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -63,20 +63,47 @@
   ],
   "history": [
     {
-      "mon_slug": "sadito",
-      "evo_stage": "stage1"
+      "slug": "chromeye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angrito",
+        "happito",
+        "neutrito",
+        "sadito"
+      ]
     },
     {
-      "mon_slug": "neutrito",
-      "evo_stage": "stage1"
+      "slug": "sadito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "happito",
-      "evo_stage": "stage1"
+      "slug": "neutrito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "angrito",
-      "evo_stage": "stage1"
+      "slug": "happito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "angrito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/claymorior.json
+++ b/mods/tuxemon/db/monster/claymorior.json
@@ -64,8 +64,20 @@
   ],
   "history": [
     {
-      "mon_slug": "regalance",
-      "evo_stage": "stage1"
+      "slug": "claymorior",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "regalance"
+      ]
+    },
+    {
+      "slug": "regalance",
+      "stage": "stage1",
+      "evolves_from": [
+        "claymorior"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/coaldiak.json
+++ b/mods/tuxemon/db/monster/coaldiak.json
@@ -38,12 +38,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "furnursus",
-      "evo_stage": "basic"
+      "slug": "coaldiak",
+      "stage": "stage2",
+      "evolves_from": [
+        "statursus"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "statursus",
-      "evo_stage": "stage1"
+      "slug": "furnursus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "statursus"
+      ]
+    },
+    {
+      "slug": "statursus",
+      "stage": "stage1",
+      "evolves_from": [
+        "furnursus"
+      ],
+      "evolves_into": [
+        "coaldiak"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cobarett.json
+++ b/mods/tuxemon/db/monster/cobarett.json
@@ -43,12 +43,30 @@
   ],
   "history": [
     {
-      "mon_slug": "hissiorite",
-      "evo_stage": "basic"
+      "slug": "cobarett",
+      "stage": "stage1",
+      "evolves_from": [
+        "hissiorite"
+      ],
+      "evolves_into": [
+        "pythonova"
+      ]
     },
     {
-      "mon_slug": "pythonova",
-      "evo_stage": "stage2"
+      "slug": "hissiorite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cobarett"
+      ]
+    },
+    {
+      "slug": "pythonova",
+      "stage": "stage2",
+      "evolves_from": [
+        "cobarett"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cochini.json
+++ b/mods/tuxemon/db/monster/cochini.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "cochini",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "food",

--- a/mods/tuxemon/db/monster/cocrune.json
+++ b/mods/tuxemon/db/monster/cocrune.json
@@ -43,12 +43,30 @@
   ],
   "history": [
     {
-      "mon_slug": "stonifly",
-      "evo_stage": "basic"
+      "slug": "cocrune",
+      "stage": "stage1",
+      "evolves_from": [
+        "stonifly"
+      ],
+      "evolves_into": [
+        "runesquito"
+      ]
     },
     {
-      "mon_slug": "runesquito",
-      "evo_stage": "stage2"
+      "slug": "stonifly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cocrune"
+      ]
+    },
+    {
+      "slug": "runesquito",
+      "stage": "stage2",
+      "evolves_from": [
+        "cocrune"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cohldrabi.json
+++ b/mods/tuxemon/db/monster/cohldrabi.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "lettice",
-      "evo_stage": "stage1"
+      "slug": "cohldrabi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "lettice"
+      ]
     },
     {
-      "mon_slug": "frostuce",
-      "evo_stage": "stage2"
+      "slug": "lettice",
+      "stage": "stage1",
+      "evolves_from": [
+        "cohldrabi"
+      ],
+      "evolves_into": [
+        "frostuce"
+      ]
+    },
+    {
+      "slug": "frostuce",
+      "stage": "stage2",
+      "evolves_from": [
+        "lettice"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/coleorus.json
+++ b/mods/tuxemon/db/monster/coleorus.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "coleorus",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "desert",
     "grassland",

--- a/mods/tuxemon/db/monster/conglolem.json
+++ b/mods/tuxemon/db/monster/conglolem.json
@@ -58,12 +58,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "slichen",
-      "evo_stage": "basic"
+      "slug": "conglolem",
+      "stage": "stage2",
+      "evolves_from": [
+        "glombroc"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "glombroc",
-      "evo_stage": "stage1"
+      "slug": "slichen",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "glombroc"
+      ]
+    },
+    {
+      "slug": "glombroc",
+      "stage": "stage1",
+      "evolves_from": [
+        "slichen"
+      ],
+      "evolves_into": [
+        "conglolem"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/conifrost.json
+++ b/mods/tuxemon/db/monster/conifrost.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "conifrost",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ice",

--- a/mods/tuxemon/db/monster/conileaf.json
+++ b/mods/tuxemon/db/monster/conileaf.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "conileaf",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant",

--- a/mods/tuxemon/db/monster/coppi.json
+++ b/mods/tuxemon/db/monster/coppi.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "helipi",
-      "evo_stage": "basic"
+      "slug": "coppi",
+      "stage": "stage1",
+      "evolves_from": [
+        "helipi"
+      ],
+      "evolves_into": [
+        "parappi"
+      ]
     },
     {
-      "mon_slug": "parappi",
-      "evo_stage": "stage2"
+      "slug": "helipi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "coppi"
+      ]
+    },
+    {
+      "slug": "parappi",
+      "stage": "stage2",
+      "evolves_from": [
+        "coppi"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "coproblight",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "shielded",

--- a/mods/tuxemon/db/monster/corvix.json
+++ b/mods/tuxemon/db/monster/corvix.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "flacono",
-      "evo_stage": "basic"
+      "slug": "corvix",
+      "stage": "stage1",
+      "evolves_from": [
+        "flacono"
+      ],
+      "evolves_into": [
+        "gryfix"
+      ]
     },
     {
-      "mon_slug": "gryfix",
-      "evo_stage": "stage2"
+      "slug": "flacono",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "corvix"
+      ]
+    },
+    {
+      "slug": "gryfix",
+      "stage": "stage2",
+      "evolves_from": [
+        "corvix"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/cowpignon.json
+++ b/mods/tuxemon/db/monster/cowpignon.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "cowpignon",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "grassland",
     "woodland"

--- a/mods/tuxemon/db/monster/crankus.json
+++ b/mods/tuxemon/db/monster/crankus.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "caper",
-      "evo_stage": "basic"
+      "slug": "crankus",
+      "stage": "stage1",
+      "evolves_from": [
+        "caper"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "caper",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "crankus"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/criniotherme.json
+++ b/mods/tuxemon/db/monster/criniotherme.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pantherafira",
-      "evo_stage": "basic"
+      "slug": "criniotherme",
+      "stage": "stage1",
+      "evolves_from": [
+        "pantherafira"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pantherafira",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "criniotherme"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/crustagu.json
+++ b/mods/tuxemon/db/monster/crustagu.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "lesmagu",
-      "evo_stage": "basic"
+      "slug": "crustagu",
+      "stage": "stage2",
+      "evolves_from": [
+        "shelagu"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "shelagu",
-      "evo_stage": "stage1"
+      "slug": "lesmagu",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shelagu"
+      ]
+    },
+    {
+      "slug": "shelagu",
+      "stage": "stage1",
+      "evolves_from": [
+        "lesmagu"
+      ],
+      "evolves_into": [
+        "crustagu"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "d0llf1n",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "leviathan",

--- a/mods/tuxemon/db/monster/dandicub.json
+++ b/mods/tuxemon/db/monster/dandicub.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "dandylion",
-      "evo_stage": "stage1"
+      "slug": "dandicub",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "dandylion"
+      ]
+    },
+    {
+      "slug": "dandylion",
+      "stage": "stage1",
+      "evolves_from": [
+        "dandicub"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/dandylion.json
+++ b/mods/tuxemon/db/monster/dandylion.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "dandicub",
-      "evo_stage": "basic"
+      "slug": "dandylion",
+      "stage": "stage1",
+      "evolves_from": [
+        "dandicub"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "dandicub",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "dandylion"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/dankush.json
+++ b/mods/tuxemon/db/monster/dankush.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "dankush",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "grassland"
   ],

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "dark_robo",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "humanoid",

--- a/mods/tuxemon/db/monster/delfeco.json
+++ b/mods/tuxemon/db/monster/delfeco.json
@@ -54,8 +54,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "dollfin",
-      "evo_stage": "basic"
+      "slug": "delfeco",
+      "stage": "stage1",
+      "evolves_from": [
+        "dollfin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "dollfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bigfin",
+        "bigfin",
+        "sharpfin",
+        "sharpfin",
+        "delfeco"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -51,12 +51,31 @@
   ],
   "history": [
     {
-      "mon_slug": "waysprite",
-      "evo_stage": "basic"
+      "slug": "demosnow",
+      "stage": "stage1",
+      "evolves_from": [
+        "waysprite"
+      ],
+      "evolves_into": [
+        "lucifice"
+      ]
     },
     {
-      "mon_slug": "lucifice",
-      "evo_stage": "stage2"
+      "slug": "waysprite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angesnow",
+        "demosnow"
+      ]
+    },
+    {
+      "slug": "lucifice",
+      "stage": "stage2",
+      "evolves_from": [
+        "demosnow"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/devidin.json
+++ b/mods/tuxemon/db/monster/devidin.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "devidra",
-      "evo_stage": "stage1"
+      "slug": "devidin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "devidra"
+      ]
     },
     {
-      "mon_slug": "deviraptor",
-      "evo_stage": "stage2"
+      "slug": "devidra",
+      "stage": "stage1",
+      "evolves_from": [
+        "devidin"
+      ],
+      "evolves_into": [
+        "deviraptor"
+      ]
+    },
+    {
+      "slug": "deviraptor",
+      "stage": "stage2",
+      "evolves_from": [
+        "devidra"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/devidra.json
+++ b/mods/tuxemon/db/monster/devidra.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "devidin",
-      "evo_stage": "basic"
+      "slug": "devidra",
+      "stage": "stage1",
+      "evolves_from": [
+        "devidin"
+      ],
+      "evolves_into": [
+        "deviraptor"
+      ]
     },
     {
-      "mon_slug": "deviraptor",
-      "evo_stage": "stage2"
+      "slug": "devidin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "devidra"
+      ]
+    },
+    {
+      "slug": "deviraptor",
+      "stage": "stage2",
+      "evolves_from": [
+        "devidra"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/deviraptor.json
+++ b/mods/tuxemon/db/monster/deviraptor.json
@@ -46,12 +46,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "devidin",
-      "evo_stage": "basic"
+      "slug": "deviraptor",
+      "stage": "stage2",
+      "evolves_from": [
+        "devidra"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "devidra",
-      "evo_stage": "stage1"
+      "slug": "devidin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "devidra"
+      ]
+    },
+    {
+      "slug": "devidra",
+      "stage": "stage1",
+      "evolves_from": [
+        "devidin"
+      ],
+      "evolves_into": [
+        "deviraptor"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/dinoflop.json
+++ b/mods/tuxemon/db/monster/dinoflop.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "dinoflop",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "sharp",

--- a/mods/tuxemon/db/monster/djinnbo.json
+++ b/mods/tuxemon/db/monster/djinnbo.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "djinnbo",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraplanar",
     "ruins"

--- a/mods/tuxemon/db/monster/doctsky.json
+++ b/mods/tuxemon/db/monster/doctsky.json
@@ -63,16 +63,39 @@
   ],
   "history": [
     {
-      "mon_slug": "medipup",
-      "evo_stage": "basic"
+      "slug": "doctsky",
+      "stage": "stage1",
+      "evolves_from": [
+        "medipup"
+      ],
+      "evolves_into": [
+        "askylpaws",
+        "erythroskyte"
+      ]
     },
     {
-      "mon_slug": "askylpaws",
-      "evo_stage": "stage2"
+      "slug": "medipup",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "doctsky"
+      ]
     },
     {
-      "mon_slug": "erythroskyte",
-      "evo_stage": "stage2"
+      "slug": "askylpaws",
+      "stage": "stage2",
+      "evolves_from": [
+        "doctsky"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "erythroskyte",
+      "stage": "stage2",
+      "evolves_from": [
+        "doctsky"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/dollfin.json
+++ b/mods/tuxemon/db/monster/dollfin.json
@@ -47,16 +47,42 @@
   ],
   "history": [
     {
-      "mon_slug": "bigfin",
-      "evo_stage": "stage1"
+      "slug": "dollfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bigfin",
+        "bigfin",
+        "sharpfin",
+        "sharpfin",
+        "delfeco"
+      ]
     },
     {
-      "mon_slug": "sharpfin",
-      "evo_stage": "stage1"
+      "slug": "bigfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "dollfin",
+        "dollfin"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "delfeco",
-      "evo_stage": "stage1"
+      "slug": "sharpfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "dollfin",
+        "dollfin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "delfeco",
+      "stage": "stage1",
+      "evolves_from": [
+        "dollfin"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/dracune.json
+++ b/mods/tuxemon/db/monster/dracune.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "vamporm",
-      "evo_stage": "basic"
+      "slug": "dracune",
+      "stage": "stage1",
+      "evolves_from": [
+        "vamporm"
+      ],
+      "evolves_into": [
+        "fluttaflap"
+      ]
     },
     {
-      "mon_slug": "fluttaflap",
-      "evo_stage": "stage2"
+      "slug": "vamporm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "dracune"
+      ]
+    },
+    {
+      "slug": "fluttaflap",
+      "stage": "stage2",
+      "evolves_from": [
+        "dracune"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/dragarbor.json
+++ b/mods/tuxemon/db/monster/dragarbor.json
@@ -58,12 +58,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chloragon",
-      "evo_stage": "basic"
+      "slug": "dragarbor",
+      "stage": "stage2",
+      "evolves_from": [
+        "sapragon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "sapragon",
-      "evo_stage": "stage1"
+      "slug": "chloragon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sapragon"
+      ]
+    },
+    {
+      "slug": "sapragon",
+      "stage": "stage1",
+      "evolves_from": [
+        "chloragon"
+      ],
+      "evolves_into": [
+        "dragarbor"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "tsushimi",
-      "evo_stage": "stage1"
+      "slug": "drashimi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tsushimi"
+      ]
     },
     {
-      "mon_slug": "tobishimi",
-      "evo_stage": "stage2"
+      "slug": "tsushimi",
+      "stage": "stage1",
+      "evolves_from": [
+        "drashimi"
+      ],
+      "evolves_into": [
+        "tobishimi"
+      ]
+    },
+    {
+      "slug": "tobishimi",
+      "stage": "stage2",
+      "evolves_from": [
+        "tsushimi"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/drokoro.json
+++ b/mods/tuxemon/db/monster/drokoro.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "drokoro",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "flame",

--- a/mods/tuxemon/db/monster/duggot.json
+++ b/mods/tuxemon/db/monster/duggot.json
@@ -29,8 +29,20 @@
   ],
   "history": [
     {
-      "mon_slug": "breem",
-      "evo_stage": "stage1"
+      "slug": "duggot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "breem"
+      ]
+    },
+    {
+      "slug": "breem",
+      "stage": "stage1",
+      "evolves_from": [
+        "duggot"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/dune_pincher.json
+++ b/mods/tuxemon/db/monster/dune_pincher.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "dune_pincher",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ground",

--- a/mods/tuxemon/db/monster/eaglace.json
+++ b/mods/tuxemon/db/monster/eaglace.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tweesher",
-      "evo_stage": "basic"
+      "slug": "eaglace",
+      "stage": "stage2",
+      "evolves_from": [
+        "heronquak"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "heronquak",
-      "evo_stage": "stage1"
+      "slug": "tweesher",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "heronquak"
+      ]
+    },
+    {
+      "slug": "heronquak",
+      "stage": "stage1",
+      "evolves_from": [
+        "tweesher"
+      ],
+      "evolves_into": [
+        "eaglace"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/elofly.json
+++ b/mods/tuxemon/db/monster/elofly.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "elowind",
-      "evo_stage": "stage1"
+      "slug": "elofly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "elowind"
+      ]
     },
     {
-      "mon_slug": "elostorm",
-      "evo_stage": "stage2"
+      "slug": "elowind",
+      "stage": "stage1",
+      "evolves_from": [
+        "elofly"
+      ],
+      "evolves_into": [
+        "elostorm"
+      ]
+    },
+    {
+      "slug": "elostorm",
+      "stage": "stage2",
+      "evolves_from": [
+        "elowind"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/elostorm.json
+++ b/mods/tuxemon/db/monster/elostorm.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "elofly",
-      "evo_stage": "basic"
+      "slug": "elostorm",
+      "stage": "stage2",
+      "evolves_from": [
+        "elowind"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "elowind",
-      "evo_stage": "stage1"
+      "slug": "elofly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "elowind"
+      ]
+    },
+    {
+      "slug": "elowind",
+      "stage": "stage1",
+      "evolves_from": [
+        "elofly"
+      ],
+      "evolves_into": [
+        "elostorm"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/elowind.json
+++ b/mods/tuxemon/db/monster/elowind.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "elofly",
-      "evo_stage": "basic"
+      "slug": "elowind",
+      "stage": "stage1",
+      "evolves_from": [
+        "elofly"
+      ],
+      "evolves_into": [
+        "elostorm"
+      ]
     },
     {
-      "mon_slug": "elostorm",
-      "evo_stage": "stage2"
+      "slug": "elofly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "elowind"
+      ]
+    },
+    {
+      "slug": "elostorm",
+      "stage": "stage2",
+      "evolves_from": [
+        "elowind"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/embazook.json
+++ b/mods/tuxemon/db/monster/embazook.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "ignibus",
-      "evo_stage": "basic"
+      "slug": "embazook",
+      "stage": "stage1",
+      "evolves_from": [
+        "ignibus",
+        "ignibus"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "ignibus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "eruptibus",
+        "eruptibus",
+        "embazook",
+        "embazook"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/embra.json
+++ b/mods/tuxemon/db/monster/embra.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "ruption",
-      "evo_stage": "stage1"
+      "slug": "embra",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ruption"
+      ]
+    },
+    {
+      "slug": "ruption",
+      "stage": "stage1",
+      "evolves_from": [
+        "embra"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "enduros",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "shielded",

--- a/mods/tuxemon/db/monster/equill.json
+++ b/mods/tuxemon/db/monster/equill.json
@@ -39,12 +39,30 @@
   ],
   "history": [
     {
-      "mon_slug": "hoarse",
-      "evo_stage": "basic"
+      "slug": "equill",
+      "stage": "stage1",
+      "evolves_from": [
+        "hoarse"
+      ],
+      "evolves_into": [
+        "hoarseshoo"
+      ]
     },
     {
-      "mon_slug": "hoarseshoo",
-      "evo_stage": "stage2"
+      "slug": "hoarse",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "equill"
+      ]
+    },
+    {
+      "slug": "hoarseshoo",
+      "stage": "stage2",
+      "evolves_from": [
+        "equill"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/eruptibus.json
+++ b/mods/tuxemon/db/monster/eruptibus.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "ignibus",
-      "evo_stage": "basic"
+      "slug": "eruptibus",
+      "stage": "stage1",
+      "evolves_from": [
+        "ignibus",
+        "ignibus"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "ignibus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "eruptibus",
+        "eruptibus",
+        "embazook",
+        "embazook"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/erythroskyte.json
+++ b/mods/tuxemon/db/monster/erythroskyte.json
@@ -58,12 +58,31 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "medipup",
-      "evo_stage": "basic"
+      "slug": "erythroskyte",
+      "stage": "stage2",
+      "evolves_from": [
+        "doctsky"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "doctsky",
-      "evo_stage": "stage1"
+      "slug": "medipup",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "doctsky"
+      ]
+    },
+    {
+      "slug": "doctsky",
+      "stage": "stage1",
+      "evolves_from": [
+        "medipup"
+      ],
+      "evolves_into": [
+        "askylpaws",
+        "erythroskyte"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/eskipup.json
+++ b/mods/tuxemon/db/monster/eskipup.json
@@ -31,8 +31,20 @@
   ],
   "history": [
     {
-      "mon_slug": "houndice",
-      "evo_stage": "stage1"
+      "slug": "eskipup",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "houndice"
+      ]
+    },
+    {
+      "slug": "houndice",
+      "stage": "stage1",
+      "evolves_from": [
+        "eskipup"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/exapode.json
+++ b/mods/tuxemon/db/monster/exapode.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chenipode",
-      "evo_stage": "basic"
+      "slug": "exapode",
+      "stage": "stage1",
+      "evolves_from": [
+        "chenipode"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chenipode",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "exapode"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "boltnu",
-      "evo_stage": "basic"
+      "slug": "exclawvate",
+      "stage": "stage1",
+      "evolves_from": [
+        "boltnu"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "boltnu",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "exclawvate"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/eyenemy.json
+++ b/mods/tuxemon/db/monster/eyenemy.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "eyesore",
-      "evo_stage": "stage1"
+      "slug": "eyenemy",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "eyesore"
+      ]
+    },
+    {
+      "slug": "eyesore",
+      "stage": "stage1",
+      "evolves_from": [
+        "eyenemy"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/eyesore.json
+++ b/mods/tuxemon/db/monster/eyesore.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "eyenemy",
-      "evo_stage": "basic"
+      "slug": "eyesore",
+      "stage": "stage1",
+      "evolves_from": [
+        "eyenemy"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "eyenemy",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "eyesore"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "f7u1t3ra",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "flier",

--- a/mods/tuxemon/db/monster/fancair.json
+++ b/mods/tuxemon/db/monster/fancair.json
@@ -39,8 +39,20 @@
   ],
   "history": [
     {
-      "mon_slug": "windeye",
-      "evo_stage": "stage1"
+      "slug": "fancair",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "windeye"
+      ]
+    },
+    {
+      "slug": "windeye",
+      "stage": "stage1",
+      "evolves_from": [
+        "fancair"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/ferricran.json
+++ b/mods/tuxemon/db/monster/ferricran.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "wrougon",
-      "evo_stage": "basic"
+      "slug": "ferricran",
+      "stage": "stage2",
+      "evolves_from": [
+        "allagon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "allagon",
-      "evo_stage": "stage1"
+      "slug": "wrougon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "allagon"
+      ]
+    },
+    {
+      "slug": "allagon",
+      "stage": "stage1",
+      "evolves_from": [
+        "wrougon"
+      ],
+      "evolves_into": [
+        "ferricran"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/firomenis.json
+++ b/mods/tuxemon/db/monster/firomenis.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "merlicun",
-      "evo_stage": "basic"
+      "slug": "firomenis",
+      "stage": "stage1",
+      "evolves_from": [
+        "merlicun"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "merlicun",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "firomenis"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/flacono.json
+++ b/mods/tuxemon/db/monster/flacono.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "corvix",
-      "evo_stage": "stage1"
+      "slug": "flacono",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "corvix"
+      ]
     },
     {
-      "mon_slug": "gryfix",
-      "evo_stage": "stage2"
+      "slug": "corvix",
+      "stage": "stage1",
+      "evolves_from": [
+        "flacono"
+      ],
+      "evolves_into": [
+        "gryfix"
+      ]
+    },
+    {
+      "slug": "gryfix",
+      "stage": "stage2",
+      "evolves_from": [
+        "corvix"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/flambear.json
+++ b/mods/tuxemon/db/monster/flambear.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "bursa",
-      "evo_stage": "basic"
+      "slug": "flambear",
+      "stage": "stage1",
+      "evolves_from": [
+        "bursa"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "bursa",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "flambear"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/flisces.json
+++ b/mods/tuxemon/db/monster/flisces.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "flisces",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "sea"

--- a/mods/tuxemon/db/monster/flounce.json
+++ b/mods/tuxemon/db/monster/flounce.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "knindling",
-      "evo_stage": "stage1"
+      "slug": "flounce",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "knindling"
+      ]
+    },
+    {
+      "slug": "knindling",
+      "stage": "stage1",
+      "evolves_from": [
+        "flounce"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/flummack.json
+++ b/mods/tuxemon/db/monster/flummack.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "flummby",
-      "evo_stage": "basic"
+      "slug": "flummack",
+      "stage": "stage1",
+      "evolves_from": [
+        "flummby"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "flummby",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "flummack"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/flummby.json
+++ b/mods/tuxemon/db/monster/flummby.json
@@ -60,8 +60,20 @@
   ],
   "history": [
     {
-      "mon_slug": "flummack",
-      "evo_stage": "stage1"
+      "slug": "flummby",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "flummack"
+      ]
+    },
+    {
+      "slug": "flummack",
+      "stage": "stage1",
+      "evolves_from": [
+        "flummby"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/fluoresfin.json
+++ b/mods/tuxemon/db/monster/fluoresfin.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "incandesfin",
-      "evo_stage": "stage1"
+      "slug": "fluoresfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "incandesfin"
+      ]
     },
     {
-      "mon_slug": "lightmare",
-      "evo_stage": "stage2"
+      "slug": "incandesfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "fluoresfin"
+      ],
+      "evolves_into": [
+        "lightmare"
+      ]
+    },
+    {
+      "slug": "lightmare",
+      "stage": "stage2",
+      "evolves_from": [
+        "incandesfin"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/fluttaflap.json
+++ b/mods/tuxemon/db/monster/fluttaflap.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vamporm",
-      "evo_stage": "basic"
+      "slug": "fluttaflap",
+      "stage": "stage2",
+      "evolves_from": [
+        "dracune"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "dracune",
-      "evo_stage": "stage1"
+      "slug": "vamporm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "dracune"
+      ]
+    },
+    {
+      "slug": "dracune",
+      "stage": "stage1",
+      "evolves_from": [
+        "vamporm"
+      ],
+      "evolves_into": [
+        "fluttaflap"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/foofle.json
+++ b/mods/tuxemon/db/monster/foofle.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "foofle",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "love"

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "stegofor",
-      "evo_stage": "stage1"
+      "slug": "fordin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "stegofor"
+      ]
     },
     {
-      "mon_slug": "brachifor",
-      "evo_stage": "stage2"
+      "slug": "stegofor",
+      "stage": "stage1",
+      "evolves_from": [
+        "fordin"
+      ],
+      "evolves_into": [
+        "brachifor"
+      ]
+    },
+    {
+      "slug": "brachifor",
+      "stage": "stage2",
+      "evolves_from": [
+        "stegofor"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/forturtle.json
+++ b/mods/tuxemon/db/monster/forturtle.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "prophetoise",
-      "evo_stage": "stage1"
+      "slug": "forturtle",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "prophetoise"
+      ]
+    },
+    {
+      "slug": "prophetoise",
+      "stage": "stage1",
+      "evolves_from": [
+        "forturtle"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/foxfire.json
+++ b/mods/tuxemon/db/monster/foxfire.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "vulpyre",
-      "evo_stage": "stage1"
+      "slug": "foxfire",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vulpyre"
+      ]
+    },
+    {
+      "slug": "vulpyre",
+      "stage": "stage1",
+      "evolves_from": [
+        "foxfire"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/foxko.json
+++ b/mods/tuxemon/db/monster/foxko.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "foxko",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "serpent",

--- a/mods/tuxemon/db/monster/fribbit.json
+++ b/mods/tuxemon/db/monster/fribbit.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tadcool",
-      "evo_stage": "basic"
+      "slug": "fribbit",
+      "stage": "stage1",
+      "evolves_from": [
+        "tadcool"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "tadcool",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "fribbit"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/frondly.json
+++ b/mods/tuxemon/db/monster/frondly.json
@@ -46,8 +46,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "budaye",
-      "evo_stage": "basic"
+      "slug": "frondly",
+      "stage": "stage1",
+      "evolves_from": [
+        "budaye",
+        "budaye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "budaye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bamboon",
+        "bamboon",
+        "frondly",
+        "frondly"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/frostuce.json
+++ b/mods/tuxemon/db/monster/frostuce.json
@@ -46,12 +46,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "cohldrabi",
-      "evo_stage": "basic"
+      "slug": "frostuce",
+      "stage": "stage2",
+      "evolves_from": [
+        "lettice"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "lettice",
-      "evo_stage": "stage1"
+      "slug": "cohldrabi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "lettice"
+      ]
+    },
+    {
+      "slug": "lettice",
+      "stage": "stage1",
+      "evolves_from": [
+        "cohldrabi"
+      ],
+      "evolves_into": [
+        "frostuce"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "megafruitera",
-      "evo_stage": "stage1"
+      "slug": "fruitera",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "megafruitera"
+      ]
     },
     {
-      "mon_slug": "spectera",
-      "evo_stage": "stage2"
+      "slug": "megafruitera",
+      "stage": "stage1",
+      "evolves_from": [
+        "fruitera"
+      ],
+      "evolves_into": [
+        "spectera"
+      ]
+    },
+    {
+      "slug": "spectera",
+      "stage": "stage2",
+      "evolves_from": [
+        "megafruitera"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -43,12 +43,30 @@
   ],
   "history": [
     {
-      "mon_slug": "statursus",
-      "evo_stage": "stage1"
+      "slug": "furnursus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "statursus"
+      ]
     },
     {
-      "mon_slug": "coaldiak",
-      "evo_stage": "stage2"
+      "slug": "statursus",
+      "stage": "stage1",
+      "evolves_from": [
+        "furnursus"
+      ],
+      "evolves_into": [
+        "coaldiak"
+      ]
+    },
+    {
+      "slug": "coaldiak",
+      "stage": "stage2",
+      "evolves_from": [
+        "statursus"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/fuzzina.json
+++ b/mods/tuxemon/db/monster/fuzzina.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "fuzzlet",
-      "evo_stage": "basic"
+      "slug": "fuzzina",
+      "stage": "stage1",
+      "evolves_from": [
+        "fuzzlet"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "fuzzlet",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "fuzzina"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "fuzzina",
-      "evo_stage": "stage1"
+      "slug": "fuzzlet",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "fuzzina"
+      ]
+    },
+    {
+      "slug": "fuzzina",
+      "stage": "stage1",
+      "evolves_from": [
+        "fuzzlet"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/galasces.json
+++ b/mods/tuxemon/db/monster/galasces.json
@@ -31,12 +31,30 @@
   ],
   "history": [
     {
-      "mon_slug": "nebufin",
-      "evo_stage": "basic"
+      "slug": "galasces",
+      "stage": "stage1",
+      "evolves_from": [
+        "nebufin"
+      ],
+      "evolves_into": [
+        "novaquarius"
+      ]
     },
     {
-      "mon_slug": "novaquarius",
-      "evo_stage": "stage2"
+      "slug": "nebufin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "galasces"
+      ]
+    },
+    {
+      "slug": "novaquarius",
+      "stage": "stage2",
+      "evolves_from": [
+        "galasces"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "galnec",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "desert"
   ],

--- a/mods/tuxemon/db/monster/gastronium.json
+++ b/mods/tuxemon/db/monster/gastronium.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "stomic",
-      "evo_stage": "basic"
+      "slug": "gastronium",
+      "stage": "stage1",
+      "evolves_from": [
+        "stomic"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "stomic",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gastronium"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/gectile.json
+++ b/mods/tuxemon/db/monster/gectile.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "anoleaf",
-      "evo_stage": "basic"
+      "slug": "gectile",
+      "stage": "stage1",
+      "evolves_from": [
+        "anoleaf"
+      ],
+      "evolves_into": [
+        "velocitile"
+      ]
     },
     {
-      "mon_slug": "velocitile",
-      "evo_stage": "stage2"
+      "slug": "anoleaf",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gectile"
+      ]
+    },
+    {
+      "slug": "velocitile",
+      "stage": "stage2",
+      "evolves_from": [
+        "gectile"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/ghosteeth.json
+++ b/mods/tuxemon/db/monster/ghosteeth.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "ghosteeth",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ghost",

--- a/mods/tuxemon/db/monster/gladiatorbug.json
+++ b/mods/tuxemon/db/monster/gladiatorbug.json
@@ -50,12 +50,32 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "katapill",
-      "evo_stage": "basic"
+      "slug": "gladiatorbug",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "katacoon",
-      "evo_stage": "stage1"
+      "slug": "katapill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "katacoon"
+      ]
+    },
+    {
+      "slug": "katacoon",
+      "stage": "stage1",
+      "evolves_from": [
+        "katapill"
+      ],
+      "evolves_into": [
+        "bugnin",
+        "sumchon",
+        "gladiatorbug"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/gliffary.json
+++ b/mods/tuxemon/db/monster/gliffary.json
@@ -36,7 +36,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "gliffary",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "mental",

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -63,12 +63,30 @@
   ],
   "history": [
     {
-      "mon_slug": "slichen",
-      "evo_stage": "basic"
+      "slug": "glombroc",
+      "stage": "stage1",
+      "evolves_from": [
+        "slichen"
+      ],
+      "evolves_into": [
+        "conglolem"
+      ]
     },
     {
-      "mon_slug": "conglolem",
-      "evo_stage": "stage2"
+      "slug": "slichen",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "glombroc"
+      ]
+    },
+    {
+      "slug": "conglolem",
+      "stage": "stage2",
+      "evolves_from": [
+        "glombroc"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/glomon.json
+++ b/mods/tuxemon/db/monster/glomon.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "glomon",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "ruins",
     "urban"

--- a/mods/tuxemon/db/monster/golnagi.json
+++ b/mods/tuxemon/db/monster/golnagi.json
@@ -58,12 +58,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "gupphish",
-      "evo_stage": "basic"
+      "slug": "golnagi",
+      "stage": "stage2",
+      "evolves_from": [
+        "gupphire"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "gupphire",
-      "evo_stage": "stage1"
+      "slug": "gupphish",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gupphire"
+      ]
+    },
+    {
+      "slug": "gupphire",
+      "stage": "stage1",
+      "evolves_from": [
+        "gupphish"
+      ],
+      "evolves_into": [
+        "golnagi"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/gourda.json
+++ b/mods/tuxemon/db/monster/gourda.json
@@ -28,7 +28,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "gourda",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant",

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "graffiki",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "soldier",

--- a/mods/tuxemon/db/monster/grimachin.json
+++ b/mods/tuxemon/db/monster/grimachin.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "tigrock",
-      "evo_stage": "stage1"
+      "slug": "grimachin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tigrock"
+      ]
+    },
+    {
+      "slug": "tigrock",
+      "stage": "stage1",
+      "evolves_from": [
+        "grimachin"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/grinflare.json
+++ b/mods/tuxemon/db/monster/grinflare.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "grintot",
-      "evo_stage": "basic"
+      "slug": "grinflare",
+      "stage": "stage1",
+      "evolves_from": [
+        "grintot",
+        "grintot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "grintot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "grinflare",
+        "grinflare",
+        "grintrock",
+        "grintrock"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/grintot.json
+++ b/mods/tuxemon/db/monster/grintot.json
@@ -43,12 +43,33 @@
   ],
   "history": [
     {
-      "mon_slug": "grinflare",
-      "evo_stage": "stage1"
+      "slug": "grintot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "grinflare",
+        "grinflare",
+        "grintrock",
+        "grintrock"
+      ]
     },
     {
-      "mon_slug": "grintrock",
-      "evo_stage": "stage1"
+      "slug": "grinflare",
+      "stage": "stage1",
+      "evolves_from": [
+        "grintot",
+        "grintot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "grintrock",
+      "stage": "stage1",
+      "evolves_from": [
+        "grintot",
+        "grintot"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/grintrock.json
+++ b/mods/tuxemon/db/monster/grintrock.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "grintot",
-      "evo_stage": "basic"
+      "slug": "grintrock",
+      "stage": "stage1",
+      "evolves_from": [
+        "grintot",
+        "grintot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "grintot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "grinflare",
+        "grinflare",
+        "grintrock",
+        "grintrock"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "grumpi",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "pseudopod",

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "flacono",
-      "evo_stage": "basic"
+      "slug": "gryfix",
+      "stage": "stage2",
+      "evolves_from": [
+        "corvix"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "corvix",
-      "evo_stage": "stage1"
+      "slug": "flacono",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "corvix"
+      ]
+    },
+    {
+      "slug": "corvix",
+      "stage": "stage1",
+      "evolves_from": [
+        "flacono"
+      ],
+      "evolves_into": [
+        "gryfix"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/gupphire.json
+++ b/mods/tuxemon/db/monster/gupphire.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "gupphish",
-      "evo_stage": "basic"
+      "slug": "gupphire",
+      "stage": "stage1",
+      "evolves_from": [
+        "gupphish"
+      ],
+      "evolves_into": [
+        "golnagi"
+      ]
     },
     {
-      "mon_slug": "golnagi",
-      "evo_stage": "stage2"
+      "slug": "gupphish",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gupphire"
+      ]
+    },
+    {
+      "slug": "golnagi",
+      "stage": "stage2",
+      "evolves_from": [
+        "gupphire"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/gupphish.json
+++ b/mods/tuxemon/db/monster/gupphish.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "gupphire",
-      "evo_stage": "stage1"
+      "slug": "gupphish",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gupphire"
+      ]
     },
     {
-      "mon_slug": "golnagi",
-      "evo_stage": "stage2"
+      "slug": "gupphire",
+      "stage": "stage1",
+      "evolves_from": [
+        "gupphish"
+      ],
+      "evolves_into": [
+        "golnagi"
+      ]
+    },
+    {
+      "slug": "golnagi",
+      "stage": "stage2",
+      "evolves_from": [
+        "gupphire"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/hampotamos.json
+++ b/mods/tuxemon/db/monster/hampotamos.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "hampotamos",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ground",

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -38,8 +38,23 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chromeye",
-      "evo_stage": "basic"
+      "slug": "happito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chromeye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angrito",
+        "happito",
+        "neutrito",
+        "sadito"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/hatchling.json
+++ b/mods/tuxemon/db/monster/hatchling.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "birdling",
-      "evo_stage": "stage1"
+      "slug": "hatchling",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "birdling"
+      ]
+    },
+    {
+      "slug": "birdling",
+      "stage": "stage1",
+      "evolves_from": [
+        "hatchling"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/hectapod.json
+++ b/mods/tuxemon/db/monster/hectapod.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "squink",
-      "evo_stage": "basic"
+      "slug": "hectapod",
+      "stage": "stage1",
+      "evolves_from": [
+        "squink"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "squink",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "hectapod"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/helipi.json
+++ b/mods/tuxemon/db/monster/helipi.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "coppi",
-      "evo_stage": "stage1"
+      "slug": "helipi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "coppi"
+      ]
     },
     {
-      "mon_slug": "parappi",
-      "evo_stage": "stage2"
+      "slug": "coppi",
+      "stage": "stage1",
+      "evolves_from": [
+        "helipi"
+      ],
+      "evolves_into": [
+        "parappi"
+      ]
+    },
+    {
+      "slug": "parappi",
+      "stage": "stage2",
+      "evolves_from": [
+        "coppi"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/heronquak.json
+++ b/mods/tuxemon/db/monster/heronquak.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "tweesher",
-      "evo_stage": "basic"
+      "slug": "heronquak",
+      "stage": "stage1",
+      "evolves_from": [
+        "tweesher"
+      ],
+      "evolves_into": [
+        "eaglace"
+      ]
     },
     {
-      "mon_slug": "eaglace",
-      "evo_stage": "stage2"
+      "slug": "tweesher",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "heronquak"
+      ]
+    },
+    {
+      "slug": "eaglace",
+      "stage": "stage2",
+      "evolves_from": [
+        "heronquak"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/hissiorite.json
+++ b/mods/tuxemon/db/monster/hissiorite.json
@@ -35,12 +35,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cobarett",
-      "evo_stage": "stage1"
+      "slug": "hissiorite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cobarett"
+      ]
     },
     {
-      "mon_slug": "pythonova",
-      "evo_stage": "stage2"
+      "slug": "cobarett",
+      "stage": "stage1",
+      "evolves_from": [
+        "hissiorite"
+      ],
+      "evolves_into": [
+        "pythonova"
+      ]
+    },
+    {
+      "slug": "pythonova",
+      "stage": "stage2",
+      "evolves_from": [
+        "cobarett"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/hoarse.json
+++ b/mods/tuxemon/db/monster/hoarse.json
@@ -31,12 +31,30 @@
   ],
   "history": [
     {
-      "mon_slug": "equill",
-      "evo_stage": "stage1"
+      "slug": "hoarse",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "equill"
+      ]
     },
     {
-      "mon_slug": "hoarseshoo",
-      "evo_stage": "stage2"
+      "slug": "equill",
+      "stage": "stage1",
+      "evolves_from": [
+        "hoarse"
+      ],
+      "evolves_into": [
+        "hoarseshoo"
+      ]
+    },
+    {
+      "slug": "hoarseshoo",
+      "stage": "stage2",
+      "evolves_from": [
+        "equill"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/hoarseshoo.json
+++ b/mods/tuxemon/db/monster/hoarseshoo.json
@@ -34,12 +34,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "hoarse",
-      "evo_stage": "basic"
+      "slug": "hoarseshoo",
+      "stage": "stage2",
+      "evolves_from": [
+        "equill"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "equill",
-      "evo_stage": "stage1"
+      "slug": "hoarse",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "equill"
+      ]
+    },
+    {
+      "slug": "equill",
+      "stage": "stage1",
+      "evolves_from": [
+        "hoarse"
+      ],
+      "evolves_into": [
+        "hoarseshoo"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/hoodoll.json
+++ b/mods/tuxemon/db/monster/hoodoll.json
@@ -55,8 +55,20 @@
   ],
   "history": [
     {
-      "mon_slug": "wolololl",
-      "evo_stage": "stage1"
+      "slug": "hoodoll",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "wolololl"
+      ]
+    },
+    {
+      "slug": "wolololl",
+      "stage": "stage1",
+      "evolves_from": [
+        "hoodoll"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/hotline.json
+++ b/mods/tuxemon/db/monster/hotline.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "hotline",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "urban"
   ],

--- a/mods/tuxemon/db/monster/houndice.json
+++ b/mods/tuxemon/db/monster/houndice.json
@@ -26,8 +26,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "eskipup",
-      "evo_stage": "basic"
+      "slug": "houndice",
+      "stage": "stage1",
+      "evolves_from": [
+        "eskipup"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "eskipup",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "houndice"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/howl.json
+++ b/mods/tuxemon/db/monster/howl.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "howl",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "bird"

--- a/mods/tuxemon/db/monster/hydrone.json
+++ b/mods/tuxemon/db/monster/hydrone.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "hydrone",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "machine",

--- a/mods/tuxemon/db/monster/ignibus.json
+++ b/mods/tuxemon/db/monster/ignibus.json
@@ -43,12 +43,33 @@
   ],
   "history": [
     {
-      "mon_slug": "embazook",
-      "evo_stage": "stage1"
+      "slug": "ignibus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "eruptibus",
+        "eruptibus",
+        "embazook",
+        "embazook"
+      ]
     },
     {
-      "mon_slug": "eruptibus",
-      "evo_stage": "stage1"
+      "slug": "embazook",
+      "stage": "stage1",
+      "evolves_from": [
+        "ignibus",
+        "ignibus"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "eruptibus",
+      "stage": "stage1",
+      "evolves_from": [
+        "ignibus",
+        "ignibus"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/imbrickcile.json
+++ b/mods/tuxemon/db/monster/imbrickcile.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "bricgard",
-      "evo_stage": "stage1"
+      "slug": "imbrickcile",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bricgard"
+      ]
     },
     {
-      "mon_slug": "brickhemoth",
-      "evo_stage": "stage2"
+      "slug": "bricgard",
+      "stage": "stage1",
+      "evolves_from": [
+        "imbrickcile"
+      ],
+      "evolves_into": [
+        "brickhemoth"
+      ]
+    },
+    {
+      "slug": "brickhemoth",
+      "stage": "stage2",
+      "evolves_from": [
+        "bricgard"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/incandesfin.json
+++ b/mods/tuxemon/db/monster/incandesfin.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "fluoresfin",
-      "evo_stage": "basic"
+      "slug": "incandesfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "fluoresfin"
+      ],
+      "evolves_into": [
+        "lightmare"
+      ]
     },
     {
-      "mon_slug": "lightmare",
-      "evo_stage": "stage2"
+      "slug": "fluoresfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "incandesfin"
+      ]
+    },
+    {
+      "slug": "lightmare",
+      "stage": "stage2",
+      "evolves_from": [
+        "incandesfin"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -63,8 +63,20 @@
   ],
   "history": [
     {
-      "mon_slug": "bedoo",
-      "evo_stage": "stage1"
+      "slug": "jelillow",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bedoo"
+      ]
+    },
+    {
+      "slug": "bedoo",
+      "stage": "stage1",
+      "evolves_from": [
+        "jelillow"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/jeluna.json
+++ b/mods/tuxemon/db/monster/jeluna.json
@@ -40,7 +40,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "jeluna",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "boreal_snow",
     "extraterrestrial",

--- a/mods/tuxemon/db/monster/jemuar.json
+++ b/mods/tuxemon/db/monster/jemuar.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "rockitten",
-      "evo_stage": "basic"
+      "slug": "jemuar",
+      "stage": "stage2",
+      "evolves_from": [
+        "rockat"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "rockat",
-      "evo_stage": "stage1"
+      "slug": "rockitten",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "rockat"
+      ]
+    },
+    {
+      "slug": "rockat",
+      "stage": "stage1",
+      "evolves_from": [
+        "rockitten"
+      ],
+      "evolves_into": [
+        "jemuar"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/joulraton.json
+++ b/mods/tuxemon/db/monster/joulraton.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "joulraton",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "electricity",

--- a/mods/tuxemon/db/monster/k9.json
+++ b/mods/tuxemon/db/monster/k9.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "botbot",
-      "evo_stage": "basic"
+      "slug": "k9",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "botbot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "av8r",
+        "picc",
+        "mrmoswitch",
+        "k9",
+        "b_ver_1"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/katacoon.json
+++ b/mods/tuxemon/db/monster/katacoon.json
@@ -46,20 +46,48 @@
   ],
   "history": [
     {
-      "mon_slug": "katapill",
-      "evo_stage": "basic"
+      "slug": "katacoon",
+      "stage": "stage1",
+      "evolves_from": [
+        "katapill"
+      ],
+      "evolves_into": [
+        "bugnin",
+        "sumchon",
+        "gladiatorbug"
+      ]
     },
     {
-      "mon_slug": "bugnin",
-      "evo_stage": "stage2"
+      "slug": "katapill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "katacoon"
+      ]
     },
     {
-      "mon_slug": "sumchon",
-      "evo_stage": "stage2"
+      "slug": "bugnin",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "gladiatorbug",
-      "evo_stage": "stage2"
+      "slug": "sumchon",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "gladiatorbug",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/katapill.json
+++ b/mods/tuxemon/db/monster/katapill.json
@@ -35,20 +35,48 @@
   ],
   "history": [
     {
-      "mon_slug": "katacoon",
-      "evo_stage": "stage1"
+      "slug": "katapill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "katacoon"
+      ]
     },
     {
-      "mon_slug": "bugnin",
-      "evo_stage": "stage2"
+      "slug": "katacoon",
+      "stage": "stage1",
+      "evolves_from": [
+        "katapill"
+      ],
+      "evolves_into": [
+        "bugnin",
+        "sumchon",
+        "gladiatorbug"
+      ]
     },
     {
-      "mon_slug": "sumchon",
-      "evo_stage": "stage2"
+      "slug": "bugnin",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "gladiatorbug",
-      "evo_stage": "stage2"
+      "slug": "sumchon",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "gladiatorbug",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/kernel.json
+++ b/mods/tuxemon/db/monster/kernel.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "kernel",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraplanar"
   ],

--- a/mods/tuxemon/db/monster/knightsand.json
+++ b/mods/tuxemon/db/monster/knightsand.json
@@ -46,8 +46,22 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pawsand",
-      "evo_stage": "basic"
+      "slug": "knightsand",
+      "stage": "stage1",
+      "evolves_from": [
+        "pawsand"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pawsand",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "knightsand",
+        "bishosand",
+        "rooksand"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/knindling.json
+++ b/mods/tuxemon/db/monster/knindling.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "flounce",
-      "evo_stage": "basic"
+      "slug": "knindling",
+      "stage": "stage1",
+      "evolves_from": [
+        "flounce"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "flounce",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "knindling"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/komodraw.json
+++ b/mods/tuxemon/db/monster/komodraw.json
@@ -63,8 +63,20 @@
   ],
   "history": [
     {
-      "mon_slug": "komoduel",
-      "evo_stage": "stage1"
+      "slug": "komodraw",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "komoduel"
+      ]
+    },
+    {
+      "slug": "komoduel",
+      "stage": "stage1",
+      "evolves_from": [
+        "komodraw"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/komoduel.json
+++ b/mods/tuxemon/db/monster/komoduel.json
@@ -58,8 +58,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "komodraw",
-      "evo_stage": "basic"
+      "slug": "komoduel",
+      "stage": "stage1",
+      "evolves_from": [
+        "komodraw"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "komodraw",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "komoduel"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/konuit.json
+++ b/mods/tuxemon/db/monster/konuit.json
@@ -32,7 +32,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "konuit",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant"

--- a/mods/tuxemon/db/monster/kroki.json
+++ b/mods/tuxemon/db/monster/kroki.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "krokivip",
-      "evo_stage": "stage1"
+      "slug": "kroki",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "krokivip"
+      ]
     },
     {
-      "mon_slug": "leviadile",
-      "evo_stage": "stage2"
+      "slug": "krokivip",
+      "stage": "stage1",
+      "evolves_from": [
+        "kroki"
+      ],
+      "evolves_into": [
+        "leviadile"
+      ]
+    },
+    {
+      "slug": "leviadile",
+      "stage": "stage2",
+      "evolves_from": [
+        "krokivip"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/krokivip.json
+++ b/mods/tuxemon/db/monster/krokivip.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "kroki",
-      "evo_stage": "basic"
+      "slug": "krokivip",
+      "stage": "stage1",
+      "evolves_from": [
+        "kroki"
+      ],
+      "evolves_into": [
+        "leviadile"
+      ]
     },
     {
-      "mon_slug": "leviadile",
-      "evo_stage": "stage2"
+      "slug": "kroki",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "krokivip"
+      ]
+    },
+    {
+      "slug": "leviadile",
+      "stage": "stage2",
+      "evolves_from": [
+        "krokivip"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "l3gk0",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "serpent",

--- a/mods/tuxemon/db/monster/lambert.json
+++ b/mods/tuxemon/db/monster/lambert.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "legko",
-      "evo_stage": "stage1"
+      "slug": "lambert",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "legko"
+      ]
     },
     {
-      "mon_slug": "moloch",
-      "evo_stage": "stage2"
+      "slug": "legko",
+      "stage": "stage1",
+      "evolves_from": [
+        "lambert"
+      ],
+      "evolves_into": [
+        "moloch"
+      ]
+    },
+    {
+      "slug": "moloch",
+      "stage": "stage2",
+      "evolves_from": [
+        "legko"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/lapinou.json
+++ b/mods/tuxemon/db/monster/lapinou.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "lapinou",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ground",

--- a/mods/tuxemon/db/monster/legko.json
+++ b/mods/tuxemon/db/monster/legko.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "lambert",
-      "evo_stage": "basic"
+      "slug": "legko",
+      "stage": "stage1",
+      "evolves_from": [
+        "lambert"
+      ],
+      "evolves_into": [
+        "moloch"
+      ]
     },
     {
-      "mon_slug": "moloch",
-      "evo_stage": "stage2"
+      "slug": "lambert",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "legko"
+      ]
+    },
+    {
+      "slug": "moloch",
+      "stage": "stage2",
+      "evolves_from": [
+        "legko"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/legoplaste.json
+++ b/mods/tuxemon/db/monster/legoplaste.json
@@ -28,7 +28,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "legoplaste",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "any"
   ],

--- a/mods/tuxemon/db/monster/lendos.json
+++ b/mods/tuxemon/db/monster/lendos.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "uneye",
-      "evo_stage": "basic"
+      "slug": "lendos",
+      "stage": "stage1",
+      "evolves_from": [
+        "uneye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "uneye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "lendos"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/lesmagu.json
+++ b/mods/tuxemon/db/monster/lesmagu.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "shelagu",
-      "evo_stage": "stage1"
+      "slug": "lesmagu",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shelagu"
+      ]
     },
     {
-      "mon_slug": "crustagu",
-      "evo_stage": "stage2"
+      "slug": "shelagu",
+      "stage": "stage1",
+      "evolves_from": [
+        "lesmagu"
+      ],
+      "evolves_into": [
+        "crustagu"
+      ]
+    },
+    {
+      "slug": "crustagu",
+      "stage": "stage2",
+      "evolves_from": [
+        "shelagu"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/lettice.json
+++ b/mods/tuxemon/db/monster/lettice.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cohldrabi",
-      "evo_stage": "basic"
+      "slug": "lettice",
+      "stage": "stage1",
+      "evolves_from": [
+        "cohldrabi"
+      ],
+      "evolves_into": [
+        "frostuce"
+      ]
     },
     {
-      "mon_slug": "frostuce",
-      "evo_stage": "stage2"
+      "slug": "cohldrabi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "lettice"
+      ]
+    },
+    {
+      "slug": "frostuce",
+      "stage": "stage2",
+      "evolves_from": [
+        "lettice"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/leviadile.json
+++ b/mods/tuxemon/db/monster/leviadile.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "kroki",
-      "evo_stage": "basic"
+      "slug": "leviadile",
+      "stage": "stage2",
+      "evolves_from": [
+        "krokivip"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "krokivip",
-      "evo_stage": "stage1"
+      "slug": "kroki",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "krokivip"
+      ]
+    },
+    {
+      "slug": "krokivip",
+      "stage": "stage1",
+      "evolves_from": [
+        "kroki"
+      ],
+      "evolves_into": [
+        "leviadile"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/lightmare.json
+++ b/mods/tuxemon/db/monster/lightmare.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "fluoresfin",
-      "evo_stage": "basic"
+      "slug": "lightmare",
+      "stage": "stage2",
+      "evolves_from": [
+        "incandesfin"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "incandesfin",
-      "evo_stage": "stage1"
+      "slug": "fluoresfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "incandesfin"
+      ]
+    },
+    {
+      "slug": "incandesfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "fluoresfin"
+      ],
+      "evolves_into": [
+        "lightmare"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -42,8 +42,21 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "seirein",
-      "evo_stage": "basic"
+      "slug": "loliferno",
+      "stage": "stage1",
+      "evolves_from": [
+        "seirein"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "seirein",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "loliferno",
+        "spirain"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/lucifice.json
+++ b/mods/tuxemon/db/monster/lucifice.json
@@ -46,12 +46,31 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "waysprite",
-      "evo_stage": "basic"
+      "slug": "lucifice",
+      "stage": "stage2",
+      "evolves_from": [
+        "demosnow"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "demosnow",
-      "evo_stage": "stage1"
+      "slug": "waysprite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angesnow",
+        "demosnow"
+      ]
+    },
+    {
+      "slug": "demosnow",
+      "stage": "stage1",
+      "evolves_from": [
+        "waysprite"
+      ],
+      "evolves_into": [
+        "lucifice"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "lunight",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraplanar",
     "ruins"

--- a/mods/tuxemon/db/monster/manosting.json
+++ b/mods/tuxemon/db/monster/manosting.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "manosting",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "toxic",

--- a/mods/tuxemon/db/monster/marvantis.json
+++ b/mods/tuxemon/db/monster/marvantis.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "marvillar",
-      "evo_stage": "basic"
+      "slug": "marvantis",
+      "stage": "stage1",
+      "evolves_from": [
+        "marvillar"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "marvillar",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "marvantis"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/marvillar.json
+++ b/mods/tuxemon/db/monster/marvillar.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "marvantis",
-      "evo_stage": "stage1"
+      "slug": "marvillar",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "marvantis"
+      ]
+    },
+    {
+      "slug": "marvantis",
+      "stage": "stage1",
+      "evolves_from": [
+        "marvillar"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/masknake.json
+++ b/mods/tuxemon/db/monster/masknake.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "masknake",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "light",

--- a/mods/tuxemon/db/monster/mauai.json
+++ b/mods/tuxemon/db/monster/mauai.json
@@ -42,8 +42,26 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "memnomnom",
-      "evo_stage": "basic"
+      "slug": "mauai",
+      "stage": "stage1",
+      "evolves_from": [
+        "memnomnom",
+        "memnomnom"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "memnomnom",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "miaownolith",
+        "miaownolith",
+        "pyraminx",
+        "pyraminx",
+        "mauai",
+        "mauai"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/medipup.json
+++ b/mods/tuxemon/db/monster/medipup.json
@@ -63,16 +63,39 @@
   ],
   "history": [
     {
-      "mon_slug": "doctsky",
-      "evo_stage": "stage1"
+      "slug": "medipup",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "doctsky"
+      ]
     },
     {
-      "mon_slug": "askylpaws",
-      "evo_stage": "stage2"
+      "slug": "doctsky",
+      "stage": "stage1",
+      "evolves_from": [
+        "medipup"
+      ],
+      "evolves_into": [
+        "askylpaws",
+        "erythroskyte"
+      ]
     },
     {
-      "mon_slug": "erythroskyte",
-      "evo_stage": "stage2"
+      "slug": "askylpaws",
+      "stage": "stage2",
+      "evolves_from": [
+        "doctsky"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "erythroskyte",
+      "stage": "stage2",
+      "evolves_from": [
+        "doctsky"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "medushock",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "freshwater"
   ],

--- a/mods/tuxemon/db/monster/megafruitera.json
+++ b/mods/tuxemon/db/monster/megafruitera.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "fruitera",
-      "evo_stage": "basic"
+      "slug": "megafruitera",
+      "stage": "stage1",
+      "evolves_from": [
+        "fruitera"
+      ],
+      "evolves_into": [
+        "spectera"
+      ]
     },
     {
-      "mon_slug": "spectera",
-      "evo_stage": "stage2"
+      "slug": "fruitera",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "megafruitera"
+      ]
+    },
+    {
+      "slug": "spectera",
+      "stage": "stage2",
+      "evolves_from": [
+        "megafruitera"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/memnomnom.json
+++ b/mods/tuxemon/db/monster/memnomnom.json
@@ -51,16 +51,44 @@
   ],
   "history": [
     {
-      "mon_slug": "pyraminx",
-      "evo_stage": "stage1"
+      "slug": "memnomnom",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "miaownolith",
+        "miaownolith",
+        "pyraminx",
+        "pyraminx",
+        "mauai",
+        "mauai"
+      ]
     },
     {
-      "mon_slug": "miaownolith",
-      "evo_stage": "stage1"
+      "slug": "pyraminx",
+      "stage": "stage1",
+      "evolves_from": [
+        "memnomnom",
+        "memnomnom"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "mauai",
-      "evo_stage": "stage1"
+      "slug": "miaownolith",
+      "stage": "stage1",
+      "evolves_from": [
+        "memnomnom",
+        "memnomnom"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "mauai",
+      "stage": "stage1",
+      "evolves_from": [
+        "memnomnom",
+        "memnomnom"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "firomenis",
-      "evo_stage": "stage1"
+      "slug": "merlicun",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "firomenis"
+      ]
+    },
+    {
+      "slug": "firomenis",
+      "stage": "stage1",
+      "evolves_from": [
+        "merlicun"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -55,8 +55,20 @@
   ],
   "history": [
     {
-      "mon_slug": "qetzlrokilus",
-      "evo_stage": "stage1"
+      "slug": "metesaur",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "qetzlrokilus"
+      ]
+    },
+    {
+      "slug": "qetzlrokilus",
+      "stage": "stage1",
+      "evolves_from": [
+        "metesaur"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/metoxic.json
+++ b/mods/tuxemon/db/monster/metoxic.json
@@ -32,7 +32,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "metoxic",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "desert",

--- a/mods/tuxemon/db/monster/miaownolith.json
+++ b/mods/tuxemon/db/monster/miaownolith.json
@@ -42,8 +42,26 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "memnomnom",
-      "evo_stage": "basic"
+      "slug": "miaownolith",
+      "stage": "stage1",
+      "evolves_from": [
+        "memnomnom",
+        "memnomnom"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "memnomnom",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "miaownolith",
+        "miaownolith",
+        "pyraminx",
+        "pyraminx",
+        "mauai",
+        "mauai"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mingdyn.json
+++ b/mods/tuxemon/db/monster/mingdyn.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "mingdyn",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "mountains"
   ],

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -51,16 +51,41 @@
   ],
   "history": [
     {
-      "mon_slug": "mk01_proto",
-      "evo_stage": "basic"
+      "slug": "mk01_alpha",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_gamma"
+      ]
     },
     {
-      "mon_slug": "mk01_gamma",
-      "evo_stage": "stage2"
+      "slug": "mk01_proto",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "mk01_alpha",
+        "mk01_beta"
+      ]
     },
     {
-      "mon_slug": "mk01_delta",
-      "evo_stage": "stage2"
+      "slug": "mk01_gamma",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "mk01_delta",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha",
+        "mk01_beta"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -51,16 +51,41 @@
   ],
   "history": [
     {
-      "mon_slug": "mk01_proto",
-      "evo_stage": "basic"
+      "slug": "mk01_beta",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_omega"
+      ]
     },
     {
-      "mon_slug": "mk01_delta",
-      "evo_stage": "stage2"
+      "slug": "mk01_proto",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "mk01_alpha",
+        "mk01_beta"
+      ]
     },
     {
-      "mon_slug": "mk01_omega",
-      "evo_stage": "stage2"
+      "slug": "mk01_delta",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha",
+        "mk01_beta"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "mk01_omega",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_beta"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mk01_delta.json
+++ b/mods/tuxemon/db/monster/mk01_delta.json
@@ -54,16 +54,44 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "mk01_proto",
-      "evo_stage": "basic"
+      "slug": "mk01_delta",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha",
+        "mk01_beta"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "mk01_alpha",
-      "evo_stage": "stage1"
+      "slug": "mk01_proto",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "mk01_alpha",
+        "mk01_beta"
+      ]
     },
     {
-      "mon_slug": "mk01_beta",
-      "evo_stage": "stage1"
+      "slug": "mk01_alpha",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_gamma"
+      ]
+    },
+    {
+      "slug": "mk01_beta",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_omega"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mk01_gamma.json
+++ b/mods/tuxemon/db/monster/mk01_gamma.json
@@ -54,12 +54,32 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "mk01_alpha",
-      "evo_stage": "stage1"
+      "slug": "mk01_gamma",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "mk01_proto",
-      "evo_stage": "basic"
+      "slug": "mk01_alpha",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_gamma"
+      ]
+    },
+    {
+      "slug": "mk01_proto",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "mk01_alpha",
+        "mk01_beta"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -54,12 +54,32 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "mk01_beta",
-      "evo_stage": "stage1"
+      "slug": "mk01_omega",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_beta"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "mk01_proto",
-      "evo_stage": "basic"
+      "slug": "mk01_beta",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_omega"
+      ]
+    },
+    {
+      "slug": "mk01_proto",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "mk01_alpha",
+        "mk01_beta"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -31,24 +31,60 @@
   ],
   "history": [
     {
-      "mon_slug": "mk01_alpha",
-      "evo_stage": "stage1"
+      "slug": "mk01_proto",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "mk01_alpha",
+        "mk01_beta"
+      ]
     },
     {
-      "mon_slug": "mk01_beta",
-      "evo_stage": "stage1"
+      "slug": "mk01_alpha",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_gamma"
+      ]
     },
     {
-      "mon_slug": "mk01_gamma",
-      "evo_stage": "stage2"
+      "slug": "mk01_beta",
+      "stage": "stage1",
+      "evolves_from": [
+        "mk01_proto"
+      ],
+      "evolves_into": [
+        "mk01_delta",
+        "mk01_omega"
+      ]
     },
     {
-      "mon_slug": "mk01_omega",
-      "evo_stage": "stage2"
+      "slug": "mk01_gamma",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "mk01_delta",
-      "evo_stage": "stage2"
+      "slug": "mk01_omega",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_beta"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "mk01_delta",
+      "stage": "stage2",
+      "evolves_from": [
+        "mk01_alpha",
+        "mk01_beta"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/moloch.json
+++ b/mods/tuxemon/db/monster/moloch.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "lambert",
-      "evo_stage": "basic"
+      "slug": "moloch",
+      "stage": "stage2",
+      "evolves_from": [
+        "legko"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "legko",
-      "evo_stage": "stage1"
+      "slug": "lambert",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "legko"
+      ]
+    },
+    {
+      "slug": "legko",
+      "stage": "stage1",
+      "evolves_from": [
+        "lambert"
+      ],
+      "evolves_into": [
+        "moloch"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/mrmoswitch.json
+++ b/mods/tuxemon/db/monster/mrmoswitch.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "botbot",
-      "evo_stage": "basic"
+      "slug": "mrmoswitch",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "botbot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "av8r",
+        "picc",
+        "mrmoswitch",
+        "k9",
+        "b_ver_1"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/myrmison.json
+++ b/mods/tuxemon/db/monster/myrmison.json
@@ -46,12 +46,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "scarlant",
-      "evo_stage": "basic"
+      "slug": "myrmison",
+      "stage": "stage2",
+      "evolves_from": [
+        "shull"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "shull",
-      "evo_stage": "stage1"
+      "slug": "scarlant",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shull"
+      ]
+    },
+    {
+      "slug": "shull",
+      "stage": "stage1",
+      "evolves_from": [
+        "scarlant"
+      ],
+      "evolves_into": [
+        "myrmison"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "mystikapi",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "jungle"
   ],

--- a/mods/tuxemon/db/monster/narcileaf.json
+++ b/mods/tuxemon/db/monster/narcileaf.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "shybulb",
-      "evo_stage": "basic"
+      "slug": "narcileaf",
+      "stage": "stage1",
+      "evolves_from": [
+        "shybulb"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "shybulb",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "narcileaf"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/nebufin.json
+++ b/mods/tuxemon/db/monster/nebufin.json
@@ -31,12 +31,30 @@
   ],
   "history": [
     {
-      "mon_slug": "galasces",
-      "evo_stage": "stage1"
+      "slug": "nebufin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "galasces"
+      ]
     },
     {
-      "mon_slug": "novaquarius",
-      "evo_stage": "stage2"
+      "slug": "galasces",
+      "stage": "stage1",
+      "evolves_from": [
+        "nebufin"
+      ],
+      "evolves_into": [
+        "novaquarius"
+      ]
+    },
+    {
+      "slug": "novaquarius",
+      "stage": "stage2",
+      "evolves_from": [
+        "galasces"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/ned.json
+++ b/mods/tuxemon/db/monster/ned.json
@@ -32,7 +32,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "ned",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "fists"

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -38,8 +38,23 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chromeye",
-      "evo_stage": "basic"
+      "slug": "neutrito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chromeye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angrito",
+        "happito",
+        "neutrito",
+        "sadito"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/nimbulex.json
+++ b/mods/tuxemon/db/monster/nimbulex.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "bumbulus",
-      "evo_stage": "basic"
+      "slug": "nimbulex",
+      "stage": "stage1",
+      "evolves_from": [
+        "bumbulus"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "bumbulus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "nimbulex"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/ninjasmine.json
+++ b/mods/tuxemon/db/monster/ninjasmine.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "rosarin",
-      "evo_stage": "basic"
+      "slug": "ninjasmine",
+      "stage": "stage2",
+      "evolves_from": [
+        "toxiris"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "toxiris",
-      "evo_stage": "stage1"
+      "slug": "rosarin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "toxiris"
+      ]
+    },
+    {
+      "slug": "toxiris",
+      "stage": "stage1",
+      "evolves_from": [
+        "rosarin"
+      ],
+      "evolves_into": [
+        "ninjasmine"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/noctalo.json
+++ b/mods/tuxemon/db/monster/noctalo.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "noctula",
-      "evo_stage": "basic"
+      "slug": "noctalo",
+      "stage": "stage1",
+      "evolves_from": [
+        "noctula"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "noctula",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "noctalo"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/noctula.json
+++ b/mods/tuxemon/db/monster/noctula.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "noctalo",
-      "evo_stage": "stage1"
+      "slug": "noctula",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "noctalo"
+      ]
+    },
+    {
+      "slug": "noctalo",
+      "stage": "stage1",
+      "evolves_from": [
+        "noctula"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/nostray.json
+++ b/mods/tuxemon/db/monster/nostray.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "shnark",
-      "evo_stage": "stage1"
+      "slug": "nostray",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shnark"
+      ]
+    },
+    {
+      "slug": "shnark",
+      "stage": "stage1",
+      "evolves_from": [
+        "nostray"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/novaquarius.json
+++ b/mods/tuxemon/db/monster/novaquarius.json
@@ -26,12 +26,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "nebufin",
-      "evo_stage": "basic"
+      "slug": "novaquarius",
+      "stage": "stage2",
+      "evolves_from": [
+        "galasces"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "galasces",
-      "evo_stage": "stage1"
+      "slug": "nebufin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "galasces"
+      ]
+    },
+    {
+      "slug": "galasces",
+      "stage": "stage1",
+      "evolves_from": [
+        "nebufin"
+      ],
+      "evolves_into": [
+        "novaquarius"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/nudiflot_female.json
+++ b/mods/tuxemon/db/monster/nudiflot_female.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "nudimind",
-      "evo_stage": "stage1"
+      "slug": "nudiflot_female",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "nudimind"
+      ]
+    },
+    {
+      "slug": "nudimind",
+      "stage": "stage1",
+      "evolves_from": [
+        "nudiflot_female"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/nudiflot_male.json
+++ b/mods/tuxemon/db/monster/nudiflot_male.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "nudikill",
-      "evo_stage": "stage1"
+      "slug": "nudiflot_male",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "nudikill"
+      ]
+    },
+    {
+      "slug": "nudikill",
+      "stage": "stage1",
+      "evolves_from": [
+        "nudiflot_male"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/nudikill.json
+++ b/mods/tuxemon/db/monster/nudikill.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "nudiflot_male",
-      "evo_stage": "basic"
+      "slug": "nudikill",
+      "stage": "stage1",
+      "evolves_from": [
+        "nudiflot_male"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "nudiflot_male",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "nudikill"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/nudimind.json
+++ b/mods/tuxemon/db/monster/nudimind.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "nudiflot_female",
-      "evo_stage": "basic"
+      "slug": "nudimind",
+      "stage": "stage1",
+      "evolves_from": [
+        "nudiflot_female"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "nudiflot_female",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "nudimind"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/nuenflu.json
+++ b/mods/tuxemon/db/monster/nuenflu.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "nuenflu",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ice",

--- a/mods/tuxemon/db/monster/nut.json
+++ b/mods/tuxemon/db/monster/nut.json
@@ -47,12 +47,30 @@
   ],
   "history": [
     {
-      "mon_slug": "bolt",
-      "evo_stage": "stage1"
+      "slug": "nut",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bolt"
+      ]
     },
     {
-      "mon_slug": "arthrobolt",
-      "evo_stage": "stage2"
+      "slug": "bolt",
+      "stage": "stage1",
+      "evolves_from": [
+        "nut"
+      ],
+      "evolves_into": [
+        "arthrobolt"
+      ]
+    },
+    {
+      "slug": "arthrobolt",
+      "stage": "stage2",
+      "evolves_from": [
+        "bolt"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "skwib",
-      "evo_stage": "basic"
+      "slug": "octabode",
+      "stage": "stage1",
+      "evolves_from": [
+        "skwib"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "skwib",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "octabode"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/ouroboutlet.json
+++ b/mods/tuxemon/db/monster/ouroboutlet.json
@@ -38,8 +38,21 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pythwire",
-      "evo_stage": "basic"
+      "slug": "ouroboutlet",
+      "stage": "stage1",
+      "evolves_from": [
+        "pythwire"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pythwire",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ouroboutlet",
+        "sockeserp"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pairagrin",
-      "evo_stage": "basic"
+      "slug": "pairagrim",
+      "stage": "stage1",
+      "evolves_from": [
+        "pairagrin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pairagrin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "pairagrim"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "pairagrim",
-      "evo_stage": "stage1"
+      "slug": "pairagrin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "pairagrim"
+      ]
+    },
+    {
+      "slug": "pairagrim",
+      "stage": "stage1",
+      "evolves_from": [
+        "pairagrin"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "criniotherme",
-      "evo_stage": "stage1"
+      "slug": "pantherafira",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "criniotherme"
+      ]
+    },
+    {
+      "slug": "criniotherme",
+      "stage": "stage1",
+      "evolves_from": [
+        "pantherafira"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/parappi.json
+++ b/mods/tuxemon/db/monster/parappi.json
@@ -54,12 +54,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "helipi",
-      "evo_stage": "basic"
+      "slug": "parappi",
+      "stage": "stage2",
+      "evolves_from": [
+        "coppi"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "coppi",
-      "evo_stage": "stage1"
+      "slug": "helipi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "coppi"
+      ]
+    },
+    {
+      "slug": "coppi",
+      "stage": "stage1",
+      "evolves_from": [
+        "helipi"
+      ],
+      "evolves_into": [
+        "parappi"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pawsand.json
+++ b/mods/tuxemon/db/monster/pawsand.json
@@ -59,16 +59,38 @@
   ],
   "history": [
     {
-      "mon_slug": "knightsand",
-      "evo_stage": "stage1"
+      "slug": "pawsand",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "knightsand",
+        "bishosand",
+        "rooksand"
+      ]
     },
     {
-      "mon_slug": "bishosand",
-      "evo_stage": "stage1"
+      "slug": "knightsand",
+      "stage": "stage1",
+      "evolves_from": [
+        "pawsand"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "rooksand",
-      "evo_stage": "stage1"
+      "slug": "bishosand",
+      "stage": "stage1",
+      "evolves_from": [
+        "pawsand"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "rooksand",
+      "stage": "stage1",
+      "evolves_from": [
+        "pawsand"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pearamanca.json
+++ b/mods/tuxemon/db/monster/pearamanca.json
@@ -44,7 +44,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "pearamanca",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "bite",

--- a/mods/tuxemon/db/monster/pharavion.json
+++ b/mods/tuxemon/db/monster/pharavion.json
@@ -58,8 +58,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pharfan",
-      "evo_stage": "basic"
+      "slug": "pharavion",
+      "stage": "stage1",
+      "evolves_from": [
+        "pharfan"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pharfan",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "pharavion"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pharfan.json
+++ b/mods/tuxemon/db/monster/pharfan.json
@@ -63,8 +63,20 @@
   ],
   "history": [
     {
-      "mon_slug": "pharavion",
-      "evo_stage": "stage1"
+      "slug": "pharfan",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "pharavion"
+      ]
+    },
+    {
+      "slug": "pharavion",
+      "stage": "stage1",
+      "evolves_from": [
+        "pharfan"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/picc.json
+++ b/mods/tuxemon/db/monster/picc.json
@@ -38,8 +38,24 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "botbot",
-      "evo_stage": "basic"
+      "slug": "picc",
+      "stage": "stage1",
+      "evolves_from": [
+        "botbot"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "botbot",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "av8r",
+        "picc",
+        "mrmoswitch",
+        "k9",
+        "b_ver_1"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pickoon.json
+++ b/mods/tuxemon/db/monster/pickoon.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "raccscal",
-      "evo_stage": "stage1"
+      "slug": "pickoon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "raccscal"
+      ]
+    },
+    {
+      "slug": "raccscal",
+      "stage": "stage1",
+      "evolves_from": [
+        "pickoon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pigabyte.json
+++ b/mods/tuxemon/db/monster/pigabyte.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "pigabyte",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "megafauna",

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "pilthropus",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ground",

--- a/mods/tuxemon/db/monster/pipis.json
+++ b/mods/tuxemon/db/monster/pipis.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "strella",
-      "evo_stage": "stage1"
+      "slug": "pipis",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "strella"
+      ]
+    },
+    {
+      "slug": "strella",
+      "stage": "stage1",
+      "evolves_from": [
+        "pipis"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "saurchin",
-      "evo_stage": "stage1"
+      "slug": "poinchin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "saurchin"
+      ]
+    },
+    {
+      "slug": "saurchin",
+      "stage": "stage1",
+      "evolves_from": [
+        "poinchin"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/polyrock.json
+++ b/mods/tuxemon/db/monster/polyrock.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "polyrock",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "rock",

--- a/mods/tuxemon/db/monster/possessun.json
+++ b/mods/tuxemon/db/monster/possessun.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "cairfrey",
-      "evo_stage": "basic"
+      "slug": "possessun",
+      "stage": "stage1",
+      "evolves_from": [
+        "cairfrey"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "cairfrey",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "possessun"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/potturmeist.json
+++ b/mods/tuxemon/db/monster/potturmeist.json
@@ -55,8 +55,20 @@
   ],
   "history": [
     {
-      "mon_slug": "potturney",
-      "evo_stage": "stage1"
+      "slug": "potturmeist",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "potturney"
+      ]
+    },
+    {
+      "slug": "potturney",
+      "stage": "stage1",
+      "evolves_from": [
+        "potturmeist"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/potturney.json
+++ b/mods/tuxemon/db/monster/potturney.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "potturmeist",
-      "evo_stage": "basic"
+      "slug": "potturney",
+      "stage": "stage1",
+      "evolves_from": [
+        "potturmeist"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "potturmeist",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "potturney"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/primordia.json
+++ b/mods/tuxemon/db/monster/primordia.json
@@ -40,7 +40,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "primordia",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "extraterrestrial",

--- a/mods/tuxemon/db/monster/propellercat.json
+++ b/mods/tuxemon/db/monster/propellercat.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "propellercat",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "bird",

--- a/mods/tuxemon/db/monster/prophetoise.json
+++ b/mods/tuxemon/db/monster/prophetoise.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "forturtle",
-      "evo_stage": "basic"
+      "slug": "prophetoise",
+      "stage": "stage1",
+      "evolves_from": [
+        "forturtle"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "forturtle",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "prophetoise"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/puparmor.json
+++ b/mods/tuxemon/db/monster/puparmor.json
@@ -51,12 +51,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cataspike",
-      "evo_stage": "basic"
+      "slug": "puparmor",
+      "stage": "stage1",
+      "evolves_from": [
+        "cataspike"
+      ],
+      "evolves_into": [
+        "weavifly"
+      ]
     },
     {
-      "mon_slug": "weavifly",
-      "evo_stage": "stage2"
+      "slug": "cataspike",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "puparmor"
+      ]
+    },
+    {
+      "slug": "weavifly",
+      "stage": "stage2",
+      "evolves_from": [
+        "puparmor"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/pyraminx.json
+++ b/mods/tuxemon/db/monster/pyraminx.json
@@ -42,8 +42,26 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "memnomnom",
-      "evo_stage": "basic"
+      "slug": "pyraminx",
+      "stage": "stage1",
+      "evolves_from": [
+        "memnomnom",
+        "memnomnom"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "memnomnom",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "miaownolith",
+        "miaownolith",
+        "pyraminx",
+        "pyraminx",
+        "mauai",
+        "mauai"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "snock",
-      "evo_stage": "basic"
+      "slug": "pythock",
+      "stage": "stage1",
+      "evolves_from": [
+        "snock"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "snock",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "pythock"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/pythonova.json
+++ b/mods/tuxemon/db/monster/pythonova.json
@@ -38,12 +38,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "hissiorite",
-      "evo_stage": "basic"
+      "slug": "pythonova",
+      "stage": "stage2",
+      "evolves_from": [
+        "cobarett"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "cobarett",
-      "evo_stage": "stage1"
+      "slug": "hissiorite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cobarett"
+      ]
+    },
+    {
+      "slug": "cobarett",
+      "stage": "stage1",
+      "evolves_from": [
+        "hissiorite"
+      ],
+      "evolves_into": [
+        "pythonova"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/pythwire.json
+++ b/mods/tuxemon/db/monster/pythwire.json
@@ -35,12 +35,29 @@
   ],
   "history": [
     {
-      "mon_slug": "ouroboutlet",
-      "evo_stage": "stage1"
+      "slug": "pythwire",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ouroboutlet",
+        "sockeserp"
+      ]
     },
     {
-      "mon_slug": "sockeserp",
-      "evo_stage": "stage1"
+      "slug": "ouroboutlet",
+      "stage": "stage1",
+      "evolves_from": [
+        "pythwire"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "sockeserp",
+      "stage": "stage1",
+      "evolves_from": [
+        "pythwire"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "metesaur",
-      "evo_stage": "basic"
+      "slug": "qetzlrokilus",
+      "stage": "stage1",
+      "evolves_from": [
+        "metesaur"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "metesaur",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "qetzlrokilus"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "r0ck1tt3n",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "hunter",

--- a/mods/tuxemon/db/monster/rabbitosaur.json
+++ b/mods/tuxemon/db/monster/rabbitosaur.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "squabbit",
-      "evo_stage": "basic"
+      "slug": "rabbitosaur",
+      "stage": "stage1",
+      "evolves_from": [
+        "squabbit"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "squabbit",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "rabbitosaur"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/raccscal.json
+++ b/mods/tuxemon/db/monster/raccscal.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pickoon",
-      "evo_stage": "basic"
+      "slug": "raccscal",
+      "stage": "stage1",
+      "evolves_from": [
+        "pickoon"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pickoon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "raccscal"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/raptoucan.json
+++ b/mods/tuxemon/db/monster/raptoucan.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "toucanary",
-      "evo_stage": "basic"
+      "slug": "raptoucan",
+      "stage": "stage1",
+      "evolves_from": [
+        "toucanary"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "toucanary",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "raptoucan"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/regalance.json
+++ b/mods/tuxemon/db/monster/regalance.json
@@ -58,8 +58,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "claymorior",
-      "evo_stage": "basic"
+      "slug": "regalance",
+      "stage": "stage1",
+      "evolves_from": [
+        "claymorior"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "claymorior",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "regalance"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/rhincus.json
+++ b/mods/tuxemon/db/monster/rhincus.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "rhincus",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "rock",

--- a/mods/tuxemon/db/monster/rhinocarpe.json
+++ b/mods/tuxemon/db/monster/rhinocarpe.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "rhinocarpe",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "freshwater",

--- a/mods/tuxemon/db/monster/rinocereed.json
+++ b/mods/tuxemon/db/monster/rinocereed.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "rinocereed",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "grassland",
     "jungle"

--- a/mods/tuxemon/db/monster/rockat.json
+++ b/mods/tuxemon/db/monster/rockat.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "rockitten",
-      "evo_stage": "basic"
+      "slug": "rockat",
+      "stage": "stage1",
+      "evolves_from": [
+        "rockitten"
+      ],
+      "evolves_into": [
+        "jemuar"
+      ]
     },
     {
-      "mon_slug": "jemuar",
-      "evo_stage": "stage2"
+      "slug": "rockitten",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "rockat"
+      ]
+    },
+    {
+      "slug": "jemuar",
+      "stage": "stage2",
+      "evolves_from": [
+        "rockat"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/rockitten.json
+++ b/mods/tuxemon/db/monster/rockitten.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "rockat",
-      "evo_stage": "stage1"
+      "slug": "rockitten",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "rockat"
+      ]
     },
     {
-      "mon_slug": "jemuar",
-      "evo_stage": "stage2"
+      "slug": "rockat",
+      "stage": "stage1",
+      "evolves_from": [
+        "rockitten"
+      ],
+      "evolves_into": [
+        "jemuar"
+      ]
+    },
+    {
+      "slug": "jemuar",
+      "stage": "stage2",
+      "evolves_from": [
+        "rockat"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "rocktot",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "brute",

--- a/mods/tuxemon/db/monster/rooksand.json
+++ b/mods/tuxemon/db/monster/rooksand.json
@@ -46,8 +46,22 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pawsand",
-      "evo_stage": "basic"
+      "slug": "rooksand",
+      "stage": "stage1",
+      "evolves_from": [
+        "pawsand"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pawsand",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "knightsand",
+        "bishosand",
+        "rooksand"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "toxiris",
-      "evo_stage": "stage1"
+      "slug": "rosarin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "toxiris"
+      ]
     },
     {
-      "mon_slug": "ninjasmine",
-      "evo_stage": "stage2"
+      "slug": "toxiris",
+      "stage": "stage1",
+      "evolves_from": [
+        "rosarin"
+      ],
+      "evolves_into": [
+        "ninjasmine"
+      ]
+    },
+    {
+      "slug": "ninjasmine",
+      "stage": "stage2",
+      "evolves_from": [
+        "toxiris"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/ruffalo.json
+++ b/mods/tuxemon/db/monster/ruffalo.json
@@ -24,7 +24,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "ruffalo",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "grassland",
     "woodland"

--- a/mods/tuxemon/db/monster/runesquito.json
+++ b/mods/tuxemon/db/monster/runesquito.json
@@ -38,12 +38,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "stonifly",
-      "evo_stage": "basic"
+      "slug": "runesquito",
+      "stage": "stage2",
+      "evolves_from": [
+        "cocrune"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "cocrune",
-      "evo_stage": "stage1"
+      "slug": "stonifly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cocrune"
+      ]
+    },
+    {
+      "slug": "cocrune",
+      "stage": "stage1",
+      "evolves_from": [
+        "stonifly"
+      ],
+      "evolves_into": [
+        "runesquito"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/ruption.json
+++ b/mods/tuxemon/db/monster/ruption.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "embra",
-      "evo_stage": "basic"
+      "slug": "ruption",
+      "stage": "stage1",
+      "evolves_from": [
+        "embra"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "embra",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ruption"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -38,8 +38,23 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chromeye",
-      "evo_stage": "basic"
+      "slug": "sadito",
+      "stage": "stage1",
+      "evolves_from": [
+        "chromeye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chromeye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angrito",
+        "happito",
+        "neutrito",
+        "sadito"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sampsack.json
+++ b/mods/tuxemon/db/monster/sampsack.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "sampsack",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "urban"
   ],

--- a/mods/tuxemon/db/monster/sampsage.json
+++ b/mods/tuxemon/db/monster/sampsage.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "sampsage",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "urban"
   ],

--- a/mods/tuxemon/db/monster/sapragon.json
+++ b/mods/tuxemon/db/monster/sapragon.json
@@ -63,12 +63,30 @@
   ],
   "history": [
     {
-      "mon_slug": "chloragon",
-      "evo_stage": "basic"
+      "slug": "sapragon",
+      "stage": "stage1",
+      "evolves_from": [
+        "chloragon"
+      ],
+      "evolves_into": [
+        "dragarbor"
+      ]
     },
     {
-      "mon_slug": "dragarbor",
-      "evo_stage": "stage2"
+      "slug": "chloragon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sapragon"
+      ]
+    },
+    {
+      "slug": "dragarbor",
+      "stage": "stage2",
+      "evolves_from": [
+        "sapragon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sapsnap.json
+++ b/mods/tuxemon/db/monster/sapsnap.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "trapsnap",
-      "evo_stage": "basic"
+      "slug": "sapsnap",
+      "stage": "stage1",
+      "evolves_from": [
+        "trapsnap"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "trapsnap",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sapsnap"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "poinchin",
-      "evo_stage": "basic"
+      "slug": "saurchin",
+      "stage": "stage1",
+      "evolves_from": [
+        "poinchin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "poinchin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "saurchin"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/scarlant.json
+++ b/mods/tuxemon/db/monster/scarlant.json
@@ -35,12 +35,30 @@
   ],
   "history": [
     {
-      "mon_slug": "shull",
-      "evo_stage": "stage1"
+      "slug": "scarlant",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shull"
+      ]
     },
     {
-      "mon_slug": "myrmison",
-      "evo_stage": "stage2"
+      "slug": "shull",
+      "stage": "stage1",
+      "evolves_from": [
+        "scarlant"
+      ],
+      "evolves_into": [
+        "myrmison"
+      ]
+    },
+    {
+      "slug": "myrmison",
+      "stage": "stage2",
+      "evolves_from": [
+        "shull"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sclairus.json
+++ b/mods/tuxemon/db/monster/sclairus.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "sclairus",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant",

--- a/mods/tuxemon/db/monster/seirein.json
+++ b/mods/tuxemon/db/monster/seirein.json
@@ -51,16 +51,39 @@
   ],
   "history": [
     {
-      "mon_slug": "loliferno",
-      "evo_stage": "stage1"
+      "slug": "seirein",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "loliferno",
+        "spirain"
+      ]
     },
     {
-      "mon_slug": "spirain",
-      "evo_stage": "stage1"
+      "slug": "loliferno",
+      "stage": "stage1",
+      "evolves_from": [
+        "seirein"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "tornicane",
-      "evo_stage": "stage2"
+      "slug": "spirain",
+      "stage": "stage1",
+      "evolves_from": [
+        "seirein"
+      ],
+      "evolves_into": [
+        "tornicane"
+      ]
+    },
+    {
+      "slug": "tornicane",
+      "stage": "stage2",
+      "evolves_from": [
+        "spirain"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "selmatek",
-      "evo_stage": "stage1"
+      "slug": "selket",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "selmatek"
+      ]
+    },
+    {
+      "slug": "selmatek",
+      "stage": "stage1",
+      "evolves_from": [
+        "selket"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "selket",
-      "evo_stage": "basic"
+      "slug": "selmatek",
+      "stage": "stage1",
+      "evolves_from": [
+        "selket"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "selket",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "selmatek"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/seraphice.json
+++ b/mods/tuxemon/db/monster/seraphice.json
@@ -46,12 +46,31 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "waysprite",
-      "evo_stage": "basic"
+      "slug": "seraphice",
+      "stage": "stage2",
+      "evolves_from": [
+        "angesnow"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "angesnow",
-      "evo_stage": "stage1"
+      "slug": "waysprite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angesnow",
+        "demosnow"
+      ]
+    },
+    {
+      "slug": "angesnow",
+      "stage": "stage1",
+      "evolves_from": [
+        "waysprite"
+      ],
+      "evolves_into": [
+        "seraphice"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/shammer.json
+++ b/mods/tuxemon/db/monster/shammer.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "shammer",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "rock",

--- a/mods/tuxemon/db/monster/sharpfin.json
+++ b/mods/tuxemon/db/monster/sharpfin.json
@@ -50,8 +50,25 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "dollfin",
-      "evo_stage": "basic"
+      "slug": "sharpfin",
+      "stage": "stage1",
+      "evolves_from": [
+        "dollfin",
+        "dollfin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "dollfin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "bigfin",
+        "bigfin",
+        "sharpfin",
+        "sharpfin",
+        "delfeco"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "lesmagu",
-      "evo_stage": "basic"
+      "slug": "shelagu",
+      "stage": "stage1",
+      "evolves_from": [
+        "lesmagu"
+      ],
+      "evolves_into": [
+        "crustagu"
+      ]
     },
     {
-      "mon_slug": "crustagu",
-      "evo_stage": "stage2"
+      "slug": "lesmagu",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shelagu"
+      ]
+    },
+    {
+      "slug": "crustagu",
+      "stage": "stage2",
+      "evolves_from": [
+        "shelagu"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sheye.json
+++ b/mods/tuxemon/db/monster/sheye.json
@@ -35,8 +35,20 @@
   ],
   "history": [
     {
-      "mon_slug": "shrab",
-      "evo_stage": "stage1"
+      "slug": "sheye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shrab"
+      ]
+    },
+    {
+      "slug": "shrab",
+      "stage": "stage1",
+      "evolves_from": [
+        "sheye"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/shimmerain.json
+++ b/mods/tuxemon/db/monster/shimmerain.json
@@ -40,7 +40,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "shimmerain",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "freshwater",

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "nostray",
-      "evo_stage": "basic"
+      "slug": "shnark",
+      "stage": "stage1",
+      "evolves_from": [
+        "nostray"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "nostray",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shnark"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/shrab.json
+++ b/mods/tuxemon/db/monster/shrab.json
@@ -30,8 +30,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "sheye",
-      "evo_stage": "basic"
+      "slug": "shrab",
+      "stage": "stage1",
+      "evolves_from": [
+        "sheye"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "sheye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shrab"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/shull.json
+++ b/mods/tuxemon/db/monster/shull.json
@@ -40,12 +40,30 @@
   ],
   "history": [
     {
-      "mon_slug": "scarlant",
-      "evo_stage": "basic"
+      "slug": "shull",
+      "stage": "stage1",
+      "evolves_from": [
+        "scarlant"
+      ],
+      "evolves_into": [
+        "myrmison"
+      ]
     },
     {
-      "mon_slug": "myrmison",
-      "evo_stage": "stage2"
+      "slug": "scarlant",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "shull"
+      ]
+    },
+    {
+      "slug": "myrmison",
+      "stage": "stage2",
+      "evolves_from": [
+        "shull"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/shybulb.json
+++ b/mods/tuxemon/db/monster/shybulb.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "narcileaf",
-      "evo_stage": "stage1"
+      "slug": "shybulb",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "narcileaf"
+      ]
+    },
+    {
+      "slug": "narcileaf",
+      "stage": "stage1",
+      "evolves_from": [
+        "shybulb"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "octabode",
-      "evo_stage": "stage1"
+      "slug": "skwib",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "octabode"
+      ]
+    },
+    {
+      "slug": "octabode",
+      "stage": "stage1",
+      "evolves_from": [
+        "skwib"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -63,12 +63,30 @@
   ],
   "history": [
     {
-      "mon_slug": "glombroc",
-      "evo_stage": "stage1"
+      "slug": "slichen",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "glombroc"
+      ]
     },
     {
-      "mon_slug": "conglolem",
-      "evo_stage": "stage2"
+      "slug": "glombroc",
+      "stage": "stage1",
+      "evolves_from": [
+        "slichen"
+      ],
+      "evolves_into": [
+        "conglolem"
+      ]
+    },
+    {
+      "slug": "conglolem",
+      "stage": "stage2",
+      "evolves_from": [
+        "glombroc"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sludgehog.json
+++ b/mods/tuxemon/db/monster/sludgehog.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "sludgehog",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "sharp",

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "snokari",
-      "evo_stage": "stage1"
+      "slug": "snaki",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "snokari"
+      ]
+    },
+    {
+      "slug": "snokari",
+      "stage": "stage1",
+      "evolves_from": [
+        "snaki"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/snarlon.json
+++ b/mods/tuxemon/db/monster/snarlon.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "snarlon",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "celestial",

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "pythock",
-      "evo_stage": "stage1"
+      "slug": "snock",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "pythock"
+      ]
+    },
+    {
+      "slug": "pythock",
+      "stage": "stage1",
+      "evolves_from": [
+        "snock"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "snaki",
-      "evo_stage": "basic"
+      "slug": "snokari",
+      "stage": "stage1",
+      "evolves_from": [
+        "snaki"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "snaki",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "snokari"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "chillimp",
-      "evo_stage": "basic"
+      "slug": "snowrilla",
+      "stage": "stage1",
+      "evolves_from": [
+        "chillimp"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "chillimp",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "snowrilla"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sockeserp.json
+++ b/mods/tuxemon/db/monster/sockeserp.json
@@ -38,8 +38,21 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pythwire",
-      "evo_stage": "basic"
+      "slug": "sockeserp",
+      "stage": "stage1",
+      "evolves_from": [
+        "pythwire"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pythwire",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "ouroboutlet",
+        "sockeserp"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "solight",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraplanar",
     "ruins"

--- a/mods/tuxemon/db/monster/spectera.json
+++ b/mods/tuxemon/db/monster/spectera.json
@@ -58,12 +58,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "fruitera",
-      "evo_stage": "basic"
+      "slug": "spectera",
+      "stage": "stage2",
+      "evolves_from": [
+        "megafruitera"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "megafruitera",
-      "evo_stage": "stage1"
+      "slug": "fruitera",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "megafruitera"
+      ]
+    },
+    {
+      "slug": "megafruitera",
+      "stage": "stage1",
+      "evolves_from": [
+        "fruitera"
+      ],
+      "evolves_into": [
+        "spectera"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sphake.json
+++ b/mods/tuxemon/db/monster/sphake.json
@@ -30,8 +30,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "sprorm",
-      "evo_stage": "basic"
+      "slug": "sphake",
+      "stage": "stage1",
+      "evolves_from": [
+        "sprorm"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "sprorm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sphake"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/spighter.json
+++ b/mods/tuxemon/db/monster/spighter.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "spighter",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "gaze",

--- a/mods/tuxemon/db/monster/spirain.json
+++ b/mods/tuxemon/db/monster/spirain.json
@@ -47,12 +47,31 @@
   ],
   "history": [
     {
-      "mon_slug": "seirein",
-      "evo_stage": "basic"
+      "slug": "spirain",
+      "stage": "stage1",
+      "evolves_from": [
+        "seirein"
+      ],
+      "evolves_into": [
+        "tornicane"
+      ]
     },
     {
-      "mon_slug": "tornicane",
-      "evo_stage": "stage2"
+      "slug": "seirein",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "loliferno",
+        "spirain"
+      ]
+    },
+    {
+      "slug": "tornicane",
+      "stage": "stage2",
+      "evolves_from": [
+        "spirain"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "spoilurm",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "bug",

--- a/mods/tuxemon/db/monster/sprightly.json
+++ b/mods/tuxemon/db/monster/sprightly.json
@@ -35,8 +35,20 @@
   ],
   "history": [
     {
-      "mon_slug": "uprout",
-      "evo_stage": "stage1"
+      "slug": "sprightly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "uprout"
+      ]
+    },
+    {
+      "slug": "uprout",
+      "stage": "stage1",
+      "evolves_from": [
+        "sprightly"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/sprorm.json
+++ b/mods/tuxemon/db/monster/sprorm.json
@@ -35,8 +35,20 @@
   ],
   "history": [
     {
-      "mon_slug": "sphake",
-      "evo_stage": "stage1"
+      "slug": "sprorm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sphake"
+      ]
+    },
+    {
+      "slug": "sphake",
+      "stage": "stage1",
+      "evolves_from": [
+        "sprorm"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "spycozeus",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant",

--- a/mods/tuxemon/db/monster/squabbit.json
+++ b/mods/tuxemon/db/monster/squabbit.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "rabbitosaur",
-      "evo_stage": "stage1"
+      "slug": "squabbit",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "rabbitosaur"
+      ]
+    },
+    {
+      "slug": "rabbitosaur",
+      "stage": "stage1",
+      "evolves_from": [
+        "squabbit"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/squink.json
+++ b/mods/tuxemon/db/monster/squink.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "hectapod",
-      "evo_stage": "stage1"
+      "slug": "squink",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "hectapod"
+      ]
+    },
+    {
+      "slug": "hectapod",
+      "stage": "stage1",
+      "evolves_from": [
+        "squink"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -43,12 +43,30 @@
   ],
   "history": [
     {
-      "mon_slug": "furnursus",
-      "evo_stage": "basic"
+      "slug": "statursus",
+      "stage": "stage1",
+      "evolves_from": [
+        "furnursus"
+      ],
+      "evolves_into": [
+        "coaldiak"
+      ]
     },
     {
-      "mon_slug": "coaldiak",
-      "evo_stage": "stage2"
+      "slug": "furnursus",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "statursus"
+      ]
+    },
+    {
+      "slug": "coaldiak",
+      "stage": "stage2",
+      "evolves_from": [
+        "statursus"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/stegofor.json
+++ b/mods/tuxemon/db/monster/stegofor.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "fordin",
-      "evo_stage": "basic"
+      "slug": "stegofor",
+      "stage": "stage1",
+      "evolves_from": [
+        "fordin"
+      ],
+      "evolves_into": [
+        "brachifor"
+      ]
     },
     {
-      "mon_slug": "brachifor",
-      "evo_stage": "stage2"
+      "slug": "fordin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "stegofor"
+      ]
+    },
+    {
+      "slug": "brachifor",
+      "stage": "stage2",
+      "evolves_from": [
+        "stegofor"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/stomic.json
+++ b/mods/tuxemon/db/monster/stomic.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "gastronium",
-      "evo_stage": "stage1"
+      "slug": "stomic",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gastronium"
+      ]
+    },
+    {
+      "slug": "gastronium",
+      "stage": "stage1",
+      "evolves_from": [
+        "stomic"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/stonifly.json
+++ b/mods/tuxemon/db/monster/stonifly.json
@@ -43,12 +43,30 @@
   ],
   "history": [
     {
-      "mon_slug": "cocrune",
-      "evo_stage": "stage1"
+      "slug": "stonifly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "cocrune"
+      ]
     },
     {
-      "mon_slug": "runesquito",
-      "evo_stage": "stage2"
+      "slug": "cocrune",
+      "stage": "stage1",
+      "evolves_from": [
+        "stonifly"
+      ],
+      "evolves_into": [
+        "runesquito"
+      ]
+    },
+    {
+      "slug": "runesquito",
+      "stage": "stage2",
+      "evolves_from": [
+        "cocrune"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/strella.json
+++ b/mods/tuxemon/db/monster/strella.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "pipis",
-      "evo_stage": "basic"
+      "slug": "strella",
+      "stage": "stage1",
+      "evolves_from": [
+        "pipis"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "pipis",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "strella"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/sumchon.json
+++ b/mods/tuxemon/db/monster/sumchon.json
@@ -50,12 +50,32 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "katapill",
-      "evo_stage": "basic"
+      "slug": "sumchon",
+      "stage": "stage2",
+      "evolves_from": [
+        "katacoon"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "katacoon",
-      "evo_stage": "stage1"
+      "slug": "katapill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "katacoon"
+      ]
+    },
+    {
+      "slug": "katacoon",
+      "stage": "stage1",
+      "evolves_from": [
+        "katapill"
+      ],
+      "evolves_into": [
+        "bugnin",
+        "sumchon",
+        "gladiatorbug"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/tadcool.json
+++ b/mods/tuxemon/db/monster/tadcool.json
@@ -51,8 +51,20 @@
   ],
   "history": [
     {
-      "mon_slug": "fribbit",
-      "evo_stage": "stage1"
+      "slug": "tadcool",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "fribbit"
+      ]
+    },
+    {
+      "slug": "fribbit",
+      "stage": "stage1",
+      "evolves_from": [
+        "tadcool"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "vigueur",
-      "evo_stage": "stage1"
+      "slug": "tarpeur",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vigueur"
+      ]
+    },
+    {
+      "slug": "vigueur",
+      "stage": "stage1",
+      "evolves_from": [
+        "tarpeur"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "taupypus",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "water"

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "teddisun",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "mountains",
     "ruins"

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -47,8 +47,20 @@
   ],
   "history": [
     {
-      "mon_slug": "apeoro",
-      "evo_stage": "stage1"
+      "slug": "tetrchimp",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "apeoro"
+      ]
+    },
+    {
+      "slug": "apeoro",
+      "stage": "stage1",
+      "evolves_from": [
+        "tetrchimp"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/thumpurn.json
+++ b/mods/tuxemon/db/monster/thumpurn.json
@@ -35,8 +35,20 @@
   ],
   "history": [
     {
-      "mon_slug": "volconey",
-      "evo_stage": "stage1"
+      "slug": "thumpurn",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "volconey"
+      ]
+    },
+    {
+      "slug": "volconey",
+      "stage": "stage1",
+      "evolves_from": [
+        "thumpurn"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/tigrock.json
+++ b/mods/tuxemon/db/monster/tigrock.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "grimachin",
-      "evo_stage": "basic"
+      "slug": "tigrock",
+      "stage": "stage1",
+      "evolves_from": [
+        "grimachin"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "grimachin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tigrock"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tikoal.json
+++ b/mods/tuxemon/db/monster/tikoal.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "tikorch",
-      "evo_stage": "stage1"
+      "slug": "tikoal",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tikorch"
+      ]
+    },
+    {
+      "slug": "tikorch",
+      "stage": "stage1",
+      "evolves_from": [
+        "tikoal"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tikorch.json
+++ b/mods/tuxemon/db/monster/tikorch.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tikoal",
-      "evo_stage": "basic"
+      "slug": "tikorch",
+      "stage": "stage1",
+      "evolves_from": [
+        "tikoal"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "tikoal",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tikorch"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "drashimi",
-      "evo_stage": "basic"
+      "slug": "tobishimi",
+      "stage": "stage2",
+      "evolves_from": [
+        "tsushimi"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "tsushimi",
-      "evo_stage": "stage1"
+      "slug": "drashimi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tsushimi"
+      ]
+    },
+    {
+      "slug": "tsushimi",
+      "stage": "stage1",
+      "evolves_from": [
+        "drashimi"
+      ],
+      "evolves_into": [
+        "tobishimi"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/tornicane.json
+++ b/mods/tuxemon/db/monster/tornicane.json
@@ -42,12 +42,31 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "seirein",
-      "evo_stage": "basic"
+      "slug": "tornicane",
+      "stage": "stage2",
+      "evolves_from": [
+        "spirain"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "spirain",
-      "evo_stage": "stage1"
+      "slug": "seirein",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "loliferno",
+        "spirain"
+      ]
+    },
+    {
+      "slug": "spirain",
+      "stage": "stage1",
+      "evolves_from": [
+        "seirein"
+      ],
+      "evolves_into": [
+        "tornicane"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/toucanary.json
+++ b/mods/tuxemon/db/monster/toucanary.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "raptoucan",
-      "evo_stage": "stage1"
+      "slug": "toucanary",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "raptoucan"
+      ]
+    },
+    {
+      "slug": "raptoucan",
+      "stage": "stage1",
+      "evolves_from": [
+        "toucanary"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/toufigel.json
+++ b/mods/tuxemon/db/monster/toufigel.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "toufigel",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ice"

--- a/mods/tuxemon/db/monster/tourbidi.json
+++ b/mods/tuxemon/db/monster/tourbidi.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "tourbidi",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "light",

--- a/mods/tuxemon/db/monster/toxiris.json
+++ b/mods/tuxemon/db/monster/toxiris.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "rosarin",
-      "evo_stage": "basic"
+      "slug": "toxiris",
+      "stage": "stage1",
+      "evolves_from": [
+        "rosarin"
+      ],
+      "evolves_into": [
+        "ninjasmine"
+      ]
     },
     {
-      "mon_slug": "ninjasmine",
-      "evo_stage": "stage2"
+      "slug": "rosarin",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "toxiris"
+      ]
+    },
+    {
+      "slug": "ninjasmine",
+      "stage": "stage2",
+      "evolves_from": [
+        "toxiris"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/trapsnap.json
+++ b/mods/tuxemon/db/monster/trapsnap.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "sapsnap",
-      "evo_stage": "stage1"
+      "slug": "trapsnap",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "sapsnap"
+      ]
+    },
+    {
+      "slug": "sapsnap",
+      "stage": "stage1",
+      "evolves_from": [
+        "trapsnap"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/trojerror.json
+++ b/mods/tuxemon/db/monster/trojerror.json
@@ -58,8 +58,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "virware",
-      "evo_stage": "basic"
+      "slug": "trojerror",
+      "stage": "stage1",
+      "evolves_from": [
+        "virware"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "virware",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "trojerror"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "drashimi",
-      "evo_stage": "basic"
+      "slug": "tsushimi",
+      "stage": "stage1",
+      "evolves_from": [
+        "drashimi"
+      ],
+      "evolves_into": [
+        "tobishimi"
+      ]
     },
     {
-      "mon_slug": "tobishimi",
-      "evo_stage": "stage2"
+      "slug": "drashimi",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tsushimi"
+      ]
+    },
+    {
+      "slug": "tobishimi",
+      "stage": "stage2",
+      "evolves_from": [
+        "tsushimi"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/tumblebee.json
+++ b/mods/tuxemon/db/monster/tumblebee.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tumbleworm",
-      "evo_stage": "basic"
+      "slug": "tumblebee",
+      "stage": "stage1",
+      "evolves_from": [
+        "tumbleworm"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "tumbleworm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tumblebee"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tumbledillo.json
+++ b/mods/tuxemon/db/monster/tumbledillo.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tumblequill",
-      "evo_stage": "basic"
+      "slug": "tumbledillo",
+      "stage": "stage1",
+      "evolves_from": [
+        "tumblequill"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "tumblequill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tumbledillo"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "tumbledillo",
-      "evo_stage": "stage1"
+      "slug": "tumblequill",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tumbledillo"
+      ]
+    },
+    {
+      "slug": "tumbledillo",
+      "stage": "stage1",
+      "evolves_from": [
+        "tumblequill"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/tumbleworm.json
+++ b/mods/tuxemon/db/monster/tumbleworm.json
@@ -43,8 +43,20 @@
   ],
   "history": [
     {
-      "mon_slug": "tumblebee",
-      "evo_stage": "stage1"
+      "slug": "tumbleworm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "tumblebee"
+      ]
+    },
+    {
+      "slug": "tumblebee",
+      "stage": "stage1",
+      "evolves_from": [
+        "tumbleworm"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -47,12 +47,30 @@
   ],
   "history": [
     {
-      "mon_slug": "beenstalker",
-      "evo_stage": "stage1"
+      "slug": "turnipper",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "beenstalker"
+      ]
     },
     {
-      "mon_slug": "wendigger",
-      "evo_stage": "stage2"
+      "slug": "beenstalker",
+      "stage": "stage1",
+      "evolves_from": [
+        "turnipper"
+      ],
+      "evolves_into": [
+        "wendigger"
+      ]
+    },
+    {
+      "slug": "wendigger",
+      "stage": "stage2",
+      "evolves_from": [
+        "beenstalker"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/tux.json
+++ b/mods/tuxemon/db/monster/tux.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "tux",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "boreal_snow",
     "coastal"

--- a/mods/tuxemon/db/monster/tweesher.json
+++ b/mods/tuxemon/db/monster/tweesher.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "heronquak",
-      "evo_stage": "stage1"
+      "slug": "tweesher",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "heronquak"
+      ]
     },
     {
-      "mon_slug": "eaglace",
-      "evo_stage": "stage2"
+      "slug": "heronquak",
+      "stage": "stage1",
+      "evolves_from": [
+        "tweesher"
+      ],
+      "evolves_into": [
+        "eaglace"
+      ]
+    },
+    {
+      "slug": "eaglace",
+      "stage": "stage2",
+      "evolves_from": [
+        "heronquak"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/uf0.json
+++ b/mods/tuxemon/db/monster/uf0.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "uf0",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraterrestrial"
   ],

--- a/mods/tuxemon/db/monster/uglip.json
+++ b/mods/tuxemon/db/monster/uglip.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "uglip",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "coastal",
     "freshwater",

--- a/mods/tuxemon/db/monster/uneye.json
+++ b/mods/tuxemon/db/monster/uneye.json
@@ -59,8 +59,20 @@
   ],
   "history": [
     {
-      "mon_slug": "lendos",
-      "evo_stage": "stage1"
+      "slug": "uneye",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "lendos"
+      ]
+    },
+    {
+      "slug": "lendos",
+      "stage": "stage1",
+      "evolves_from": [
+        "uneye"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/uprout.json
+++ b/mods/tuxemon/db/monster/uprout.json
@@ -46,8 +46,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "sprightly",
-      "evo_stage": "basic"
+      "slug": "uprout",
+      "stage": "stage1",
+      "evolves_from": [
+        "sprightly"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "sprightly",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "uprout"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/urcheedle.json
+++ b/mods/tuxemon/db/monster/urcheedle.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "urcheedle",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "sea"
   ],

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "urcine",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "fists",

--- a/mods/tuxemon/db/monster/vamporm.json
+++ b/mods/tuxemon/db/monster/vamporm.json
@@ -55,12 +55,30 @@
   ],
   "history": [
     {
-      "mon_slug": "dracune",
-      "evo_stage": "stage1"
+      "slug": "vamporm",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "dracune"
+      ]
     },
     {
-      "mon_slug": "fluttaflap",
-      "evo_stage": "stage2"
+      "slug": "dracune",
+      "stage": "stage1",
+      "evolves_from": [
+        "vamporm"
+      ],
+      "evolves_into": [
+        "fluttaflap"
+      ]
+    },
+    {
+      "slug": "fluttaflap",
+      "stage": "stage2",
+      "evolves_from": [
+        "dracune"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/velocitile.json
+++ b/mods/tuxemon/db/monster/velocitile.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "anoleaf",
-      "evo_stage": "basic"
+      "slug": "velocitile",
+      "stage": "stage2",
+      "evolves_from": [
+        "gectile"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "gectile",
-      "evo_stage": "stage1"
+      "slug": "anoleaf",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "gectile"
+      ]
+    },
+    {
+      "slug": "gectile",
+      "stage": "stage1",
+      "evolves_from": [
+        "anoleaf"
+      ],
+      "evolves_into": [
+        "velocitile"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -42,8 +42,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "tarpeur",
-      "evo_stage": "basic"
+      "slug": "vigueur",
+      "stage": "stage1",
+      "evolves_from": [
+        "tarpeur"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "tarpeur",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vigueur"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/virware.json
+++ b/mods/tuxemon/db/monster/virware.json
@@ -63,8 +63,20 @@
   ],
   "history": [
     {
-      "mon_slug": "trojerror",
-      "evo_stage": "stage1"
+      "slug": "virware",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "trojerror"
+      ]
+    },
+    {
+      "slug": "trojerror",
+      "stage": "stage1",
+      "evolves_from": [
+        "virware"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vivicinder.json
+++ b/mods/tuxemon/db/monster/vivicinder.json
@@ -46,8 +46,28 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "vivicinder",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -46,8 +46,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "vividactil",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere",
+        "vivipere",
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -65,32 +65,78 @@
   ],
   "history": [
     {
-      "mon_slug": "vivisource",
-      "evo_stage": "stage1"
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     },
     {
-      "mon_slug": "vividactil",
-      "evo_stage": "stage1"
+      "slug": "vivisource",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "vivitron",
-      "evo_stage": "stage1"
+      "slug": "vividactil",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere",
+        "vivipere",
+        "vivipere"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "vivitrans",
-      "evo_stage": "stage1"
+      "slug": "vivitron",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "viviteel",
-      "evo_stage": "stage1"
+      "slug": "vivitrans",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "viviphyta",
-      "evo_stage": "stage1"
+      "slug": "viviteel",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "vivicinder",
-      "evo_stage": "stage1"
+      "slug": "viviphyta",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivicinder",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/viviphyta.json
+++ b/mods/tuxemon/db/monster/viviphyta.json
@@ -42,8 +42,28 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "viviphyta",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -42,8 +42,28 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "vivisource",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/viviteel.json
+++ b/mods/tuxemon/db/monster/viviteel.json
@@ -46,8 +46,28 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "viviteel",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vivitrans.json
+++ b/mods/tuxemon/db/monster/vivitrans.json
@@ -38,8 +38,28 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "vivitrans",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vivitron.json
+++ b/mods/tuxemon/db/monster/vivitron.json
@@ -46,8 +46,28 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "vivipere",
-      "evo_stage": "basic"
+      "slug": "vivitron",
+      "stage": "stage1",
+      "evolves_from": [
+        "vivipere"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "vivipere",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vivicinder",
+        "viviphyta",
+        "viviteel",
+        "vivitrans",
+        "vivitron",
+        "vividactil",
+        "vividactil",
+        "vividactil",
+        "vivisource"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/volcoli.json
+++ b/mods/tuxemon/db/monster/volcoli.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "volcoli",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "plant",

--- a/mods/tuxemon/db/monster/volconey.json
+++ b/mods/tuxemon/db/monster/volconey.json
@@ -30,8 +30,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "thumpurn",
-      "evo_stage": "basic"
+      "slug": "volconey",
+      "stage": "stage1",
+      "evolves_from": [
+        "thumpurn"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "thumpurn",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "volconey"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/vulpyre.json
+++ b/mods/tuxemon/db/monster/vulpyre.json
@@ -54,8 +54,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "foxfire",
-      "evo_stage": "basic"
+      "slug": "vulpyre",
+      "stage": "stage1",
+      "evolves_from": [
+        "foxfire"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "foxfire",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "vulpyre"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -45,20 +45,49 @@
   ],
   "history": [
     {
-      "mon_slug": "angesnow",
-      "evo_stage": "stage1"
+      "slug": "waysprite",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "angesnow",
+        "demosnow"
+      ]
     },
     {
-      "mon_slug": "demosnow",
-      "evo_stage": "stage1"
+      "slug": "angesnow",
+      "stage": "stage1",
+      "evolves_from": [
+        "waysprite"
+      ],
+      "evolves_into": [
+        "seraphice"
+      ]
     },
     {
-      "mon_slug": "lucifice",
-      "evo_stage": "stage2"
+      "slug": "demosnow",
+      "stage": "stage1",
+      "evolves_from": [
+        "waysprite"
+      ],
+      "evolves_into": [
+        "lucifice"
+      ]
     },
     {
-      "mon_slug": "seraphice",
-      "evo_stage": "stage2"
+      "slug": "lucifice",
+      "stage": "stage2",
+      "evolves_from": [
+        "demosnow"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "seraphice",
+      "stage": "stage2",
+      "evolves_from": [
+        "angesnow"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/weavifly.json
+++ b/mods/tuxemon/db/monster/weavifly.json
@@ -50,12 +50,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "cataspike",
-      "evo_stage": "basic"
+      "slug": "weavifly",
+      "stage": "stage2",
+      "evolves_from": [
+        "puparmor"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "puparmor",
-      "evo_stage": "stage1"
+      "slug": "cataspike",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "puparmor"
+      ]
+    },
+    {
+      "slug": "puparmor",
+      "stage": "stage1",
+      "evolves_from": [
+        "cataspike"
+      ],
+      "evolves_into": [
+        "weavifly"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/weedlantis.json
+++ b/mods/tuxemon/db/monster/weedlantis.json
@@ -50,8 +50,22 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "weedsea",
-      "evo_stage": "basic"
+      "slug": "weedlantis",
+      "stage": "stage1",
+      "evolves_from": [
+        "weedsea",
+        "weedsea"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "weedsea",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "weedlantis",
+        "weedlantis"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/weedsea.json
+++ b/mods/tuxemon/db/monster/weedsea.json
@@ -63,8 +63,22 @@
   ],
   "history": [
     {
-      "mon_slug": "weedlantis",
-      "evo_stage": "stage1"
+      "slug": "weedsea",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "weedlantis",
+        "weedlantis"
+      ]
+    },
+    {
+      "slug": "weedlantis",
+      "stage": "stage1",
+      "evolves_from": [
+        "weedsea",
+        "weedsea"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/wendigger.json
+++ b/mods/tuxemon/db/monster/wendigger.json
@@ -42,12 +42,30 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "turnipper",
-      "evo_stage": "basic"
+      "slug": "wendigger",
+      "stage": "stage2",
+      "evolves_from": [
+        "beenstalker"
+      ],
+      "evolves_into": []
     },
     {
-      "mon_slug": "beenstalker",
-      "evo_stage": "stage1"
+      "slug": "turnipper",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "beenstalker"
+      ]
+    },
+    {
+      "slug": "beenstalker",
+      "stage": "stage1",
+      "evolves_from": [
+        "turnipper"
+      ],
+      "evolves_into": [
+        "wendigger"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -38,8 +38,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "fancair",
-      "evo_stage": "basic"
+      "slug": "windeye",
+      "stage": "stage1",
+      "evolves_from": [
+        "fancair"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "fancair",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "windeye"
+      ]
     }
   ],
   "terrains": [],

--- a/mods/tuxemon/db/monster/wolffsky.json
+++ b/mods/tuxemon/db/monster/wolffsky.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "wolffsky",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "boreal_snow",
     "woodland"

--- a/mods/tuxemon/db/monster/wolololl.json
+++ b/mods/tuxemon/db/monster/wolololl.json
@@ -50,8 +50,20 @@
   "evolutions": [],
   "history": [
     {
-      "mon_slug": "hoodoll",
-      "evo_stage": "basic"
+      "slug": "wolololl",
+      "stage": "stage1",
+      "evolves_from": [
+        "hoodoll"
+      ],
+      "evolves_into": []
+    },
+    {
+      "slug": "hoodoll",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "wolololl"
+      ]
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/woodoor.json
+++ b/mods/tuxemon/db/monster/woodoor.json
@@ -55,8 +55,20 @@
   ],
   "history": [
     {
-      "mon_slug": "blasdoor",
-      "evo_stage": "stage1"
+      "slug": "woodoor",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "blasdoor"
+      ]
+    },
+    {
+      "slug": "blasdoor",
+      "stage": "stage1",
+      "evolves_from": [
+        "woodoor"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/wrougon.json
+++ b/mods/tuxemon/db/monster/wrougon.json
@@ -59,12 +59,30 @@
   ],
   "history": [
     {
-      "mon_slug": "allagon",
-      "evo_stage": "stage1"
+      "slug": "wrougon",
+      "stage": "basic",
+      "evolves_from": [],
+      "evolves_into": [
+        "allagon"
+      ]
     },
     {
-      "mon_slug": "ferricran",
-      "evo_stage": "stage2"
+      "slug": "allagon",
+      "stage": "stage1",
+      "evolves_from": [
+        "wrougon"
+      ],
+      "evolves_into": [
+        "ferricran"
+      ]
+    },
+    {
+      "slug": "ferricran",
+      "stage": "stage2",
+      "evolves_from": [
+        "allagon"
+      ],
+      "evolves_into": []
     }
   ],
   "terrains": [

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "xeon",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "humanoid",

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "xeon_2",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [],
   "shape": "humanoid",

--- a/mods/tuxemon/db/monster/yamada.json
+++ b/mods/tuxemon/db/monster/yamada.json
@@ -44,7 +44,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "yamada",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [
     "extraplanar",
     "ruins"

--- a/mods/tuxemon/db/monster/yiinaang.json
+++ b/mods/tuxemon/db/monster/yiinaang.json
@@ -56,7 +56,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "yiinaang",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "celestial",

--- a/mods/tuxemon/db/monster/ziggurat.json
+++ b/mods/tuxemon/db/monster/ziggurat.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "ziggurat",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "ground",

--- a/mods/tuxemon/db/monster/zunna.json
+++ b/mods/tuxemon/db/monster/zunna.json
@@ -52,7 +52,14 @@
     }
   ],
   "evolutions": [],
-  "history": [],
+  "history": [
+    {
+      "slug": "zunna",
+      "stage": "standalone",
+      "evolves_from": [],
+      "evolves_into": []
+    }
+  ],
   "terrains": [],
   "tags": [
     "food"

--- a/scripts/validate_monster_evolutions.py
+++ b/scripts/validate_monster_evolutions.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import json
+from collections import defaultdict
+
+MONSTER_FOLDER = Path.home() / "Tuxemon/mods/tuxemon/db/monster"
+
+def load_monsters(folder: Path):
+    monsters = {}
+    for file in folder.glob("*.json"):
+        with file.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+            monsters[data["slug"]] = data
+    return monsters
+
+def validate_monsters(monsters):
+    errors = []
+    all_slugs = set(monsters.keys())
+    stage_order = {"basic": 0, "stage1": 1, "stage2": 2}
+
+    # Build evolution graph
+    graph = defaultdict(list)
+    for slug, data in monsters.items():
+        for evo in data.get("evolutions", []):
+            graph[slug].append(evo["monster_slug"])
+
+    for slug, data in monsters.items():
+        # Validate history references
+        for entry in data.get("history", []):
+            target = entry["slug"]
+            if target not in all_slugs:
+                errors.append(f"{slug}: history references unknown monster '{target}'")
+
+            for ref in entry.get("evolves_from", []):
+                if ref not in all_slugs:
+                    errors.append(f"{slug}: evolves_from references unknown monster '{ref}'")
+
+            for ref in entry.get("evolves_into", []):
+                if ref not in all_slugs:
+                    errors.append(f"{slug}: evolves_into references unknown monster '{ref}'")
+
+        # Validate stage progression
+        for evo in data.get("evolutions", []):
+            target_slug = evo["monster_slug"]
+            if target_slug in monsters:
+                from_stage = stage_order.get(data.get("stage", "basic"), -1)
+                to_stage = stage_order.get(monsters[target_slug].get("stage", "basic"), -1)
+                if to_stage <= from_stage:
+                    errors.append(f"{slug}: evolves into '{target_slug}' with equal or lower stage ({data.get('stage')} → {monsters[target_slug].get('stage')})")
+
+        # Detect circular evolution
+        visited = set()
+        def dfs(current, path):
+            if current in path:
+                cycle = " → ".join(path + [current])
+                errors.append(f"{slug}: circular evolution detected: {cycle}")
+                return
+            if current in visited:
+                return  # already checked this path
+            visited.add(current)
+            path.append(current)
+            for next_slug in graph.get(current, []):
+                dfs(next_slug, path.copy())
+
+        dfs(slug, [])
+
+    return errors
+
+def main():
+    monsters = load_monsters(MONSTER_FOLDER)
+    issues = validate_monsters(monsters)
+
+    if issues:
+        print("\n Validation Issues Found:")
+        for issue in issues:
+            print(" -", issue)
+    else:
+        print("\n All monster files passed validation!")
+
+if __name__ == "__main__":
+    main()

--- a/tests/tuxemon/test_jsons_monster.py
+++ b/tests/tuxemon/test_jsons_monster.py
@@ -5,35 +5,24 @@ import unittest
 from pathlib import Path
 from typing import Any
 
-from tuxemon.constants.asset_loader import fetch_asset
-
 ALL_MONSTERS: int = 411
 MAX_TXMN_ID: int = 393
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MONSTER_FOLDER = PROJECT_ROOT / "mods/tuxemon/db/monster"
 
 
-def process_json_data(directory: str) -> list[dict[str, Any]]:
+def process_json_data() -> list[dict[str, Any]]:
     data_list = []
-    directory_path = Path(fetch_asset("db")) / directory
-    for file in directory_path.iterdir():
+    for file in MONSTER_FOLDER.iterdir():
         if file.suffix == ".json" and file.is_file():
             with file.open("r") as f:
                 data_list.append(json.load(f))
     return data_list
 
 
-def get_history(
-    data_list: list[dict[str, Any]], slug: str
-) -> list[dict[str, Any]]:
-    for data in data_list:
-        if data["slug"] == slug:
-            return data["history"]
-    return []
-
-
 class TestJSONProcessing(unittest.TestCase):
     def setUp(self) -> None:
-        sample_data = "monster"
-        self.data_list = process_json_data(sample_data)
+        self.data_list = process_json_data()
 
     def test_nr_jsons(self) -> None:
         self.assertEqual(len(self.data_list), ALL_MONSTERS)
@@ -67,122 +56,65 @@ class TestJSONProcessing(unittest.TestCase):
         if duplicates:
             self.fail(f"There are duplicates txmn_ids: {duplicates}")
 
-    def test_history_current_slug(self) -> None:
-        missing_monsters = []
+    def test_history_structure_and_links(self) -> None:
+        errors = []
+
+        all_slugs = {data["slug"] for data in self.data_list}
+        stage_order = {"basic": 0, "stage1": 1, "stage2": 2}
+
         for data in self.data_list:
             slug = data["slug"]
-            history = data["history"]
-            if history:
-                for element in history:
-                    if element["mon_slug"] == "slug":
-                        missing_monsters.append(
-                            f"{slug}'s history cannot contain {slug} ({history})"
-                        )
-        if missing_monsters:
-            print(
-                "The following monsters have history that contains themselves:"
-            )
-            for monster in missing_monsters:
-                print(monster)
-            self.fail("History cannot contain slug.")
-
-    def test_history_evolution(self) -> None:
-        missing_monsters = []
-        for data in self.data_list:
-            original = data["slug"]
-            history = data["history"]
-            evolutions = data["evolutions"]
-            if evolutions:
-                for evolution in evolutions:
-                    slug = evolution["monster_slug"]
-                    if history and slug not in [
-                        h["mon_slug"] for h in history
-                    ]:
-                        missing_monsters.append(
-                            f"{original}'s history must contain {evolution['monster_slug']} ({history})"
-                        )
-        if missing_monsters:
-            print(
-                "The following monsters have history that doesn't contain their evolution:"
-            )
-            for monster in missing_monsters:
-                print(monster)
-            self.fail("History must contain evolution slug.")
-
-    def test_history_standalone(self) -> None:
-        for data in self.data_list:
             stage = data["stage"]
-            if stage == "standalone":
-                self.assertEqual(
-                    len(data["history"]),
-                    0,
-                    f"{data['slug']} is standalone, it has no history",
-                )
+            history = data.get("history", [])
+            evolutions = data.get("evolutions", [])
 
-    def test_history_standalone(self) -> None:
-        for data in self.data_list:
-            stage = data["stage"]
-            if stage == "standalone":
-                self.assertEqual(
-                    len(data["history"]),
-                    0,
-                    f"{data['slug']} is standalone, it has no history",
-                )
+            # 1. Self-entry must exist
+            if not any(h["slug"] == slug for h in history):
+                errors.append(f"{slug} is missing self-entry in history")
 
-    def test_stage_basic(self) -> None:
-        for data in self.data_list:
-            evo_stages = [h["evo_stage"] for h in data["history"]]
-            if data["stage"] == "basic" and data["evolutions"]:
-                self.assertIn(
-                    "stage1",
-                    evo_stages,
-                    f"{data['slug']}'s history lacks the 'evo_stage':'stage1' ({data['history']})",
-                )
-            if data["stage"] == "basic" and not data["evolutions"]:
-                self.fail(
-                    f"{data['slug']} is basic, but there are no evolutions ({data['evolutions']})"
-                )
+            # 2. All referenced slugs must exist
+            for h in history:
+                for ref in h.get("evolves_from", []) + h.get(
+                    "evolves_into", []
+                ):
+                    if ref not in all_slugs:
+                        errors.append(
+                            f"{slug}'s history references unknown monster '{ref}'"
+                        )
 
-    def test_stage_stage1(self) -> None:
-        for data in self.data_list:
-            evo_stages = [h["evo_stage"] for h in data["history"]]
-            if data["stage"] == "stage1":
-                self.assertIn(
-                    "basic",
-                    evo_stages,
-                    f"{data['slug']}'s history lacks the 'evo_stage':'basic' ({data['history']})",
-                )
-                if data["evolutions"]:
-                    self.assertIn(
-                        "stage2",
-                        evo_stages,
-                        f"{data['slug']}'s history lacks the 'evo_stage':'stage2' ({data['history']})",
+            # 3. Evolution slugs must appear in history
+            for evo in evolutions:
+                evo_slug = evo["monster_slug"]
+                if not any(h["slug"] == evo_slug for h in history):
+                    errors.append(
+                        f"{slug}'s history missing evolution '{evo_slug}'"
                     )
-                names = [h["mon_slug"] for h in data["history"]]
-                for name in names:
-                    history = get_history(self.data_list, name)
-                    history_names = [h["mon_slug"] for h in history]
-                    self.assertIn(data["slug"], history_names)
 
-    def test_stage_stage2(self) -> None:
-        for data in self.data_list:
-            evo_stages = [h["evo_stage"] for h in data["history"]]
-            if data["stage"] == "stage2":
-                self.assertIn(
-                    "basic",
-                    evo_stages,
-                    f"{data['slug']}'s history lacks the 'evo_stage':'basic' ({data['history']})",
+            # 4. Standalone monsters should only have self-entry
+            if stage == "standalone":
+                if len(history) != 1 or history[0]["slug"] != slug:
+                    errors.append(
+                        f"{slug} is standalone but has non-self history entries"
+                    )
+
+            # 5. Stage progression check (informational only)
+            # Optional: warn if links point to lower stages, but don't fail
+            for h in history:
+                target = next(
+                    (d for d in self.data_list if d["slug"] == h["slug"]), None
                 )
-                self.assertIn(
-                    "stage1",
-                    evo_stages,
-                    f"{data['slug']}'s history lacks the 'evo_stage':'stage1' ({data['history']})",
-                )
-                names = [h["mon_slug"] for h in data["history"]]
-                for name in names:
-                    history = get_history(self.data_list, name)
-                    history_names = [h["mon_slug"] for h in history]
-                    self.assertIn(data["slug"], history_names)
+                if target and h["slug"] != slug:
+                    from_stage = stage_order.get(stage, -1)
+                    to_stage = stage_order.get(target["stage"], -1)
+                    if to_stage <= from_stage:
+                        # This is now allowed, but you can log it if needed
+                        pass  # or log as a warning
+
+        if errors:
+            print("\n History validation errors:")
+            for error in errors:
+                print(" -", error)
+            self.fail("History model validation failed.")
 
     def test_moveset_level_learned_evolution_at_level(self) -> None:
         START_LEVEL = 1

--- a/tests/tuxemon/test_jsons_technique.py
+++ b/tests/tuxemon/test_jsons_technique.py
@@ -5,20 +5,19 @@ import unittest
 from pathlib import Path
 from typing import Any
 
-from tuxemon.constants.asset_loader import fetch_asset
-
 ALL_TECHNIQUES: int = 250
 MAX_TECH_ID: int = 244
 # effects with simple_damage_calculate()
 SIMPLE_DAMAGE_EFFECT = ("damage", "retaliate", "revenge", "money", "splash")
 # effects with simple_heal()
 SIMPLE_HEAL_EFFECT = ("healing", "photogenesis")
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TECHNIQUE_FOLDER = PROJECT_ROOT / "mods/tuxemon/db/technique"
 
 
-def process_json_data(directory: str) -> list[dict[str, Any]]:
+def process_json_data() -> list[dict[str, Any]]:
     data_list = []
-    directory_path = Path(fetch_asset("db")) / directory
-    for file in directory_path.iterdir():
+    for file in TECHNIQUE_FOLDER.iterdir():
         if file.suffix == ".json" and file.is_file():
             with file.open("r") as f:
                 data_list.append(json.load(f))
@@ -27,8 +26,7 @@ def process_json_data(directory: str) -> list[dict[str, Any]]:
 
 class TestTechniqueJSON(unittest.TestCase):
     def setUp(self) -> None:
-        sample_data = "technique"
-        self.data_list = process_json_data(sample_data)
+        self.data_list = process_json_data()
 
     def test_nr_jsons(self) -> None:
         self.assertEqual(len(self.data_list), ALL_TECHNIQUES)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -467,16 +467,36 @@ class MonsterMovesetItemModel(BaseModel):
 
 
 class MonsterHistoryItemModel(BaseModel):
-    mon_slug: str = Field(..., description="The monster in the evolution path")
-    evo_stage: EvolutionStage = Field(
-        ..., description="The evolution stage of the monster"
+    slug: str = Field(
+        ..., description="The monster slug in the evolution path."
+    )
+    stage: EvolutionStage = Field(
+        ..., description="The evolution stage of the monster."
+    )
+    evolves_from: list[str] = Field(
+        default_factory=list, description="Monsters this monster evolves from."
+    )
+    evolves_into: list[str] = Field(
+        default_factory=list,
+        description="Monsters this monster can evolve into.",
     )
 
-    @field_validator("mon_slug")
-    def monster_exists(cls: MonsterHistoryItemModel, v: str) -> str:
-        if has.db_entry("monster", v):
+    @field_validator("slug", "evolves_from", "evolves_into")
+    def validate_monsters_exist(
+        cls, v: Union[str, list[str]]
+    ) -> Union[str, list[str]]:
+        if isinstance(v, str):
+            if has.db_entry("monster", v):
+                return v
+            raise ValueError(f"Monster slug '{v}' not found in database.")
+        elif isinstance(v, list):
+            for slug in v:
+                if not has.db_entry("monster", slug):
+                    raise ValueError(
+                        f"Monster slug '{slug}' not found in database."
+                    )
             return v
-        raise ValueError(f"the monster {v} doesn't exist in the db")
+        return v
 
 
 class MonsterEvolutionItemModel(BaseModel):

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -8,6 +8,7 @@ from functools import partial
 from typing import TYPE_CHECKING, final
 from uuid import UUID
 
+from tuxemon.db import EvolutionStage
 from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
@@ -92,19 +93,26 @@ class DojoMethodAction(EventAction):
             devolvable_monsters = [
                 mon
                 for mon in monster.history
-                if (monster.stage == "stage1" and mon.evo_stage == "basic")
-                or (
-                    monster.stage == "stage2"
-                    and mon.evo_stage in ["stage1", "basic"]
+                if monster.slug in mon.evolves_into
+                and (
+                    (
+                        monster.stage == EvolutionStage.stage1
+                        and mon.stage == EvolutionStage.basic
+                    )
+                    or (
+                        monster.stage == EvolutionStage.stage2
+                        and mon.stage
+                        in [EvolutionStage.stage1, EvolutionStage.basic]
+                    )
                 )
             ]
 
             for mon in devolvable_monsters:
                 menu_options.append(
                     ChoiceOption(
-                        key=mon.mon_slug,
-                        display_text=T.translate(mon.mon_slug),
-                        action=partial(self.devolve, monster, mon.mon_slug),
+                        key=mon.slug,
+                        display_text=T.translate(mon.slug),
+                        action=partial(self.devolve, monster, mon.slug),
                     )
                 )
 

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -81,14 +81,13 @@ class SpawnMonsterAction(EventAction):
         # Get the basic form of the seed monster
         seed_slug = seed.slug
         if seed.history:
-            seed_slug = next(
-                (
-                    element.mon_slug
-                    for element in seed.history
-                    if element.evo_stage.basic
-                ),
-                seed_slug,
-            )
+            basic_forms = [
+                element.slug
+                for element in seed.history
+                if element.stage == EvolutionStage.basic
+            ]
+            if basic_forms:
+                seed_slug = random.choice(basic_forms)
 
         level = (father.level + mother.level) // 2
 

--- a/tuxemon/monster_dir/evolution.py
+++ b/tuxemon/monster_dir/evolution.py
@@ -32,7 +32,10 @@ class Evolution:
 
     def has_history_to(self, slug: str) -> bool:
         return any(
-            history.mon_slug == slug for history in self.monster.history
+            history.slug == slug
+            or slug in history.evolves_from
+            or slug in history.evolves_into
+            for history in self.monster.history
         )
 
     def evolve_monster(self, new_monster: Monster) -> None:


### PR DESCRIPTION
PR updates the structure of the `history` model used in monster definitions to improve clarity, consistency and bidirectional evolution tracking.

The main changes are:
- each monster now includes a self-referential entry in its `history` array. This entry records the monster’s own `slug`, its current `stage`, and its evolution relationships (`evolves_from` and `evolves_into`)
- All entries in the `history` array follow a standardized format: `slug`: the identifier of the monster, `stage`: its evolution stage (e.g. `basic`, `stage1`, `stage2`), `evolves_from`: a list of monsters it evolved from and `evolves_into`: a list of monsters it can evolve into
- evolution relationships are now bidirectional, if Monster A evolves into Monster B, then Monster B’s history reflects that it evolved from Monster A, and Monster A’s history shows that it evolves into Monster B
- the model now supports branching evolution paths, so monsters that evolve into multiple forms list all outcomes in their `evolves_into` array, and each branch is reflected in the corresponding monster’s `evolves_from`
- a validation script has been introduced to detect missing evolution links, broken references and circular evolution paths, it ensures the integrity of the evolution graph and prevents logical inconsistencies