### PR TITLE
Fixing Normal damage vs Normal, and vs Metal

### DIFF
--- a/mods/tuxemon/db/element/normal.json
+++ b/mods/tuxemon/db/element/normal.json
@@ -32,11 +32,11 @@
     },
     {
       "against": "metal",
-      "multiplier": 1
+      "multiplier": 0.5
     },
     {
       "against": "normal",
-      "multiplier": 0.5
+      "multiplier": 1
     },
     {
       "against": "shadow",


### PR DESCRIPTION
Quick fix -- the damage multiplier for Normal was out by one element, so Normal vs Normal did half damage when it should be Normal vs Metal.