### PR TITLE
Add `InputVisualizer` for On-Screen Controller Feedback

### DIFF
--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -95,6 +95,8 @@ class LocalPygameClient(BaseClient):
                     draw()
                     if self.input_manager.controller_overlay:
                         self.input_manager.controller_overlay.draw(screen)
+                    if self.input_manager.show_visualizer:
+                        self.input_manager.draw_visualizer(screen)
                     flip()
                 if self.config.show_fps:
                     self.renderer.update_fps(clock_tick)

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -192,6 +192,7 @@ class ControllerConfig:
         self.overlay: bool = display["controller_overlay"]
         self.transparency: int = display["controller_transparency"]
         self.hide_mouse: bool = display["hide_mouse"]
+        self.show_input_visualizer: bool = display["show_input_visualizer"]
 
 
 class LocaleConfig:
@@ -303,6 +304,7 @@ def generate_default_config() -> dict[str, Any]:
             "controller_overlay": False,
             "controller_transparency": 45,
             "hide_mouse": True,
+            "show_input_visualizer": False,
         },
         "game": {
             "data": "tuxemon",

--- a/tuxemon/platform/input_manager.py
+++ b/tuxemon/platform/input_manager.py
@@ -6,7 +6,10 @@ import logging
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Optional
 
+from pygame.surface import Surface
+
 from tuxemon.platform.input_history import InputHistory
+from tuxemon.platform.input_visualizer import InputVisualizer
 from tuxemon.platform.platform_pygame.events import (
     PygameEventQueueHandler,
     PygameGamepadInput,
@@ -14,6 +17,7 @@ from tuxemon.platform.platform_pygame.events import (
     PygameMouseInput,
     PygameTouchOverlayInput,
 )
+from tuxemon.prepare import SCREEN_SIZE
 
 if TYPE_CHECKING:
     from tuxemon.config import TuxemonConfig
@@ -37,6 +41,8 @@ class InputManager:
         self.input = config.input
         self.controller_overlay: Optional[PygameTouchOverlayInput] = None
         self.setup_inputs()
+        self.input_visualizer = InputVisualizer(SCREEN_SIZE)
+        self.show_visualizer = config.controller.show_input_visualizer
 
     def setup_inputs(self) -> None:
         """
@@ -96,9 +102,15 @@ class InputManager:
             logger.info("Mouse set up successfully")
 
     def process_events(self) -> Generator[PlayerInput, None, None]:
-        """
-        Processes the input events.
-        """
+        """Processes the input events."""
         for event in self.event_queue.process_events():
             self.input_history.add(event)
             yield event
+
+    def draw_visualizer(self, screen: Surface) -> None:
+        all_inputs = {}
+        for player_handlers in self.event_queue._inputs.values():
+            for handler in player_handlers:
+                for button_id, player_input in handler.buttons.items():
+                    all_inputs[button_id] = player_input
+        self.input_visualizer.draw(screen, all_inputs)

--- a/tuxemon/platform/input_visualizer.py
+++ b/tuxemon/platform/input_visualizer.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from pygame import draw
+from pygame.font import Font
+from pygame.rect import Rect
+from pygame.surface import Surface
+
+from tuxemon.platform.const import buttons
+from tuxemon.platform.platform_pygame.events import (
+    DPadButtonInfo,
+    DPadInfo,
+)
+from tuxemon.ui.draw import blit_alpha
+
+if TYPE_CHECKING:
+    from tuxemon.platform.events import PlayerInput
+
+logger = logging.getLogger(__name__)
+
+# Grid layout parameters
+GRID_COLUMNS = 4
+GRID_ROWS = 3
+CELL_SIZE = 90
+GRID_PADDING = 10
+
+BUTTON_LAYOUT: dict[int, dict[str, Any]] = {
+    buttons.A: {"label": "A", "color": (255, 0, 0), "grid": (3, 2)},
+    buttons.B: {"label": "B", "color": (0, 0, 255), "grid": (2, 2)},
+    buttons.X: {"label": "X", "color": (255, 255, 0), "grid": (1, 2)},
+    buttons.Y: {"label": "Y", "color": (0, 255, 255), "grid": (0, 2)},
+    buttons.R1: {"label": "R1", "color": (255, 100, 100), "grid": (3, 1)},
+    buttons.L1: {"label": "L1", "color": (100, 255, 100), "grid": (0, 1)},
+    buttons.R2: {"label": "R2", "color": (255, 150, 150), "grid": (3, 0)},
+    buttons.L2: {"label": "L2", "color": (150, 255, 150), "grid": (0, 0)},
+    buttons.START: {
+        "label": "Start",
+        "color": (200, 200, 200),
+        "grid": (2, 1),
+    },
+    buttons.SELECT: {
+        "label": "Select",
+        "color": (180, 180, 180),
+        "grid": (1, 1),
+    },
+    buttons.BACK: {"label": "Back", "color": (160, 160, 160), "grid": (1, 0)},
+}
+
+
+class InputVisualizer:
+    def __init__(self, screen_size: tuple[int, int]) -> None:
+        self.screen_size = screen_size
+        self.font = Font(None, 24)
+        self.dpad_visualizer: DPadInfo = self.create_visual_dpad()
+        self.button_visualizers: dict[int, DPadButtonInfo] = {}
+        self.load()
+
+        grid_origin = (
+            self.screen_size[0] - GRID_COLUMNS * CELL_SIZE - GRID_PADDING,
+            self.screen_size[1] - GRID_ROWS * CELL_SIZE - GRID_PADDING,
+        )
+
+        for btn, props in BUTTON_LAYOUT.items():
+            col, row = props["grid"]
+            x = grid_origin[0] + col * CELL_SIZE
+            y = grid_origin[1] + row * CELL_SIZE
+            self.button_visualizers[btn] = self.create_visual_button(x, y)
+
+    def create_visual_dpad(self) -> DPadInfo:
+        return {
+            "surface": Surface((150, 150)),
+            "position": (20, self.screen_size[1] - 170),
+            "rect": {
+                "up": Rect(70, self.screen_size[1] - 170, 50, 50),
+                "down": Rect(70, self.screen_size[1] - 120, 50, 50),
+                "left": Rect(20, self.screen_size[1] - 120, 50, 50),
+                "right": Rect(120, self.screen_size[1] - 120, 50, 50),
+            },
+        }
+
+    def create_visual_button(self, x: int, y: int) -> DPadButtonInfo:
+        return {
+            "surface": Surface((75, 75)),
+            "position": (x, y),
+            "rect": Rect(x, y, 75, 75),
+        }
+
+    def load(self) -> None:
+        pass
+
+    def draw(self, screen: Surface, inputs: Mapping[int, PlayerInput]) -> None:
+        # Draw D-pad background
+        self.dpad_visualizer["surface"].fill((50, 50, 50))
+        blit_alpha(
+            screen,
+            self.dpad_visualizer["surface"],
+            self.dpad_visualizer["position"],
+            150,
+        )
+
+        # Highlight D-pad directions
+        if inputs.get(buttons.UP) and inputs[buttons.UP].held:
+            draw.rect(screen, (0, 255, 0), self.dpad_visualizer["rect"]["up"])
+        if inputs.get(buttons.DOWN) and inputs[buttons.DOWN].held:
+            draw.rect(
+                screen, (0, 255, 0), self.dpad_visualizer["rect"]["down"]
+            )
+        if inputs.get(buttons.LEFT) and inputs[buttons.LEFT].held:
+            draw.rect(
+                screen, (0, 255, 0), self.dpad_visualizer["rect"]["left"]
+            )
+        if inputs.get(buttons.RIGHT) and inputs[buttons.RIGHT].held:
+            draw.rect(
+                screen, (0, 255, 0), self.dpad_visualizer["rect"]["right"]
+            )
+
+        # Draw and highlight buttons
+        for btn, visualizer in self.button_visualizers.items():
+            visualizer["surface"].fill((50, 50, 50))
+            blit_alpha(
+                screen, visualizer["surface"], visualizer["position"], 150
+            )
+
+            if inputs.get(btn) and inputs[btn].held:
+                color = BUTTON_LAYOUT[btn]["color"]
+                draw.circle(
+                    screen,
+                    color,
+                    visualizer["rect"].center,
+                    visualizer["rect"].width // 2,
+                )
+
+            label = BUTTON_LAYOUT[btn]["label"]
+            text = self.font.render(label, True, (255, 255, 255))
+            screen.blit(text, text.get_rect(center=visualizer["rect"].center))


### PR DESCRIPTION
PR introduces a new `InputVisualizer` component that displays real-time input feedback on screen.

Here's a breakdown of what this addition includes:
- implements a visual representation of the D-pad and action buttons (A, B, X, Y, L1/L2, R1/R2, Start, Select, Back)
- highlights buttons when they are actively held, using color-coded indicators
- uses a grid-based auto-layout system to position buttons dynamically based on screen size and layout configuration
- supports easy extension by defining button properties (label, color, grid position) in a centralized layout dictionary
- keeps rendering logic clean and scalable by separating layout from drawing behavior

To activate the input visualizer set `show_input_visualizer: True` in the main `tuxemon.yaml` configuration file.


https://github.com/user-attachments/assets/b5be2afd-8867-430f-bf2d-8a0e0df21c17
