### PR TITLE
Fix animation playing over wrong monster when technique is shared

### DIFF
--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -748,11 +748,16 @@ class CombatState(CombatAnimations):
         if target_sprite and animation:
             animation.rect.center = target_sprite.rect.center
             assert animation.animation
-            self.task(animation.animation.play, interval=0.6)
+            start_delay = 0.6
+            self.task(animation.animation.play, interval=start_delay)
             self.task(
-                partial(self.sprites.add, animation, layer=50), interval=0.6
+                partial(self.sprites.add, animation, layer=50),
+                interval=start_delay,
             )
-            self.task(animation.kill, interval=action_time)
+            safe_action_time = max(
+                action_time, animation.animation.duration + start_delay
+            )
+            self.task(animation.kill, interval=safe_action_time)
 
     def faint_monster(self, monster: Monster) -> None:
         """


### PR DESCRIPTION
PR fixes #3115 

Bug: when both monsters in a battle select the same technique (e.g. Agnite and Aardorn both use *Gnaw*), the animation appears to play over the player's monster regardless of whose turn it is. This happens even when the opponent is slower and the player's monster acts first.

Cause: the animation was being scheduled to play with a short delay (`interval=0.6`), but the kill timer was based on `action_time`, which could be `0.0` if no combat text was generated. As a result, the animation was often killed before it started, making it appear as if it played over the wrong sprite.

Fix: we now ensure that every animation has a minimum visible duration by calculating a `safe_action_time` that accounts for both the animation’s intrinsic duration and the delay before it starts:

```python
safe_action_time = max(action_time, animation.animation.duration + start_delay)
```

This guarantees that the animation remains on screen long enough to play, even when `action_time` is zero. The animation is also positioned over the target sprite, so this fix resolves the visual misplacement.