### PR TITLE
Extendable FishingEffect Refactor with Weighted Monster Selection and Config Enhancements

### DIFF
--- a/mods/fishing.yaml
+++ b/mods/fishing.yaml
@@ -1,49 +1,70 @@
-fishing_rod: # slug of the item
-  bait: 0.6 # probability of fishing something
-  lower_bound: 5 # min level of the fished monster
-  upper_bound: 15 # max level of the fished monster
-  exp_req_mod: 2.0 # experience modifier
-  stage: # stages: basic, stage1, stage2 or standalone
+# Fishing Config Format
+# Each key is the slug of a fishing item (e.g., "fishing_rod", "neptune", "poseidon")
+# Fields:
+#   trigger: float                  # Probability of triggering a fishing encounter (0.0–1.0)
+#   lower_bound: int            # Minimum level of the fished monster
+#   upper_bound: int            # Maximum level of the fished monster
+#   exp_req_mod: float          # Experience modifier for the encounter
+#   stages: list[str]            # Allowed monster stages (e.g., basic, stage1, stage2, standalone)
+#   stage_weights: dict[str, float]   # Optional: weight per stages (e.g., basic: 0.5)
+#   shapes: list[str]            # Allowed monster shapes (e.g., piscine, polliwog)
+#   shape_weights: dict[str, float]   # Weight per shapes
+#   types: list[str]             # Allowed monster types (e.g., water, electric)
+#   type_weights: dict[str, float]    # Weight per types
+#   tags: list[str]              # Required monster tags (e.g., aquatic, rare)
+#   tag_shape: dict[str, float]       # Weight per tags
+#   animation_color: list[int]  # RGB color for animation (e.g., [0, 105, 148])
+#   environment: dict[str, str]      # Battle background by time of day (default/night)
+#   held_items: dict[str, float]     # Weighted held items (e.g., lure: 0.5, pearl: 0.5)
+
+fishing_rod:
+  trigger: 0.6
+  lower_bound: 5
+  upper_bound: 15
+  exp_req_mod: 2.0
+  stages:
     - basic
-  shape:
+  shapes:
     - polliwog
     - piscine
-  shape_weights: # which shape higher probability
+  shape_weights:
     polliwog: 0.7
     piscine: 0.3
-  sea_blue_color: [0, 105, 148] # rgb animation color
-  environment: # battle background
+  animation_color: [0, 105, 148]
+  environment:
     default: ocean
     night: night_ocean
-  held_items: []
+  held_items: {}
+
 neptune:
-  bait: 0.8
+  trigger: 0.8
   lower_bound: 10
   upper_bound: 25
   exp_req_mod: 2.0
-  stage:
+  stages:
     - basic
     - stage1
-  shape:
+  shapes:
     - polliwog
     - piscine
   shape_weights:
     polliwog: 0.3
     piscine: 0.7
-  sea_blue_color: [0, 105, 148]
+  animation_color: [0, 105, 148]
   environment:
     default: ocean
     night: night_ocean
-  held_items: []
+  held_items: {}
+
 poseidon:
-  bait: 0.95
+  trigger: 0.95
   lower_bound: 15
   upper_bound: 40
   exp_req_mod: 2.0
-  stage:
+  stages:
     - stage2
     - stage1
-  shape:
+  shapes:
     - polliwog
     - piscine
     - leviathan
@@ -51,8 +72,8 @@ poseidon:
     polliwog: 0.3
     piscine: 0.4
     leviathan: 0.3
-  sea_blue_color: [0, 105, 148]
+  animation_color: [0, 105, 148]
   environment:
     default: ocean
     night: night_ocean
-  held_items: []
+  held_items: {}

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -24,27 +24,30 @@ lookup_cache: dict[str, MonsterModel] = {}
 
 
 @dataclass
-class FishingConfig:
-    bait: float
-    lower_bound: int
-    upper_bound: int
-    stage: list[str]
-    shape: list[str]
-    shape_weights: dict[str, float]
-    sea_blue_color: list[int]
-    environment: dict[str, str]
-    held_items: list[str]
-    exp_req_mod: list[float]
+class ActionConfig:
+    trigger: float = 0.0
+    lower_bound: int = 0
+    upper_bound: int = 0
+    stages: list[str] = field(default_factory=list)
+    stage_weights: dict[str, float] = field(default_factory=dict)
+    shapes: list[str] = field(default_factory=list)
+    shape_weights: dict[str, float] = field(default_factory=dict)
+    types: list[str] = field(default_factory=list)
+    type_weights: dict[str, float] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    tag_shape: dict[str, float] = field(default_factory=dict)
+    animation_color: list[int] = field(default_factory=list)
+    environment: dict[str, str] = field(default_factory=dict)
+    held_items: dict[str, float] = field(default_factory=dict)
+    exp_req_mod: list[float] = field(default_factory=list)
 
     def validate_parameters(self) -> None:
-        if not (0 <= self.bait <= 1):
-            raise ValueError("Bait must be between 0 and 1 inclusive.")
-        if self.lower_bound < 0:
-            raise ValueError("Lower bound must be non-negative.")
-        if self.upper_bound < 0:
-            raise ValueError("Upper bound must be non-negative.")
+        if not (0 <= self.trigger <= 1):
+            raise ValueError("Trigger must be between 0 and 1 inclusive.")
+        if self.lower_bound < 0 or self.upper_bound < 0:
+            raise ValueError("Bounds must be non-negative.")
         if self.lower_bound > self.upper_bound:
-            raise ValueError("Lower bound cannot be greater than upper bound.")
+            raise ValueError("Lower bound cannot exceed upper bound.")
 
 
 def load_yaml(filepath: Path) -> Any:
@@ -60,15 +63,15 @@ def load_yaml(filepath: Path) -> Any:
 
 
 class Loader:
-    _config_fishing: dict[str, FishingConfig] = {}
+    _config_fishing: dict[str, ActionConfig] = {}
 
     @classmethod
-    def get_config_fishing(cls, filename: str) -> dict[str, FishingConfig]:
+    def get_config_fishing(cls, filename: str) -> dict[str, ActionConfig]:
         yaml_path = paths.mods_folder / filename
         if not cls._config_fishing:
             raw_map = load_yaml(yaml_path)
             cls._config_fishing = {
-                key: FishingConfig(**item) for key, item in raw_map.items()
+                key: ActionConfig(**item) for key, item in raw_map.items()
             }
         return cls._config_fishing
 
@@ -87,55 +90,87 @@ class FishingEffect(CoreEffect):
         self.client = session.client
         fishing_configs = Loader.get_config_fishing(f"{self.name}.yaml")
 
-        self._fish: FishingConfig = fishing_configs[item.slug]
+        self._fish: ActionConfig = fishing_configs[item.slug]
         self._fish.validate_parameters()
 
-        monster_lists = self._get_fishing_monsters()
+        monster_slugs = self._get_fishing_monsters()
 
-        if monster_lists and random.random() <= self._fish.bait:
-            mon_slug = random.choice(monster_lists)
+        if monster_slugs and random.random() <= self._fish.trigger:
+            mon_slug = monster_slugs[0]
             level = random.randint(
                 self._fish.lower_bound, self._fish.upper_bound
             )
             self._trigger_fishing_encounter(mon_slug, level)
             return ItemEffectResult(name=item.name, success=True)
+
         return ItemEffectResult(name=item.name)
 
     def _get_fishing_monsters(self) -> list[str]:
-        """Return a list of monster slugs based on config and shapes with logging for errors."""
-        monsters = [
-            mon.slug
-            for mon in lookup_cache.values()
-            if mon.stage.value in self._fish.stage
-            and mon.shape in self._fish.shape
-        ]
+        """Return a list of monster slugs based on config filters and weighted selection."""
 
-        if not monsters:
-            logger.error(
-                f" Expected shapes: {self._fish.shape}, but none matched."
+        def matches(mon: MonsterModel) -> bool:
+            return (
+                (not self._fish.stages or mon.stage.value in self._fish.stages)
+                and (not self._fish.shapes or mon.shape in self._fish.shapes)
+                and (
+                    not self._fish.types
+                    or any(t in self._fish.types for t in mon.types)
+                )
+                and (
+                    not self._fish.tags
+                    or any(tag in self._fish.tags for tag in mon.tags)
+                )
             )
 
-        weights = [self._fish.shape_weights.get(mon, 1.0) for mon in monsters]
-        if not monsters:
+        filtered = [mon for mon in lookup_cache.values() if matches(mon)]
+
+        if not filtered:
+            logger.error(
+                f"No monsters matched. Expected stage: {self._fish.stages}, shape: {self._fish.shapes}, "
+                f"type: {self._fish.types}, tag: {self._fish.tags}"
+            )
             return []
-        else:
-            return random.choices(monsters, weights=weights, k=1)
+
+        weights = [self._compute_monster_weight(mon) for mon in filtered]
+        return random.choices(
+            [mon.slug for mon in filtered], weights=weights, k=1
+        )
+
+    def _compute_monster_weight(self, mon: MonsterModel) -> float:
+        """Compute total weight for a monster based on config weight maps."""
+        shape_weight = self._fish.shape_weights.get(mon.shape, 1.0)
+        stage_weight = self._fish.stage_weights.get(mon.stage.value, 1.0)
+        type_weight = max(
+            [self._fish.type_weights.get(t, 1.0) for t in mon.types],
+            default=1.0,
+        )
+        tag_weight = max(
+            [self._fish.tag_shape.get(tag, 1.0) for tag in mon.tags],
+            default=1.0,
+        )
+        return shape_weight * stage_weight * type_weight * tag_weight
 
     def _trigger_fishing_encounter(self, mon_slug: str, level: int) -> None:
-        """Trigger a fishing encounter"""
-
+        """Trigger a fishing encounter with environment, color, held item, and exp modifier."""
         environment = (
             self._fish.environment.get("night")
             if self.player.game_variables.get("stage_of_day") == "night"
             else self._fish.environment.get("default")
         )
-        rgb = ":".join(map(str, self._fish.sea_blue_color))
-        held_item = (
-            random.choice(self._fish.held_items)
-            if self._fish.held_items
-            else None
+
+        rgb = ":".join(map(str, self._fish.animation_color))
+
+        held_item = None
+        if self._fish.held_items:
+            items, weights = zip(*self._fish.held_items.items())
+            held_item = random.choices(items, weights=weights, k=1)[0]
+
+        logger.debug(
+            f"Selected monster: {mon_slug}, level: {level}, held_item: {held_item}"
         )
+
         exp_req_mod = self._fish.exp_req_mod
+
         self.client.event_engine.execute_action(
             "wild_encounter",
             [mon_slug, level, exp_req_mod, None, environment, rgb, held_item],


### PR DESCRIPTION
PR refactors the `FishingEffect` system to support more flexible and extensible monster selection logic, paving the way for future action-based effects such as slingshot and trap. These systems will target different kinds of Tuxemon and rely on similar configuration structures.

Changes include:
- replaced hardcoded monster filters with dynamic, config-driven selection based on stage, shape, type, and tag
- added support for weighted selection across multiple dimensions: `stage_weights`, `shape_weights`, `type_weights` and `tag_shape`
- updated `held_items` from a list to a weighted dictionary (`dict[str, float]`) to allow probabilistic item assignment
- introduced a modular `_compute_monster_weight()` method to calculate selection weights based on config
- config fields are now optional—empty lists or dicts disable filtering for that dimension
- refactored `_get_fishing_monsters()` to skip filters when config fields are empty, improving flexibility
- added default values to `ActionConfig` using `field(default_factory=...)` for safe YAML parsing
- renamed fields in `ActionConfig` for clarity (`stages`, `shapes`, `types`, `tags`) and aligned them with YAML keys
- improved error logging for unmatched monster filters to aid debugging and mod tuning
- updated YAML structure to reflect new schema, including documentation comments for modders

This system will be reused for other encounter-based effects such as slingshot and trap, which will hint at different monsters. The shared config format and weight logic will make it easy to extend and customize these effects independently.