### PR TITLE
Centralize event parsing logic via new `EventParser` class

### DIFF
--- a/tests/tuxemon/test_event_parser.py
+++ b/tests/tuxemon/test_event_parser.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+from tuxemon.event import EventObject
+from tuxemon.map.map_loader import EventParser
+
+
+class TestEventParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = EventParser()
+        self.event_data = {
+            "behav": ["walk:north"],
+            "conditions": ["is flag quest_started"],
+            "actions": ["set flag quest_completed"],
+        }
+        self.name = "test_event"
+        self.source_type = "event"
+        self.x, self.y, self.w, self.h = 5, 10, 2, 3
+
+    def test_create_event_object(self):
+        event = self.parser.create_event_object(
+            self.event_data,
+            self.source_type,
+            self.name,
+            self.x,
+            self.y,
+            self.w,
+            self.h,
+        )
+
+        # Basic structure
+        self.assertIsInstance(event, EventObject)
+        self.assertEqual(event.name, self.name)
+        self.assertEqual(event.x, self.x)
+        self.assertEqual(len(event.conds), 2)  # 1 behav + 1 condition
+        self.assertEqual(len(event.acts), 2)  # 1 behav + 1 action
+
+        # Check behavior condition
+        behav_cond = event.conds[0]
+        self.assertEqual(behav_cond.type, "behav")
+        self.assertEqual(behav_cond.parameters, ["walk:north"])
+        self.assertEqual(behav_cond.operator, "is")
+
+        # Check behavior action
+        behav_act = event.acts[0]
+        self.assertEqual(behav_act.type, "behav")
+        self.assertEqual(behav_act.parameters, ["walk:north"])
+
+        # Check parsed condition
+        cond = event.conds[1]
+        self.assertEqual(cond.type, "flag")
+        self.assertEqual(cond.parameters, ["quest_started"])
+        self.assertEqual(cond.operator, "is")
+
+        # Check parsed action
+        act = event.acts[1]
+        self.assertEqual(act.type, "set")
+        self.assertEqual(act.parameters, ["flag quest_completed"])
+
+    def test_empty_event_data(self):
+        event = self.parser.create_event_object(
+            {}, self.source_type, self.name, self.x, self.y, self.w, self.h
+        )
+        self.assertEqual(len(event.conds), 0)
+        self.assertEqual(len(event.acts), 0)
+
+    def test_behav_only(self):
+        data = {"behav": ["run:east"]}
+        event = self.parser.create_event_object(
+            data, self.source_type, self.name, self.x, self.y, self.w, self.h
+        )
+        self.assertEqual(len(event.conds), 1)
+        self.assertEqual(len(event.acts), 1)
+        self.assertEqual(event.conds[0].parameters, ["run:east"])
+        self.assertEqual(event.acts[0].parameters, ["run:east"])
+
+    def test_malformed_condition(self):
+        data = {"conditions": ["is"]}
+        with self.assertRaises(ValueError):
+            self.parser.create_event_object(
+                data,
+                self.source_type,
+                self.name,
+                self.x,
+                self.y,
+                self.w,
+                self.h,
+            )
+
+    def test_multiple_behaviors(self):
+        data = {"behav": ["jump:up", "slide:left"]}
+        event = self.parser.create_event_object(
+            data, self.source_type, self.name, self.x, self.y, self.w, self.h
+        )
+        self.assertEqual(len(event.conds), 2)
+        self.assertEqual(len(event.acts), 2)
+        self.assertEqual(event.conds[0].name, "behav20")
+        self.assertEqual(event.conds[1].name, "behav10")
+
+    def test_complex_action(self):
+        data = {"actions": ["set flag quest_completed:true"]}
+        event = self.parser.create_event_object(
+            data, self.source_type, self.name, self.x, self.y, self.w, self.h
+        )
+        self.assertEqual(
+            event.acts[0].parameters, ["flag quest_completed:true"]
+        )
+
+    def test_event_object_integrity(self):
+        event = self.parser.create_event_object(
+            self.event_data,
+            self.source_type,
+            self.name,
+            self.x,
+            self.y,
+            self.w,
+            self.h,
+        )
+        self.assertTrue(hasattr(event, "id"))
+        self.assertEqual(event.name, "test_event")
+        self.assertEqual(event.x, 5)
+        self.assertEqual(event.y, 10)

--- a/tuxemon/event/eventparser.py
+++ b/tuxemon/event/eventparser.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import uuid4
+
+from tuxemon.event import EventObject, MapAction, MapCondition
+from tuxemon.script.parser import (
+    parse_action_string,
+    parse_behav_string,
+    parse_condition_string,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EventParser:
+    """Parses raw event data from TMX or YAML files into game objects."""
+
+    def create_event_object(
+        self,
+        event_data: dict[str, Any],
+        source_type: str,
+        name: str,
+        x: int,
+        y: int,
+        w: int,
+        h: int,
+    ) -> EventObject:
+        """
+        Creates an EventObject from a dictionary of event data.
+
+        Expected keys:
+        - "behav": list of behavior strings
+        - "conditions": list of condition strings
+        - "actions": list of action strings
+
+        This method centralizes parsing logic from TMX or YAML sources.
+        """
+        event_id = uuid4().int
+        conditions: list[MapCondition] = []
+        actions: list[MapAction] = []
+        logger.debug(f"Creating event object: {name} at ({x}, {y}, {w}, {h})")
+
+        # Parse behaviors first, as they add both conditions and actions
+        # NOTE: Conditions use structured lists; actions require joined strings.
+        # This reflects how the engine parses behavior logic.
+        behavs = event_data.get("behav") or []
+        for key, value in enumerate(behavs, start=1):
+            logger.debug(f"Parsing behavior {key}: {value}")
+            behav_type, args = parse_behav_string(value)
+            logger.debug(f" → type: {behav_type}, args: {args}")
+
+            # Create a behavior condition
+            conditions.insert(
+                0,
+                MapCondition(
+                    "behav",
+                    [behav_type, *args],
+                    x,
+                    y,
+                    w,
+                    h,
+                    "is",
+                    f"behav{str(key*10)}",
+                ),
+            )
+            # Create a behavior action
+            actions.insert(
+                0,
+                MapAction(
+                    "behav",
+                    [":".join([behav_type, *args])],
+                    f"behav{str(key*10)}",
+                ),
+            )
+
+        # Parse conditions
+        conds = event_data.get("conditions") or []
+        for key, value in enumerate(conds, start=1):
+            logger.debug(f"Parsing condition {key}: {value}")
+            operator, cond_type, args = parse_condition_string(value)
+            logger.debug(
+                f" → operator: {operator}, type: {cond_type}, args: {args}"
+            )
+            conditions.append(
+                MapCondition(
+                    type=cond_type,
+                    parameters=args,
+                    x=x,
+                    y=y,
+                    width=w,
+                    height=h,
+                    operator=operator,
+                    name=f"cond{str(key*10)}",
+                )
+            )
+
+        # Parse actions
+        acts = event_data.get("actions") or []
+        for key, value in enumerate(acts, start=1):
+            logger.debug(f"Parsing action {key}: {value}")
+            act_type, args = parse_action_string(value)
+            logger.debug(f" → type: {act_type}, args: {args}")
+            actions.append(MapAction(act_type, args, f"act{str(key*10)}"))
+
+        return EventObject(event_id, name, x, y, w, h, conditions, actions)

--- a/tuxemon/map/map_loader.py
+++ b/tuxemon/map/map_loader.py
@@ -8,7 +8,6 @@ from collections.abc import Generator, MutableMapping
 from math import cos, pi, sin
 from pathlib import Path
 from typing import Any, Optional
-from uuid import uuid4
 
 import pytmx
 import yaml
@@ -18,7 +17,8 @@ from tuxemon import prepare
 from tuxemon.compat import Rect
 from tuxemon.constants.asset_loader import fetch_asset
 from tuxemon.db import Direction, Orientation
-from tuxemon.event import EventObject, MapAction, MapCondition
+from tuxemon.event import EventObject
+from tuxemon.event.eventparser import EventParser
 from tuxemon.graphics import scaled_image_loader
 from tuxemon.lib.bresenham import bresenham
 from tuxemon.map.map import (
@@ -30,11 +30,6 @@ from tuxemon.map.map import (
     point_to_grid,
     snap_rect,
     tiles_inside_rect,
-)
-from tuxemon.script.parser import (
-    parse_action_string,
-    parse_behav_string,
-    parse_condition_string,
 )
 from tuxemon.tools import copy_dict_with_keys
 
@@ -280,57 +275,19 @@ class YAMLEventLoader:
             A dictionary with "events" and "inits" as keys, each containing a list
             of EventObject instances.
         """
+        event_parser = EventParser()
         yaml_data: dict[str, dict[str, dict[str, Any]]] = parse_yaml(path)
-
         events_dict: dict[str, list[EventObject]] = {"event": [], "init": []}
 
         for name, event_data in yaml_data["events"].items():
-            _id = uuid4().int
-            conds = []
-            acts = []
-            x = event_data.get("x", 0)
-            y = event_data.get("y", 0)
-            w = event_data.get("width", 1)
-            h = event_data.get("height", 1)
             event_type = str(event_data.get("type"))
-
-            for key, value in enumerate(
-                event_data.get("actions", []), start=1
-            ):
-                act_type, args = parse_action_string(value)
-                action = MapAction(act_type, args, f"act{str(key*10)}")
-                acts.append(action)
-            for key, value in enumerate(
-                event_data.get("conditions", []), start=1
-            ):
-                operator, cond_type, args = parse_condition_string(value)
-                condition = MapCondition(
-                    type=cond_type,
-                    parameters=args,
-                    x=x,
-                    y=y,
-                    width=w,
-                    height=h,
-                    operator=operator,
-                    name=f"cond{str(key*10)}",
-                )
-                conds.append(condition)
-            for key, value in enumerate(event_data.get("behav", []), start=1):
-                behav_type, args = parse_behav_string(value)
-                _args = list(args)
-                _args.insert(0, behav_type)
-                _conds = MapCondition(
-                    "behav", _args, x, y, w, h, "is", f"behav{str(key*10)}"
-                )
-                conds.insert(0, _conds)
-                _squeeze = [":".join(_args)]
-                _acts = MapAction("behav", _squeeze, f"behav{str(key*10)}")
-                acts.insert(0, _acts)
-
             if event_type == source:
-                event = EventObject(_id, name, x, y, w, h, conds, acts)
+                x, y = event_data.get("x", 0), event_data.get("y", 0)
+                w, h = event_data.get("width", 1), event_data.get("height", 1)
+                event = event_parser.create_event_object(
+                    event_data, event_type, name, x, y, w, h
+                )
                 events_dict[event_type].append(event)
-
         return events_dict
 
 
@@ -612,9 +569,7 @@ class TMXMapLoader:
         Returns:
             Loaded event.
         """
-        event_id = uuid4().int
-        conditions = []
-        actions = []
+        event_parser = EventParser()
         x, y, w, h = (
             int(obj.x / tile_size[0]),
             int(obj.y / tile_size[1]),
@@ -622,28 +577,23 @@ class TMXMapLoader:
             int(obj.height / tile_size[1]),
         )
 
-        properties = obj.properties
-        for key, value in natsorted(properties.items()):
+        raw_props = obj.properties or {}
+        event_data: dict[str, Any] = {
+            "conditions": [],
+            "actions": [],
+            "behav": [],
+        }
+
+        for key, value in natsorted(raw_props.items()):
             if not isinstance(key, str):
                 continue
             if key.startswith("cond"):
-                operator, cond_type, args = parse_condition_string(value)
-                conditions.append(
-                    MapCondition(cond_type, args, x, y, w, h, operator, key)
-                )
+                event_data["conditions"].append(value)
             elif key.startswith("act"):
-                act_type, args = parse_action_string(value)
-                actions.append(MapAction(act_type, args, key))
+                event_data["actions"].append(value)
             elif key.startswith("behav"):
-                behav_type, args = parse_behav_string(value)
-                conditions.insert(
-                    0,
-                    MapCondition(
-                        "behav", [behav_type, *args], x, y, w, h, "is", key
-                    ),
-                )
-                actions.insert(
-                    0, MapAction("behav", [":".join([behav_type, *args])], key)
-                )
+                event_data["behav"].append(value)
 
-        return EventObject(event_id, obj.name, x, y, w, h, conditions, actions)
+        return event_parser.create_event_object(
+            event_data, obj.type or "event", obj.name, x, y, w, h
+        )


### PR DESCRIPTION
PR introduces a new `EventParser` class to consolidate and streamline the logic for converting raw event data into `EventObject`, `MapCondition`, and `MapAction` instances.

Key changes:
- added `EventParser` class to encapsulate parsing logic for behaviors, conditions and actions
- refactored `YAMLEventLoader.load_events()` to delegate event creation to `EventParser`
- refactored `TMXMapLoader.load_event()` to use `EventParser` for parsing Tiled object properties
- removed redundant parsing logic from both loaders, making them cleaner and more focused
- ensured consistent behavior parsing across YAML and TMX sources