### PR TITLE
Add experience multipliers based on acquisition method

### DIFF
--- a/mods/config_monster.yaml
+++ b/mods/config_monster.yaml
@@ -5,3 +5,13 @@ bond_range: [0, 100]
 weight_range: [-0.1, 0.1]
 # Defines a random interval for height fluctuation (±10% variation)
 height_range: [-0.1, 0.1]
+# Experience gain multipliers based on acquisition method
+experience_multipliers:
+  unknown: 1.0        # Neutral baseline
+  captured: 1.0       # Standard experience gain
+  traded: 1.5         # Boost for socially acquired creatures
+  bred: 1.2           # Slight bonus for homegrown companions
+  gifted: 1.2         # Emotional value translates to faster growth
+  purchased: 0.9      # Slight malus—less personal connection
+  rescued: 1.3        # Strong emotional arc boosts experience
+  created: 1.0        # Neutral—can be adjusted based on lore

--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -10,6 +10,7 @@ from tuxemon.combat.reward_system import (
     calculate_experience_base,
     calculate_money,
 )
+from tuxemon.db import Acquisition
 from tuxemon.monster import Monster
 from tuxemon.monster_dir.status import MonsterStatusHandler
 from tuxemon.npc import NPC
@@ -35,6 +36,7 @@ class TestRewardSystem(unittest.TestCase):
         self.winner.moves = MagicMock()
         self.winner.current_hp = 50
         self.winner.stage = "basic"
+        self.winner.acquisition = Acquisition.UNKNOWN
         self.winner.owner = MagicMock(spec=NPC)
         self.winner.owner.is_player = True
         self.winner.owner.monsters = [self.winner]
@@ -217,6 +219,7 @@ class TestRewardSystem(unittest.TestCase):
         second_winner.level = 5
         second_winner.moves = MagicMock()
         second_winner.moves.update_moves.return_value = ["Ram"]
+        second_winner.acquisition = Acquisition.UNKNOWN
         second_winner.owner = self.winner.owner
         second_winner.status = MagicMock(spec=MonsterStatusHandler)
         second_winner.current_hp = 50

--- a/tuxemon/combat/reward_system.py
+++ b/tuxemon/combat/reward_system.py
@@ -2,19 +2,23 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
 
 from tuxemon.combat.utils import alive_party
+from tuxemon.formula import config_monster
 from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.combat.damage_tracker import DamageTracker
-    from tuxemon.technique.technique import Technique
     from tuxemon.monster import Monster
     from tuxemon.session import Session
+    from tuxemon.technique.technique import Technique
 
-from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 class ExperienceMethod(Enum):
@@ -165,12 +169,20 @@ def calculate_experience(
     """
     total_hits, monster_hits = damages.count_hits(loser, winner)
 
+    exp_multiplier = 1.0
+    experience_multipliers = config_monster.experience_multipliers
+    if experience_multipliers:
+        method = winner.acquisition.value
+        exp_multiplier = experience_multipliers.get(method, 1.0)
+        logger.debug(f"Experience multiplier for {method}: {exp_multiplier}")
+
     def default_method() -> tuple[int, int]:
-        total_exp = calculate_experience_base(
+        base_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
             loser.experience_modifier,
         )
+        total_exp = round(base_exp * exp_multiplier)
 
         participants = damages.get_attackers(loser)
         num_participants = len(participants) if participants else 1
@@ -179,20 +191,22 @@ def calculate_experience(
         return divided_exp, 0
 
     def equal_method() -> tuple[int, int]:
-        total_exp = calculate_experience_base(
+        base_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
             loser.experience_modifier,
         )
+        total_exp = round(base_exp * exp_multiplier)
         proportional_exp = int(total_exp * (monster_hits / total_hits))
         return proportional_exp, 0
 
     def feeder_method() -> tuple[int, int]:
-        total_exp = calculate_experience_base(
+        base_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
             loser.experience_modifier,
         )
+        total_exp = round(base_exp * exp_multiplier)
 
         participants = damages.get_attackers(loser)
         item_holder_exp = total_exp // 2
@@ -209,11 +223,12 @@ def calculate_experience(
         return participant_exp, 0
 
     def transmitter_method() -> tuple[int, int]:
-        total_exp = calculate_experience_base(
+        base_exp = calculate_experience_base(
             loser.total_experience,
             loser.level,
             loser.experience_modifier,
         )
+        total_exp = round(base_exp * exp_multiplier)
 
         participants = damages.get_attackers(loser)
 

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -6,7 +6,7 @@ import logging
 import math
 import random
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -90,6 +90,7 @@ class MonsterConfig:
     bond_range: tuple[int, int] = (0, 100)
     weight_range: tuple[float, float] = (-0.1, 0.1)
     height_range: tuple[float, float] = (-0.1, 0.1)
+    experience_multipliers: dict[str, float] = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
PR introduces support for acquisition-based experience gain modifiers.

Specifically:
- added an `experience_multipliers` field to `MonsterConfig` as an empty dictionary placeholder
- intended to map acquisition methods (e.g. traded, bred, rescued) to experience gain multipliers
- enables future logic where creatures gain more or less experience depending on how they were acquired
- keeps the system flexible for modders and narrative tuning