### PR TITLE
Simplify Crafting Logic by Removing Redundant Ingredient Checks

### DIFF
--- a/tests/tuxemon/test_crafting.py
+++ b/tests/tuxemon/test_crafting.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tuxemon.item.crafting_system import CraftingSystem
+from tuxemon.item.item import Item
+from tuxemon.item.recipe import Recipe
+
+
+class TestCraftingSystem(unittest.TestCase):
+    def setUp(self):
+        self.system = CraftingSystem()
+
+        # Create a mock recipe
+        self.recipe_slug = "healing_potion"
+        self.recipe = Recipe(
+            {
+                "recipe_slug": self.recipe_slug,
+                "required_ingredients": {"herb": 2, "water": 1},
+                "required_tools": [{"slug": "mortar", "consumed": True}],
+                "possible_outputs": [
+                    {
+                        "slug": "potion",
+                        "type": "item",
+                        "quantity": 1,
+                        "weight": 1,
+                    }
+                ],
+                "crafting_method": None,
+            }
+        )
+        self.system.recipes[self.recipe_slug] = self.recipe
+
+        # Mock BagHandler
+        self.bag = MagicMock()
+        self.bag.get_all_item_quantities.return_value = {
+            "herb": 2,
+            "water": 1,
+            "mortar": 1,
+        }
+        self.bag.has_item.side_effect = lambda slug: slug in [
+            "herb",
+            "water",
+            "mortar",
+        ]
+        self.bag.find_item.side_effect = lambda slug: MagicMock(
+            quantity=2, slug=slug
+        )
+
+        # Patch Item creation
+        self.item_mock = MagicMock(spec=Item)
+        self.item_mock.slug = "potion"
+        self.item_mock.quantity = 1
+        self.item_mock.create.return_value = self.item_mock
+
+        patcher = patch(
+            "tuxemon.item.item.Item.create", return_value=self.item_mock
+        )
+        self.addCleanup(patcher.stop)
+        self.mock_create = patcher.start()
+
+    def test_successful_craft(self):
+        result = self.system.craft_item_for_bag(self.recipe_slug, self.bag)
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_slug, "generic_success")
+        self.assertEqual(result.output_type, "item")
+        self.assertEqual(len(result.crafted_items), 1)
+        self.assertEqual(result.crafted_items[0].slug, "potion")
+
+    def test_missing_recipe(self):
+        result = self.system.craft_item_for_bag("unknown_slug", self.bag)
+        self.assertFalse(result.success)
+        self.assertEqual(result.message_slug, "invalid_recipe")
+
+    def test_check_can_craft_blocks_execution(self):
+        # Simulate missing ingredients
+        self.system.check_can_craft = MagicMock(return_value=False)
+        result = self.system.craft_item_for_bag(self.recipe_slug, self.bag)
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.failure_reason, "Missing required ingredients."
+        )
+
+    def test_tool_consumption(self):
+        tool = MagicMock(quantity=1)
+        self.bag.find_item.side_effect = lambda slug: (
+            tool if slug == "mortar" else MagicMock(quantity=2)
+        )
+        result = self.system.craft_item_for_bag(self.recipe_slug, self.bag)
+        self.bag.remove_item.assert_called_with(tool)
+        self.assertTrue(result.success)
+
+    def test_output_type_lore_trigger(self):
+        self.recipe.possible_outputs = [
+            {"slug": "ancient_scroll", "type": "lore_trigger", "weight": 1}
+        ]
+        result = self.system.craft_item_for_bag(self.recipe_slug, self.bag)
+        self.assertTrue(result.success)
+        self.assertEqual(result.output_type, "lore_trigger")
+        self.assertEqual(result.message_slug, "lore_trigger_success")
+        self.assertEqual(result.revealed_content_slug, "ancient_scroll")
+
+    def test_output_type_quest_trigger(self):
+        self.recipe.possible_outputs = [
+            {"slug": "quest_start", "type": "quest_trigger", "weight": 1}
+        ]
+        result = self.system.craft_item_for_bag(self.recipe_slug, self.bag)
+        self.assertTrue(result.success)
+        self.assertEqual(result.output_type, "quest_trigger")
+        self.assertEqual(result.message_slug, "quest_trigger_success")
+        self.assertEqual(result.revealed_content_slug, "quest_start")
+
+    def test_unknown_output_type_raises(self):
+        self.recipe.possible_outputs = [
+            {"slug": "mystery", "type": "unknown", "weight": 1}
+        ]
+        with self.assertRaises(ValueError):
+            self.system.craft_item_for_bag(self.recipe_slug, self.bag)

--- a/tuxemon/item/crafting_system.py
+++ b/tuxemon/item/crafting_system.py
@@ -125,18 +125,7 @@ class CraftingSystem:
     ) -> CraftingResult:
         logger.debug(f"[Craft] Attempting to craft recipe: '{recipe_slug}'")
 
-        if not self.check_can_craft(recipe_slug, npc_bag_handler):
-            logger.debug(
-                f"[Craft] Preconditions not met for recipe '{recipe_slug}'."
-            )
-            return CraftingResult(
-                success=False,
-                message_slug="generic_failure",
-                output_type="",
-                crafted_items=[],
-                failure_reason="Missing required ingredients.",
-            )
-
+        # Retrieve the recipe from the database
         recipe = self.recipes.get(recipe_slug)
         if not recipe:
             logger.debug(
@@ -150,35 +139,44 @@ class CraftingSystem:
                 failure_reason=f"Recipe '{recipe_slug}' not found.",
             )
 
-        for item_slug, item_quantity in recipe.required_ingredients.items():
-            item = npc_bag_handler.find_item(item_slug)
-            if not item or item.quantity < item_quantity:
-                logger.debug(
-                    f"[Craft] Missing or insufficient '{item_slug}' (needed: {item_quantity}, available: {item.quantity if item else 0})"
-                )
-                return CraftingResult(
-                    success=False,
-                    message_slug="generic_failure",
-                    output_type="",
-                    crafted_items=[],
-                    failure_reason=f"Missing or insufficient '{item_slug}'",
-                )
+        # Check if crafting is possible before proceeding
+        if not self.check_can_craft(recipe_slug, npc_bag_handler):
+            logger.debug(
+                f"[Craft] Preconditions not met for recipe '{recipe_slug}'."
+            )
+            return CraftingResult(
+                success=False,
+                message_slug="generic_failure",
+                output_type="",
+                crafted_items=[],
+                failure_reason="Missing required ingredients.",
+            )
 
-            if item.quantity > item_quantity:
-                item.decrease_quantity(item_quantity)
+        # Consume required ingredients (check_can_craft has validated availability)
+        for item_slug, item_quantity in recipe.required_ingredients.items():
+            bag_item = npc_bag_handler.find_item(item_slug)
+
+            if bag_item and bag_item.quantity > item_quantity:
+                bag_item.decrease_quantity(item_quantity)
                 logger.debug(
                     f"[Craft] Decreased '{item_slug}' by {item_quantity}"
                 )
-            else:
-                npc_bag_handler.remove_item(item)
+            elif bag_item and bag_item.quantity == item_quantity:
+                npc_bag_handler.remove_item(bag_item)
                 logger.debug(
                     f"[Craft] Removed '{item_slug}' (exact quantity matched)"
+                )
+            else:
+                # Should not occur if check_can_craft passed, but log for safety
+                logger.error(
+                    f"[Craft] Failed to find or remove '{item_slug}'."
                 )
 
         crafted_items: list[Item] = []
         revealed_content_slug: Optional[str] = None
         message_slug: str = "generic_success"
 
+        # Select output from recipe's weighted options
         selected = self.select_weighted_output(recipe.possible_outputs)
         slug: str = selected["slug"]
         output_type: str = selected.get("type", "item")
@@ -187,6 +185,7 @@ class CraftingSystem:
             f"[Craft] Selected output: {slug} x{qty} (type: {output_type})"
         )
 
+        # Handle output based on type
         if output_type == "item":
             if npc_bag_handler.has_item(slug):
                 existing = npc_bag_handler.find_item(slug)
@@ -197,7 +196,7 @@ class CraftingSystem:
                         f"[Craft] Increased quantity of existing item '{slug}' by {qty}"
                     )
             else:
-                new_item = Item().create(slug)
+                new_item = Item.create(slug)
                 npc_bag_handler.add_item(new_item, qty)
                 crafted_items.append(new_item)
                 logger.debug(f"[Craft] Added new item '{slug}' x{qty} to bag")


### PR DESCRIPTION
Key changes:
- refactored `craft_item_for_bag` to eliminate duplicate validation of required ingredients
- relied solely on `check_can_craft()` to verify ingredient availability before consumption
- removed conditional checks for missing or insufficient items inside the crafting loop
- streamlined item consumption logic for better readability and performance
- added a fallback error log in case of unexpected item absence, ensuring robustness