### PR TITLE
Improve NSIS Installation and Artifact Handling in Windows Installer Workflow + Batch Script (`build_installer.bat`)

### DIFF
--- a/.github/workflows/installer_windows.yml
+++ b/.github/workflows/installer_windows.yml
@@ -28,16 +28,21 @@ jobs:
           copy buildconfig/build_config.yaml build_config.yaml
           python setup_cx_freeze.py build
 
-      - name: Install nsis
+      - name: Install NSIS
         run: |
-          Invoke-WebRequest -Uri "https://sourceforge.net/projects/nsis/files/NSIS%203/3.11/nsis-3.11-setup.exe" -OutFile "nsis.exe"
+          choco install nsis -y
+          $nsisPath = "${env:ProgramFiles(x86)}\NSIS"
+          echo "$nsisPath" | Out-File -Append $env:GITHUB_PATH
+
+      - name: Check NSIS availability
+        run: where makensis.exe
 
       - name: Build Installer
         run: |
           cd buildconfig
           cmd.exe /c "build_installer.bat"
           mkdir ../dist/
-          mv tuxemon-installer.exe ../dist/.
+          Move-Item tuxemon-installer.exe ../dist/
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/buildconfig/build_installer.bat
+++ b/buildconfig/build_installer.bat
@@ -1,43 +1,53 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
-echo Building Tuxemon Windows Installer...
+echo === Building Tuxemon Windows Installer ===
 
 rem Get the script's directory
-set ScriptDir=%~dp0
+set "ScriptDir=%~dp0"
 
 rem Set the installer script path
-set ScriptPath="%ScriptDir%setup_windows.nsi"
+set "ScriptPath=%ScriptDir%setup_windows.nsi"
 
-rem Find the build directory
+rem Find the build directory (first match)
 for /d %%a in ("%ScriptDir%..\build\exe.*") do (
     set "TXMNBuildDir=%%~fa"
+    goto :found
 )
+:found
 
-rem Check if the build directory exists
-if not exist "%TXMNBuildDir%\" (
-    echo Error: Build directory not found: "%TXMNBuildDir%"
+rem Validate build directory
+if not exist "!TXMNBuildDir!\" (
+    echo [ERROR] Build directory not found: "!TXMNBuildDir!"
     exit /b 1
 )
 
-echo ScriptPath: "%ScriptPath%"
-echo TXMNBuildDir: "%TXMNBuildDir%"
+echo ScriptPath: "!ScriptPath!"
+echo TXMNBuildDir: "!TXMNBuildDir!"
 
 rem Check for NSIS installation
 where makensis.exe >nul 2>&1
 if errorlevel 1 (
-    echo Error: NSIS not found. Make sure it's installed and in your PATH.
+    echo [ERROR] NSIS not found. Ensure it's installed and added to PATH.
     exit /b 1
 )
 
-rem Build the installer
-makensis.exe "%ScriptPath%" /V4
+rem Run NSIS to build the installer
+echo Running NSIS...
+makensis.exe "!ScriptPath!" /V4
 if errorlevel 1 (
-    echo Error: NSIS build failed.
+    echo [ERROR] NSIS build failed.
     exit /b 1
 )
 
-echo Installer build complete.
+rem Confirm installer was created
+set "InstallerPath=%ScriptDir%tuxemon-installer.exe"
+if not exist "!InstallerPath!" (
+    echo [ERROR] Installer not created: "!InstallerPath!"
+    exit /b 1
+)
+
+echo Installer build complete: "!InstallerPath!"
 
 endlocal
 exit /b 0


### PR DESCRIPTION
PR updates the Windows installer workflow.

Key changes:
- replaced manual NSIS installer download with Chocolatey-based installation: the previous version downloaded the NSIS `.exe` installer directly from SourceForge, the new version uses Chocolatey (`choco install nsis -y`) to install NSIS, which is more reliable and ensures proper installation and path setup
- added a step to verify NSIS availability
- improved artifact upload clarity: the artifact upload step now explicitly names the output folder (`dist/`) and the artifact (`tuxemon_windows_installer`) for better traceability
- minor cleanup and consistency improvements: replaced `mv` with `Move-Item` for consistency with PowerShell syntax and ensured all paths and commands are compatible with Windows runners

PR updates the batch script.

Key changes:
- added `setlocal enabledelayedexpansion` to support dynamic variable evaluation inside loops and conditional blocks
- replaced plain `echo` statements with clearer, bracketed messages like `[ERROR]` and `=== Building Tuxemon Windows Installer ===` for better visibility in logs
- added a `goto :found` statement to exit the loop after the first matching build directory is found, preventing unintended overwrites
- added a check to confirm that the installer file (`tuxemon-installer.exe`) was successfully created after running NSIS
- provided more descriptive error messages for missing build directories, NSIS installation issues, and failed installer creation
- used consistent quoting style (`set "VAR=value"`) to avoid issues with spaces in paths
- replaced `%VAR%` with `!VAR!` where delayed expansion is needed