### PR TITLE
Fix: Correct Status Resolution in `pre_checking` Phase - 2984

### DIFF
--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -514,7 +514,7 @@ class CombatSession:
         status = monster.status.get_current_status()
         if status:
             result_status = status.use(
-                session, target, EffectPhase.PRE_CHECKING
+                session, monster, EffectPhase.PRE_CHECKING
             )
             if result_status.techniques:
                 technique = random.choice(result_status.techniques)
@@ -525,10 +525,13 @@ class CombatSession:
         ):
             infected_slugs = monster.plague.get_infected_slugs()
             slug = random.choice(infected_slugs)
-            method = Technique.create(slug)
-            result_tech = method.use(session, monster, target)
-            if result_tech.success:
-                technique = method
+            alt_technique = Technique.create(slug)
+            result = alt_technique.use(session, monster, target)
+            if result.success:
+                logger.debug(
+                    f"[Plague Override] {monster.name} switches to {alt_technique.slug}"
+                )
+                technique = alt_technique
         logger.debug(f"[PreCheck End] {monster.name} using {technique.slug}")
         return technique
 
@@ -577,7 +580,6 @@ class CombatSession:
         phase: EffectPhase,
     ) -> StatusEffectResult:
         result = status.use(session, target, phase)
-        status.advance_round()
         logger.debug(
             f"{status.slug} applied to {target.name} during {phase.name}"
         )

--- a/tuxemon/core/effects/flinching.py
+++ b/tuxemon/core/effects/flinching.py
@@ -41,7 +41,8 @@ class FlinchingEffect(CoreEffect):
             assert empty
             skip = Technique.create(empty)
             tech = [skip]
-            target.status.clear_status(session)
+            status.advance_round()
+            status.check_counter_expiry(session)
         return StatusEffectResult(
             name=status.name, success=True, techniques=tech
         )

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -189,6 +189,25 @@ class Status:
     def advance_round(self) -> None:
         """Advance the counter for this status if used."""
         self.counter += 1
+        logger.debug(
+            f"[Status Counter] {self.slug} used {self.counter} times."
+        )
+
+    def check_counter_expiry(
+        self, session: Session, max_uses: int = 1
+    ) -> None:
+        """
+        Checks if the status has reached its use-based expiration threshold.
+        If so, clears the status from the host.
+        """
+        logger.debug(
+            f"[Status Expired] {self.slug} used {self.counter}/{max_uses} times."
+        )
+        if self.counter >= max_uses:
+            logger.debug(
+                f"[Status Expired] {self.slug} removed from {self.host.name} after {self.counter} uses."
+            )
+            self.host.status.clear_status(session)
 
     def validate_monster(self, session: Session, target: Monster) -> bool:
         """


### PR DESCRIPTION
Fixes #2984. Previously, the `status.use()` call mistakenly passed `target` instead of `monster` as the subject of the status effect. This caused status resolution to behave incorrectly, especially for flinching, since the status was being queried from the wrong entity. The fix ensures that `monster` is correctly passed, allowing status effects to resolve as intended during the `PRE_CHECKING` phase. This change restores proper status behavior and prevents issues like premature status disappearance or incorrect technique overrides.

This made me realize that a refactor of the Status effect system is needed. There are several confusing behaviors and edge cases that warrant a more structured intervention. That’s why this PR is just a temporary patch to address the immediate issue, I'll handle the broader refactor in a separate PR #3154.