### PR TITLE
Refactor Shop System with Generic `ShopMenuState` and `ShopAsset` Protocol

### DIFF
--- a/tuxemon/states/shop_base.py
+++ b/tuxemon/states/shop_base.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    Optional,
+    Protocol,
+    TypeVar,
+)
+
+from pygame.rect import Rect
+from pygame.surface import Surface
+
+from tuxemon import prepare, tools
+from tuxemon.item.shop_utils import (
+    TransactionManager,
+    calc_internal_rect,
+)
+from tuxemon.menu.interface import MenuItem
+from tuxemon.menu.menu import Menu
+from tuxemon.menu.quantity import QuantityAndCostMenu
+from tuxemon.npc import NPC
+from tuxemon.platform.const import buttons
+from tuxemon.platform.events import PlayerInput
+from tuxemon.sprite import Sprite
+from tuxemon.ui.paginator import Paginator
+from tuxemon.ui.text import TextArea
+
+if TYPE_CHECKING:
+    from tuxemon.economy.economy import Economy
+
+
+class ShopAsset(Protocol):
+    name: str
+    description: str
+
+
+T = TypeVar("T", bound=ShopAsset)
+
+
+class ShopMenuState(Menu[T], Generic[T], ABC):
+    """
+    A generic shop menu state that can handle any type of asset.
+    All shared logic is implemented here. Subclasses provide the specific
+    details for their respective asset types.
+    """
+
+    name: ClassVar[str] = "ShopMenuState"
+    draw_borders = False
+
+    def __init__(
+        self,
+        buyer: NPC,
+        seller: NPC,
+        economy: Economy,
+    ) -> None:
+        super().__init__()
+
+        # This sprite is used to display the selected asset.
+        self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
+        self.asset_sprite = Sprite()
+        self.sprites.add(self.asset_sprite)
+
+        self.menu_items.line_spacing = tools.scale(7)
+        self.current_page = 0
+        self.total_pages = 0
+        self.inventory: list[T] = []
+
+        # This is the area where the asset's description is displayed.
+        rect = prepare.SCREEN_RECT.copy()
+        rect.top = tools.scale(106)
+        rect.left = tools.scale(3)
+        rect.width = tools.scale(250)
+        rect.height = tools.scale(32)
+        self.text_area = TextArea(self.font, self.font_color)
+        self.text_area.rect = rect
+        self.sprites.add(self.text_area, layer=100)
+
+        self.image_center = self.rect.width * 0.16, self.rect.height * 0.45
+        self.buyer = buyer
+        self.seller = seller
+        self.economy = economy
+        self.update_background(self.economy.model.background)
+        self.buyer_manager = self.buyer.money_controller.money_manager
+        self.seller_manager = self.seller.money_controller.money_manager
+        self.transaction_manager = TransactionManager(
+            self.buyer_manager, self.seller_manager
+        )
+        self.paginator = Paginator(self.inventory, prepare.MAX_MENU_ITEMS)
+
+    def calc_internal_rect(self) -> Rect:
+        return calc_internal_rect(self.rect)
+
+    def on_menu_selection_change(self) -> None:
+        """Called when menu selection changes."""
+        asset = self.get_selected_item()
+        if asset:
+            image = self._get_asset_image(asset)
+            if image:
+                self.asset_sprite.image = image
+                self.asset_sprite.rect = image.get_rect(
+                    center=self.image_center
+                )
+            self._display_asset_description(asset)
+
+    def _add_menu_item(
+        self,
+        asset: T,
+        label: str,
+        metadata: dict[str, Any],
+        unavailable: bool = False,
+    ) -> None:
+        """Helper to create and add a MenuItem for an asset with shared styling."""
+        fg = self.unavailable_color_shop if unavailable else None
+        image = self.shadow_text(label, fg=fg)
+        menu_item = MenuItem(
+            image, asset.name, asset.description, asset, not unavailable
+        )
+        menu_item.metadata.update(metadata)
+        self.add(menu_item)
+
+    @abstractmethod
+    def _get_asset_image(self, asset: MenuItem[T]) -> Optional[Surface]:
+        """Returns the visual representation for the asset."""
+
+    @abstractmethod
+    def _display_asset_description(self, asset: MenuItem[T]) -> None:
+        """Displays the description for the asset."""
+
+    @abstractmethod
+    def _filter_inventory(self) -> list[T]:
+        """Returns the filtered list of assets for the shop."""
+
+    @abstractmethod
+    def _populate_menu(self, inventory: list[T]) -> None:
+        """Populates the menu with assets based on a provided inventory list."""
+
+    @abstractmethod
+    def _get_selection_menu_params(
+        self, menu_item: MenuItem[T]
+    ) -> dict[str, Any]:
+        """Provides parameters for the transaction menu."""
+
+    def initialize_items(self) -> Generator[MenuItem[T], None, None]:
+        self.inventory = self._filter_inventory()
+        if not self.inventory:
+            return
+
+        self.paginator.update_items(self.inventory)
+        self.total_pages = self.paginator.total_pages()
+        self.current_page = max(
+            0, min(self.current_page, self.total_pages - 1)
+        )
+
+        paged_inventory = self.paginator.paginate(self.current_page)
+        self._populate_menu(paged_inventory)
+        yield from self.menu_items
+
+    def reload_shop(self) -> None:
+        self.clear()
+        self.inventory = self._filter_inventory()
+        paged_inventory = self.paginator.paginate(self.current_page)
+        self._populate_menu(paged_inventory)
+        self.selected_index = (
+            min(self.selected_index, len(self.menu_items) - 1)
+            if self.menu_items
+            else -1
+        )
+        self.on_menu_selection_change()
+
+    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+        total_pages = self.paginator.total_pages()
+        if event.button == buttons.RIGHT and event.pressed:
+            if self.current_page < total_pages - 1:
+                self.current_page += 1
+                self.reload_shop()
+        elif event.button == buttons.LEFT and event.pressed:
+            if self.current_page > 0:
+                self.current_page -= 1
+                self.reload_shop()
+        else:
+            return super().process_event(event)
+        return None
+
+    def on_menu_selection(self, menu_item: MenuItem[T]) -> None:
+        """Handles the common logic for pushing the quantity menu."""
+        params = self._get_selection_menu_params(menu_item)
+        self.client.state_manager.push_state(
+            QuantityAndCostMenu(
+                callback=params["callback"],
+                max_quantity=params["max_quantity"],
+                quantity=1,
+                shrink_to_items=True,
+                cost=params["cost"],
+            )
+        )

--- a/tuxemon/states/shop_item.py
+++ b/tuxemon/states/shop_item.py
@@ -2,195 +2,100 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Generator
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
-from pygame.rect import Rect
+from pygame.surface import Surface
 
-from tuxemon import prepare, tools
 from tuxemon.item.item import INFINITE_ITEMS, Item
 from tuxemon.item.shop_utils import (
-    TransactionManager,
-    calc_internal_rect,
     filter_inventory,
     generate_label,
 )
 from tuxemon.menu.interface import MenuItem
-from tuxemon.menu.menu import Menu
 from tuxemon.menu.quantity import QuantityAndCostMenu, QuantityAndPriceMenu
-from tuxemon.platform.const import buttons
-from tuxemon.platform.events import PlayerInput
-from tuxemon.sprite import Sprite
-from tuxemon.ui.paginator import Paginator
-from tuxemon.ui.text import TextArea
-
-if TYPE_CHECKING:
-    from tuxemon.economy.economy import Economy
-    from tuxemon.npc import NPC
+from tuxemon.states.shop_base import ShopMenuState
 
 
-class ShopItemMenuState(Menu[Item]):
+class ShopItemMenuState(ShopMenuState[Item]):
+    """State for buying and selling items, implementing the abstract methods of the generic ShopMenuState."""
 
     name: ClassVar[str] = "ShopItemMenuState"
-    draw_borders = False
 
-    def __init__(
-        self,
-        buyer: NPC,
-        seller: NPC,
-        economy: Economy,
-        buyer_purge: bool = False,
-    ) -> None:
-        super().__init__()
+    def _get_asset_image(self, asset: MenuItem[Item]) -> Optional[Surface]:
+        image = asset.game_object.surface
+        return image if image else None
 
-        # this sprite is used to display the item
-        self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
-        self.item_sprite = Sprite()
-        self.sprites.add(self.item_sprite)
+    def _display_asset_description(self, asset: MenuItem[Item]) -> None:
+        if asset.description:
+            self.dialog.alert(asset.description, dialog_speed="max")
 
-        self.menu_items.line_spacing = tools.scale(7)
-        self.current_page = 0
-        self.total_pages = 0
-        self.inventory: list[Item] = []
+    def _filter_inventory(self) -> list[Item]:
+        return filter_inventory(self.buyer, self.seller, self.economy)
 
-        # this is the area where the item description is displayed
-        rect = self.client.screen.get_rect()
-        rect.top = tools.scale(106)
-        rect.left = tools.scale(3)
-        rect.width = tools.scale(250)
-        rect.height = tools.scale(32)
-        self.text_area = TextArea(self.font, self.font_color)
-        self.text_area.rect = rect
-        self.sprites.add(self.text_area, layer=100)
-
-        self.image_center = self.rect.width * 0.16, self.rect.height * 0.45
-        self.buyer = buyer
-        self.seller = seller
-        self.buyer_purge = buyer_purge
-        self.economy = economy
-        self.update_background(self.economy.model.background)
-        self.buyer_manager = self.buyer.money_controller.money_manager
-        self.seller_manager = self.seller.money_controller.money_manager
-        self.transaction_manager = TransactionManager(
-            self.buyer_manager, self.seller_manager
-        )
-        self.paginator = Paginator(self.inventory, prepare.MAX_MENU_ITEMS)
-
-    def calc_internal_rect(self) -> Rect:
-        return calc_internal_rect(self.rect)
-
-    def is_valid_entry(self, item: Optional[Item]) -> bool:
-        """Check if the selected item is valid for purchase or sale."""
-        if not item:
-            return False
-        if self.buyer.is_player:
-            _, _, price = generate_label(item, self.economy, 1)
-            wallet = self.buyer_manager.get_money()
-            key = f"{self.economy.model.slug}:{item.slug}"
-            qty = self.buyer.game_variables.get(key, 0)
-            if price > wallet or qty == 0:
-                return False
-        return True
-
-    def on_menu_selection_change(self) -> None:
-        """Called when menu selection changes."""
-        item = self.get_selected_item()
-        if item:
-            image = item.game_object.surface
-            assert image
-            self.item_sprite.image = image
-            self.item_sprite.rect = image.get_rect(center=self.image_center)
-            if item.description:
-                self.dialog.alert(item.description, dialog_speed="max")
-
-    def generate_label(
-        self,
-        item: Item,
-        qty: Optional[int] = None,
-        seller_mode: bool = False,
-    ) -> tuple[str, str, int]:
-        """Generate the label for shop items, handling both buyer and seller modes."""
-        return generate_label(item, self.economy, qty, seller_mode)
-
-    def _populate_menu_items(
-        self, inventory: list[Item]
-    ) -> Generator[MenuItem[Item], None, None]:
+    def _populate_menu(self, inventory: list[Item]) -> None:
         for item in inventory:
             if self.buyer.is_player:
                 key = f"{self.economy.model.slug}:{item.slug}"
                 qty = self.buyer.game_variables.get(key, 0)
-                label, discount, price = self.generate_label(item, qty)
-                fg = (
-                    self.unavailable_color_shop
-                    if price > self.buyer_manager.get_money()
-                    else None
-                )
-                image = self.shadow_text(label, fg=fg)
-                menu_item = MenuItem(image, item.name, item.description, item)
-                yield menu_item
-                menu_item.metadata["price"] = price
-                self.add(menu_item)
+                label, _, price = generate_label(item, self.economy, qty)
+                unavailable = price > self.buyer_manager.get_money()
+                self._add_menu_item(item, label, {"price": price}, unavailable)
             elif self.seller.is_player:
-                label, discount, cost = self.generate_label(
-                    item, qty=None, seller_mode=True
+                label, _, cost = generate_label(
+                    item, self.economy, qty=None, seller_mode=True
                 )
-                image = self.shadow_text(label)
-                menu_item = MenuItem(image, item.name, item.description, item)
-                yield menu_item
-                menu_item.metadata["cost"] = cost
-                self.add(menu_item)
+                self._add_menu_item(item, label, {"cost": cost})
 
-    def initialize_items(self) -> Generator[MenuItem[Item], None, None]:
-        self.inventory = filter_inventory(
-            self.buyer, self.seller, self.economy
-        )
-        if not self.inventory:
-            return
+    def _get_selection_menu_params(
+        self, menu_item: MenuItem[Item]
+    ) -> dict[str, Any]:
+        item = menu_item.game_object
+        if self.buyer.is_player:
+            price: int = menu_item.metadata.get("price", 1)
+            label = f"{self.economy.model.slug}:{item.slug}"
 
-        self.paginator.update_items(self.inventory)
-        self.total_pages = self.paginator.total_pages()
-        self.current_page = max(
-            0, min(self.current_page, self.total_pages - 1)
-        )
-
-        paged_inventory = self.paginator.paginate(self.current_page)
-        yield from self._populate_menu_items(paged_inventory)
-
-    def reload_shop(self) -> None:
-        self.clear()
-        self.inventory = filter_inventory(
-            self.buyer, self.seller, self.economy
-        )
-
-        paged_inventory = self.paginator.paginate(self.current_page)
-        # Force generator execution
-        list(self._populate_menu_items(paged_inventory))
-
-        self.selected_index = (
-            min(self.selected_index, len(self.menu_items) - 1)
-            if self.menu_items
-            else -1
-        )
-        self.on_menu_selection_change()
-
-    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        total_pages = self.paginator.total_pages()
-
-        if event.button == buttons.RIGHT and event.pressed:
-            # Move to the next page if possible
-            if self.current_page < total_pages - 1:
-                self.current_page += 1
+            def buy_item(quantity: int) -> None:
+                self.transaction_manager.buy_item(
+                    self.buyer, item, quantity, label, price
+                )
                 self.reload_shop()
-        elif event.button == buttons.LEFT and event.pressed:
-            # Move to the previous page if possible
-            if self.current_page > 0:
-                self.current_page -= 1
-                self.reload_shop()
-        else:
-            return super().process_event(event)
 
-        return None
+            money = self.buyer_manager.get_money()
+            qty_can_afford = int(money / price)
+            inventory = self.buyer.game_variables.get(label, INFINITE_ITEMS)
+            max_quantity = (
+                qty_can_afford
+                if inventory == INFINITE_ITEMS
+                else min(qty_can_afford, inventory)
+            )
+            return {
+                "callback": partial(buy_item),
+                "max_quantity": max_quantity,
+                "cost": price,
+            }
+        elif self.seller.is_player:
+            metadata_cost = menu_item.metadata.get("cost")
+            basic_cost = self.economy.lookup_item_field(item.slug, "cost")
+            if metadata_cost is not None:
+                cost = metadata_cost
+            elif basic_cost:
+                cost = basic_cost
+            else:
+                cost = round(item.cost * self.economy.model.resale_multiplier)
+
+            def sell_item(quantity: int) -> None:
+                self.transaction_manager.sell_item(
+                    self.seller, item, quantity, cost
+                )
+                self.reload_shop()
+
+            return {
+                "callback": partial(sell_item),
+                "max_quantity": item.quantity,
+                "cost": cost,
+            }
+        return {}
 
 
 class ShopItemBuyMenuState(ShopItemMenuState):
@@ -223,7 +128,7 @@ class ShopItemBuyMenuState(ShopItemMenuState):
             else min(qty_can_afford, inventory)
         )
 
-        self.client.push_state(
+        self.client.state_manager.push_state(
             QuantityAndPriceMenu(
                 callback=partial(buy_item),
                 max_quantity=max_quantity,
@@ -259,7 +164,7 @@ class ShopItemSellMenuState(ShopItemMenuState):
             if not self.seller.items.has_item(item.slug):
                 self.on_menu_selection_change()
 
-        self.client.push_state(
+        self.client.state_manager.push_state(
             QuantityAndCostMenu(
                 callback=partial(sell_item),
                 max_quantity=item.quantity,

--- a/tuxemon/states/shop_monster.py
+++ b/tuxemon/states/shop_monster.py
@@ -2,203 +2,103 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Generator
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
-from pygame.rect import Rect
+from pygame.surface import Surface
 
-from tuxemon import prepare, tools
 from tuxemon.item.item import INFINITE_ITEMS
 from tuxemon.item.shop_utils import (
-    TransactionManager,
-    calc_internal_rect,
     filter_party,
     generate_label,
 )
 from tuxemon.menu.interface import MenuItem
-from tuxemon.menu.menu import Menu
 from tuxemon.menu.quantity import QuantityAndCostMenu, QuantityAndPriceMenu
 from tuxemon.monster import Monster
-from tuxemon.platform.const import buttons
-from tuxemon.platform.events import PlayerInput
-from tuxemon.sprite import Sprite
-from tuxemon.ui.paginator import Paginator
-from tuxemon.ui.text import TextArea
-
-if TYPE_CHECKING:
-    from tuxemon.economy.economy import Economy
-    from tuxemon.npc import NPC
+from tuxemon.states.shop_base import ShopMenuState
 
 
-class ShopMonsterMenuState(Menu[Monster]):
+class ShopMonsterMenuState(ShopMenuState[Monster]):
+    """State for buying and selling monsters, implementing the abstract methods of the generic ShopMenuState."""
 
     name: ClassVar[str] = "ShopMonsterMenuState"
-    draw_borders = False
 
-    def __init__(
-        self,
-        buyer: NPC,
-        seller: NPC,
-        economy: Economy,
-        buyer_purge: bool = False,
-    ) -> None:
-        super().__init__()
+    def _get_asset_image(self, asset: MenuItem[Monster]) -> Optional[Surface]:
+        image = asset.game_object.get_sprite("front")
+        return image.image if image else None
 
-        # this sprite is used to display the monster
-        self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
-        self.monster_sprite = Sprite()
-        self.sprites.add(self.monster_sprite)
+    def _display_asset_description(self, asset: MenuItem[Monster]) -> None:
+        if asset.description:
+            self.dialog.alert(asset.description, dialog_speed="max")
 
-        self.menu_items.line_spacing = tools.scale(7)
-        self.current_page = 0
-        self.total_pages = 0
-        self.inventory: list[Monster] = []
+    def _filter_inventory(self) -> list[Monster]:
+        return filter_party(self.buyer, self.seller, self.economy)
 
-        # this is the area where the monster description is displayed
-        rect = self.client.screen.get_rect()
-        rect.top = tools.scale(106)
-        rect.left = tools.scale(3)
-        rect.width = tools.scale(250)
-        rect.height = tools.scale(32)
-        self.text_area = TextArea(self.font, self.font_color)
-        self.text_area.rect = rect
-        self.sprites.add(self.text_area, layer=100)
-
-        self.image_center = self.rect.width * 0.16, self.rect.height * 0.45
-        self.buyer = buyer
-        self.seller = seller
-        self.buyer_purge = buyer_purge
-        self.economy = economy
-        self.update_background(self.economy.model.background)
-        self.buyer_manager = self.buyer.money_controller.money_manager
-        self.seller_manager = self.seller.money_controller.money_manager
-        self.transaction_manager = TransactionManager(
-            self.buyer_manager, self.seller_manager
-        )
-        self.paginator = Paginator(self.inventory, prepare.MAX_MENU_ITEMS)
-
-    def calc_internal_rect(self) -> Rect:
-        return calc_internal_rect(self.rect)
-
-    def is_valid_entry(self, monster: Optional[Monster]) -> bool:
-        """Check if the selected monster is valid for purchase or sale."""
-        if not monster:
-            return False
-        if self.buyer.is_player:
-            _, _, price = generate_label(monster, self.economy, 1)
-            wallet = self.buyer_manager.get_money()
-            key = f"{self.economy.model.slug}:{monster.slug}"
-            qty = self.buyer.game_variables.get(key, 0)
-            if price > wallet or qty == 0:
-                return False
-        if self.seller.is_player:
-            if self.seller.party.party_size == 1:
-                return False
-        return True
-
-    def on_menu_selection_change(self) -> None:
-        """Called when menu selection changes."""
-        monster = self.get_selected_item()
-        if monster:
-            image = monster.game_object.get_sprite("front")
-            assert image
-            self.monster_sprite.image = image.image
-            self.monster_sprite.rect = image.image.get_rect(
-                center=self.image_center
-            )
-            if monster.description:
-                self.dialog.alert(monster.description, dialog_speed="max")
-
-    def generate_monster_label(
-        self,
-        monster: Monster,
-        qty: Optional[int] = None,
-        seller_mode: bool = False,
-    ) -> tuple[str, str, int]:
-        """Generate the label for shop monsters, handling both buyer and seller modes."""
-        return generate_label(monster, self.economy, qty, seller_mode)
-
-    def _populate_menu_monsters(
-        self, inventory: list[Monster]
-    ) -> Generator[MenuItem[Monster], None, None]:
+    def _populate_menu(self, inventory: list[Monster]) -> None:
         for monster in inventory:
             if self.buyer.is_player:
                 key = f"{self.economy.model.slug}:{monster.slug}"
                 qty = self.buyer.game_variables.get(key, 0)
-                label, discount, price = self.generate_monster_label(
-                    monster, qty
+                label, _, price = generate_label(monster, self.economy, qty)
+                unavailable = price > self.buyer_manager.get_money()
+                self._add_menu_item(
+                    monster, label, {"price": price}, unavailable
                 )
-                fg = (
-                    self.unavailable_color_shop
-                    if price > self.buyer_manager.get_money()
-                    else None
-                )
-                image = self.shadow_text(label, fg=fg)
-                menu_monster = MenuItem(
-                    image, monster.name, monster.description, monster
-                )
-                yield menu_monster
-                menu_monster.metadata["price"] = price
-                self.add(menu_monster)
             elif self.seller.is_player:
-                label, discount, cost = self.generate_monster_label(
-                    monster, qty=None, seller_mode=True
+                label, _, cost = generate_label(
+                    monster, self.economy, qty=None, seller_mode=True
                 )
-                image = self.shadow_text(label)
-                menu_monster = MenuItem(
-                    image, monster.name, monster.description, monster
+                self._add_menu_item(monster, label, {"cost": cost})
+
+    def _get_selection_menu_params(
+        self, menu_item: MenuItem[Monster]
+    ) -> dict[str, Any]:
+        monster = menu_item.game_object
+        if self.buyer.is_player:
+            price: int = menu_item.metadata.get("price", 1)
+            label = f"{self.economy.model.slug}:{monster.slug}"
+
+            def buy_monster(quantity: int) -> None:
+                self.transaction_manager.buy_monster(
+                    self.buyer, monster, quantity, label, price
                 )
-                yield menu_monster
-                menu_monster.metadata["cost"] = cost
-                self.add(menu_monster)
-
-    def initialize_items(self) -> Generator[MenuItem[Monster], None, None]:
-        self.inventory = filter_party(self.buyer, self.seller, self.economy)
-        if not self.inventory:
-            return
-
-        self.paginator.update_items(self.inventory)
-        self.total_pages = self.paginator.total_pages()
-        self.current_page = max(
-            0, min(self.current_page, self.total_pages - 1)
-        )
-
-        paged_inventory = self.paginator.paginate(self.current_page)
-        yield from self._populate_menu_monsters(paged_inventory)
-
-    def reload_shop(self) -> None:
-        self.clear()
-        self.inventory = filter_party(self.buyer, self.seller, self.economy)
-
-        paged_inventory = self.paginator.paginate(self.current_page)
-        # Force generator execution
-        list(self._populate_menu_monsters(paged_inventory))
-
-        self.selected_index = (
-            min(self.selected_index, len(self.menu_items) - 1)
-            if self.menu_items
-            else -1
-        )
-        self.on_menu_selection_change()
-
-    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        total_pages = self.paginator.total_pages()
-
-        if event.button == buttons.RIGHT and event.pressed:
-            # Move to the next page if possible
-            if self.current_page < total_pages - 1:
-                self.current_page += 1
                 self.reload_shop()
-        elif event.button == buttons.LEFT and event.pressed:
-            # Move to the previous page if possible
-            if self.current_page > 0:
-                self.current_page -= 1
-                self.reload_shop()
-        else:
-            return super().process_event(event)
 
-        return None
+            money = self.buyer_manager.get_money()
+            qty_can_afford = int(money / price)
+            inventory = self.buyer.game_variables.get(label, INFINITE_ITEMS)
+            max_quantity = (
+                qty_can_afford
+                if inventory == INFINITE_ITEMS
+                else min(qty_can_afford, inventory)
+            )
+            return {
+                "callback": partial(buy_monster),
+                "max_quantity": max_quantity,
+                "cost": price,
+            }
+        elif self.seller.is_player:
+            metadata_cost = menu_item.metadata.get("cost")
+            basic_cost = self.economy.lookup_item_field(monster.slug, "cost")
+            if metadata_cost is not None:
+                cost = metadata_cost
+            elif basic_cost:
+                cost = basic_cost
+            else:
+                cost = round(monster.hp * self.economy.model.resale_multiplier)
+
+            def sell_monster(quantity: int) -> None:
+                self.transaction_manager.sell_monster(
+                    self.seller, monster, cost
+                )
+                self.reload_shop()
+
+            return {
+                "callback": partial(sell_monster),
+                "max_quantity": 1,
+                "cost": cost,
+            }
+        return {}
 
 
 class ShopMonsterBuyMenuState(ShopMonsterMenuState):
@@ -231,7 +131,7 @@ class ShopMonsterBuyMenuState(ShopMonsterMenuState):
             else min(qty_can_afford, inventory)
         )
 
-        self.client.push_state(
+        self.client.state_manager.push_state(
             QuantityAndPriceMenu(
                 callback=partial(buy_monster),
                 max_quantity=max_quantity,
@@ -265,7 +165,7 @@ class ShopMonsterSellMenuState(ShopMonsterMenuState):
             if not self.seller.party.has_monster(monster):
                 self.on_menu_selection_change()
 
-        self.client.push_state(
+        self.client.state_manager.push_state(
             QuantityAndCostMenu(
                 callback=partial(sell_monster),
                 max_quantity=1,


### PR DESCRIPTION
PR refactors the shop menu architecture to reduce duplication and improve extensibility across asset types. Previously, `ShopItemMenuState` and `ShopMonsterMenuState` contained a large amount of redundant logic. This update introduces a generic base class and a shared protocol to streamline behavior and support future asset types more easily.

Changes included:
- introduced a new `ShopAsset` protocol to define the minimal interface (`name` and `description`) required for any shop asset
- added a generic abstract base class `ShopMenuState[T]` that encapsulates all shared shop logic, including pagination, selection handling, sprite rendering, and transaction setup
- refactored `ShopItemMenuState` and `ShopMonsterMenuState` to subclass `ShopMenuState`, implementing only the asset-specific logic (image rendering, filtering, and transaction parameters)
- removed duplicated code from the previous shop menu implementations, centralizing it in `ShopMenuState`
- preserved full compatibility with existing shop behavior while making it easier to add new asset types in the future