### PR TITLE
Enhance `TechniqueMenuState`: Dynamic Sprite Resolution via Technique Ownership

### DIFF
--- a/tuxemon/entity_dir/party.py
+++ b/tuxemon/entity_dir/party.py
@@ -129,6 +129,25 @@ class PartyHandler:
             (m for m in self._monsters if m.instance_id == instance_id), None
         )
 
+    def find_monster_by_tech_id(self, instance_id: UUID) -> Optional[Monster]:
+        """
+        Finds a monster in the party by its technique instance ID.
+
+        Parameters:
+            instance_id: The instance_id of the technique.
+
+        Returns:
+            Monster found, or None.
+        """
+        return next(
+            (
+                monster
+                for monster in self._monsters
+                if monster.moves.find_tech_by_id(instance_id)
+            ),
+            None,
+        )
+
     def release_monster(self, monster: Monster) -> bool:
         """
         Releases a monster from this party. Used to release into the wild.

--- a/tuxemon/event/actions/get_monster_tech.py
+++ b/tuxemon/event/actions/get_monster_tech.py
@@ -151,7 +151,6 @@ class GetMonsterTechAction(EventAction):
                 TechniqueMenuState(
                     character=session.player,
                     techniques=mon.moves.get_moves(),
-                    monster=mon,
                 )
             )
             menu.is_valid_entry = self.validate  # type: ignore[method-assign]

--- a/tuxemon/event/actions/get_pending_moves.py
+++ b/tuxemon/event/actions/get_pending_moves.py
@@ -80,7 +80,6 @@ class GetPendingMovesAction(EventAction):
                 TechniqueMenuState(
                     character=player,
                     techniques=mon.moves.get_moves(),
-                    monster=mon,
                 )
             )
             menu.escape_key_exits = False

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -11,11 +11,11 @@ from tuxemon import prepare
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
-from tuxemon.monster import Monster
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
 from tuxemon.technique.controller import TechController
 from tuxemon.technique.filter import TechFilter
+from tuxemon.technique.sorter import TechSorter
 from tuxemon.technique.technique import Technique
 from tuxemon.tools import (
     open_choice_dialog,
@@ -39,12 +39,12 @@ class TechniqueMenuState(Menu[Technique]):
         self,
         character: NPC,
         techniques: list[Technique],
-        monster: Optional[Monster] = None,
         tech_filter: Optional[TechFilter] = None,
+        tech_sorter: Optional[TechSorter] = None,
     ) -> None:
         self.char = character
-        self.monster = monster
         self.tech_filter = tech_filter or TechFilter(techniques)
+        self.tech_sorter = tech_sorter or TechSorter()
 
         super().__init__()
 
@@ -109,24 +109,22 @@ class TechniqueMenuState(Menu[Technique]):
         """Get all player techniques."""
         # load the backpack icon
         self.backpack_center = self.rect.width * 0.16, self.rect.height * 0.45
-        if self.monster:
-            sprite = self.monster.sprite_handler.front_path
-        else:
-            sprite = prepare.MISSING_IMAGE
-
-        self.load_sprite(
-            sprite,
-            center=self.backpack_center,
-            layer=100,
-        )
 
         output = self.tech_filter.get_filtered_techniques()
         if not output:
             return
 
-        output = sorted(output, key=lambda x: x.tech_id)
-
-        for tech in output:
+        for tech in self.tech_sorter.sort(output):
+            mon = self.char.party.find_monster_by_tech_id(tech.instance_id)
+            if mon:
+                sprite = mon.sprite_handler.front_path
+            else:
+                sprite = prepare.MISSING_IMAGE
+            self.load_sprite(
+                sprite,
+                center=self.backpack_center,
+                layer=100,
+            )
             yield self.create_technique_menu_item(tech)
 
     def on_menu_selection_change(self) -> None:

--- a/tuxemon/technique/sorter.py
+++ b/tuxemon/technique/sorter.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from tuxemon.technique.technique import Technique
+
+
+class TechSorter:
+    def __init__(
+        self, attribute: Optional[str] = None, reverse: bool = False
+    ) -> None:
+        self.attribute = attribute or "tech_id"
+        self.reverse = reverse
+
+    def sort(self, techniques: Sequence[Technique]) -> Sequence[Technique]:
+        return sorted(
+            techniques,
+            key=lambda tech: getattr(tech, self.attribute, 0),
+            reverse=self.reverse,
+        )
+
+    def set_sort_attribute(
+        self, attribute: str, reverse: bool = False
+    ) -> None:
+        self.attribute = attribute
+        self.reverse = reverse


### PR DESCRIPTION
PR refactors the `TechniqueMenuState` class to improve flexibility and clarity:
- introduces early returns in `on_menu_selection`
- removes the optional `Monster` injection from the class constructor
- introduces support for resolving the owning monster of a technique using the new `find_monster_by_tech_id` method from the party
- enables rendering of the correct monster sprite for each technique, even when the technique list contains mixed sources
- replaces inline sorting with an injected `TechSorter`, allowing configurable sort attributes and reverse ordering for improved control over technique presentation

This change allows the menu to dynamically associate techniques with their respective monsters, improving visual feedback and supporting more diverse technique lists.