### PR TITLE
Enhance `ItemMenuState`

### DIFF
--- a/tuxemon/item/filter.py
+++ b/tuxemon/item/filter.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import Optional
 
 from tuxemon.db import State
 from tuxemon.item.item import Item
 
-if TYPE_CHECKING:
-    from tuxemon.npc import NPC
 logger = logging.getLogger(__name__)
 
 
@@ -27,8 +25,8 @@ def not_filter(filter_func: Callable[[Item], bool]) -> Callable[[Item], bool]:
 
 
 class ItemFilter:
-    def __init__(self, character: NPC):
-        self.character = character
+    def __init__(self, items: list[Item]):
+        self.items = items
         self._filters: list[Callable[[Item], bool]] = []
 
     def clear_filters(self) -> None:
@@ -39,8 +37,10 @@ class ItemFilter:
         """Add a single filter to the filter stack."""
         self._filters.append(filter_func)
 
-    def get_filtered_inventory(self) -> list[Item]:
-        all_items = self.character.items.get_items()
+    def get_filtered_inventory(
+        self, items: Optional[list[Item]] = None
+    ) -> list[Item]:
+        all_items = items if items is not None else self.items
         if not self._filters:
             return all_items
 
@@ -54,8 +54,7 @@ class ItemFilter:
                 for f in self._filters
             ]
             logger.debug(
-                f"[ItemFilter] No items passed current filters for {self.character.name}. "
-                f"Total items: {len(all_items)}. Filters applied: {active_filters}"
+                f"[ItemFilter] Total items: {len(all_items)}. Filters applied: {active_filters}"
             )
 
         return filtered

--- a/tuxemon/item/sorter.py
+++ b/tuxemon/item/sorter.py
@@ -18,7 +18,13 @@ class ItemSorter:
 
     def rank_item(self, item: Item) -> tuple[int, str]:
         rank = self.sort_order_rank.get(item.sort, len(self.sort_order))
-        return rank, item.name
+        return rank, item.name.lower()
 
     def sort(self, items: Sequence[Item]) -> Sequence[Item]:
         return sorted(items, key=self.rank_item)
+
+    def set_sort_order(self, new_order: list[str]) -> None:
+        self.sort_order = new_order
+        self.sort_order_rank = {
+            category: i for i, category in enumerate(new_order)
+        }

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -193,7 +193,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_item() -> None:
             # open menu to choose item
-            items_filtered = ItemFilter(self.character)
+            items_filtered = ItemFilter(self.character.items.get_items())
             items_filtered.set_filter_usable_in_state("MainCombatMenuState")
             menu = self.client.push_state(
                 ItemMenuState(self.character, self.name, items_filtered)

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -2,12 +2,13 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Generator, Sequence
+from collections.abc import Generator
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 from pygame.rect import Rect
 
 from tuxemon import prepare
+from tuxemon.graphics import load_and_scale
 from tuxemon.item.controller import ItemController
 from tuxemon.item.filter import ItemFilter
 from tuxemon.item.item import Item
@@ -31,42 +32,6 @@ if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
 
-def sort_inventory(
-    inventory: Sequence[Item], sort_order: Optional[list[str]] = None
-) -> Sequence[Item]:
-    """
-    Sorts a given inventory of items by category and name for improved usability.
-
-    The function performs the following steps:
-    - Groups items by their category as defined by the `sort` attribute of each item.
-    - Sorts items within each category alphabetically by name.
-    - Orders categories according to `sort_order` if provided, otherwise defaults to:
-      ["potion", "food", "utility", "quest"].
-    - Items with unrecognized categories are placed after known categories, sorted by name.
-
-    Parameters:
-        inventory: A sequence of inventory items, where each item has
-            a `name` and `sort` attribute.
-        sort_order: A list specifying the desired order of item categories.
-            If not provided, defaults to ["potion", "food", "utility", "quest"].
-
-    Returns:
-        A new sequence of inventory items sorted by category and name.
-    """
-    default_order = ["potion", "food", "utility", "quest"]
-    order_list = sort_order or default_order
-    sort_order_rank = {
-        category: index for index, category in enumerate(order_list)
-    }
-
-    def rank_item(item: Item) -> tuple[int, str]:
-        # Unknown types last
-        rank = sort_order_rank.get(item.sort, len(order_list))
-        return rank, item.name
-
-    return sorted(inventory, key=rank_item)
-
-
 class ItemMenuState(Menu[Item]):
     """The item menu allows you to view and use items in your inventory."""
 
@@ -85,7 +50,9 @@ class ItemMenuState(Menu[Item]):
         self.source = source
         super().__init__()
 
-        self.filter_controller = item_filter or ItemFilter(character)
+        self.filter_controller = item_filter or ItemFilter(
+            self.char.items.get_items()
+        )
         self.sorter = sorter or ItemSorter()
         # this sprite is used to display the item
         # it's also animated to pop out of the backpack
@@ -142,16 +109,20 @@ class ItemMenuState(Menu[Item]):
             self.on_menu_selection_change()
             error_message = self.get_error_message(item)
             open_dialog(self.client, [error_message])
+            return
+
         # Check if the item can be used in the current state
-        elif not any(
+        if not any(
             s.name in self.client.active_state_names for s in item.usable_in
         ):
             error_message = T.format(
                 "item_cannot_use_here", {"name": item.name}
             )
             open_dialog(self.client, [error_message])
-        else:
-            self.open_confirm_use_menu(item)
+            return
+
+        # All checks passed, proceed to confirmation
+        self.open_confirm_use_menu(item)
 
     def open_confirm_use_menu(self, item: Item) -> None:
         """
@@ -213,7 +184,7 @@ class ItemMenuState(Menu[Item]):
         end_index = (self.current_page + 1) * self.page_size
         page_items = self.inventory[start_index:end_index]
 
-        for obj in sort_inventory(page_items):
+        for obj in self.sorter.sort(page_items):
             enable = self.is_valid_entry(obj)
             menu_item = self.create_menu_item(obj, is_enabled=enable)
             yield menu_item
@@ -231,7 +202,9 @@ class ItemMenuState(Menu[Item]):
     def animate_item_selection(self, item: Item) -> None:
         """Animate the selected item being pulled from the bag."""
         image = item.surface
-        assert image
+        if not image:
+            image = load_and_scale(prepare.MISSING_IMAGE)
+
         self.item_sprite.image = image
         self.item_sprite.rect = image.get_rect(center=self.backpack_center)
         self.animate(
@@ -260,7 +233,7 @@ class ItemMenuState(Menu[Item]):
             self.update_page_number_display(0)
             return
 
-        for obj in sort_inventory(page_items):
+        for obj in self.sorter.sort(page_items):
             enable = self.is_valid_entry(obj)
             menu_item = self.create_menu_item(obj, is_enabled=enable)
             self.add(menu_item)

--- a/tuxemon/states/monster_item.py
+++ b/tuxemon/states/monster_item.py
@@ -35,7 +35,7 @@ class MonsterItemState(PygameMenuState):
         owner = monster.get_owner()
 
         def add_item() -> None:
-            items_filtered = ItemFilter(owner)
+            items_filtered = ItemFilter(owner.items.get_items())
             items_filtered.add_filter(lambda item: item.behaviors.holdable)
             menu = self.client.push_state(
                 ItemMenuState(owner, self.name, items_filtered)

--- a/tuxemon/states/park_menu.py
+++ b/tuxemon/states/park_menu.py
@@ -146,7 +146,7 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
             self.itm_description = choice.description
 
         def choose_item() -> None:
-            items_filtered = ItemFilter(self.player)
+            items_filtered = ItemFilter(self.player.items.get_items())
             items_filtered.set_filter_usable_in_state("MainCombatMenuState")
             menu = self.client.push_state(
                 ItemMenuState(self.player, self.name, items_filtered)

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -392,7 +392,7 @@ class ItemDropOff(ItemMenuState):
     name: ClassVar[str] = "ItemDropOff"
 
     def __init__(self, box_name: str, character: NPC) -> None:
-        items_filtered = ItemFilter(character)
+        items_filtered = ItemFilter(character.items.get_items())
         items_filtered.set_filter_all_visible()
         super().__init__(
             character=character, source=self.name, item_filter=items_filtered

--- a/tuxemon/world/manager.py
+++ b/tuxemon/world/manager.py
@@ -213,7 +213,7 @@ class WorldMenuManager:
             )
 
         if player.items.get_items() and self.menu_flags.is_enabled("menu_bag"):
-            items_filtered = ItemFilter(player)
+            items_filtered = ItemFilter(player.items.get_items())
             items_filtered.set_filter_all_visible()
             current_menu.append(
                 self._menu_item(


### PR DESCRIPTION
PR refactors the `ItemMenuState` class to improve flexibility and clarity:
- introduces early returns in `on_menu_selection`
- replaces the standalone `sort_inventory()` function with an injected `ItemSorter` class to support customizable sorting strategies
- refactors the `ItemFilter` class to decouple it from `NPC`: it now accepts a direct list of `Item` objects instead of retrieving them from a character, this change improves modularity and allows filtering to be applied to arbitrary item collections