### PR TITLE
Add working repellent mechanic

### DIFF
--- a/mods/tuxemon/db/item/alpha_seep.json
+++ b/mods/tuxemon/db/item/alpha_seep.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [],
+  "effects": [
+    {
+      "type": "repellent",
+      "parameters": ["100"]
+    }
+  ],
+  "slug": "alpha_seep",
+  "sort": "utility",
+  "sprite": "gfx/items/box.png",
+  "category": "none",
+  "usable_in": [
+    "WorldState"
+  ],
+  "modifiers": [],
+  "behaviors": {
+    "requires_monster_menu": false
+  },
+  "use_failure": "generic_failure",
+  "use_item": "combat_used_x",
+  "use_success": "generic_success"
+}

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -341,6 +341,14 @@ msgstr "Raise Speed"
 msgid "raise_speed_description"
 msgstr "Learn the reflexes of the spinel. Increase Speed by 5%."
 
+msgid "alpha_seep"
+msgstr "Alpha Seep"
+
+msgid "alpha_seep_description"
+msgstr ""
+"Thick, mucosal secretion harvested from the scent glands of apex predators "
+"at the peak of their territorial cycle."
+
 msgid "fishing_rod"
 msgstr "Fishing Rod"
 

--- a/tuxemon/combat/utils.py
+++ b/tuxemon/combat/utils.py
@@ -57,6 +57,16 @@ def check_battle_legal(character: NPC) -> bool:
     return True
 
 
+def check_repellent(character: NPC) -> bool:
+    """
+    Checks if the repellent is still active.
+    """
+    repellent_tracker = character.step_tracker.get_tracker("repellent")
+    if repellent_tracker is None:
+        return False
+    return repellent_tracker.countdown > 0
+
+
 def has_effect(technique: Technique, effect_name: str) -> bool:
     """
     Checks to see if the technique has a specific effect (eg ram -> damage).

--- a/tuxemon/core/effects/repellent.py
+++ b/tuxemon/core/effects/repellent.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
+from tuxemon.step_tracker import StepTracker
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RepellentEffect(CoreEffect):
+    """
+    Applies a repellent effect that prevents wild encounters for a
+    set number of steps.
+    """
+
+    name = "repellent"
+    steps: float
+
+    def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
+        player = session.player
+        current_steps = round(player.steps)
+
+        player.step_tracker.add_tracker(
+            self.name,
+            StepTracker(
+                steps=current_steps, countdown=self.steps, milestones=[]
+            ),
+        )
+
+        logger.info(
+            f"Applied repellent from '{item.name}' to '{player.name}' for {self.steps} steps."
+        )
+        return ItemEffectResult(success=True)

--- a/tuxemon/encounter.py
+++ b/tuxemon/encounter.py
@@ -99,15 +99,13 @@ class Encounter:
         return valid_encs
 
     def _choose_single_encounter(
-        self, encounters: list[EncounterItemModel], total_prob: Optional[float]
+        self, encounters: list[EncounterItemModel], total_prob: float
     ) -> Optional[EncounterItemModel]:
         """
         Internal helper to choose one single monster based on rates.
         """
         if not encounters:
             return None
-
-        total_prob = total_prob or 1.0
 
         sum_rates = sum(enc.encounter_rate for enc in encounters)
         if sum_rates == 0:
@@ -132,7 +130,7 @@ class Encounter:
         return None
 
     def get_single_encounter(
-        self, character: NPC, total_prob: Optional[float]
+        self, character: NPC, total_prob: float
     ) -> Optional[tuple[EncounterItemModel, int, Optional[str]]]:
         """
         Public method to get a single monster encounter.

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -12,7 +12,7 @@ from tuxemon.combat.combat_context import (
     CombatContext,
     CombatType,
 )
-from tuxemon.combat.utils import check_battle_legal
+from tuxemon.combat.utils import check_battle_legal, check_repellent
 from tuxemon.db import EnvironmentModel, db
 from tuxemon.encounter import Encounter, EncounterData
 from tuxemon.event import get_npc
@@ -62,9 +62,14 @@ class RandomEncounterAction(EventAction):
             logger.error("Battle is not legal, won't start")
             return
 
+        if check_repellent(player):
+            logger.info(f"Repellent active, skipping encounter.")
+            return
+
         zone = EncounterData(self.encounter_slug)
         encounter = Encounter(zone)
-        results = encounter.get_single_encounter(player, self.total_prob)
+        total_prob = self.total_prob if self.total_prob else 1.0
+        results = encounter.get_single_encounter(player, total_prob)
 
         if results is None:
             return


### PR DESCRIPTION
PR adds the repellent mechanic. We can set different step durations per item, like so:
```json
"effects": [
  {
    "type": "repellent",
    "parameters": ["100"]
  }
]
```
Still marked as draft since I want to hook it up to a few actual items before finalizing.