### PR TITLE
Refactor Type Hints and Imports Post-Merge

### DIFF
--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1096,6 +1096,13 @@ class SpeedLabel(str, Enum):
             SpeedLabel.EXTREMELY_FAST: 3,
         }[self]
 
+    @classmethod
+    def from_numeric(cls, value: int) -> SpeedLabel:
+        for label in cls:
+            if label.numeric_value == value:
+                return label
+        return cls.NORMAL
+
 
 class TechSort(str, Enum):
     damage = "damage"

--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -67,7 +67,7 @@ class ChangeBgAction(EventAction):
             raise RuntimeError
 
         # this function cleans up the previous state without crashing
-        if len(client.state_manager.active_states) > 2:
+        if len(client.active_states) > 2:
             client.pop_state()
 
         if self.image and self.category:
@@ -90,7 +90,7 @@ class ChangeBgAction(EventAction):
 
         if client.current_state.name != "ImageState":
             if self.background is None:
-                if len(client.state_manager.active_states) > 2:
+                if len(client.active_states) > 2:
                     client.pop_state()
                     return
             else:

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -57,7 +57,7 @@ class EvolutionAction(EventAction):
 
         self.char = character
 
-        if len(self.client.state_manager.active_states) > MAX_ACTIVE_STATES:
+        if len(self.client.active_states) > MAX_ACTIVE_STATES:
             return
 
         self._pending_map: dict[UUID, str] = {}

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -200,6 +200,10 @@ class StateManager:
         """
         Remove a state from the stack by its name.
 
+        If the specified state is currently active (i.e., at the top of the stack),
+        it will be popped using `pop_current_state()` to ensure proper resumption
+        of the previous state. Otherwise, it will be removed directly from the stack.
+
         Parameters:
             state_name: The name of the state to remove.
         """
@@ -210,9 +214,15 @@ class StateManager:
             return
 
         for state in matches:
-            logger.debug(f"Removing state: {state.name}")
-            self.state_stack.remove(state)
-            state.shutdown()
+            if state == self.state_stack.current():
+                logger.info(
+                    f"State '{state_name}' is currently active. Automatically popping instead of removing."
+                )
+                self.pop_current_state()
+            else:
+                logger.debug(f"Removing state: {state.name}")
+                self.state_stack.remove(state)
+                state.shutdown()
 
     @overload
     def push_state(

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -82,6 +82,7 @@ class CombatAnimations(Menu[None], ABC):
         self.hud_manager = CombatLayoutManager(_layout)
         self.status_icons = StatusIconManager(self, _layout, self.hud_manager)
         self.combat_zone = CombatZone(prepare.SCREEN_RECT)
+        self.background_sprite: Optional[Sprite] = None
 
     def draw(self, surface: Surface) -> None:
         """
@@ -592,8 +593,6 @@ class CombatAnimations(Menu[None], ABC):
                 dev.animate_capture(animate)
 
     def update_background(self, bg_path: str) -> None:
-        import pygame
-
         # Clear old
         if hasattr(self, "background_sprite") and self.background_sprite:
             if self.background_sprite in self.sprites:
@@ -606,7 +605,7 @@ class CombatAnimations(Menu[None], ABC):
         # Create a full-screen surface (black by default)
         full_height = prepare.SCREEN_RECT.height
         full_width = prepare.SCREEN_RECT.width
-        full_surf = pygame.Surface((full_width, full_height))
+        full_surf = Surface((full_width, full_height))
         full_surf.fill((0, 0, 0))  # fill rest with black
 
         # Blit background onto the top of the full surface
@@ -614,13 +613,13 @@ class CombatAnimations(Menu[None], ABC):
 
         # Extend last row of background downward to fill gap
         last_row = surf.subsurface(
-            pygame.Rect(0, surf.get_height() - 1, surf.get_width(), 1)
+            Rect(0, surf.get_height() - 1, surf.get_width(), 1)
         )
         for y in range(surf.get_height(), full_height):
             full_surf.blit(last_row, (0, y))
 
         # Wrap in sprite
-        spr = pygame.sprite.Sprite()
+        spr = Sprite()
         spr.image = full_surf
         spr.rect = full_surf.get_rect()
         spr.rect.topleft = (0, 0)

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os  # make sure this is at the top of your file if not already
 from collections import defaultdict
 from collections.abc import Callable, Generator
 from functools import partial
@@ -22,6 +21,7 @@ from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu, PopUpMenu
 from tuxemon.monster import Monster
+from tuxemon.sprite import Sprite
 from tuxemon.states.item_menu import ItemMenuState
 from tuxemon.states.monster_menu import MonsterMenuState
 from tuxemon.technique.technique import Technique
@@ -79,6 +79,11 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         message = T.format("combat_monster_choice", params)
         self.combat.dialog.alert(message)
 
+        self.type_icon_sprites: list[Sprite] = []
+        self.text_sprites: dict[str, Sprite] = {}
+        self.range_icon_sprite: Optional[Sprite] = None
+        self.speed_icon_sprite: Optional[Sprite] = None
+
     def _clear_tech_overlay(self) -> None:
         """Remove technique icons/text from the overlay."""
         if hasattr(self, "range_icon_sprite") and self.range_icon_sprite:
@@ -95,13 +100,11 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             for spr in self.type_icon_sprites:
                 if spr in self.sprites:
                     self.sprites.remove(spr)
-        self.type_icon_sprites = []
 
         if hasattr(self, "text_sprites"):
             for spr in self.text_sprites.values():
                 if spr in self.sprites:
                     self.sprites.remove(spr)
-        self.text_sprites = {}
 
     def calculate_menu_rectangle(self) -> Rect:
         rect_screen = prepare.SCREEN_RECT.copy()
@@ -335,14 +338,10 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             menu.on_menu_selection = choose_target  # type: ignore[assignment]
 
             def show() -> None:
-                import pygame
-
-                from tuxemon.tools import fix_measure
-
                 # Clear the combat dialog so the old "What will X do?" text disappears
                 self.combat.dialog.alert("", dialog_speed="max")
 
-                screen_w, screen_h = self.client.screen.get_size()
+                screen_w, screen_h = prepare.SCREEN_SIZE
 
                 # --- Clear old sprites if they exist ---
                 if (
@@ -386,7 +385,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                             icon_surface = graphics.load_and_scale(
                                 path, prepare.SCALE
                             )
-                            spr = pygame.sprite.Sprite()
+                            spr = Sprite()
                             spr.image = icon_surface
                             spr.rect = spr.image.get_rect()
 
@@ -412,7 +411,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
                     try:
                         surf = graphics.load_and_scale(path, prepare.SCALE)
-                        spr = pygame.sprite.Sprite()
+                        spr = Sprite()
                         spr.image = surf
                         spr.rect = surf.get_rect()
                         spr.rect.topleft = (
@@ -445,7 +444,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     path = f"gfx/ui/icons/speed/{speed_val}.png"
                     try:
                         surf = graphics.load_and_scale(path, prepare.SCALE)
-                        spr = pygame.sprite.Sprite()
+                        spr = Sprite()
                         spr.image = surf
                         spr.rect = surf.get_rect()
                         spr.rect.topleft = (
@@ -474,7 +473,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
                 for key, line in text_lines.items():
                     surf = font.render(line, True, (0, 0, 0))  # black text
-                    spr = pygame.sprite.Sprite()
+                    spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
 

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -11,7 +11,7 @@ from pygame_menu.widgets.widget.label import Label
 from pygame_menu.widgets.widget.progressbar import ProgressBar
 
 from tuxemon import prepare
-from tuxemon.db import MonsterModel, db
+from tuxemon.db import MonsterModel, SpeedLabel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons
@@ -39,6 +39,14 @@ class MonsterMovesState(PygameMenuState):
     """
 
     name: ClassVar[str] = "MonsterMovesState"
+    description_label: Optional[Any] = None
+    info_label: Optional[Any] = None
+    bar_accuracy: Optional[ProgressBar] = None
+    bar_potency: Optional[ProgressBar] = None
+    power_label: Optional[Any] = None
+    range_icon_widget: Optional[Any] = None
+    speed_icon_widget: Optional[Any] = None
+    type_icon_widgets: list[Any] = []
 
     # -------------------------
     # Top section (static per monster)
@@ -291,30 +299,14 @@ class MonsterMovesState(PygameMenuState):
             self.range_icon_widget.translate(fxw(4 / 256), fxh(86.8 / 144))
 
         # Speed icon
-        if getattr(technique, "speed", None) is not None:
-            # Normalize speed into filename
-            speed = technique.speed
-            if hasattr(speed, "value"):  # enum-like
-                speed_key = speed.value
-            elif isinstance(speed, int):  # numeric
-                mapping = {
-                    -3: "extremely_slow",
-                    -2: "very_slow",
-                    -1: "slow",
-                    0: "normal",
-                    1: "fast",
-                    2: "very_fast",
-                    3: "extremely_fast",
-                }
-                speed_key = mapping.get(speed, "normal")
-            else:
-                speed_key = str(speed).lower()
+        speed_label = SpeedLabel.from_numeric(technique.speed)
+        speed_key = speed_label.value
 
-            spath = f"gfx/ui/icons/speed/{speed_key}.png"
-            simg = self._create_image(spath)
-            simg.scale(prepare.SCALE, prepare.SCALE)
-            self.speed_icon_widget = menu.add.image(simg.copy(), float=True)
-            self.speed_icon_widget.translate(fxw(222 / 256), fxh(51.8 / 144))
+        spath = f"gfx/ui/icons/speed/{speed_key}.png"
+        simg = self._create_image(spath)
+        simg.scale(prepare.SCALE, prepare.SCALE)
+        self.speed_icon_widget = menu.add.image(simg.copy(), float=True)
+        self.speed_icon_widget.translate(fxw(222 / 256), fxh(51.8 / 144))
 
     # -------- power label ----------
     def _add_power_label(
@@ -349,17 +341,6 @@ class MonsterMovesState(PygameMenuState):
     def __init__(self, **kwargs: Any) -> None:
         if not lookup_cache:
             _lookup_monsters()
-
-        # Instance attributes used by helpers
-        self.description_label: Optional[Label] = None
-        self.info_label: Optional[Label] = None
-        self.bar_accuracy: Optional[ProgressBar] = None
-        self.bar_potency: Optional[ProgressBar] = None
-        self.power_label: Optional[Label] = None
-
-        self.range_icon_widget: Optional[Any] = None
-        self.speed_icon_widget: Optional[Any] = None
-        self.type_icon_widgets: list[Any] = []
 
         monster: Optional[Monster] = None
         source = ""


### PR DESCRIPTION
PR resolves several type hint inconsistencies and incorrect imports introduced during the last merge. Specifically, it replaces references to `pygame.sprite.Sprite()` with the correct internal `Sprite` class. Additionally, newly introduced fields have been explicitly defined in the `__init__` method to ensure proper type checking and initialization.

The `remove_state_by_name()` method has also been enhanced to automatically pop the state if it's currently active, ensuring proper resumption of the previous state. This prevents issues where removing the top state could interrupt game flow, such as freezing movement or input. Fixes #3172