### PR TITLE
Refactor `NuPhoneContacts` to Support Conditional Dialogue and Dynamic Call Logic

### DIFF
--- a/mods/phone_calls.yaml
+++ b/mods/phone_calls.yaml
@@ -1,0 +1,60 @@
+# PHONE_CALLS_DATA structure for NPC interactions via NuPhone.
+# Each NPC (e.g., npc_example) defines how phone calls behave based on game state.
+# The system checks each entry in 'conditional_calls' in order. The first matching
+# condition is used.
+# If no conditions match, the 'default' dialogue is used.
+
+npc_example:
+  conditional_calls:
+    # --- CONDITION 1 ---
+    # This call will trigger if:
+    # - The player is currently on the map "spyder_candy_town"
+    # - AND the game variable 'quest_maple_start' is set to the string "yes"
+    # Notes:
+    # - Both 'map_slug' and 'variables' are optional, but at least one must be present.
+    # - 'variables' is a dictionary of key-value pairs that must match exactly.
+    # - Dialogue is a list of message IDs that will be shown in order.
+    - conditions:
+        map_slug: "spyder_candy_town"
+        variables: 
+          quest_maple_start: "yes"
+      dialogue: 
+        - "maple_dialogue_quest_update_1"
+        - "maple_dialogue_quest_update_2"
+
+    # --- CONDITION 2 ---
+    # This call will trigger if:
+    # - The player is on the map "spyder_cotton_town"
+    # Notes:
+    # - Only 'map_slug' is used here; 'variables' is omitted.
+    # - If this condition matches, the specified dialogue will be used.
+    - conditions:
+        map_slug: "spyder_cotton_town"
+      dialogue:
+        - "maple_dialogue_local_greeting"
+
+    # --- CONDITION 3 ---
+    # This call will trigger if:
+    # - The game variable 'flag_maple_met' is set to True
+    # Notes:
+    # - Only 'variables' is used here; 'map_slug' is omitted.
+    # - Useful for general conditions not tied to location.
+    - conditions:
+        variables: 
+          flag_maple_met: True
+      dialogue:
+        - "maple_dialogue_general_greeting"
+
+  # --- DEFAULT ---
+  # This dialogue is used if none of the above conditions match.
+  # Notes:
+  # - 'default' must always be present to ensure fallback behavior.
+  # - Dialogue should be a list, even if it contains only one message ID.
+  default:
+    dialogue: ["phone_no_answer"]
+
+# --- CALLS ---
+
+spyder_papertown_mom:
+  default:
+    dialogue: ["phone_no_answer"]

--- a/tuxemon/states/phone.py
+++ b/tuxemon/states/phone.py
@@ -21,8 +21,6 @@ from tuxemon.tools import fix_measure, open_dialog
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
-MenuGameObj = Callable[[], Any]
-
 
 class NuPhone(PygameMenuState):
     """Menu for Nu Phone."""

--- a/tuxemon/states/phone_banking.py
+++ b/tuxemon/states/phone_banking.py
@@ -2,9 +2,8 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import pygame_menu
 from pygame_menu import locals
@@ -19,8 +18,6 @@ from tuxemon.ui.menu_options import ChoiceOption, MenuOptions
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
-
-MenuGameObj = Callable[[], Any]
 
 
 class NuPhoneBanking(PygameMenuState):

--- a/tuxemon/states/phone_contacts.py
+++ b/tuxemon/states/phone_contacts.py
@@ -2,15 +2,18 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Callable
+import logging
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import pygame_menu
+import yaml
 from pygame_menu import locals
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon import prepare
+from tuxemon.constants import paths
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.relationship import RELATIONSHIP_STRENGTH
@@ -20,65 +23,142 @@ from tuxemon.ui.menu_options import ChoiceOption, MenuOptions
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
-MenuGameObj = Callable[[], Any]
+logger = logging.getLogger(__name__)
+
+
+def load_yaml(filepath: Path) -> Any:
+    try:
+        with filepath.open() as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:
+        logger.error(f"Config file not found: {filepath}")
+        raise
+    except yaml.YAMLError as exc:
+        logger.error(f"Error parsing YAML file: {exc}")
+        raise exc
+
+
+class Loader:
+    _phone_calls_data: Optional[dict[str, Any]] = None
+
+    @classmethod
+    def get_phone_calls_data(cls, filename: str) -> dict[str, Any]:
+        yaml_path = paths.mods_folder / filename
+        if not cls._phone_calls_data:
+            raw_data = load_yaml(yaml_path)
+            if not isinstance(raw_data, dict):
+                raise ValueError("Invalid YAML data for phone calls")
+            cls._phone_calls_data = raw_data
+        return cls._phone_calls_data
+
+
+PHONE_CALLS_DATA = Loader.get_phone_calls_data("phone_calls.yaml")
 
 
 class NuPhoneContacts(PygameMenuState):
     name: ClassVar[str] = "NuPhoneContacts"
 
+    _current_call_slug: str = ""
+
+    def _check_conditions(self, conditions: dict[str, Any]) -> bool:
+        """
+        Check if the required conditions (location and variables) are met.
+        """
+        required_map_slug = conditions.get("map_slug")
+        if required_map_slug:
+            current_map_slug = self.client.get_map_name().split(".")[0]
+            if current_map_slug != required_map_slug:
+                return False
+
+        required_vars = conditions.get("variables")
+        if required_vars:
+            game_vars = self.char.game_variables
+            for var_name, expected_value in required_vars.items():
+                if game_vars.get(var_name) != expected_value:
+                    return False
+
+        return True
+
+    def _start_call(self) -> None:
+        """Handles the actual phone call logic based on dynamic data."""
+        slug = self._current_call_slug
+        self.client.remove_state_by_name("ChoiceState")
+
+        print(slug)
+        npc_calls = PHONE_CALLS_DATA.get(slug, {})
+
+        dialogue_msgids: list[str] = ["phone_no_answer"]
+
+        conditional_calls = npc_calls.get("conditional_calls", [])
+        for call in conditional_calls:
+            conditions = call.get("conditions", {})
+            if self._check_conditions(conditions):
+                dialogue_msgids = call.get("dialogue", ["phone_no_answer"])
+                break
+        else:
+            dialogue_msgids = npc_calls.get(
+                "default", {"dialogue": ["phone_no_answer"]}
+            ).get("dialogue")
+
+        dialogue_text = [T.translate(msgid) for msgid in dialogue_msgids]
+
+        open_dialog(
+            self.client,
+            dialogue_text,
+        )
+
+    def choice(self, slug: str) -> None:
+        """Opens the choice dialog to confirm the call."""
+        self._current_call_slug = slug
+        label = f"{T.translate('action_call')} {T.translate(slug).upper()}"
+
+        option = ChoiceOption(
+            key=slug, display_text=label, action=self._start_call
+        )
+
+        open_choice_dialog(
+            self.client,
+            menu=MenuOptions([option]),
+            escape_key_exits=True,
+        )
+
     def add_menu_items(
         self,
         menu: pygame_menu.Menu,
     ) -> None:
-        def choice(slug: str) -> None:
-            label = f"{T.translate('action_call')} {T.translate(slug).upper()}"
 
-            option = ChoiceOption(key=slug, display_text=label, action=call)
+        T_RELATIONSHIP = T.translate("relation_relationship")
+        T_STRENGTH = T.translate("relation_strength")
+        MAX_STRENGTH = RELATIONSHIP_STRENGTH[1]
 
-            open_choice_dialog(
-                self.client,
-                menu=MenuOptions([option]),
-                escape_key_exits=True,
-            )
-
-        def call() -> None:
-            self.client.remove_state_by_name("ChoiceState")
-            self.client.remove_state_by_name("NuPhoneContacts")
-            # from spyder_cotton_town.tmx to spyder_cotton_town
-            map = self.client.get_map_name()
-            map_name = map.split(".")[0]
-            if T.translate(map_name) != map_name:
-                open_dialog(
-                    self.client,
-                    [T.translate(map_name)],
-                )
-            else:
-                open_dialog(
-                    self.client,
-                    [T.translate("phone_no_answer")],
-                )
-
-        # slug and phone number from the tuple
         connections = self.char.relationships.get_all_connections()
         for slug, contact in connections.items():
+
             menu.add.button(
                 title=T.translate(slug),
-                action=partial(choice, slug),
+                action=partial(self.choice, slug),
                 font_size=self.font_type.small,
                 selection_effect=HighlightSelection(),
             )
-            relationship = T.translate(f"relation_relationship")
-            relation = T.translate(f"relation_{contact.relationship_type}")
-            menu.add.label(
-                title=f"{relationship}: {relation}",
-                font_size=self.font_type.small,
+
+            # Relationship Type Label
+            relation_type = T.translate(
+                f"relation_{contact.relationship_type}"
             )
-            relation_strength = T.translate(f"relation_strength")
             menu.add.label(
-                title=f"{relation_strength}: {contact.strength}/{RELATIONSHIP_STRENGTH[1]}",
+                title=f"{T_RELATIONSHIP}: {relation_type}",
                 font_size=self.font_type.small,
+                padding=(5, 0, 5, 0),
             )
-            menu.add.vertical_margin(25)
+
+            # Relationship Strength Label
+            menu.add.label(
+                title=f"{T_STRENGTH}: {contact.strength}/{MAX_STRENGTH}",
+                font_size=self.font_type.small,
+                padding=(5, 0, 5, 0),
+            )
+
+            menu.add.vertical_margin(15)
 
         # menu
         menu.set_title(T.translate("app_contacts")).center_content()
@@ -89,19 +169,17 @@ class NuPhoneContacts(PygameMenuState):
         theme = self._setup_theme(prepare.BG_PHONE_CONTACTS)
         theme.scrollarea_position = locals.POSITION_EAST
         theme.widget_alignment = locals.ALIGN_CENTER
-
-        # menu
         theme.title = True
 
         self.char = character
+
+        for relation in self.char.relationships.connections.values():
+            relation.apply_decay(self.char)
 
         super().__init__(
             height=height,
             width=width,
         )
-
-        for relation in self.char.relationships.connections.values():
-            relation.apply_decay(self.char)
 
         self.add_menu_items(self.menu)
         self.reset_theme()

--- a/tuxemon/states/phone_map.py
+++ b/tuxemon/states/phone_map.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
@@ -21,7 +20,6 @@ from tuxemon.tools import fix_measure
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
-MenuGameObj = Callable[[], Any]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PR refactors the `NuPhoneContacts` menu system to support more flexible and context-aware phone call interactions with NPCs. The previous implementation relied solely on map name translation to determine call outcomes. The new version introduces structured call logic based on game state conditions and external data.

Key changes:
- replaced hardcoded map translation logic with a dynamic call system using `PHONE_CALLS_DATA`
- introduced `_check_conditions()` method to evaluate map and variable-based conditions for each NPC
- added `_start_call()` method to handle dialogue selection based on matched conditions
- updated `choice()` to store the selected NPC slug and trigger a confirmation dialog before initiating the call
- improved fallback behavior by using default dialogue when no conditions match
- preserved relationship display (type and strength) in the contact list
- ensured compatibility with existing UI styling and menu layout