### PR TITLE
NuPhone: `app_radio` Added and Dialog Completion Hook

### DIFF
--- a/mods/radio_data.yaml
+++ b/mods/radio_data.yaml
@@ -1,0 +1,129 @@
+# ------------------------------------------------------------------------------------
+# RADIO_DATA
+# ------------------------------------------------------------------------------------
+# This section defines the content and behavior of each radio station in the game.
+#
+# Keys:
+#   - Each key represents a unique station slug (e.g., "station_news_88_3").
+#   - These slugs must match those listed in RADIO_MAP_LISTS to be accessible.
+#
+# Values:
+#   - Each station can define:
+#       - `default`: A fallback broadcast used when no conditions are met.
+#       - `conditional_broadcasts`: A prioritized list of broadcasts triggered by
+#         specific game conditions (e.g., quest progress, time of day, location).
+#       - `frequency`: (Optional) A float value representing the station's FM frequency
+#         in MHz. Used by the tuner interface to match stations based on dial position.
+#
+# Conditional Broadcasts:
+#   - Each broadcast includes:
+#       - `conditions`: A dictionary of game variables (and optionally map_slugs)
+#         that must match for the broadcast to trigger.
+#       - `dialogue`: A list of message IDs to display.
+#       - `set_variables`: Optional variables to update after the broadcast.
+#
+# Notes:
+#   - Broadcasts are evaluated in order; the first matching one is used.
+#   - If no conditions match, the `default` dialogue is used.
+#   - This structure allows dynamic storytelling and reactive radio content.
+#   - Stations without a `frequency` will not be accessible via the tuner interface.
+#
+# Example station definition:
+#
+# station_example:
+#   frequency: 88.3
+#   conditional_broadcasts:
+#     - conditions:
+#         variables: 
+#           quest_maple_delivered: True
+#           broadcast_q1_news_heard: False
+#       dialogue: 
+#         - "radio_news_breaking_report_q1"
+#         - "radio_news_report_q1_details"
+#       set_variables:
+#         broadcast_q1_news_heard: True
+#
+#     - conditions:
+#         variables: 
+#           is_night: True
+#       dialogue:
+#         - "radio_news_late_night_report"
+#
+#   default:
+#     dialogue: ["radio_news_standard_report_msgid"]
+# ------------------------------------------------------------------------------------
+
+station_scrambled_frequency:
+  default:
+    dialogue: ["radio_static_msgid"]
+
+station_route_rhythms:
+  frequency: 94.7
+  conditional_broadcasts:
+    # Bedroom broadcasts
+    - conditions:
+        map_slugs: ["spyder_paper_rival_bedroom"]
+        variables:
+          stage_of_day: "morning"
+      dialogue:
+        - "spyder_rivalbedroom_radio_morning"
+
+    - conditions:
+        map_slugs: ["spyder_paper_rival_bedroom"]
+        variables:
+          stage_of_day: "afternoon"
+      dialogue:
+        - "spyder_rivalbedroom_radio_afternoon"
+
+    - conditions:
+        map_slugs: ["spyder_paper_rival_bedroom"]
+        variables:
+          stage_of_day: "dusk"
+      dialogue:
+        - "spyder_rivalbedroom_radio_dusk"
+
+    - conditions:
+        map_slugs: ["spyder_paper_rival_bedroom"]
+        variables:
+          stage_of_day: "dawn"
+      dialogue:
+        - "spyder_rivalbedroom_radio_dawn"
+
+    - conditions:
+        map_slugs: ["spyder_paper_rival_bedroom"]
+        variables:
+          stage_of_day: "night"
+      dialogue:
+        - "spyder_rivalbedroom_radio_night"
+
+    # Leather house broadcasts
+    - conditions:
+        map_slugs: ["spyder_leather_house1"]
+        variables:
+          stage_of_day: "morning"
+      dialogue:
+        - "spyder_leatherhouse1_radio_morning"
+
+    - conditions:
+        map_slugs: ["spyder_leather_house1"]
+        variables:
+          stage_of_day: "dusk"
+      dialogue:
+        - "spyder_leatherhouse1_radio_dusk"
+
+    - conditions:
+        map_slugs: ["spyder_leather_house1"]
+        variables:
+          stage_of_day: "dawn"
+      dialogue:
+        - "spyder_leatherhouse1_radio_dawn"
+
+    - conditions:
+        map_slugs: ["spyder_leather_house1"]
+        variables:
+          stage_of_day: "night"
+      dialogue:
+        - "spyder_leatherhouse1_radio_night"
+
+  default:
+    dialogue: ["radio_static_msgid"]

--- a/mods/radio_map_lists.yaml
+++ b/mods/radio_map_lists.yaml
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------------------------
+# RADIO_MAP_LISTS
+# ------------------------------------------------------------------------------------
+# This section defines which radio stations are available in each map region.
+# 
+# Keys:
+#   - Each key represents a map slug (e.g., "map_spyder_cotton_town").
+#   - The special key "all_maps" lists stations available globally across all maps.
+#
+# Values:
+#   - Each value is a list of station slugs (e.g., "station_news_88_3").
+#   - These slugs must correspond to entries in the RADIO_DATA section.
+#
+# Notes:
+#   - Map-specific stations override or extend the global list.
+#   - If a map does not have a specific entry, the system falls back to "all_maps".
+#   - This structure allows dynamic station availability based on player location.
+# ------------------------------------------------------------------------------------
+
+all_maps:
+  - station_scrambled_frequency # Always available (static noise fallback)
+
+spyder_paper_rival_bedroom:
+  - station_route_rhythms
+
+spyder_leather_house1:
+  - station_route_rhythms

--- a/mods/tuxemon/db/item/app_radio.json
+++ b/mods/tuxemon/db/item/app_radio.json
@@ -1,0 +1,24 @@
+{
+  "effects": [],
+  "slug": "app_radio",
+  "sort": "utility",
+  "sprite": "gfx/items/app_contacts.png",
+  "category": "phone",
+  "usable_in": [
+    "WorldState"
+  ],
+  "modifiers": [],
+  "behaviors": {
+    "consumable": false,
+    "visible": false
+  },
+  "dynamic_menu": {
+    "position": 4,
+    "label_key": "app_radio",
+    "menu_type": "phone",
+    "state": "NuPhoneRadioMenu"
+  },
+  "use_failure": "generic_failure",
+  "use_item": "combat_used_x",
+  "use_success": "generic_success"
+}

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -426,6 +426,12 @@ msgid "spyder_pass_description"
 msgstr ""
 "This should let you in to places only Spyder conspirators are meant to go."
 
+msgid "app_radio"
+msgstr "Radio App"
+
+msgid "app_radio_description"
+msgstr "Tune in to local broadcasts, quest updates, and ambient chatter from across the region."
+
 msgid "app_banking"
 msgstr "Bank App"
 
@@ -1464,6 +1470,52 @@ msgstr ""
 "Room 31, Block 2, Omnichannel Tower, Cotton Town\n"
 "\n"
 "There's a kiss mark next to the address"
+
+# Radio
+msgid "radio_no_signal"
+msgstr "No signal. Try tuning in from another location."
+
+msgid "radio_station_list_header"
+msgstr "List of Available Stations"
+
+msgid "station_scrambled_frequency"
+msgstr "Scrambled Frequency"
+
+msgid "station_route_rhythms"
+msgstr "Route 101 Rhythms"
+
+msgid "radio_static_msgid"
+msgstr "The signal fades into static..."
+
+msgid "radio_tuner"
+msgstr "Tuner"
+
+msgid "app_radio_tuner"
+msgstr "Radio Tuner"
+
+msgid "radio_tuning_static"
+msgstr "The signal is full of static..."
+
+msgid "signal_strong"
+msgstr "Strong"
+
+msgid "signal_moderate"
+msgstr "Moderate"
+
+msgid "signal_weak"
+msgstr "Weak"
+
+msgid "signal_none"
+msgstr "No Signal"
+
+msgid "radio_play_button"
+msgstr "Play Radio"
+
+msgid "radio_tuner_hint"
+msgstr "Slide to tune into stations"
+
+msgid "radio_signal_strength"
+msgstr "Signal Strength"
 
 # Money notification
 msgid "player_wallet"

--- a/mods/tuxemon/maps/spyder_leather_house1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house1.tmx
@@ -62,44 +62,11 @@
     <property name="behav1" value="talk spyder_leatherhouse1_gail"/>
    </properties>
   </object>
-  <object id="15" name="Radio Dawn" type="event" x="112" y="80" width="16" height="32">
+  <object id="17" name="Radio" type="event" x="112" y="80" width="16" height="32">
    <properties>
-    <property name="act1" value="translated_dialog spyder_leatherhouse1_radio_dawn"/>
+    <property name="act1" value="tune_radio player,94.7"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is variable_set stage_of_day:dawn"/>
-   </properties>
-  </object>
-  <object id="16" name="Radio Dusk" type="event" x="112" y="80" width="16" height="32">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leatherhouse1_radio_dusk"/>
-    <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is variable_set stage_of_day:dusk"/>
-   </properties>
-  </object>
-  <object id="17" name="Radio Afternoon" type="event" x="112" y="80" width="16" height="32">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leatherhouse1_radio"/>
-    <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is variable_set stage_of_day:afternoon"/>
-   </properties>
-  </object>
-  <object id="18" name="Radio Night" type="event" x="112" y="80" width="16" height="32">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leatherhouse1_radio_night"/>
-    <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is variable_set stage_of_day:night"/>
-   </properties>
-  </object>
-  <object id="27" name="Radio Morning" type="event" x="112" y="80" width="16" height="32">
-   <properties>
-    <property name="act1" value="translated_dialog spyder_leatherhouse1_radio_morning"/>
-    <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="is variable_set stage_of_day:morning"/>
    </properties>
   </object>
   <object id="28" name="Create Tennis Player" type="event" x="144" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
@@ -31,53 +31,12 @@ events:
     type: event
     x: 0
     y: 3
-  Radio Afternoon:
+  Radio:
     actions:
-    - translated_dialog spyder_rivalbedroom_radio_afternoon
+    - tune_radio player,94.7
     conditions:
     - is char_facing_tile player
     - is button_pressed K_RETURN
-    - is variable_set stage_of_day:afternoon
-    type: event
-    x: 0
-    y: 5
-  Radio Dawn:
-    actions:
-    - translated_dialog spyder_rivalbedroom_radio_dawn
-    conditions:
-    - is char_facing_tile player
-    - is button_pressed K_RETURN
-    - is variable_set stage_of_day:dawn
-    type: event
-    x: 0
-    y: 5
-  Radio Dusk:
-    actions:
-    - translated_dialog spyder_rivalbedroom_radio_dusk
-    conditions:
-    - is char_facing_tile player
-    - is button_pressed K_RETURN
-    - is variable_set stage_of_day:dusk
-    type: event
-    x: 0
-    y: 5
-  Radio Morning:
-    actions:
-    - translated_dialog spyder_rivalbedroom_radio_morning
-    conditions:
-    - is char_facing_tile player
-    - is button_pressed K_RETURN
-    - is variable_set stage_of_day:morning
-    type: event
-    x: 0
-    y: 5
-  Radio Night:
-    actions:
-    - translated_dialog spyder_rivalbedroom_radio_night
-    conditions:
-    - is char_facing_tile player
-    - is button_pressed K_RETURN
-    - is variable_set stage_of_day:night
     type: event
     x: 0
     y: 5

--- a/tuxemon/event/actions/tune_radio.py
+++ b/tuxemon/event/actions/tune_radio.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, final
+
+from tuxemon.event import get_npc
+from tuxemon.event.eventaction import EventAction
+from tuxemon.session import Session
+from tuxemon.states.phone_radio import MAX_FREQ, MIN_FREQ
+
+logger = logging.getLogger()
+
+
+@final
+@dataclass
+class TuneRadioAction(EventAction):
+    """
+    Launches the NuPhoneRadio interface for a given character, optionally tuned
+    to a specific frequency.
+
+    This action transitions the game into a radio interface state, allowing the
+    player to access broadcasts associated with a specific NPC. It can launch
+    either the standard radio menu or the tuner interface, depending on whether
+    a frequency is provided.
+
+    This is typically used in scripted events to simulate tuning into a radio
+    station from a character's perspective or location, enabling dynamic
+    storytelling and immersive audio experiences.
+
+    Script usage:
+        .. code-block::
+
+            tune_radio <character_slug>
+            tune_radio <character_slug>[,frequency]
+
+    Script parameters:
+        character_slug: The slug of the character (NPC) whose context will be
+            used to determine available radio stations and broadcasts.
+        frequency: If provided, launches the tuner interface and attempts to
+            tune directly to the specified frequency (in MHz). If omitted, the
+            standard radio menu is shown instead.
+    """
+
+    name = "tune_radio"
+    character_slug: str
+    frequency: Optional[float] = None
+
+    def start(self, session: Session) -> None:
+        self.session = session
+        self.client = session.client
+
+        if self.client.current_state is None:
+            raise RuntimeError("No current state active. This is unexpected.")
+
+        if self.client.current_state.name in {
+            "NuPhoneRadioMenu",
+            "NuPhoneRadioTuner",
+        }:
+            logger.error(
+                f"The state '{self.client.current_state.name}' is already active. No action taken."
+            )
+            return
+
+        character = get_npc(self.session, self.character_slug)
+        if character is None:
+            logger.error(
+                f"Character '{self.character_slug}' not found for radio tuning."
+            )
+            return
+
+        if self.frequency is not None:
+            if not (MIN_FREQ <= self.frequency <= MAX_FREQ):
+                logger.error(
+                    f"Frequency {self.frequency} is out of FM range {MIN_FREQ}-{MAX_FREQ}."
+                )
+                return
+
+            self.client.push_state(
+                "NuPhoneRadioTuner",
+                character=character,
+                frequency=self.frequency,
+            )
+        else:
+            self.client.push_state("NuPhoneRadioMenu", character=character)
+
+    def update(self, session: Session) -> None:
+        if not any(
+            state.name in {"NuPhoneRadioMenu", "NuPhoneRadioTuner"}
+            for state in session.client.active_states
+        ):
+            self.stop()

--- a/tuxemon/game_variables.py
+++ b/tuxemon/game_variables.py
@@ -54,6 +54,16 @@ class ScopeVariablesManager:
             self._variables.update(data)
             self._dirty = True
 
+    def update(self, data: dict[str, Any]) -> None:
+        """
+        Update multiple variables at once. Marks the manager as dirty
+        if any value changes or new keys are added.
+        """
+        for key, value in data.items():
+            if self._variables.get(key) != value:
+                self._variables[key] = value
+                self._dirty = True
+
     def is_dirty(self) -> bool:
         return self._dirty
 

--- a/tuxemon/states/dialog_state.py
+++ b/tuxemon/states/dialog_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from tuxemon.graphics import load_and_scale
@@ -39,11 +39,13 @@ class DialogState(PopUpMenu[None]):
         text: Sequence[str] = (),
         avatar: Optional[Sprite] = None,
         box_style: Optional[dict[str, Any]] = None,
+        on_complete: Optional[Callable[[], None]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.text_queue = list(text)
         self.avatar = avatar
+        self.on_complete = on_complete
 
         default_box_style: dict[str, Any] = {
             "bg_color": self.background_color,
@@ -103,4 +105,6 @@ class DialogState(PopUpMenu[None]):
             return text
         except IndexError:
             self.client.pop_state(self)
+            if self.on_complete:
+                self.on_complete()
             return None

--- a/tuxemon/states/phone_radio.py
+++ b/tuxemon/states/phone_radio.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
+
+import pygame_menu
+import yaml
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+
+from tuxemon import prepare
+from tuxemon.constants import paths
+from tuxemon.locale import T
+from tuxemon.menu.menu import PygameMenuState
+from tuxemon.tools import open_dialog
+
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+
+logger = logging.getLogger(__name__)
+
+MIN_FREQ = 88.0
+MAX_FREQ = 108.0
+INITIAL_FREQ = 98.0
+TUNING_TOLERANCE = 0.2
+
+
+def load_yaml(filepath: Path) -> Any:
+    try:
+        with filepath.open() as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:
+        logger.error(f"Config file not found: {filepath}")
+        raise
+    except yaml.YAMLError as exc:
+        logger.error(f"Error parsing YAML file: {exc}")
+        raise exc
+
+
+class Loader:
+    _radio_map_lists: Optional[dict[str, Any]] = None
+    _radio_data: Optional[dict[str, Any]] = None
+
+    @classmethod
+    def get_radio_map_lists(
+        cls, filename: str = "radio_map_lists.yaml"
+    ) -> dict[str, Any]:
+        yaml_path = paths.mods_folder / filename
+        if not cls._radio_map_lists:
+            raw_data = load_yaml(yaml_path)
+            if not isinstance(raw_data, dict):
+                raise ValueError("Invalid YAML data for radio map lists")
+            cls._radio_map_lists = raw_data
+        return cls._radio_map_lists
+
+    @classmethod
+    def get_radio_data(
+        cls, filename: str = "radio_data.yaml"
+    ) -> dict[str, Any]:
+        yaml_path = paths.mods_folder / filename
+        if not cls._radio_data:
+            raw_data = load_yaml(yaml_path)
+            if not isinstance(raw_data, dict):
+                raise ValueError("Invalid YAML data for radio station data")
+            cls._radio_data = raw_data
+        return cls._radio_data
+
+
+RADIO_MAP_LISTS = Loader.get_radio_map_lists()
+RADIO_DATA = Loader.get_radio_data()
+
+
+def _check_conditions(
+    radio_state: NuPhoneRadioBase, conditions: dict[str, Any]
+) -> bool:
+    """Checks if the required conditions (map_slugs and variables) are met."""
+    required_map_slug = conditions.get("map_slugs")
+    if required_map_slug:
+        current_map_slug = radio_state.client.get_map_name().split(".")[0]
+        required_map_slug = (
+            [required_map_slug]
+            if not isinstance(required_map_slug, list)
+            else required_map_slug
+        )
+        if current_map_slug not in required_map_slug:
+            return False
+
+    required_vars = conditions.get("variables")
+    if required_vars:
+        game_vars = radio_state.char.game_variables
+        for var_name, expected_value in required_vars.items():
+            if game_vars.get(var_name) != expected_value:
+                return False
+    return True
+
+
+def _get_broadcast_content(
+    radio_state: NuPhoneRadioBase, station_slug: str
+) -> tuple[list[str], Optional[dict[str, Any]]]:
+    """Finds the correct dialogue and variables to set for a given station slug."""
+    station_content = RADIO_DATA.get(station_slug, {})
+    ULTIMATE_FALLBACK_DIALOGUE = ["radio_static_msgid"]
+
+    default_broadcast = station_content.get(
+        "default", {"dialogue": ULTIMATE_FALLBACK_DIALOGUE}
+    )
+
+    dialogue_msgids: list[str] = default_broadcast.get(
+        "dialogue", ULTIMATE_FALLBACK_DIALOGUE
+    )
+    set_variables: Optional[dict[str, Any]] = None
+
+    conditional_broadcasts = station_content.get("conditional_broadcasts", [])
+
+    for broadcast in conditional_broadcasts:
+        conditions = broadcast.get("conditions", {})
+        if _check_conditions(radio_state, conditions):
+            dialogue_msgids = broadcast.get("dialogue", dialogue_msgids)
+            set_variables = broadcast.get("set_variables")
+            break
+
+    return dialogue_msgids, set_variables
+
+
+class NuPhoneRadioBase(PygameMenuState, ABC):
+    name: ClassVar[str] = "NuPhoneRadioBase"
+
+    def __init__(self, character: NPC) -> None:
+        width, height = prepare.SCREEN_SIZE
+        theme = self._setup_theme(prepare.BG_PHONE_CONTACTS)
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
+        theme.title = True
+
+        self.char = character
+
+        super().__init__(height=height, width=width)
+        self.reset_theme()
+
+    def _apply_variable_changes(self, set_variables: dict[str, Any]) -> None:
+        """Applies variables changes to the character's game variables (Shared)."""
+        if set_variables:
+            self.char.game_variables.update(set_variables)
+
+    def _start_broadcast(self, station_slug: str) -> None:
+        """Initiates the dialogue playback for the found station (Shared)."""
+
+        dialogue_msgids, set_variables = _get_broadcast_content(
+            self, station_slug
+        )
+
+        dialogue_text = [T.translate(msgid) for msgid in dialogue_msgids]
+        on_dialog_complete = None
+        if set_variables:
+            on_dialog_complete = partial(
+                self._apply_variable_changes, set_variables
+            )
+
+        open_dialog(
+            self.client,
+            dialogue_text,
+            on_complete=on_dialog_complete,
+        )
+
+    @abstractmethod
+    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+        pass
+
+
+class NuPhoneRadioMenu(NuPhoneRadioBase):
+    name: ClassVar[str] = "NuPhoneRadioMenu"
+
+    def __init__(self, character: NPC) -> None:
+        super().__init__(character)
+        self.add_menu_items(self.menu)
+
+    def _start_radio_button(self, station_slug: str) -> None:
+        """Starts the broadcast when a button is clicked."""
+        self._start_broadcast(station_slug)
+
+    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+        """Builds the menu with clickable station buttons based on map location."""
+        current_map_slug = self.client.get_map_name().split(".")[0]
+
+        available_stations = RADIO_MAP_LISTS.get(
+            current_map_slug, RADIO_MAP_LISTS.get("all_maps", [])
+        )
+
+        if not available_stations:
+            menu.add.label(T.translate("radio_no_signal"), align=ALIGN_CENTER)
+            return
+
+        menu.add.label(
+            title=T.translate("radio_station_list_header"),
+            font_size=self.font_type.medium,
+            align=ALIGN_CENTER,
+        )
+
+        menu.add.vertical_margin(10)
+
+        for station_slug in available_stations:
+            menu.add.button(
+                title=T.translate(station_slug),
+                action=partial(self._start_radio_button, station_slug),
+                font_size=self.font_type.medium,
+                align=ALIGN_CENTER,
+            )
+            menu.add.vertical_margin(15)
+
+        menu.set_title(T.translate("app_radio")).center_content()
+
+
+class NuPhoneRadioTuner(NuPhoneRadioBase):
+    name: ClassVar[str] = "NuPhoneRadioTuner"
+    current_station_slug: str = "station_scrambled_frequency"
+
+    def __init__(
+        self, character: NPC, frequency: Optional[float] = None
+    ) -> None:
+        self.initial_freq = (
+            frequency if frequency is not None else INITIAL_FREQ
+        )
+        self.selected_freq = self.initial_freq
+        super().__init__(character)
+        self.current_station_slug = "station_scrambled_frequency"
+        self.add_menu_items(self.menu)
+
+    def _play_selected_station(self) -> None:
+        self._tune_radio(self.selected_freq, broadcast=False)
+        best_match_slug = self._get_best_station_slug(self.selected_freq)
+        signal_strength = self._get_signal_strength(self.selected_freq)
+
+        if (
+            signal_strength >= 80
+            and best_match_slug != "station_scrambled_frequency"
+        ):
+            self._start_broadcast(best_match_slug)
+            self.current_station_slug = best_match_slug
+        else:
+            self._start_broadcast("station_scrambled_frequency")
+            self.current_station_slug = "station_scrambled_frequency"
+
+    def _get_signal_strength(self, dial_value: float) -> int:
+        min_diff = float("inf")
+
+        current_map_slug = self.client.get_map_name().split(".")[0]
+        map_specific = RADIO_MAP_LISTS.get(current_map_slug, [])
+        global_stations = RADIO_MAP_LISTS.get("all_maps", [])
+        available_stations = set(map_specific + global_stations)
+
+        for slug in available_stations:
+            data = RADIO_DATA.get(slug)
+            if not data or "frequency" not in data:
+                continue
+
+            station_freq = data["frequency"]
+            diff = abs(dial_value - station_freq)
+            if diff < min_diff:
+                min_diff = diff
+
+        return (
+            max(0, int((1.0 - (min_diff / TUNING_TOLERANCE)) * 100))
+            if min_diff != float("inf")
+            else 0
+        )
+
+    def _signal_label(self, strength: int) -> str:
+        if strength >= 80:
+            return T.translate("signal_strong")
+        elif strength >= 50:
+            return T.translate("signal_moderate")
+        elif strength > 0:
+            return T.translate("signal_weak")
+        else:
+            return T.translate("signal_none")
+
+    def _get_available_stations(self) -> set[str]:
+        current_map_slug = self.client.get_map_name().split(".")[0]
+        map_specific = RADIO_MAP_LISTS.get(current_map_slug, [])
+        global_stations = RADIO_MAP_LISTS.get("all_maps", [])
+        return set(map_specific + global_stations)
+
+    def _tune_radio(self, dial_value: float, broadcast: bool = True) -> None:
+        self.selected_freq = dial_value
+        signal_strength = self._get_signal_strength(dial_value)
+        best_match_slug = self._get_best_station_slug(dial_value)
+
+        station_label = self.menu.get_widget("station_label")
+        if station_label:
+            if best_match_slug == "station_scrambled_frequency":
+                display_text = T.translate("radio_tuning_static")
+            else:
+                display_text = T.translate(
+                    f"Tuning: {T.translate(best_match_slug)}"
+                )
+            station_label.set_title(display_text)
+
+        if (
+            broadcast
+            and signal_strength >= 80
+            and best_match_slug != self.current_station_slug
+        ):
+            self._start_broadcast(best_match_slug)
+            self.current_station_slug = best_match_slug
+
+        if hasattr(self, "signal_bar"):
+            self.signal_bar.set_value(signal_strength)
+
+    def _get_best_station_slug(self, dial_value: float) -> str:
+        current_map_slug = self.client.get_map_name().split(".")[0]
+        map_specific = RADIO_MAP_LISTS.get(current_map_slug, [])
+        global_stations = RADIO_MAP_LISTS.get("all_maps", [])
+        available_stations = set(map_specific + global_stations)
+
+        best_match_slug = "station_scrambled_frequency"
+        min_diff = float("inf")
+
+        for slug, data in RADIO_DATA.items():
+            if slug not in available_stations:
+                continue
+
+            station_freq = data.get("frequency")
+            if station_freq is None:
+                continue
+
+            diff = abs(dial_value - station_freq)
+            if diff <= TUNING_TOLERANCE and diff < min_diff:
+                min_diff = diff
+                best_match_slug = slug
+
+        return best_match_slug
+
+    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+        """Builds the menu with the frequency tuner slider."""
+
+        menu.add.label(
+            title=T.translate("app_radio_tuner"),
+            font_size=self.font_type.medium,
+            align=ALIGN_CENTER,
+        )
+        menu.add.vertical_margin(10)
+
+        menu.add.label(
+            title=T.translate("radio_tuning_static"),
+            font_size=self.font_type.medium,
+            label_id="station_label",
+            align=ALIGN_CENTER,
+        )
+        menu.add.vertical_margin(10)
+        menu.add.label(
+            title=T.translate("radio_tuner_hint"),
+            font_size=self.font_type.small,
+            align=ALIGN_CENTER,
+        )
+        menu.add.vertical_margin(10)
+        menu.add.range_slider(
+            title=T.translate("radio_tuner"),
+            default=self.initial_freq,
+            range_values=(MIN_FREQ, MAX_FREQ),
+            increment=0.1,
+            value_format=lambda x: f"{x:.1f} MHz",
+            onchange=self._tune_radio,
+            font_size=self.font_type.medium,
+            align=ALIGN_CENTER,
+        )
+        menu.add.vertical_margin(10)
+        self.signal_bar = menu.add.progress_bar(
+            title=T.translate("radio_signal_strength"),
+            default=0.0,
+            range_values=(0, 100),
+            progress_text=lambda val: f"{self._signal_label(val)} ({val}%)",
+            font_size=self.font_type.small,
+            align=ALIGN_CENTER,
+        )
+        self._tune_radio(self.initial_freq, broadcast=False)
+        menu.add.vertical_margin(10)
+        menu.add.button(
+            title=T.translate("radio_play_button"),
+            action=self._play_selected_station,
+            font_size=self.font_type.medium,
+            align=ALIGN_CENTER,
+        )
+
+        menu.set_title(T.translate("app_radio_tuner")).center_content()

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -203,6 +203,7 @@ def open_dialog(
     position: DialogPosition = DialogPosition.BOTTOM,
     target_coords: Optional[Union[tuple[int, int], Rect]] = None,
     custom_rect: Optional[Rect] = None,
+    on_complete: Optional[Callable[[], None]] = None,
 ) -> State:
     """
     Open a dialog with the standard window size or a custom size/position.
@@ -241,6 +242,7 @@ def open_dialog(
         avatar=avatar,
         rect=dialog_rect,
         box_style=box_style,
+        on_complete=on_complete,
     )
 
 


### PR DESCRIPTION
PR introduces the new `app_radio` interface and enhances the `open_dialog` function with an optional `on_complete` callback. This addition enables post-dialogue actions such as updating game variables or triggering events once the dialogue sequence finishes, improving flexibility and interactivity across game systems.

from the app radio

https://github.com/user-attachments/assets/0402ee36-41d0-42fd-a2ab-4cb043bfcb35

from the radio (through event action):
```xml
  <object id="17" name="Radio" type="event" x="112" y="80" width="16" height="32">
   <properties>
    <property name="act1" value="tune_radio player,94.7"/> <--- is it possible to set a different frequency and make the player search for the right one
    <property name="cond1" value="is char_facing_tile player"/>
    <property name="cond2" value="is button_pressed K_RETURN"/>
   </properties>
  </object>
```
or yaml
```yaml
  Radio:
    actions:
    - tune_radio player,94.7
    conditions:
    - is char_facing_tile player
    - is button_pressed K_RETURN
    type: event
    x: 0
    y: 5
```

https://github.com/user-attachments/assets/90d4a71e-ee90-4f49-8c32-4459bcd62e47
