### PR TITLE
Vivipere => Vivicinder morph modification

### DIFF
--- a/mods/tuxemon/db/monster/vivipere.json
+++ b/mods/tuxemon/db/monster/vivipere.json
@@ -26,7 +26,7 @@
   "evolutions": [
     {
       "monster_slug": "vivicinder",
-      "tech": "flamethrower"
+      "tech": "salamander"
     },
     {
       "monster_slug": "viviphyta",
@@ -145,6 +145,7 @@
   ],
   "tags": [
     "shapeshifter",
+	"toxic",
     "bite"
   ],
   "shape": "serpent",


### PR DESCRIPTION
Vivipere used to morph into Vivicinder if it knew the Flamethrower technique - but there's no way for it to learn that technique. 

This gives Vivipere the Toxic tag, which includes the technique Salamander which is associated with fire. Vivipere now morphs into Vivicinder if it knows Salamander -- a technique it can actually learn, that still has a fire-association like Flamethrower does. 