### PR TITLE
Introduce `SessionSave` and generic `AbstractSession` base class

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4140,6 +4140,9 @@ msgstr "The adventure began today."
 msgid "player_start_adventure"
 msgstr "The adventure began {date} days ago."
 
+msgid "player_total_playtime"
+msgstr "Total Playtime"
+
 msgid "player_walked"
 msgstr "Walked {distance} {unit}"
 

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -12,17 +12,17 @@ from datetime import datetime
 from enum import Enum
 from operator import itemgetter
 from pathlib import Path
-from typing import Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 from pygame.image import tobytes
 from pygame.surface import Surface
 
 from tuxemon import prepare
-from tuxemon.client import LocalPygameClient
-from tuxemon.save_state import SaveData
+from tuxemon.save_state import TIME_FORMAT, SaveData
 from tuxemon.save_upgrader import SAVE_VERSION, upgrade_save
-from tuxemon.session import Session
-from tuxemon.states.world_state import WorldState
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
 
 try:
     import cbor
@@ -36,7 +36,6 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 slot_number: Optional[int] = None
-TIME_FORMAT = "%Y-%m-%d %H:%M"
 config = prepare.CONFIG
 
 
@@ -53,19 +52,10 @@ class SaveMethod(Enum):
             return cls.JSON
 
 
-def capture_screenshot(client: LocalPygameClient) -> Surface:
-    """
-    Capture a screenshot.
-
-    Parameters:
-        client: Tuxemon client.
-
-    Returns:
-        Captured image.
-    """
+def capture_screenshot(session: Session) -> Surface:
+    """Capture a screenshot."""
     screenshot = Surface(prepare.SCREEN_SIZE)
-    world = client.get_state_by_name(WorldState)
-    world.draw(screenshot)
+    session.world.draw(screenshot)
     return screenshot
 
 
@@ -79,9 +69,10 @@ def get_save_data(session: Session) -> SaveData:
     Returns:
         Game data to save, must be JSON encodable.
     """
-    screenshot = capture_screenshot(session.client)
+    screenshot = capture_screenshot(session)
     npc_state = session.player.get_state(session)
     world_state = session.world.get_state(session)
+    session_state = session.get_state()
 
     return {
         "screenshot": b64encode(tobytes(screenshot, "RGB")).decode(),
@@ -91,6 +82,7 @@ def get_save_data(session: Session) -> SaveData:
         "version": SAVE_VERSION,
         "npc_state": npc_state,
         "world_state": world_state,
+        "session_state": session_state,
     }
 
 

--- a/tuxemon/save_state.py
+++ b/tuxemon/save_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, TypedDict
 
+TIME_FORMAT = "%Y-%m-%d %H:%M"
+
 
 class SaveData(TypedDict, total=False):
     screenshot: str
@@ -14,11 +16,19 @@ class SaveData(TypedDict, total=False):
     version: int
     npc_state: NPCState
     world_state: WorldSave
+    session_state: SessionSave
 
 
 class WorldSave(TypedDict, total=False):
     factions_manager: dict[str, Any]
     menu_flags: dict[str, bool]
+
+
+class SessionSave(TypedDict, total=False):
+    uuid: str
+    start_time: str
+    duration: float
+    total_playtime: float
 
 
 class NPCState(TypedDict, total=False):

--- a/tuxemon/session.py
+++ b/tuxemon/session.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional
+import time
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from uuid import UUID, uuid4
 
-from tuxemon.save_state import NPCState, WorldSave
+from tuxemon import save
+from tuxemon.save_state import TIME_FORMAT, NPCState, SessionSave, WorldSave
 
 if TYPE_CHECKING:
+    from tuxemon.base_client import BaseClient
     from tuxemon.client import LocalPygameClient
     from tuxemon.player import Player
     from tuxemon.save_state import SaveData
@@ -16,17 +22,98 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Session:
-    """
-    Contains Client, World, and Player.
+ClientType = TypeVar("ClientType", bound="BaseClient")
 
-    Eventually this will be extended to support network sessions.
+
+class AbstractSession(ABC, Generic[ClientType]):
+    """
+    Defines the abstract interface for all game sessions (local, network, etc.).
+    This class cannot be instantiated directly.
     """
 
     def __init__(self) -> None:
-        self._client: Optional[LocalPygameClient] = None
+        self._uuid: UUID = uuid4()
+        self._start_time: datetime = datetime.now()
+        self._start_timestamp: float = time.time()
+        self._total_playtime: float = 0.0
+
+        self._client: Optional[ClientType] = None
         self._world: Optional[WorldState] = None
         self._player: Optional[Player] = None
+        self._session_state: SessionSave = {}
+
+    @property
+    @abstractmethod
+    def client(self) -> ClientType:
+        """Returns the client instance."""
+
+    @property
+    @abstractmethod
+    def world(self) -> WorldState:
+        """Returns the world instance."""
+
+    @property
+    @abstractmethod
+    def player(self) -> Player:
+        """Returns the player instance."""
+
+    def set_client(self, client: ClientType) -> None:
+        """Sets the client. Can be overridden, but is provided for local convenience."""
+        self._client = client
+        logger.debug("Client initialized successfully.")
+
+    def set_world(self, world: WorldState) -> None:
+        """Sets the world. Can be overridden, but is provided for local convenience."""
+        self._world = world
+        logger.debug("World initialized successfully.")
+
+    def set_player(self, player: Player) -> None:
+        """Sets the player. Can be overridden, but is provided for local convenience."""
+        self._player = player
+        logger.debug("Player initialized successfully.")
+
+    def has_player(self) -> bool:
+        """Checks if a player is attached to the session."""
+        return self._player is not None
+
+    def reset(
+        self,
+        reset_client: bool = True,
+        reset_world: bool = True,
+        reset_player: bool = True,
+    ) -> None:
+        """Resets the main session components."""
+        if reset_client:
+            self._client = None
+        if reset_world:
+            self._world = None
+        if reset_player:
+            self._player = None
+
+    def get_state(self) -> SessionSave:
+        """Returns session-level state to be saved and updates internal playtime."""
+        current_duration = time.time() - self._start_timestamp
+        self._total_playtime += current_duration
+        self._start_timestamp = time.time()
+
+        return {
+            "uuid": self._uuid.hex,
+            "start_time": self._start_time.strftime(TIME_FORMAT),
+            "duration": current_duration,
+            "total_playtime": self._total_playtime,
+        }
+
+    def set_state(self, save_data: SessionSave) -> None:
+        """Restores session-level state from saved data."""
+        self._session_state = save_data
+        self._total_playtime = save_data.get("total_playtime", 0.0)
+
+
+class Session(AbstractSession["LocalPygameClient"]):
+    """
+    Contains Client, World, and Player.
+    This is the concrete local session implementation.
+    """
 
     @property
     def client(self) -> LocalPygameClient:
@@ -46,58 +133,18 @@ class Session:
             raise ValueError("Player is not initialized")
         return self._player
 
-    def set_client(self, client: LocalPygameClient) -> None:
-        self._client = client
-        logger.info("Client initialized successfully.")
-
-    def set_world(self, world: WorldState) -> None:
-        self._world = world
-        logger.info("World initialized successfully.")
-
-    def set_player(self, player: Player) -> None:
-        self._player = player
-        logger.info("Player initialized successfully.")
-
-    def has_player(self) -> bool:
-        return self._player is not None
-
-    def reset(
-        self,
-        reset_client: bool = True,
-        reset_world: bool = True,
-        reset_player: bool = True,
-    ) -> None:
-        if reset_client:
-            self._client = None
-        if reset_world:
-            self._world = None
-        if reset_player:
-            self._player = None
-
     def load_state(self, save_data: SaveData) -> None:
         """
         Loads the player, world, and other session-level states from a saved game dictionary.
         """
-        if self._player is None or self._world is None:
-            raise ValueError(
-                "Player and World must be initialized before loading state."
-            )
-
-        self._player.set_state(self, save_data.get("npc_state", NPCState()))
-        self._world.set_state(self, save_data.get("world_state", WorldSave()))
+        self.player.set_state(self, save_data.get("npc_state", NPCState()))
+        self.world.set_state(self, save_data.get("world_state", WorldSave()))
+        self.set_state(save_data.get("session_state", SessionSave()))
 
     def save_state(self, index: int, slot: int) -> SaveData:
         """
         Saves the player, world, and other session-level states to a dictionary.
         """
-        if self._player is None or self._world is None:
-            raise ValueError(
-                "Player and World must be initialized before saving state."
-            )
-
-        # Local import to avoid circular dependency
-        from tuxemon import save
-
         save_data = save.get_save_data(self)
         save.save(save_data, index)
         save.slot_number = slot

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -540,3 +540,10 @@ def check_condition(value: str, dataset: set[str]) -> bool:
     result = value in dataset
     logging.debug(f"Checking '{value}' in {dataset}: {result}")
     return result
+
+
+def format_playtime(seconds: float) -> str:
+    """Convert seconds into a human-readable hours and minutes format."""
+    minutes, sec = divmod(int(seconds), 60)
+    hours, min = divmod(minutes, 60)
+    return f"{hours}h {min}m"


### PR DESCRIPTION
PR adds `SessionSave` and introduces `AbstractSession` for session abstraction

Summary of changes:
- Introduced session-level metadata to the `Session` class, including a unique session ID, session start time, and total playtime tracking
- Added a new `SessionSave` structure to persist session-specific data across saves
- Implemented `get_state()` and `set_state()` methods in `Session` to manage session-level state
- Calculated `duration` based on the current session runtime and added `total_playtime` to accumulate time across multiple sessions
- Updated `load_state()` and `save_state()` to include session-level data in the save/load process
- Initialized session-related fields (`_uuid`, `_start_time`, `_start_timestamp`, `_total_playtime`) during session creation
- Refactored `capture_screenshot()` to accept the `Session` object instead of the `Client`, allowing direct access to the `World` instance and resolving a circular import issue
- Introduced a new `AbstractSession` base class to define a generic interface for all session types (e.g. networked)
- Parameterized `AbstractSession` with a generic `ClientType` bound to `BaseClient`, enabling type-safe specialization in concrete subclasses
- Updated `Session` to inherit from `AbstractSession[LocalPygameClient]`, ensuring strong typing while avoiding circular imports via forward references and `TYPE_CHECKING` blocks