### PR TITLE
Fix Linux Startup Failure Caused by PR #3185

### DIFF
--- a/tests/tuxemon/test_monster_actions.py
+++ b/tests/tuxemon/test_monster_actions.py
@@ -55,6 +55,7 @@ class TestMonsterActions(unittest.TestCase):
         height=80,
         weight=24,
         catch_rate=100.0,
+        sounds={},
         lower_catch_resistance=0.95,
         upper_catch_resistance=1.25,
     )
@@ -74,6 +75,7 @@ class TestMonsterActions(unittest.TestCase):
         height=45,
         weight=4,
         catch_rate=100.0,
+        sounds={},
         lower_catch_resistance=0.95,
         upper_catch_resistance=1.25,
     )

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -851,22 +851,22 @@ class MonsterSpritesModel(BaseModel):
 
 
 class MonsterSoundsModel(BaseModel):
-    combat_call: str = Field(
-        ..., description="The sound used when entering combat"
+    combat_call: Optional[str] = Field(
+        None, description="The sound used when entering combat"
     )
-    faint_call: str = Field(
-        ..., description="The sound used when the monster faints"
+    faint_call: Optional[str] = Field(
+        None, description="The sound used when the monster faints"
     )
 
     @field_validator("combat_call")
     def combat_call_exists(cls: MonsterSoundsModel, v: str) -> str:
-        if has.db_entry("sounds", v):
+        if v and has.db_entry("sounds", v):
             return v
         raise ValueError(f"the sound {v} doesn't exist in the db")
 
     @field_validator("faint_call")
     def faint_call_exists(cls: MonsterSoundsModel, v: str) -> str:
-        if has.db_entry("sounds", v):
+        if v and has.db_entry("sounds", v):
             return v
         raise ValueError(f"the sound {v} doesn't exist in the db")
 
@@ -930,9 +930,8 @@ class MonsterModel(BaseModel, BaseLookupModel, validate_assignment=True):
     flairs: set[str] = Field(
         default_factory=set, description="The flairs this monster has"
     )
-    sounds: Optional[MonsterSoundsModel] = Field(
-        None,
-        description="The sounds this monster has",
+    sounds: MonsterSoundsModel = Field(
+        description="The sounds this monster has"
     )
 
     @classmethod

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -305,12 +305,12 @@ class Monster:
         # get sound slugs for this monster, defaulting to a generic type-based sound
         self.combat_call = (
             results.sounds.combat_call
-            if results.sounds
+            if results.sounds.combat_call
             else f"sound_{self.types.primary.slug}_call"
         )
         self.faint_call = (
             results.sounds.faint_call
-            if results.sounds
+            if results.sounds.faint_call
             else f"sound_{self.types.primary.slug}_faint"
         )
 


### PR DESCRIPTION
PR fixes the Linux Startup failure introduced after merging PR #3185. On Linux, the game flat-out refused to start because Pydantic threw a fit over the monster sounds config. This issue could’ve been caught instantly by simply starting the game on Linux.

To clean up it and simplify the flow, `MonsterSoundsModel` is no longer optional. Both parameters inside it are now optional, which actually makes sense. With this fix, the game finally launches properly on Linux again.