### PR TITLE
Replace Adventure Start Strings with Accurate Total Playtime Display

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4217,12 +4217,6 @@ msgstr "Seen {param} out of {all}"
 msgid "tuxepedia_data_caught"
 msgstr "Caught {param} out of {all}"
 
-msgid "player_start_adventure_today"
-msgstr "The adventure began today."
-
-msgid "player_start_adventure"
-msgstr "The adventure began {date} days ago."
-
 msgid "player_total_playtime"
 msgstr "Total Playtime"
 

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -6891,9 +6891,6 @@ msgstr "看到了{param}只精灵,共有{all}"
 msgid "tuxepedia_data_caught"
 msgstr "捉住了{param}只精灵,共有{all}"
 
-msgid "player_start_adventure"
-msgstr "冒险开始了{date}天."
-
 msgid "player_walked"
 msgstr "行走的路程 {distance} {unit}"
 

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -17,8 +17,7 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.npc import NPC
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
-from tuxemon.time_handler import today_ordinal
-from tuxemon.tools import fix_measure
+from tuxemon.tools import fix_measure, format_playtime
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}
@@ -78,14 +77,8 @@ class CharacterState(PygameMenuState):
         msg_seen = T.format("tuxepedia_data_seen", _msg_seen)
         msg_caught = T.format("tuxepedia_data_caught", _msg_caught)
 
-        today = today_ordinal()
-        date = self.char.game_variables.get("date_start_game", today)
-        date_begin = today - int(date)
-        msg_begin = (
-            T.format("player_start_adventure", {"date": date_begin})
-            if date_begin >= 1
-            else T.translate("player_start_adventure_today")
-        )
+        play_time = format_playtime(self.char.session._total_playtime)
+        msg_begin = f"{T.translate('player_total_playtime')}: {play_time}"
 
         if self.char.battle_handler.get_battles():
             summary = self.char.battle_handler.get_battle_outcome_summary()
@@ -156,7 +149,7 @@ class CharacterState(PygameMenuState):
             float=True,
         )
         lab4.translate(fxw(0.45), fxh(0.35))
-        # begin adventure
+        # total playtime
         lab5: Any = menu.add.label(
             title=msg_begin,
             label_id="begin",


### PR DESCRIPTION
PR updates the `CharacterState` UI by replacing the following localized strings:

- `msgid "player_start_adventure_today"`  `msgstr "The adventure began today."`
- `msgid "player_start_adventure"`  `msgstr "The adventure began {date} days ago."`

with a new label: **"Total Playtime"**, which reflects the actual cumulative time the player has spent in-game. The new format displays time in hours and minutes (e.g., `7h 15m`), offering a more precise and meaningful metric for player progression.

The previous implementation relied on tracking the number of days since the adventure began, which proved unreliable and often misleading, especially in cases where players played intermittently or across multiple sessions. By switching to a direct measurement of total playtime, we ensure consistency and accuracy, aligning the display with actual gameplay duration rather than calendar-based estimates.