### PR TITLE
Add Field Migration Logic to Save Upgrade System

### DIFF
--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -58,7 +58,8 @@ Notes:
 
 SAVE_VERSION = 2
 
-
+# "evolution_registry": ("npc_state", "world_state"),
+FIELD_MIGRATION_MAP: dict[str, tuple[str, str]] = {}
 MONSTER_RENAMES: dict[str, str] = {"axylightl": "axolightl"}  # old: new
 TECHNIQUE_RENAMES: dict[str, str] = {}  # old: new
 
@@ -83,6 +84,23 @@ def apply_universal_fixes(npc_state: dict[str, Any]) -> None:
     _handle_change_tech_slug(npc_state)
 
 
+def apply_field_migrations(save_data: dict[str, Any]) -> None:
+    """
+    Migrates fields between sections of the save data based on FIELD_MIGRATION_MAP.
+
+    This function moves specific fields from one nested section (e.g., "npc_state")
+    to another (e.g., "world_state" or "session_state") as defined in the
+    FIELD_MIGRATION_MAP dictionary. It ensures that fields are relocated to their
+    appropriate structural location in the updated save format.
+    """
+    for field, (source, target) in FIELD_MIGRATION_MAP.items():
+        source_dict = save_data.get(source, {})
+        target_dict = save_data.setdefault(target, {})
+
+        if field in source_dict:
+            target_dict[field] = source_dict.pop(field)
+
+
 VERSION_UPGRADES: dict[int, Callable[[dict[str, Any]], None]] = {
     0: upgrade_from_v0_to_v1,
     1: upgrade_from_v1_to_v2,
@@ -104,6 +122,7 @@ def upgrade_save(save_data: dict[str, Any]) -> SaveData:
             upgrade_func(save_data)
 
     save_data["version"] = SAVE_VERSION
+    apply_field_migrations(save_data)
     apply_universal_fixes(save_data["npc_state"])
     return save_data  # type: ignore[return-value]
 


### PR DESCRIPTION
waiting
- [x] #3166

PR introduces a new utility function `apply_field_migrations` and a centralized migration table (`FIELD_MIGRATION_MAP`) to the save upgrade module.

Key changes:
- added `FIELD_MIGRATION_MAP`, a dictionary that defines which fields should be moved between sections of the save data (e.g., from `npc_state` to `world_state` or `session_state`)
- implemented `apply_field_migrations(save_data)` to perform these moves automatically during the upgrade process
- integrated the migration step into the `upgrade_save` pipeline, ensuring fields are relocated before universal fixes are applied

Historically `npc_state` has been a catch-all for everything, not just NPC-related data, but also world flags, session metadata and player identity. This was before the save system was split into multiple sectors (`npc_state`, `world_state`, `session_state`). Now that the structure is clearer, we need to start purging misplaced fields and relocating them to where they truly belong.

Possible rule of thumb:
- if it’s about what the world is, it goes in `WorldSave`
- if it’s about what the player/NPC is doing or experiencing, it goes in `NPCState`
- if it’s about who the player is and how long they’ve been playing, it goes in `SessionSave`

This lays the groundwork for future migrations and helps clarify the purpose of each save section.