### PR TITLE
Adding faint calls where they are missing

### DIFF
--- a/mods/tuxemon/db/monster/agnsher.json
+++ b/mods/tuxemon/db/monster/agnsher.json
@@ -75,7 +75,8 @@
   "height": 60,
   "weight": 5,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/altie.json
+++ b/mods/tuxemon/db/monster/altie.json
@@ -88,7 +88,8 @@
   "height": 130,
   "weight": 30,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 5.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/ambuwl.json
+++ b/mods/tuxemon/db/monster/ambuwl.json
@@ -83,7 +83,8 @@
   "height": 98,
   "weight": 38,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/ampystoma.json
+++ b/mods/tuxemon/db/monster/ampystoma.json
@@ -99,7 +99,8 @@
   "height": 180,
   "weight": 80,
   "sounds": {
-    "combat_call": "sound_retro_beep_06"
+    "combat_call": "sound_retro_beep_06",
+    "faint_call": "sound_retro_beep_06_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/angesnow.json
+++ b/mods/tuxemon/db/monster/angesnow.json
@@ -101,7 +101,8 @@
   "height": 120,
   "weight": 30,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/angrito.json
+++ b/mods/tuxemon/db/monster/angrito.json
@@ -79,7 +79,8 @@
   "height": 90,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/apeoro.json
+++ b/mods/tuxemon/db/monster/apeoro.json
@@ -82,7 +82,8 @@
   "height": 197,
   "weight": 145,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/askylpaws.json
+++ b/mods/tuxemon/db/monster/askylpaws.json
@@ -115,7 +115,8 @@
   "height": 200,
   "weight": 80,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/babysnitch.json
+++ b/mods/tuxemon/db/monster/babysnitch.json
@@ -80,7 +80,8 @@
   "height": 35,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_ghost_1"
+    "combat_call": "sound_ghost_1",
+    "faint_call": "sound_ghost_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/baddrscratch.json
+++ b/mods/tuxemon/db/monster/baddrscratch.json
@@ -76,7 +76,8 @@
   "height": 140,
   "weight": 65,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/banling.json
+++ b/mods/tuxemon/db/monster/banling.json
@@ -110,7 +110,8 @@
   "height": 120,
   "weight": 180,
   "sounds": {
-    "combat_call": "sound_wood_call"
+    "combat_call": "sound_wood_call",
+    "faint_call": "sound_wood_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/bansaken.json
+++ b/mods/tuxemon/db/monster/bansaken.json
@@ -111,7 +111,8 @@
   "height": 430,
   "weight": 267,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/banvengeance.json
+++ b/mods/tuxemon/db/monster/banvengeance.json
@@ -106,7 +106,8 @@
   "height": 800,
   "weight": 354,
   "sounds": {
-    "combat_call": "sound_monster_16"
+    "combat_call": "sound_monster_16",
+    "faint_call": "sound_monster_16_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/baobaraffe.json
+++ b/mods/tuxemon/db/monster/baobaraffe.json
@@ -81,7 +81,8 @@
   "height": 320,
   "weight": 302,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/baoby.json
+++ b/mods/tuxemon/db/monster/baoby.json
@@ -82,7 +82,8 @@
   "height": 54,
   "weight": 23,
   "sounds": {
-    "combat_call": "sound_cute_03"
+    "combat_call": "sound_cute_03",
+    "faint_call": "sound_cute_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/bearloch.json
+++ b/mods/tuxemon/db/monster/bearloch.json
@@ -75,7 +75,8 @@
   "height": 131,
   "weight": 46,
   "sounds": {
-    "combat_call": "sound_retro_beep_05"
+    "combat_call": "sound_retro_beep_05",
+    "faint_call": "sound_retro_beep_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/bedoo.json
+++ b/mods/tuxemon/db/monster/bedoo.json
@@ -95,7 +95,8 @@
   "height": 200,
   "weight": 15,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/beenstalker.json
+++ b/mods/tuxemon/db/monster/beenstalker.json
@@ -96,7 +96,8 @@
   "height": 98,
   "weight": 41,
   "sounds": {
-    "combat_call": "sound_ice"
+    "combat_call": "sound_ice",
+    "faint_call": "sound_ice_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/bewhich.json
+++ b/mods/tuxemon/db/monster/bewhich.json
@@ -83,7 +83,8 @@
   "height": 152,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_crow_caw"
+    "combat_call": "sound_crow_caw",
+    "faint_call": "sound_crow_caw_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/birdee.json
+++ b/mods/tuxemon/db/monster/birdee.json
@@ -88,7 +88,8 @@
   "height": 26,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_crow_caw"
+    "combat_call": "sound_crow_caw",
+    "faint_call": "sound_crow_caw_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/bishosand.json
+++ b/mods/tuxemon/db/monster/bishosand.json
@@ -86,7 +86,8 @@
   "height": 180,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/blasdoor.json
+++ b/mods/tuxemon/db/monster/blasdoor.json
@@ -87,7 +87,8 @@
   "height": 2040,
   "weight": 204,
   "sounds": {
-    "combat_call": "sound_ghost_1"
+    "combat_call": "sound_ghost_1",
+    "faint_call": "sound_ghost_1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/boltnu.json
+++ b/mods/tuxemon/db/monster/boltnu.json
@@ -81,7 +81,8 @@
   "height": 47,
   "weight": 8,
   "sounds": {
-    "combat_call": "sound_steel_clang"
+    "combat_call": "sound_steel_clang",
+    "faint_call": "sound_steel_clang_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/boxali.json
+++ b/mods/tuxemon/db/monster/boxali.json
@@ -83,7 +83,8 @@
   "height": 180,
   "weight": 90,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/boxorox.json
+++ b/mods/tuxemon/db/monster/boxorox.json
@@ -53,7 +53,8 @@
   "height": 187,
   "weight": 154,
   "sounds": {
-    "combat_call": "sound_bugthing"
+    "combat_call": "sound_bugthing",
+    "faint_call": "sound_bugthing_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/brachifor.json
+++ b/mods/tuxemon/db/monster/brachifor.json
@@ -99,7 +99,8 @@
   "height": 2000,
   "weight": 40000,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/breem.json
+++ b/mods/tuxemon/db/monster/breem.json
@@ -74,7 +74,8 @@
   "height": 100,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/brewdin.json
+++ b/mods/tuxemon/db/monster/brewdin.json
@@ -87,7 +87,8 @@
   "height": 22,
   "weight": 1,
   "sounds": {
-    "combat_call": "sfx_bubbles"
+    "combat_call": "sfx_bubbles",
+    "faint_call": "sfx_bubbles_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/bricgard.json
+++ b/mods/tuxemon/db/monster/bricgard.json
@@ -105,7 +105,8 @@
   "height": 50,
   "weight": 35,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/brickhemoth.json
+++ b/mods/tuxemon/db/monster/brickhemoth.json
@@ -100,7 +100,8 @@
   "height": 180,
   "weight": 120,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/brumi.json
+++ b/mods/tuxemon/db/monster/brumi.json
@@ -93,7 +93,8 @@
   "height": 123,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/bumbulus.json
+++ b/mods/tuxemon/db/monster/bumbulus.json
@@ -93,7 +93,8 @@
   "height": 78,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/burrlock.json
+++ b/mods/tuxemon/db/monster/burrlock.json
@@ -72,7 +72,8 @@
   "height": 50,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cacaburr.json
+++ b/mods/tuxemon/db/monster/cacaburr.json
@@ -71,7 +71,8 @@
   "height": 90,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cackleen.json
+++ b/mods/tuxemon/db/monster/cackleen.json
@@ -93,7 +93,8 @@
   "height": 91,
   "weight": 40,
   "sounds": {
-    "combat_call": "sound_cute_04"
+    "combat_call": "sound_cute_04",
+    "faint_call": "sound_cute_04_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/caper.json
+++ b/mods/tuxemon/db/monster/caper.json
@@ -89,7 +89,8 @@
   "height": 65,
   "weight": 36,
   "sounds": {
-    "combat_call": "sound_ice"
+    "combat_call": "sound_ice",
+    "faint_call": "sound_ice_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/capinyah.json
+++ b/mods/tuxemon/db/monster/capinyah.json
@@ -100,7 +100,8 @@
   "height": 160,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_cat_purr_twit5"
+    "combat_call": "sound_cat_purr_twit5",
+    "faint_call": "sound_cat_purr_twit5_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/carcharock.json
+++ b/mods/tuxemon/db/monster/carcharock.json
@@ -79,7 +79,8 @@
   "height": 120,
   "weight": 45,
   "sounds": {
-    "combat_call": "sound_frog"
+    "combat_call": "sound_frog",
+    "faint_call": "sound_frog_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/cherubat.json
+++ b/mods/tuxemon/db/monster/cherubat.json
@@ -83,7 +83,8 @@
   "height": 30,
   "weight": 0.5,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chibiro.json
+++ b/mods/tuxemon/db/monster/chibiro.json
@@ -79,7 +79,8 @@
   "height": 36,
   "weight": 3,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/chickadee.json
+++ b/mods/tuxemon/db/monster/chickadee.json
@@ -85,7 +85,8 @@
   "height": 12,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_crow_caw"
+    "combat_call": "sound_crow_caw",
+    "faint_call": "sound_crow_caw_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/chrome_robo.json
+++ b/mods/tuxemon/db/monster/chrome_robo.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_misc_07_metal"
+    "combat_call": "sound_misc_07_metal",
+    "faint_call": "sound_misc_07_metal_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -127,7 +127,8 @@
   "height": 38,
   "weight": 3.5,
   "sounds": {
-    "combat_call": "sound_retro_beep_05"
+    "combat_call": "sound_retro_beep_05",
+    "faint_call": "sound_retro_beep_05_faint"
   },
   "catch_rate": 100,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/claymorior.json
+++ b/mods/tuxemon/db/monster/claymorior.json
@@ -106,7 +106,8 @@
   "height": 150,
   "weight": 112,
   "sounds": {
-    "combat_call": "sound_swords_clash"
+    "combat_call": "sound_swords_clash",
+    "faint_call": "sound_swords_clash_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/coaldiak.json
+++ b/mods/tuxemon/db/monster/coaldiak.json
@@ -85,7 +85,8 @@
   "height": 260,
   "weight": 300,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/cobarett.json
+++ b/mods/tuxemon/db/monster/cobarett.json
@@ -90,7 +90,8 @@
   "height": 300,
   "weight": 12,
   "sounds": {
-    "combat_call": "sound_spell_fire_07"
+    "combat_call": "sound_spell_fire_07",
+    "faint_call": "sound_spell_fire_07_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cocrune.json
+++ b/mods/tuxemon/db/monster/cocrune.json
@@ -94,7 +94,8 @@
   "height": 33,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/cohldrabi.json
+++ b/mods/tuxemon/db/monster/cohldrabi.json
@@ -100,7 +100,8 @@
   "height": 30,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_ice"
+    "combat_call": "sound_ice",
+    "faint_call": "sound_ice_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/conglolem.json
+++ b/mods/tuxemon/db/monster/conglolem.json
@@ -104,7 +104,8 @@
   "height": 245,
   "weight": 197,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/coppi.json
+++ b/mods/tuxemon/db/monster/coppi.json
@@ -102,7 +102,8 @@
   "height": 50,
   "weight": 12,
   "sounds": {
-    "combat_call": "sound_wood_call"
+    "combat_call": "sound_wood_call",
+    "faint_call": "sound_wood_call_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/coproblight.json
+++ b/mods/tuxemon/db/monster/coproblight.json
@@ -80,7 +80,8 @@
   "height": 45,
   "weight": 8,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/crankus.json
+++ b/mods/tuxemon/db/monster/crankus.json
@@ -86,7 +86,8 @@
   "height": 180,
   "weight": 102,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/crustagu.json
+++ b/mods/tuxemon/db/monster/crustagu.json
@@ -104,7 +104,8 @@
   "height": 90,
   "weight": 45,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/d0llf1n.json
+++ b/mods/tuxemon/db/monster/d0llf1n.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_echo_gurgle_whoosh_1"
+    "combat_call": "sound_echo_gurgle_whoosh_1",
+    "faint_call": "sound_echo_gurgle_whoosh_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dankush.json
+++ b/mods/tuxemon/db/monster/dankush.json
@@ -84,7 +84,8 @@
   "weight": 0.5,
   "randomly": false,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/dark_robo.json
+++ b/mods/tuxemon/db/monster/dark_robo.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_robot1"
+    "combat_call": "sound_robot1",
+    "faint_call": "sound_robot1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/delfeco.json
+++ b/mods/tuxemon/db/monster/delfeco.json
@@ -98,7 +98,8 @@
   "height": 200,
   "weight": 150,
   "sounds": {
-    "combat_call": "sfx_bubbles"
+    "combat_call": "sfx_bubbles",
+    "faint_call": "sfx_bubbles_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/demosnow.json
+++ b/mods/tuxemon/db/monster/demosnow.json
@@ -101,7 +101,8 @@
   "height": 120,
   "weight": 35,
   "sounds": {
-    "combat_call": "sound_woosh_1"
+    "combat_call": "sound_woosh_1",
+    "faint_call": "sound_woosh_1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/devidin.json
+++ b/mods/tuxemon/db/monster/devidin.json
@@ -103,7 +103,8 @@
   "height": 73,
   "weight": 36,
   "sounds": {
-    "combat_call": "sound_roar_03"
+    "combat_call": "sound_roar_03",
+    "faint_call": "sound_roar_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/devidra.json
+++ b/mods/tuxemon/db/monster/devidra.json
@@ -104,7 +104,8 @@
   "height": 152,
   "weight": 113,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/deviraptor.json
+++ b/mods/tuxemon/db/monster/deviraptor.json
@@ -99,7 +99,8 @@
   "height": 183,
   "weight": 295,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/doctsky.json
+++ b/mods/tuxemon/db/monster/doctsky.json
@@ -124,7 +124,8 @@
   "height": 94,
   "weight": 30,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/drashimi.json
+++ b/mods/tuxemon/db/monster/drashimi.json
@@ -102,7 +102,8 @@
   "height": 38,
   "weight": 12,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/duggot.json
+++ b/mods/tuxemon/db/monster/duggot.json
@@ -67,7 +67,8 @@
   "height": 12,
   "weight": 0.5,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/enduros.json
+++ b/mods/tuxemon/db/monster/enduros.json
@@ -82,7 +82,8 @@
   "height": 170,
   "weight": 65,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/equill.json
+++ b/mods/tuxemon/db/monster/equill.json
@@ -85,7 +85,8 @@
   "height": 160,
   "weight": 500,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/erythroskyte.json
+++ b/mods/tuxemon/db/monster/erythroskyte.json
@@ -110,7 +110,8 @@
   "height": 200,
   "weight": 70,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/eskipup.json
+++ b/mods/tuxemon/db/monster/eskipup.json
@@ -67,7 +67,8 @@
   "height": 56,
   "weight": 24,
   "sounds": {
-    "combat_call": "sound_bark"
+    "combat_call": "sound_bark",
+    "faint_call": "sound_bark_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/exclawvate.json
+++ b/mods/tuxemon/db/monster/exclawvate.json
@@ -79,7 +79,8 @@
   "height": 213,
   "weight": 1000,
   "sounds": {
-    "combat_call": "sound_misc_07_metal"
+    "combat_call": "sound_misc_07_metal",
+    "faint_call": "sound_misc_07_metal_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/f7u1t3ra.json
+++ b/mods/tuxemon/db/monster/f7u1t3ra.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/firomenis.json
+++ b/mods/tuxemon/db/monster/firomenis.json
@@ -86,7 +86,8 @@
   "height": 183,
   "weight": 30,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/flisces.json
+++ b/mods/tuxemon/db/monster/flisces.json
@@ -82,7 +82,8 @@
   "height": 28,
   "weight": 1.5,
   "sounds": {
-    "combat_call": "sound_echo_gurgle_whoosh_1"
+    "combat_call": "sound_echo_gurgle_whoosh_1",
+    "faint_call": "sound_echo_gurgle_whoosh_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/flounce.json
+++ b/mods/tuxemon/db/monster/flounce.json
@@ -86,7 +86,8 @@
   "height": 49,
   "weight": 22,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/flummack.json
+++ b/mods/tuxemon/db/monster/flummack.json
@@ -90,7 +90,8 @@
   "height": 90,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/flummby.json
+++ b/mods/tuxemon/db/monster/flummby.json
@@ -98,7 +98,8 @@
   "height": 90,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/fordin.json
+++ b/mods/tuxemon/db/monster/fordin.json
@@ -103,7 +103,8 @@
   "height": 56,
   "weight": 19,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/foxko.json
+++ b/mods/tuxemon/db/monster/foxko.json
@@ -75,7 +75,8 @@
   "height": 71,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/fribbit.json
+++ b/mods/tuxemon/db/monster/fribbit.json
@@ -81,7 +81,8 @@
   "height": 50,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_frog"
+    "combat_call": "sound_frog",
+    "faint_call": "sound_frog_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/frostuce.json
+++ b/mods/tuxemon/db/monster/frostuce.json
@@ -93,7 +93,8 @@
   "height": 100,
   "weight": 18,
   "sounds": {
-    "combat_call": "sound_ice"
+    "combat_call": "sound_ice",
+    "faint_call": "sound_ice_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/fruitera.json
+++ b/mods/tuxemon/db/monster/fruitera.json
@@ -103,7 +103,8 @@
   "height": 30,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/furnursus.json
+++ b/mods/tuxemon/db/monster/furnursus.json
@@ -86,7 +86,8 @@
   "height": 110,
   "weight": 47,
   "sounds": {
-    "combat_call": "sound_growl1"
+    "combat_call": "sound_growl1",
+    "faint_call": "sound_growl1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/fuzzina.json
+++ b/mods/tuxemon/db/monster/fuzzina.json
@@ -90,7 +90,8 @@
   "height": 50,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/fuzzlet.json
+++ b/mods/tuxemon/db/monster/fuzzlet.json
@@ -98,7 +98,8 @@
   "height": 33,
   "weight": 0.5,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/galasces.json
+++ b/mods/tuxemon/db/monster/galasces.json
@@ -79,7 +79,8 @@
   "height": 60,
   "weight": 30,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/galnec.json
+++ b/mods/tuxemon/db/monster/galnec.json
@@ -80,7 +80,8 @@
   "height": 40,
   "weight": 6,
   "sounds": {
-    "combat_call": "sound_bugthing"
+    "combat_call": "sound_bugthing",
+    "faint_call": "sound_bugthing_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/gastronium.json
+++ b/mods/tuxemon/db/monster/gastronium.json
@@ -81,7 +81,8 @@
   "height": 100,
   "weight": 40,
   "sounds": {
-    "combat_call": "sound_misc_07_metal"
+    "combat_call": "sound_misc_07_metal",
+    "faint_call": "sound_misc_07_metal_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/gladiatorbug.json
+++ b/mods/tuxemon/db/monster/gladiatorbug.json
@@ -101,7 +101,8 @@
   "height": 178,
   "weight": 78,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/gliffary.json
+++ b/mods/tuxemon/db/monster/gliffary.json
@@ -63,7 +63,8 @@
   "height": 50,
   "weight": 1.5,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/glombroc.json
+++ b/mods/tuxemon/db/monster/glombroc.json
@@ -110,7 +110,8 @@
   "height": 87,
   "weight": 35,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/glomon.json
+++ b/mods/tuxemon/db/monster/glomon.json
@@ -83,7 +83,8 @@
   "height": 150,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 50.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/golnagi.json
+++ b/mods/tuxemon/db/monster/golnagi.json
@@ -105,7 +105,8 @@
   "height": 130,
   "weight": 16,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/gourda.json
+++ b/mods/tuxemon/db/monster/gourda.json
@@ -55,7 +55,8 @@
   "height": 40,
   "weight": 28,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/graffiki.json
+++ b/mods/tuxemon/db/monster/graffiki.json
@@ -82,7 +82,8 @@
   "height": 65,
   "weight": 13,
   "sounds": {
-    "combat_call": "sound_spell_fire_07"
+    "combat_call": "sound_spell_fire_07",
+    "faint_call": "sound_spell_fire_07_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/grumpi.json
+++ b/mods/tuxemon/db/monster/grumpi.json
@@ -78,7 +78,8 @@
   "height": 150,
   "weight": 160,
   "sounds": {
-    "combat_call": "sound_growl1"
+    "combat_call": "sound_growl1",
+    "faint_call": "sound_growl1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/gryfix.json
+++ b/mods/tuxemon/db/monster/gryfix.json
@@ -101,7 +101,8 @@
   "height": 180,
   "weight": 31,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/gupphire.json
+++ b/mods/tuxemon/db/monster/gupphire.json
@@ -107,7 +107,8 @@
   "height": 80,
   "weight": 7,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/gupphish.json
+++ b/mods/tuxemon/db/monster/gupphish.json
@@ -107,7 +107,8 @@
   "height": 40,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/happito.json
+++ b/mods/tuxemon/db/monster/happito.json
@@ -80,7 +80,8 @@
   "height": 90,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_misc_07_metal"
+    "combat_call": "sound_misc_07_metal",
+    "faint_call": "sound_misc_07_metal_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hectapod.json
+++ b/mods/tuxemon/db/monster/hectapod.json
@@ -76,7 +76,8 @@
   "height": 120,
   "weight": 45,
   "sounds": {
-    "combat_call": "sound_frog"
+    "combat_call": "sound_frog",
+    "faint_call": "sound_frog_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/helipi.json
+++ b/mods/tuxemon/db/monster/helipi.json
@@ -104,7 +104,8 @@
   "height": 30,
   "weight": 4,
   "sounds": {
-    "combat_call": "sound_wood_call"
+    "combat_call": "sound_wood_call",
+    "faint_call": "sound_wood_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/hissiorite.json
+++ b/mods/tuxemon/db/monster/hissiorite.json
@@ -82,7 +82,8 @@
   "height": 100,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hoarse.json
+++ b/mods/tuxemon/db/monster/hoarse.json
@@ -75,7 +75,8 @@
   "height": 130,
   "weight": 130,
   "sounds": {
-    "combat_call": "sound_troll_01"
+    "combat_call": "sound_troll_01",
+    "faint_call": "sound_troll_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hoarseshoo.json
+++ b/mods/tuxemon/db/monster/hoarseshoo.json
@@ -80,7 +80,8 @@
   "height": 300,
   "weight": 1300,
   "sounds": {
-    "combat_call": "sound_ghost_1"
+    "combat_call": "sound_ghost_1",
+    "faint_call": "sound_ghost_1_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hoodoll.json
+++ b/mods/tuxemon/db/monster/hoodoll.json
@@ -93,7 +93,8 @@
   "height": 80,
   "weight": 6,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/hotline.json
+++ b/mods/tuxemon/db/monster/hotline.json
@@ -83,7 +83,8 @@
   "weight": 50,
   "randomly": false,
   "sounds": {
-    "combat_call": "sound_robotic_pig"
+    "combat_call": "sound_robotic_pig",
+    "faint_call": "sound_robotic_pig_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/howl.json
+++ b/mods/tuxemon/db/monster/howl.json
@@ -78,7 +78,8 @@
   "height": 63,
   "weight": 2.5,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/imbrickcile.json
+++ b/mods/tuxemon/db/monster/imbrickcile.json
@@ -105,7 +105,8 @@
   "height": 35,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_stones_04"
+    "combat_call": "sound_stones_04",
+    "faint_call": "sound_stones_04_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/jelillow.json
+++ b/mods/tuxemon/db/monster/jelillow.json
@@ -96,7 +96,8 @@
   "height": 66,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/jeluna.json
+++ b/mods/tuxemon/db/monster/jeluna.json
@@ -72,7 +72,8 @@
   "height": 30,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_splash_1"
+    "combat_call": "sound_splash_1",
+    "faint_call": "sound_splash_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/joulraton.json
+++ b/mods/tuxemon/db/monster/joulraton.json
@@ -82,7 +82,8 @@
   "height": 30,
   "weight": 2.5,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/kernel.json
+++ b/mods/tuxemon/db/monster/kernel.json
@@ -82,7 +82,8 @@
   "height": 30,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/knightsand.json
+++ b/mods/tuxemon/db/monster/knightsand.json
@@ -86,7 +86,8 @@
   "height": 180,
   "weight": 140,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/knindling.json
+++ b/mods/tuxemon/db/monster/knindling.json
@@ -81,7 +81,8 @@
   "height": 50,
   "weight": 22,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/komoduel.json
+++ b/mods/tuxemon/db/monster/komoduel.json
@@ -97,7 +97,8 @@
   "height": 165,
   "weight": 75,
   "sounds": {
-    "combat_call": "sound_game_shot_light_gun"
+    "combat_call": "sound_game_shot_light_gun",
+    "faint_call": "sound_game_shot_light_gun_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/konuit.json
+++ b/mods/tuxemon/db/monster/konuit.json
@@ -57,7 +57,8 @@
   "height": 65,
   "weight": 14,
   "sounds": {
-    "combat_call": "sound_cute_02"
+    "combat_call": "sound_cute_02",
+    "faint_call": "sound_cute_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/kroki.json
+++ b/mods/tuxemon/db/monster/kroki.json
@@ -102,7 +102,8 @@
   "height": 30,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_splash_1"
+    "combat_call": "sound_splash_1",
+    "faint_call": "sound_splash_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/krokivip.json
+++ b/mods/tuxemon/db/monster/krokivip.json
@@ -105,7 +105,8 @@
   "height": 120,
   "weight": 45,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/l3gk0.json
+++ b/mods/tuxemon/db/monster/l3gk0.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_cute_03"
+    "combat_call": "sound_cute_03",
+    "faint_call": "sound_cute_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/legoplaste.json
+++ b/mods/tuxemon/db/monster/legoplaste.json
@@ -54,7 +54,8 @@
   "height": 100,
   "weight": 60,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/lendos.json
+++ b/mods/tuxemon/db/monster/lendos.json
@@ -89,7 +89,8 @@
   "height": 97,
   "weight": 7,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/lesmagu.json
+++ b/mods/tuxemon/db/monster/lesmagu.json
@@ -107,7 +107,8 @@
   "height": 42,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/lettice.json
+++ b/mods/tuxemon/db/monster/lettice.json
@@ -101,7 +101,8 @@
   "height": 60,
   "weight": 8,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/leviadile.json
+++ b/mods/tuxemon/db/monster/leviadile.json
@@ -100,7 +100,8 @@
   "height": 680,
   "weight": 2500,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/loliferno.json
+++ b/mods/tuxemon/db/monster/loliferno.json
@@ -80,7 +80,8 @@
   "height": 60,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_ghost_1"
+    "combat_call": "sound_ghost_1",
+    "faint_call": "sound_ghost_1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/lucifice.json
+++ b/mods/tuxemon/db/monster/lucifice.json
@@ -97,7 +97,8 @@
   "height": 180,
   "weight": 90,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/lunight.json
+++ b/mods/tuxemon/db/monster/lunight.json
@@ -83,7 +83,8 @@
   "height": 55,
   "weight": 17,
   "sounds": {
-    "combat_call": "sound_ghost_1"
+    "combat_call": "sound_ghost_1",
+    "faint_call": "sound_ghost_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/marvantis.json
+++ b/mods/tuxemon/db/monster/marvantis.json
@@ -81,7 +81,8 @@
   "height": 214,
   "weight": 270,
   "sounds": {
-    "combat_call": "sound_bug_03"
+    "combat_call": "sound_bug_03",
+    "faint_call": "sound_bug_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/marvillar.json
+++ b/mods/tuxemon/db/monster/marvillar.json
@@ -82,7 +82,8 @@
   "height": 30,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_bug_05"
+    "combat_call": "sound_bug_05",
+    "faint_call": "sound_bug_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mauai.json
+++ b/mods/tuxemon/db/monster/mauai.json
@@ -87,7 +87,8 @@
   "height": 203,
   "weight": 139,
   "sounds": {
-    "combat_call": "sound_misc_06_wood_and_metal"
+    "combat_call": "sound_misc_06_wood_and_metal",
+    "faint_call": "sound_misc_06_wood_and_metal_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/medipup.json
+++ b/mods/tuxemon/db/monster/medipup.json
@@ -117,7 +117,8 @@
   "height": 30,
   "weight": 3,
   "sounds": {
-    "combat_call": "sound_cute_01"
+    "combat_call": "sound_cute_01",
+    "faint_call": "sound_cute_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/medushock.json
+++ b/mods/tuxemon/db/monster/medushock.json
@@ -82,7 +82,8 @@
   "height": 133,
   "weight": 3,
   "sounds": {
-    "combat_call": "sound_retro_beep_06"
+    "combat_call": "sound_retro_beep_06",
+    "faint_call": "sound_retro_beep_06_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/megafruitera.json
+++ b/mods/tuxemon/db/monster/megafruitera.json
@@ -104,7 +104,8 @@
   "height": 60,
   "weight": 5,
   "sounds": {
-    "combat_call": "sound_woosh_1"
+    "combat_call": "sound_woosh_1",
+    "faint_call": "sound_woosh_1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/merlicun.json
+++ b/mods/tuxemon/db/monster/merlicun.json
@@ -85,7 +85,8 @@
   "height": 28,
   "weight": 3,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/metesaur.json
+++ b/mods/tuxemon/db/monster/metesaur.json
@@ -94,7 +94,8 @@
   "height": 95,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/metoxic.json
+++ b/mods/tuxemon/db/monster/metoxic.json
@@ -63,7 +63,8 @@
   "height": 100,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mingdyn.json
+++ b/mods/tuxemon/db/monster/mingdyn.json
@@ -87,7 +87,8 @@
   "height": 274,
   "weight": 124,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/mk01_alpha.json
+++ b/mods/tuxemon/db/monster/mk01_alpha.json
@@ -102,7 +102,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_robot1"
+    "combat_call": "sound_robot1",
+    "faint_call": "sound_robot1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_beta.json
+++ b/mods/tuxemon/db/monster/mk01_beta.json
@@ -102,7 +102,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_retro_beep_05"
+    "combat_call": "sound_retro_beep_05",
+    "faint_call": "sound_retro_beep_05_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_delta.json
+++ b/mods/tuxemon/db/monster/mk01_delta.json
@@ -108,7 +108,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_steel_clang"
+    "combat_call": "sound_steel_clang",
+    "faint_call": "sound_steel_clang_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_gamma.json
+++ b/mods/tuxemon/db/monster/mk01_gamma.json
@@ -96,7 +96,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_omega.json
+++ b/mods/tuxemon/db/monster/mk01_omega.json
@@ -96,7 +96,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_robotic_pig"
+    "combat_call": "sound_robotic_pig",
+    "faint_call": "sound_robotic_pig_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mk01_proto.json
+++ b/mods/tuxemon/db/monster/mk01_proto.json
@@ -101,7 +101,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_steel_clang"
+    "combat_call": "sound_steel_clang",
+    "faint_call": "sound_steel_clang_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/myrmison.json
+++ b/mods/tuxemon/db/monster/myrmison.json
@@ -100,7 +100,8 @@
   "height": 120,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/mystikapi.json
+++ b/mods/tuxemon/db/monster/mystikapi.json
@@ -81,7 +81,8 @@
   "height": 160,
   "weight": 250,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/nebufin.json
+++ b/mods/tuxemon/db/monster/nebufin.json
@@ -79,7 +79,8 @@
   "height": 20,
   "weight": 0.5,
   "sounds": {
-    "combat_call": "sound_robot2"
+    "combat_call": "sound_robot2",
+    "faint_call": "sound_robot2_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/ned.json
+++ b/mods/tuxemon/db/monster/ned.json
@@ -57,7 +57,8 @@
   "height": 87,
   "weight": 32,
   "sounds": {
-    "combat_call": "sound_bark"
+    "combat_call": "sound_bark",
+    "faint_call": "sound_bark_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/neutrito.json
+++ b/mods/tuxemon/db/monster/neutrito.json
@@ -79,7 +79,8 @@
   "height": 90,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_retro_beep_05"
+    "combat_call": "sound_retro_beep_05",
+    "faint_call": "sound_retro_beep_05_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/nimbulex.json
+++ b/mods/tuxemon/db/monster/nimbulex.json
@@ -91,7 +91,8 @@
   "height": 141,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/ninjasmine.json
+++ b/mods/tuxemon/db/monster/ninjasmine.json
@@ -104,7 +104,8 @@
   "height": 160,
   "weight": 60,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/novaquarius.json
+++ b/mods/tuxemon/db/monster/novaquarius.json
@@ -72,7 +72,8 @@
   "height": 100,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/octabode.json
+++ b/mods/tuxemon/db/monster/octabode.json
@@ -77,7 +77,8 @@
   "height": 44,
   "weight": 19,
   "sounds": {
-    "combat_call": "sound_grunt_03"
+    "combat_call": "sound_grunt_03",
+    "faint_call": "sound_grunt_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pairagrim.json
+++ b/mods/tuxemon/db/monster/pairagrim.json
@@ -79,7 +79,8 @@
   "height": 110,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pairagrin.json
+++ b/mods/tuxemon/db/monster/pairagrin.json
@@ -82,7 +82,8 @@
   "height": 70,
   "weight": 4,
   "sounds": {
-    "combat_call": "sound_woosh_1"
+    "combat_call": "sound_woosh_1",
+    "faint_call": "sound_woosh_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pantherafira.json
+++ b/mods/tuxemon/db/monster/pantherafira.json
@@ -82,7 +82,8 @@
   "height": 90,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_cat_meow3"
+    "combat_call": "sound_cat_meow3",
+    "faint_call": "sound_cat_meow3_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/parappi.json
+++ b/mods/tuxemon/db/monster/parappi.json
@@ -101,7 +101,8 @@
   "height": 120,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pawsand.json
+++ b/mods/tuxemon/db/monster/pawsand.json
@@ -120,7 +120,8 @@
   "height": 90,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_stones_04"
+    "combat_call": "sound_stones_04",
+    "faint_call": "sound_stones_04_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pearamanca.json
+++ b/mods/tuxemon/db/monster/pearamanca.json
@@ -70,7 +70,8 @@
   "height": 90,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/pharavion.json
+++ b/mods/tuxemon/db/monster/pharavion.json
@@ -98,7 +98,8 @@
   "height": 300,
   "weight": 2000,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pickoon.json
+++ b/mods/tuxemon/db/monster/pickoon.json
@@ -81,7 +81,8 @@
   "height": 40,
   "weight": 8,
   "sounds": {
-    "combat_call": "sound_grunt_04"
+    "combat_call": "sound_grunt_04",
+    "faint_call": "sound_grunt_04_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pilthropus.json
+++ b/mods/tuxemon/db/monster/pilthropus.json
@@ -79,7 +79,8 @@
   "height": 154,
   "weight": 82,
   "sounds": {
-    "combat_call": "sound_grunt_03"
+    "combat_call": "sound_grunt_03",
+    "faint_call": "sound_grunt_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/poinchin.json
+++ b/mods/tuxemon/db/monster/poinchin.json
@@ -79,7 +79,8 @@
   "height": 30,
   "weight": 6,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/potturmeist.json
+++ b/mods/tuxemon/db/monster/potturmeist.json
@@ -90,7 +90,8 @@
   "height": 48,
   "weight": 2.5,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/potturney.json
+++ b/mods/tuxemon/db/monster/potturney.json
@@ -85,7 +85,8 @@
   "height": 45,
   "weight": 6,
   "sounds": {
-    "combat_call": "sound_misc_07"
+    "combat_call": "sound_misc_07",
+    "faint_call": "sound_misc_07_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/primordia.json
+++ b/mods/tuxemon/db/monster/primordia.json
@@ -72,7 +72,8 @@
   "height": 1,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pythock.json
+++ b/mods/tuxemon/db/monster/pythock.json
@@ -86,7 +86,8 @@
   "height": 154,
   "weight": 32,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/pythonova.json
+++ b/mods/tuxemon/db/monster/pythonova.json
@@ -86,7 +86,8 @@
   "height": 600,
   "weight": 120,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/qetzlrokilus.json
+++ b/mods/tuxemon/db/monster/qetzlrokilus.json
@@ -92,7 +92,8 @@
   "height": 183,
   "weight": 41,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/r0ck1tt3n.json
+++ b/mods/tuxemon/db/monster/r0ck1tt3n.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_stones_04"
+    "combat_call": "sound_stones_04",
+    "faint_call": "sound_stones_04_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/raccscal.json
+++ b/mods/tuxemon/db/monster/raccscal.json
@@ -80,7 +80,8 @@
   "height": 80,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_grunt_04"
+    "combat_call": "sound_grunt_04",
+    "faint_call": "sound_grunt_04_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/raptoucan.json
+++ b/mods/tuxemon/db/monster/raptoucan.json
@@ -91,7 +91,8 @@
   "height": 160,
   "weight": 18,
   "sounds": {
-    "combat_call": "sound_crow_caw"
+    "combat_call": "sound_crow_caw",
+    "faint_call": "sound_crow_caw_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/regalance.json
+++ b/mods/tuxemon/db/monster/regalance.json
@@ -99,7 +99,8 @@
   "height": 182,
   "weight": 137,
   "sounds": {
-    "combat_call": "sound_grunt_03"
+    "combat_call": "sound_grunt_03",
+    "faint_call": "sound_grunt_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rhinocarpe.json
+++ b/mods/tuxemon/db/monster/rhinocarpe.json
@@ -83,7 +83,8 @@
   "height": 225,
   "weight": 95,
   "sounds": {
-    "combat_call": "sound_splash_1"
+    "combat_call": "sound_splash_1",
+    "faint_call": "sound_splash_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rinocereed.json
+++ b/mods/tuxemon/db/monster/rinocereed.json
@@ -82,7 +82,8 @@
   "height": 92,
   "weight": 402,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rocktot.json
+++ b/mods/tuxemon/db/monster/rocktot.json
@@ -74,7 +74,8 @@
   "height": 62,
   "weight": 58,
   "sounds": {
-    "combat_call": "sound_stones_04"
+    "combat_call": "sound_stones_04",
+    "faint_call": "sound_stones_04_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/rooksand.json
+++ b/mods/tuxemon/db/monster/rooksand.json
@@ -85,7 +85,8 @@
   "height": 300,
   "weight": 1000,
   "sounds": {
-    "combat_call": "sound_bugthing"
+    "combat_call": "sound_bugthing",
+    "faint_call": "sound_bugthing_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/rosarin.json
+++ b/mods/tuxemon/db/monster/rosarin.json
@@ -108,7 +108,8 @@
   "height": 48,
   "weight": 14,
   "sounds": {
-    "combat_call": "sound_cute_03"
+    "combat_call": "sound_cute_03",
+    "faint_call": "sound_cute_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/ruffalo.json
+++ b/mods/tuxemon/db/monster/ruffalo.json
@@ -53,7 +53,8 @@
   "height": 180,
   "weight": 350,
   "sounds": {
-    "combat_call": "sound_bark"
+    "combat_call": "sound_bark",
+    "faint_call": "sound_bark_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/runesquito.json
+++ b/mods/tuxemon/db/monster/runesquito.json
@@ -91,7 +91,8 @@
   "height": 66,
   "weight": 6,
   "sounds": {
-    "combat_call": "sound_bug_09"
+    "combat_call": "sound_bug_09",
+    "faint_call": "sound_bug_09_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/sadito.json
+++ b/mods/tuxemon/db/monster/sadito.json
@@ -80,7 +80,8 @@
   "height": 90,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_retro_beep_05"
+    "combat_call": "sound_retro_beep_05",
+    "faint_call": "sound_retro_beep_05_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/saurchin.json
+++ b/mods/tuxemon/db/monster/saurchin.json
@@ -88,7 +88,8 @@
   "height": 800,
   "weight": 3000,
   "sounds": {
-    "combat_call": "sound_roar_03"
+    "combat_call": "sound_roar_03",
+    "faint_call": "sound_roar_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/scarlant.json
+++ b/mods/tuxemon/db/monster/scarlant.json
@@ -87,7 +87,8 @@
   "height": 30,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/selket.json
+++ b/mods/tuxemon/db/monster/selket.json
@@ -79,7 +79,8 @@
   "height": 17,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/selmatek.json
+++ b/mods/tuxemon/db/monster/selmatek.json
@@ -74,7 +74,8 @@
   "height": 155,
   "weight": 80,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/seraphice.json
+++ b/mods/tuxemon/db/monster/seraphice.json
@@ -97,7 +97,8 @@
   "height": 180,
   "weight": 85,
   "sounds": {
-    "combat_call": "sound_ice"
+    "combat_call": "sound_ice",
+    "faint_call": "sound_ice_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.85,

--- a/mods/tuxemon/db/monster/shelagu.json
+++ b/mods/tuxemon/db/monster/shelagu.json
@@ -109,7 +109,8 @@
   "height": 60,
   "weight": 4,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sheye.json
+++ b/mods/tuxemon/db/monster/sheye.json
@@ -77,7 +77,8 @@
   "height": 40,
   "weight": 19,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/shimmerain.json
+++ b/mods/tuxemon/db/monster/shimmerain.json
@@ -71,7 +71,8 @@
   "height": 80,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_echo_gurgle_whoosh_1"
+    "combat_call": "sound_echo_gurgle_whoosh_1",
+    "faint_call": "sound_echo_gurgle_whoosh_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/shnark.json
+++ b/mods/tuxemon/db/monster/shnark.json
@@ -81,7 +81,8 @@
   "height": 205,
   "weight": 120,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/shrab.json
+++ b/mods/tuxemon/db/monster/shrab.json
@@ -69,7 +69,8 @@
   "height": 100,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/shull.json
+++ b/mods/tuxemon/db/monster/shull.json
@@ -93,7 +93,8 @@
   "height": 40,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_roar_05"
+    "combat_call": "sound_roar_05",
+    "faint_call": "sound_roar_05_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/skwib.json
+++ b/mods/tuxemon/db/monster/skwib.json
@@ -80,7 +80,8 @@
   "height": 30,
   "weight": 9,
   "sounds": {
-    "combat_call": "sound_cute_01"
+    "combat_call": "sound_cute_01",
+    "faint_call": "sound_cute_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/slichen.json
+++ b/mods/tuxemon/db/monster/slichen.json
@@ -111,7 +111,8 @@
   "height": 37,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/snaki.json
+++ b/mods/tuxemon/db/monster/snaki.json
@@ -81,7 +81,8 @@
   "height": 70,
   "weight": 15,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/snock.json
+++ b/mods/tuxemon/db/monster/snock.json
@@ -85,7 +85,8 @@
   "height": 30,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/snokari.json
+++ b/mods/tuxemon/db/monster/snokari.json
@@ -76,7 +76,8 @@
   "height": 145,
   "weight": 45,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/snowrilla.json
+++ b/mods/tuxemon/db/monster/snowrilla.json
@@ -76,7 +76,8 @@
   "height": 192,
   "weight": 112,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/solight.json
+++ b/mods/tuxemon/db/monster/solight.json
@@ -83,7 +83,8 @@
   "height": 55,
   "weight": 17,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/spectera.json
+++ b/mods/tuxemon/db/monster/spectera.json
@@ -105,7 +105,8 @@
   "height": 140,
   "weight": 20,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/sphake.json
+++ b/mods/tuxemon/db/monster/sphake.json
@@ -64,7 +64,8 @@
   "height": 600,
   "weight": 2000,
   "sounds": {
-    "combat_call": "sound_robot1"
+    "combat_call": "sound_robot1",
+    "faint_call": "sound_robot1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/spirain.json
+++ b/mods/tuxemon/db/monster/spirain.json
@@ -96,7 +96,8 @@
   "height": 100,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/spoilurm.json
+++ b/mods/tuxemon/db/monster/spoilurm.json
@@ -78,7 +78,8 @@
   "height": 41,
   "weight": 4,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/sprightly.json
+++ b/mods/tuxemon/db/monster/sprightly.json
@@ -72,7 +72,8 @@
   "height": 30,
   "weight": 9,
   "sounds": {
-    "combat_call": "sound_wood_call"
+    "combat_call": "sound_wood_call",
+    "faint_call": "sound_wood_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/sprorm.json
+++ b/mods/tuxemon/db/monster/sprorm.json
@@ -68,7 +68,8 @@
   "height": 30,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_robot1"
+    "combat_call": "sound_robot1",
+    "faint_call": "sound_robot1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/spycozeus.json
+++ b/mods/tuxemon/db/monster/spycozeus.json
@@ -79,7 +79,8 @@
   "height": 60,
   "weight": 18,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/squink.json
+++ b/mods/tuxemon/db/monster/squink.json
@@ -80,7 +80,8 @@
   "height": 70,
   "weight": 24,
   "sounds": {
-    "combat_call": "sound_burble_02"
+    "combat_call": "sound_burble_02",
+    "faint_call": "sound_burble_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/statursus.json
+++ b/mods/tuxemon/db/monster/statursus.json
@@ -88,7 +88,8 @@
   "height": 190,
   "weight": 160,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/stegofor.json
+++ b/mods/tuxemon/db/monster/stegofor.json
@@ -104,7 +104,8 @@
   "height": 650,
   "weight": 2800,
   "sounds": {
-    "combat_call": "sound_cute_02"
+    "combat_call": "sound_cute_02",
+    "faint_call": "sound_cute_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/stomic.json
+++ b/mods/tuxemon/db/monster/stomic.json
@@ -86,7 +86,8 @@
   "height": 30,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_misc_07_metal"
+    "combat_call": "sound_misc_07_metal",
+    "faint_call": "sound_misc_07_metal_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/stonifly.json
+++ b/mods/tuxemon/db/monster/stonifly.json
@@ -87,7 +87,8 @@
   "height": 30,
   "weight": 16,
   "sounds": {
-    "combat_call": "sound_bug_03"
+    "combat_call": "sound_bug_03",
+    "faint_call": "sound_bug_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tadcool.json
+++ b/mods/tuxemon/db/monster/tadcool.json
@@ -85,7 +85,8 @@
   "height": 25,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_frog"
+    "combat_call": "sound_frog",
+    "faint_call": "sound_frog_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tarpeur.json
+++ b/mods/tuxemon/db/monster/tarpeur.json
@@ -82,7 +82,8 @@
   "height": 19,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_cute_02"
+    "combat_call": "sound_cute_02",
+    "faint_call": "sound_cute_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/taupypus.json
+++ b/mods/tuxemon/db/monster/taupypus.json
@@ -78,7 +78,8 @@
   "height": 60,
   "weight": 3,
   "sounds": {
-    "combat_call": "sound_echo_gurgle_whoosh_1"
+    "combat_call": "sound_echo_gurgle_whoosh_1",
+    "faint_call": "sound_echo_gurgle_whoosh_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/teddisun.json
+++ b/mods/tuxemon/db/monster/teddisun.json
@@ -84,7 +84,8 @@
   "height": 110,
   "weight": 60,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tetrchimp.json
+++ b/mods/tuxemon/db/monster/tetrchimp.json
@@ -83,7 +83,8 @@
   "height": 45,
   "weight": 4,
   "sounds": {
-    "combat_call": "sound_whistle"
+    "combat_call": "sound_whistle",
+    "faint_call": "sound_whistle_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/thumpurn.json
+++ b/mods/tuxemon/db/monster/thumpurn.json
@@ -74,7 +74,8 @@
   "height": 65,
   "weight": 23,
   "sounds": {
-    "combat_call": "sound_spell_fire_06"
+    "combat_call": "sound_spell_fire_06",
+    "faint_call": "sound_spell_fire_06_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/tobishimi.json
+++ b/mods/tuxemon/db/monster/tobishimi.json
@@ -98,7 +98,8 @@
   "height": 180,
   "weight": 169,
   "sounds": {
-    "combat_call": "sound_creature_roar"
+    "combat_call": "sound_creature_roar",
+    "faint_call": "sound_creature_roar_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tornicane.json
+++ b/mods/tuxemon/db/monster/tornicane.json
@@ -92,7 +92,8 @@
   "height": 300,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sfx_tornado"
+    "combat_call": "sfx_tornado",
+    "faint_call": "sfx_tornado_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/toucanary.json
+++ b/mods/tuxemon/db/monster/toucanary.json
@@ -96,7 +96,8 @@
   "height": 12,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_wood_call"
+    "combat_call": "sound_wood_call",
+    "faint_call": "sound_wood_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/toxiris.json
+++ b/mods/tuxemon/db/monster/toxiris.json
@@ -109,7 +109,8 @@
   "height": 100,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_monster_19"
+    "combat_call": "sound_monster_19",
+    "faint_call": "sound_monster_19_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/trojerror.json
+++ b/mods/tuxemon/db/monster/trojerror.json
@@ -94,7 +94,8 @@
   "height": 30,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tsushimi.json
+++ b/mods/tuxemon/db/monster/tsushimi.json
@@ -103,7 +103,8 @@
   "height": 136,
   "weight": 85,
   "sounds": {
-    "combat_call": "sound_monster_19"
+    "combat_call": "sound_monster_19",
+    "faint_call": "sound_monster_19_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tumbledillo.json
+++ b/mods/tuxemon/db/monster/tumbledillo.json
@@ -90,7 +90,8 @@
   "height": 64,
   "weight": 14,
   "sounds": {
-    "combat_call": "sound_stones_04"
+    "combat_call": "sound_stones_04",
+    "faint_call": "sound_stones_04_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tumblequill.json
+++ b/mods/tuxemon/db/monster/tumblequill.json
@@ -94,7 +94,8 @@
   "height": 27,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_grunt_03"
+    "combat_call": "sound_grunt_03",
+    "faint_call": "sound_grunt_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/turnipper.json
+++ b/mods/tuxemon/db/monster/turnipper.json
@@ -95,7 +95,8 @@
   "height": 65,
   "weight": 25,
   "sounds": {
-    "combat_call": "sound_cute_03"
+    "combat_call": "sound_cute_03",
+    "faint_call": "sound_cute_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/tux.json
+++ b/mods/tuxemon/db/monster/tux.json
@@ -84,7 +84,8 @@
   "height": 115,
   "weight": 55,
   "sounds": {
-    "combat_call": "sound_tux"
+    "combat_call": "sound_tux",
+    "faint_call": "sound_tux_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/uf0.json
+++ b/mods/tuxemon/db/monster/uf0.json
@@ -83,7 +83,8 @@
   "height": 80,
   "weight": 7,
   "sounds": {
-    "combat_call": "sound_glitch_call"
+    "combat_call": "sound_glitch_call",
+    "faint_call": "sound_glitch_call_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/uglip.json
+++ b/mods/tuxemon/db/monster/uglip.json
@@ -81,7 +81,8 @@
   "height": 30,
   "weight": 2,
   "sounds": {
-    "combat_call": "sound_frog"
+    "combat_call": "sound_frog",
+    "faint_call": "sound_frog_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/uneye.json
+++ b/mods/tuxemon/db/monster/uneye.json
@@ -94,7 +94,8 @@
   "height": 45,
   "weight": 3.5,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/uprout.json
+++ b/mods/tuxemon/db/monster/uprout.json
@@ -85,7 +85,8 @@
   "height": 100,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/urcheedle.json
+++ b/mods/tuxemon/db/monster/urcheedle.json
@@ -82,7 +82,8 @@
   "height": 30,
   "weight": 0.5,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/urcine.json
+++ b/mods/tuxemon/db/monster/urcine.json
@@ -85,7 +85,8 @@
   "height": 115,
   "weight": 45,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/vigueur.json
+++ b/mods/tuxemon/db/monster/vigueur.json
@@ -79,7 +79,8 @@
   "height": 38,
   "weight": 4,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/virware.json
+++ b/mods/tuxemon/db/monster/virware.json
@@ -101,7 +101,8 @@
   "height": 30,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_misc_07_metal"
+    "combat_call": "sound_misc_07_metal",
+    "faint_call": "sound_misc_07_metal_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/vividactil.json
+++ b/mods/tuxemon/db/monster/vividactil.json
@@ -94,7 +94,8 @@
   "height": 97,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_woosh_2"
+    "combat_call": "sound_woosh_2",
+    "faint_call": "sound_woosh_2_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/vivisource.json
+++ b/mods/tuxemon/db/monster/vivisource.json
@@ -90,7 +90,8 @@
   "height": 107,
   "weight": 9,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/volconey.json
+++ b/mods/tuxemon/db/monster/volconey.json
@@ -70,7 +70,8 @@
   "height": 85,
   "weight": 32,
   "sounds": {
-    "combat_call": "sound_spell_fire_07"
+    "combat_call": "sound_spell_fire_07",
+    "faint_call": "sound_spell_fire_07_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/vulpyre.json
+++ b/mods/tuxemon/db/monster/vulpyre.json
@@ -92,7 +92,8 @@
   "height": 100,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_spell_fire_07"
+    "combat_call": "sound_spell_fire_07",
+    "faint_call": "sound_spell_fire_07_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -110,7 +110,8 @@
   "height": 15,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_cute_04"
+    "combat_call": "sound_cute_04",
+    "faint_call": "sound_cute_04_faint"
   },
   "catch_rate": 100,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/weedlantis.json
+++ b/mods/tuxemon/db/monster/weedlantis.json
@@ -92,7 +92,8 @@
   "height": 185,
   "weight": 120,
   "sounds": {
-    "combat_call": "sound_frog"
+    "combat_call": "sound_frog",
+    "faint_call": "sound_frog_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/weedsea.json
+++ b/mods/tuxemon/db/monster/weedsea.json
@@ -106,7 +106,8 @@
   "height": 100,
   "weight": 10,
   "sounds": {
-    "combat_call": "sound_splash_1"
+    "combat_call": "sound_splash_1",
+    "faint_call": "sound_splash_1_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/wendigger.json
+++ b/mods/tuxemon/db/monster/wendigger.json
@@ -95,7 +95,8 @@
   "height": 210,
   "weight": 75,
   "sounds": {
-    "combat_call": "sound_monster_19"
+    "combat_call": "sound_monster_19",
+    "faint_call": "sound_monster_19_faint"
   },
   "catch_rate": 35.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/windeye.json
+++ b/mods/tuxemon/db/monster/windeye.json
@@ -76,7 +76,8 @@
   "height": 300,
   "weight": 600,
   "sounds": {
-    "combat_call": "sound_robot1"
+    "combat_call": "sound_robot1",
+    "faint_call": "sound_robot1_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/wolffsky.json
+++ b/mods/tuxemon/db/monster/wolffsky.json
@@ -83,7 +83,8 @@
   "height": 130,
   "weight": 50,
   "sounds": {
-    "combat_call": "sound_bark"
+    "combat_call": "sound_bark",
+    "faint_call": "sound_bark_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/wolololl.json
+++ b/mods/tuxemon/db/monster/wolololl.json
@@ -87,7 +87,8 @@
   "height": 130,
   "weight": 40,
   "sounds": {
-    "combat_call": "sound_spit_02"
+    "combat_call": "sound_spit_02",
+    "faint_call": "sound_spit_02_faint"
   },
   "catch_rate": 70.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/woodoor.json
+++ b/mods/tuxemon/db/monster/woodoor.json
@@ -93,7 +93,8 @@
   "height": 2040,
   "weight": 46,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/xeon.json
+++ b/mods/tuxemon/db/monster/xeon.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_terminal_03"
+    "combat_call": "sound_terminal_03",
+    "faint_call": "sound_terminal_03_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/xeon_2.json
+++ b/mods/tuxemon/db/monster/xeon_2.json
@@ -74,7 +74,8 @@
   "height": 0.1,
   "weight": 100,
   "sounds": {
-    "combat_call": "sound_retro_beep_05"
+    "combat_call": "sound_retro_beep_05",
+    "faint_call": "sound_retro_beep_05_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.95,

--- a/mods/tuxemon/db/monster/yamada.json
+++ b/mods/tuxemon/db/monster/yamada.json
@@ -76,7 +76,8 @@
   "height": 150,
   "weight": 0.1,
   "sounds": {
-    "combat_call": "sound_weird_09"
+    "combat_call": "sound_weird_09",
+    "faint_call": "sound_weird_09_faint"
   },
   "catch_rate": 50.0,
   "lower_catch_resistance": 0.9,

--- a/mods/tuxemon/db/monster/ziggurat.json
+++ b/mods/tuxemon/db/monster/ziggurat.json
@@ -81,7 +81,8 @@
   "height": 30,
   "weight": 1,
   "sounds": {
-    "combat_call": "sound_spit_01"
+    "combat_call": "sound_spit_01",
+    "faint_call": "sound_spit_01_faint"
   },
   "catch_rate": 100.0,
   "lower_catch_resistance": 0.9,


### PR DESCRIPTION
I forgot to add faint calls to a bunch of monsters when I gave them main calls - this should correct that