### PR TITLE
Refactor and Cleanup of `MonsterInfoState` After PR #3143 Merge

### DIFF
--- a/mods/config_monster.yaml
+++ b/mods/config_monster.yaml
@@ -1,6 +1,10 @@
 # Defines the bond value range (0 = no bond, 100 = max bond)
 bond_range: [0, 100]
 
+# Bond modifiers triggered by specific monster events
+bond_modifiers:
+  fainted: -10
+
 # Defines a random interval for weight fluctuation (±10% variation)
 weight_range: [-0.1, 0.1]
 
@@ -13,6 +17,15 @@ bond_sentiments:
   wary: [21, 50]
   gets_along: [51, 75]
   adores: [76, 100]
+
+# Maps each bond sentiment label to its corresponding icon file path.
+# These icons are used in the UI to visually represent the monster's bond level.
+# The labels must match those defined in 'bond_sentiments' to ensure correct mapping.
+bond_icons:
+  despises: gfx/ui/icons/bond/bond1.png
+  wary: gfx/ui/icons/bond/bond2.png
+  gets_along: gfx/ui/icons/bond/bond3.png
+  adores: gfx/ui/icons/bond/bond4.png
 
 # Maps sentiment labels to localized string templates for player-facing messages.
 bond_strings:

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -7,14 +7,6 @@ events:
     - is variable_set swimming:yes
     - is current_state WorldState
     type: event
-  Bond Down -10 Fainted:
-    actions:
-    - modify_monster_bond combatstate_faint,-10
-    - clear_variable combatstate_faint
-    conditions:
-    - is variable_set combatstate_faint
-    - is has_item player,friendship_scroll
-    type: event
   Bond Up 1000 Steps:
     actions:
     - modify_monster_bond

--- a/tuxemon/combat/damage_tracker.py
+++ b/tuxemon/combat/damage_tracker.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
-from tuxemon.monster import Monster
-
 if TYPE_CHECKING:
-    pass
+    from tuxemon.monster import Monster
 
 
 @dataclass

--- a/tuxemon/combat/menu_visibility.py
+++ b/tuxemon/combat/menu_visibility.py
@@ -2,11 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
-
 
 class MenuProfiles:
     @staticmethod

--- a/tuxemon/combat/reward_system.py
+++ b/tuxemon/combat/reward_system.py
@@ -53,6 +53,13 @@ class RewardSystem:
         self.session = session
         self.damage_map = damage_map
 
+    def apply_penalties(self, monster: Monster) -> None:
+        """Applies defeat-related penalties to the specified monster."""
+        monster.current_hp = 0
+        owner = monster.get_owner()
+        if owner.items.find_item("friendship_scroll"):
+            monster.bond_handler.apply_bond_modifier("fainted")
+
     def award_rewards(self, monster: Monster) -> RewardData:
         """
         Calculate and distribute rewards (experience, money, and moves)

--- a/tuxemon/economy/price_policy.py
+++ b/tuxemon/economy/price_policy.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 
 import yaml
 from pydantic import BaseModel, Field
 
 from tuxemon.constants import paths
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -88,10 +88,12 @@ class CaptureConfig:
 @dataclass
 class MonsterConfig:
     bond_range: tuple[int, int] = (0, 100)
+    bond_modifiers: dict[str, int] = field(default_factory=dict)
     weight_range: tuple[float, float] = (-0.1, 0.1)
     height_range: tuple[float, float] = (-0.1, 0.1)
     bond_sentiments: dict[str, tuple[int, int]] = field(default_factory=dict)
     bond_strings: dict[str, str] = field(default_factory=dict)
+    bond_icons: dict[str, str] = field(default_factory=dict)
     opposite_tastes: dict[str, list[str]] = field(default_factory=dict)
     bond_preferences: dict[str, int] = field(default_factory=dict)
     experience_multipliers: dict[str, float] = field(default_factory=dict)
@@ -565,14 +567,14 @@ def set_height(monster: Monster, value: float) -> float:
     return round(random.uniform(min_height, max_height), 2)
 
 
-def convert_lbs(kg: float) -> float:
+def convert_lbs(kg: float) -> int:
     """It converts kilograms into pounds."""
-    return round(kg * pre.COEFF_POUNDS, 2)
+    return round(kg * pre.COEFF_POUNDS)
 
 
-def convert_ft(cm: float) -> float:
+def convert_ft(cm: float) -> int:
     """It converts centimeters into feet."""
-    return round(cm * pre.COEFF_FEET, 2)
+    return round(cm * pre.COEFF_FEET)
 
 
 def convert_km(steps: float) -> float:
@@ -584,22 +586,6 @@ def convert_mi(steps: float) -> float:
     """It converts steps into miles."""
     km = convert_km(steps)
     return round(km * pre.COEFF_MILES, 2)
-
-
-def diff_percentage(part: float, total: float, decimal: int = 1) -> float:
-    """
-    It returns the difference between two numbers in percentage format.
-
-    Parameters:
-        part: The part, number.
-        total: The total, number.
-        decimal: How many decimals, default 1.
-
-    Returns:
-        The difference in percentage.
-
-    """
-    return round(((part - total) / total) * 100, decimal)
 
 
 def shake_check(

--- a/tuxemon/monster_dir/bond.py
+++ b/tuxemon/monster_dir/bond.py
@@ -105,3 +105,25 @@ class BondHandler:
                     )
 
         return None
+
+    def get_bond_icon_path(self) -> Optional[str]:
+        """
+        Returns the file path to the bond icon based on the monster's current bond level.
+        """
+        bond_level = self.bond
+        bond_sentiments = config_monster.bond_sentiments
+        bond_icons = config_monster.bond_icons
+
+        for sentiment_key, (min_bond, max_bond) in bond_sentiments.items():
+            if min_bond <= bond_level <= max_bond:
+                return bond_icons.get(sentiment_key)
+
+        return None
+
+    def apply_bond_modifier(self, event: str) -> None:
+        """
+        Applies a bond change based on a named event using config_monster.bond_modifiers.
+        """
+        modifier = config_monster.bond_modifiers.get(event)
+        if modifier is not None:
+            self.change_bond(modifier)

--- a/tuxemon/monster_dir/evolution_registry.py
+++ b/tuxemon/monster_dir/evolution_registry.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 from uuid import UUID
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/tuxemon/monster_dir/filter.py
+++ b/tuxemon/monster_dir/filter.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,8 @@ from tuxemon.monster import Monster
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
+
+logger = logging.getLogger(__name__)
 
 
 def or_monster_filter(
@@ -99,7 +102,7 @@ class MonsterFilter:
                 f.__name__ if hasattr(f, "__name__") else repr(f)
                 for f in self._filters
             ]
-            print(
+            logger.debug(
                 f"[MonsterFilter] No monsters passed current filters. "
                 f"Total monsters: {len(monsters)}. Filters applied: {active_filters}"
             )

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -404,7 +404,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                             self.sprites.add(spr, layer=200)
                             self.type_icon_sprites.append(spr)
                         except Exception as e:
-                            print(f"Could not load type icon {path}: {e}")
+                            logger.error(
+                                f"Could not load type icon {path}: {e}"
+                            )
 
                 # --- Draw range icon ---
                 if technique.range:
@@ -421,7 +423,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                         self.sprites.add(spr, layer=200)
                         self.range_icon_sprite = spr
                     except Exception as e:
-                        print(f"Could not load range icon {path}: {e}")
+                        logger.error(f"Could not load range icon {path}: {e}")
 
                 # --- Draw speed icon ---
                 if technique.speed is not None:
@@ -454,7 +456,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                         self.sprites.add(spr, layer=200)
                         self.speed_icon_sprite = spr
                     except Exception as e:
-                        print(f"Could not load speed icon {path}: {e}")
+                        logger.error(f"Could not load speed icon {path}: {e}")
 
                 # --- Draw text labels ---
                 font = self.font

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -47,7 +47,6 @@ from tuxemon.combat.combat_context import CombatContext
 from tuxemon.combat.machine import CombatMachine, CombatPhase
 from tuxemon.combat.reward_system import RewardSystem
 from tuxemon.combat.utils import (
-    set_var,
     track_battles,
 )
 from tuxemon.db import (
@@ -757,17 +756,6 @@ class CombatState(CombatAnimations):
             )
             self.task(animation.kill, interval=safe_action_time)
 
-    def faint_monster(self, monster: Monster) -> None:
-        """
-        Instantly make the monster faint (will be removed later).
-
-        Parameters:
-            monster: Monster that will faint.
-        """
-        monster.current_hp = 0
-        label = f"{self.name.lower()}_faint"
-        set_var(self.session, label, monster.instance_id.hex)
-
     def award_experience_and_money(self, monster: Monster) -> None:
         """
         Award experience and money to the winners.
@@ -777,6 +765,7 @@ class CombatState(CombatAnimations):
         """
         damage_map = self.client.combat_session.damage_tracker
         reward_system = RewardSystem(self.session, damage_map)
+        reward_system.apply_penalties(monster)
         rewards = reward_system.award_rewards(monster)
 
         # Update combat state with rewards
@@ -892,7 +881,6 @@ class CombatState(CombatAnimations):
             monster: Monster that was defeated.
         """
         self.remove_monster_actions_from_queue(monster)
-        self.faint_monster(monster)
         self.award_experience_and_money(monster)
         # Remove monster from damage map
         self.client.combat_session.damage_tracker.remove_monster(monster)

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -9,24 +9,27 @@ import pygame_menu
 from pygame_menu import locals
 
 from tuxemon import formula, prepare
-from tuxemon.db import MonsterModel, db
+from tuxemon.db import MonsterModel, TasteModel, db
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 from tuxemon.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
-from tuxemon.session import local_session
 from tuxemon.time_handler import today_ordinal
 from tuxemon.tools import fix_measure, transform_resource_filename
 
 lookup_cache: dict[str, MonsterModel] = {}
+lookup_tastes: dict[str, TasteModel] = {}
 
 
-import json
-
-with open("mods/tuxemon/db/taste/taste.json", "r") as f:
-    taste_map = json.load(f)
+def _lookup_tastes() -> None:
+    global lookup_tastes
+    lookup_tastes = {
+        taste_name: result
+        for taste_name in db.database["taste"]
+        if (result := TasteModel.lookup(taste_name, db)).slug
+    }
 
 
 def _lookup_monsters() -> None:
@@ -60,12 +63,8 @@ class MonsterInfoState(PygameMenuState):
         background.scale(prepare.SCALE, prepare.SCALE)
         background_widget = menu.add.image(image_path=background)
         background_widget.set_float(origin_position=True)
-        background_widget.translate(fxw((0 / 256)), fxh((0 / 144)))
+        background_widget.translate(fxw(0 / 256), fxh(0 / 144))
 
-        # types
-        types = " ".join(
-            map(lambda s: T.translate(s.slug), monster.types.current)
-        )
         # weight and height
         models = list(lookup_cache.values())
         results = next(
@@ -73,8 +72,7 @@ class MonsterInfoState(PygameMenuState):
         )
         if results is None:
             return
-        diff_weight = formula.diff_percentage(monster.weight, results.weight)
-        diff_height = formula.diff_percentage(monster.height, results.height)
+
         unit = self.client.config.unit_measure
         if unit == "metric":
             mon_weight = round(monster.weight)
@@ -101,7 +99,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab1.translate(fxw((37 / 256)), fxh((9.8 / 144)))
+        lab1.translate(fxw(37 / 256), fxh(9.8 / 144))
         # level + exp
         exp = monster.total_experience
         lab2: Any = menu.add.label(
@@ -112,7 +110,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab2.translate(fxw((169 / 256)), fxh((12.8 / 144)))
+        lab2.translate(fxw(169 / 256), fxh(12.8 / 144))
         # XP progress to next level
         exp_current_level = monster.experience_required(
             0
@@ -134,7 +132,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab3.translate(fxw((84 / 256)), fxh((86.8 / 144)))
+        lab3.translate(fxw(84 / 256), fxh(86.8 / 144))
 
         lab3b: Any = menu.add.label(
             title=f"{y:,}",  # add commas for readability
@@ -144,7 +142,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab3b.translate(fxw((92 / 256)), fxh((96.8 / 144)))
+        lab3b.translate(fxw(92 / 256), fxh(96.8 / 144))
 
         # section labels
         height_label: Any = menu.add.label(
@@ -156,7 +154,7 @@ class MonsterInfoState(PygameMenuState):
             font_name=thin_font_path,
             font_color=light_color,
         )
-        height_label.translate(fxw((79 / 256)), fxh((25.8 / 144)))
+        height_label.translate(fxw(79 / 256), fxh(25.8 / 144))
 
         weight_label: Any = menu.add.label(
             title=T.translate("weight"),
@@ -167,7 +165,7 @@ class MonsterInfoState(PygameMenuState):
             font_name=thin_font_path,
             font_color=light_color,
         )
-        weight_label.translate(fxw((118 / 256)), fxh((25.8 / 144)))
+        weight_label.translate(fxw(118 / 256), fxh(25.8 / 144))
 
         tastes_label: Any = menu.add.label(
             title=T.translate("tastes"),
@@ -178,7 +176,7 @@ class MonsterInfoState(PygameMenuState):
             font_name=thin_font_path,
             font_color=light_color,
         )
-        tastes_label.translate(fxw((79 / 256)), fxh((48.8 / 144)))
+        tastes_label.translate(fxw(79 / 256), fxh(48.8 / 144))
 
         exp_label: Any = menu.add.label(
             title=T.translate("exp_to_next_level"),
@@ -189,7 +187,7 @@ class MonsterInfoState(PygameMenuState):
             font_name=thin_font_path,
             font_color=light_color,
         )
-        exp_label.translate(fxw((79 / 256)), fxh((78.8 / 144)))
+        exp_label.translate(fxw(79 / 256), fxh(78.8 / 144))
 
         # gender
         gender_symbol = ""
@@ -207,7 +205,7 @@ class MonsterInfoState(PygameMenuState):
                 font_color=dark_color,
                 float=True,
             )
-            lab_gender.translate(fxw((11 / 256)), fxh((9 / 144)))
+            lab_gender.translate(fxw(11 / 256), fxh(9 / 144))
 
         # weight
         lab4: Any = menu.add.label(
@@ -218,7 +216,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab4.translate(fxw((122 / 256)), fxh((34.8 / 144)))
+        lab4.translate(fxw(122 / 256), fxh(34.8 / 144))
         # height
         lab5: Any = menu.add.label(
             title=f"{mon_height}{unit_height}",
@@ -228,7 +226,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab5.translate(fxw((84 / 256)), fxh((34.8 / 144)))
+        lab5.translate(fxw(84 / 256), fxh(34.8 / 144))
 
         # taste
         cold = T.translate(f"taste_{monster.taste_cold.lower()}")
@@ -241,7 +239,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab8.translate(fxw((84 / 256)), fxh((58 / 144)))
+        lab8.translate(fxw(84 / 256), fxh(58 / 144))
 
         lab9: Any = menu.add.label(
             title=f"{cold}",
@@ -251,7 +249,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab9.translate(fxw((84 / 256)), fxh((66 / 144)))
+        lab9.translate(fxw(84 / 256), fxh(66 / 144))
 
         # capture
         reference = get_acquisition_reference(monster)
@@ -265,7 +263,7 @@ class MonsterInfoState(PygameMenuState):
             font_name=thin_font_path,
             font_color=dark_color,
         )
-        lab10.translate(fxw((38 / 256)), fxh((118.8 / 144)))
+        lab10.translate(fxw(38 / 256), fxh(118.8 / 144))
 
         # type icons (first and second type separately)
         types = monster.types.current
@@ -299,7 +297,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab11.translate(fxw((200 / 256)), fxh(34.8 / 144))
+        lab11.translate(fxw(200 / 256), fxh(34.8 / 144))
         # armour
         lab12: Any = menu.add.label(
             title=f"{monster.armour}",
@@ -309,7 +307,7 @@ class MonsterInfoState(PygameMenuState):
             float=True,
             font_color=dark_color,
         )
-        lab12.translate(fxw((200 / 256)), fxh(47.8 / 144))
+        lab12.translate(fxw(200 / 256), fxh(47.8 / 144))
         # dodge
         lab13: Any = menu.add.label(
             title=f"{monster.dodge}",
@@ -352,9 +350,9 @@ class MonsterInfoState(PygameMenuState):
         lab16.translate(fxw(200 / 256), fxh(98.8 / 144))
 
         stat_positions = {
-            "hp": (fxw((165 / 256)), fxh(34.8 / 144)),
-            "armour": (fxw((165 / 256)), fxh(47.8 / 144)),
-            "dodge": (fxw((165 / 256)), fxh(60.8 / 144)),
+            "hp": (fxw(165 / 256), fxh(34.8 / 144)),
+            "armour": (fxw(165 / 256), fxh(47.8 / 144)),
+            "dodge": (fxw(165 / 256), fxh(60.8 / 144)),
             "melee": (fxw(165 / 256), fxh(72.8 / 144)),
             "ranged": (fxw(165 / 256), fxh(85.8 / 144)),
             "speed": (fxw(165 / 256), fxh(98.8 / 144)),
@@ -370,7 +368,7 @@ class MonsterInfoState(PygameMenuState):
         }
 
         for stat, title in stat_labels.items():
-            stat_label = menu.add.label(
+            stat_label: Any = menu.add.label(
                 title=title,
                 label_id=f"label-{stat}",
                 font_size=self.font_type.biggest,
@@ -389,10 +387,10 @@ class MonsterInfoState(PygameMenuState):
 
         # Helper: find which stat a taste affects
         def get_stat_for_taste(slug: str) -> str | None:
-            for entry in taste_map:
-                if entry["slug"] == slug.lower():
-                    return entry["modifiers"][0]["values"][0]
-            return None
+            taste = lookup_tastes.get(slug.lower())
+            if not taste or not taste.modifiers:
+                return None
+            return taste.modifiers[0].attribute
 
         # Warm taste gives +10%
         warm_stat = get_stat_for_taste(monster.taste_warm)
@@ -411,36 +409,22 @@ class MonsterInfoState(PygameMenuState):
             minus.translate(x + fxw(36 / 256), y + (0.2 / 144))
 
         # bond icon
-        try:
-            player = local_session.player
-        except ValueError:
-            player = None
-
-        if player is not None and player.items.find_item("friendship_scroll"):
-            bond_value = monster.bond
-
-            if bond_value <= 20:
-                bond_file = "gfx/ui/icons/bond/bond1.png"
-            elif bond_value <= 50:
-                bond_file = "gfx/ui/icons/bond/bond2.png"
-            elif bond_value <= 75:
-                bond_file = "gfx/ui/icons/bond/bond3.png"
-            else:
-                bond_file = "gfx/ui/icons/bond/bond4.png"
-
-            bond_icon = self._create_image(bond_file)
-            bond_icon.scale(prepare.SCALE, prepare.SCALE)
-            bond_widget = menu.add.image(image_path=bond_icon)
-            bond_widget.set_float(origin_position=True)
-
-            bond_widget.translate(fxw(20 / 256), fxh(29 / 144))
+        owner = monster.get_owner()
+        if owner.items.find_item("friendship_scroll"):
+            bond_file = monster.bond_handler.get_bond_icon_path()
+            if bond_file:
+                bond_icon = self._create_image(bond_file)
+                bond_icon.scale(prepare.SCALE, prepare.SCALE)
+                bond_widget = menu.add.image(image_path=bond_icon)
+                bond_widget.set_float(origin_position=True)
+                bond_widget.translate(fxw(20 / 256), fxh(29 / 144))
 
         # image
         new_image = self._create_image(monster.sprite_handler.front_path)
         new_image.scale(prepare.SCALE, prepare.SCALE)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)
-        image_widget.translate(fxw((16 / 256)), fxh((27 / 144)))
+        image_widget.translate(fxw(16 / 256), fxh(27 / 144))
         # tuxeball
         tuxeball = self._create_image(
             f"gfx/items/{monster.capture_device}.png"
@@ -448,11 +432,13 @@ class MonsterInfoState(PygameMenuState):
         tuxeball.scale(prepare.SCALE, prepare.SCALE)
         capture_device = menu.add.image(image_path=tuxeball)
         capture_device.set_float(origin_position=True)
-        capture_device.translate(fxw((17 / 256)), fxh((110 / 144)))
+        capture_device.translate(fxw(17 / 256), fxh(110 / 144))
 
     def __init__(self, **kwargs: Any) -> None:
         if not lookup_cache:
             _lookup_monsters()
+        if not lookup_tastes:
+            _lookup_tastes()
         monster: Optional[Monster] = None
         source = ""
         for element in kwargs.values():

--- a/tuxemon/states/phone_contacts.py
+++ b/tuxemon/states/phone_contacts.py
@@ -84,7 +84,6 @@ class NuPhoneContacts(PygameMenuState):
         slug = self._current_call_slug
         self.client.remove_state_by_name("ChoiceState")
 
-        print(slug)
         npc_calls = PHONE_CALLS_DATA.get(slug, {})
 
         dialogue_msgids: list[str] = ["phone_no_answer"]

--- a/tuxemon/ui/cipher_processor.py
+++ b/tuxemon/ui/cipher_processor.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Optional
-
-if TYPE_CHECKING:
-    pass
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PR improves and refines several aspects of the `MonsterInfoState` class following the merge of PR #3143. Most of the changes address type consistency, particularly around float and integer usage. Key updates include:

- fixed various type hints
- removed hardcoded JSON loading logic from the `_lookup_tastes` method, replacing it with a cleaner, config-driven approach
- moved hardcoded bond icon paths into the YAML configuration file
- added a new method to the `BondHandler` class to retrieve the appropriate bond icon path based on bond level
- optimized the method for retrieving taste names (e.g., warm and cold) to improve performance and readability
- removed the unused `diff_percentage` method, which was originally intended to compare a monster’s weight to the average but is no longer relevant
- removed the `Bond Down -10 Fainted:` entry from `spyder.yaml` because the bond penalty system is no longer variable-based and is now handled through a different dynamic