### PR TITLE
Fix #2981: Correct battle tracking and enhance event scripting

### DIFF
--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -1,3 +1,4 @@
+.. autoscriptinfoclass:: tuxemon.event.conditions.battle_outcome.BattleOutcomeCountCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.battle_outcome.BattleOutcomeCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.bill_exists.BillExistsCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.bill_is.BillIsCondition

--- a/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
@@ -201,25 +201,6 @@
     }
   },
   {
-    "slug": "spyder_dragonscave_tru",
-    "speech": {
-      "profile": {
-        "default": {
-          "pre_battle": "spyder_dragonscave_tru1",
-          "post_battle_win": null,
-          "post_battle_lose": "spyder_dragonscave_tru2",
-          "post_battle_draw": null
-        }
-      }
-    },
-    "combat": {},
-    "template": {
-      "sprite_name": "knight",
-      "combat_front": "knightlord",
-      "slug": "knightlord"
-    }
-  },
-  {
     "slug": "spyder_drokoro",
     "speech": {"profile": {"default": {}}},
     "combat": {},

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -13943,6 +13943,11 @@ msgstr ""
 msgid "spyder_route6_gunner2"
 msgstr "You're not a Greenwash employee? I've heard that one before!"
 
+msgid "spyder_flower_guard"
+msgstr ""
+"Access restricted. Only those who've completed the combat evaluation at "
+"the Dojo are cleared for entry. Orders from above — no exceptions."
+
 msgid "spyder_flower_artist1"
 msgstr ""
 "Simplistic and clumsy brushstrokes and a pedestrian theme. Bah! Another "
@@ -15462,9 +15467,6 @@ msgstr "Ray"
 
 msgid "spyder_dragonscave_lucille"
 msgstr "Lucille"
-
-msgid "spyder_dragonscave_tru"
-msgstr "Tru"
 
 msgid "spyder_flower_cady"
 msgstr "Cady"

--- a/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/fr_FR/LC_MESSAGES/base.po
@@ -3813,9 +3813,6 @@ msgstr "Mieke"
 msgid "spyder_flower_sandy"
 msgstr "Sandy"
 
-msgid "spyder_dragonscave_tru"
-msgstr "Tru"
-
 msgid "spyder_flower_cady"
 msgstr "Cady"
 

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -6227,9 +6227,6 @@ msgstr "雷"
 msgid "spyder_dragonscave_lucille"
 msgstr "卢 克"
 
-msgid "spyder_dragonscave_tru"
-msgstr "特鲁"
-
 msgid "spyder_flower_cady"
 msgstr "卡迪"
 

--- a/mods/tuxemon/maps/spyder_candy_hospital1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital1.tmx
@@ -111,9 +111,9 @@
     <property name="act05" value="add_monster exclawvate,40,spyder_hospital1_aurora,5,10"/>
     <property name="act06" value="start_battle player,spyder_hospital1_aurora"/>
     <property name="act07" value="char_talk spyder_hospital1_aurora,post_battle_lose"/>
-    <property name="act08" value="set_variable hospital1aurora:yes"/>
-    <property name="cond1" value="not variable_set hospital1aurora:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_aurora"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="71" name="Create Aurora" type="event" x="64" y="128" width="16" height="16">
@@ -134,9 +134,9 @@
     <property name="act08" value="add_monster galnec,30,spyder_hospital1_eleni,5,10"/>
     <property name="act09" value="start_battle player,spyder_hospital1_eleni"/>
     <property name="act10" value="char_talk spyder_hospital1_eleni,post_battle_lose"/>
-    <property name="act11" value="set_variable hospital1eleni:yes"/>
-    <property name="cond1" value="not variable_set hospital1eleni:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_eleni"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="73" name="Create Felu" type="event" x="0" y="304" width="16" height="16">
@@ -156,9 +156,9 @@
     <property name="act06" value="add_monster galnec,30,spyder_hospital1_felu,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_felu"/>
     <property name="act08" value="char_talk spyder_hospital1_felu,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1felu:yes"/>
-    <property name="cond1" value="not variable_set hospital1felu:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_felu"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="75" name="Create Fring" type="event" x="96" y="32" width="16" height="16">
@@ -177,9 +177,9 @@
     <property name="act06" value="add_monster selket,30,spyder_hospital1_fring,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_fring"/>
     <property name="act08" value="char_talk spyder_hospital1_fring,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1fring:yes"/>
-    <property name="cond1" value="not variable_set hospital1fring:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_fring"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="79" name="Create Walt" type="event" x="224" y="32" width="16" height="16">
@@ -198,9 +198,9 @@
     <property name="act06" value="add_monster taupypus,27,spyder_hospital1_walt,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_walt"/>
     <property name="act08" value="char_talk spyder_hospital1_walt,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1walt:yes"/>
-    <property name="cond1" value="not variable_set hospital1walt:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_walt"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="83" name="Create Liane" type="event" x="272" y="128" width="16" height="16">
@@ -219,9 +219,9 @@
     <property name="act06" value="add_monster snaki,36,spyder_hospital1_liane,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_liane"/>
     <property name="act08" value="char_talk spyder_hospital1_liane,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1liane:yes"/>
-    <property name="cond1" value="not variable_set hospital1liane:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_liane"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="85" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -272,9 +272,9 @@
     <property name="act06" value="add_monster selket,30,spyder_hospital1_fring,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_fring"/>
     <property name="act08" value="char_talk spyder_hospital1_fring,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1fring:yes"/>
-    <property name="cond1" value="not variable_set hospital1fring:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_fring"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="96" name="Talk Walt" type="event" x="288" y="80" width="16" height="16">
@@ -287,9 +287,9 @@
     <property name="act06" value="add_monster taupypus,27,spyder_hospital1_walt,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_walt"/>
     <property name="act08" value="char_talk spyder_hospital1_walt,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1walt:yes"/>
-    <property name="cond1" value="not variable_set hospital1walt:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_walt"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="97" name="Create Garvan" type="event" x="16" y="176" width="16" height="16">
@@ -313,7 +313,7 @@
    <properties>
     <property name="act1" value="char_talk spyder_hospital1_felu,post_battle_lose"/>
     <property name="behav1" value="talk spyder_hospital1_felu"/>
-    <property name="cond1" value="is variable_set hospital1felu:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_hospital1_felu"/>
    </properties>
   </object>
   <object id="100" name="Post Talk Fring" type="event" x="32" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_candy_hospital2.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital2.tmx
@@ -151,9 +151,9 @@
     <property name="act06" value="add_monster exclawvate,36,spyder_hospital1_luzia,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_luzia"/>
     <property name="act08" value="char_talk spyder_hospital1_luzia,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1luzia:yes"/>
-    <property name="cond1" value="not variable_set hospital1luzia:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_luzia"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="99" name="Create Zekar" type="event" x="32" y="128" width="16" height="16">
@@ -172,9 +172,9 @@
     <property name="act06" value="add_monster taupypus,32,spyder_hospital1_zekar,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_zekar"/>
     <property name="act08" value="char_talk spyder_hospital1_zekar,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1zekar:yes"/>
-    <property name="cond1" value="not variable_set hospital1zekar:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_zekar"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="101" name="Create Rea" type="event" x="288" y="128" width="16" height="16">
@@ -207,9 +207,9 @@
     <property name="act06" value="add_monster strella,30,spyder_hospital1_rakez,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_rakez"/>
     <property name="act08" value="char_talk spyder_hospital1_rakez,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1rakez:yes"/>
-    <property name="cond1" value="not variable_set hospital1rakez:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_rakez"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="105" name="Create Rhizome" type="event" x="304" y="32" width="16" height="16">
@@ -229,9 +229,9 @@
     <property name="act06" value="add_monster fancair,33,spyder_hospital1_rhizome,5,10"/>
     <property name="act07" value="start_battle player,spyder_hospital1_rhizome"/>
     <property name="act08" value="char_talk spyder_hospital1_rhizome,post_battle_lose"/>
-    <property name="act09" value="set_variable hospital1rhizome:yes"/>
-    <property name="cond1" value="not variable_set hospital1rhizome:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_hospital1_rhizome"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="107" name="Create Scientist" type="event" x="64" y="208" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -257,7 +257,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_greenwash_guard,25,24"/>
     <property name="cond1" value="not char_exists spyder_greenwash_guard"/>
-    <property name="cond2" value="not variable_set gotaardant:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_greenwash_looten"/>
    </properties>
   </object>
   <object id="217" name="Talk Guard" type="event" x="384" y="384" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -235,9 +235,8 @@
     <property name="act3" value="add_monster shybulb,8,spyder_citypark_frances,5,10"/>
     <property name="act4" value="start_battle player,spyder_citypark_frances"/>
     <property name="act5" value="char_talk spyder_citypark_frances,post_battle_lose"/>
-    <property name="act6" value="set_variable citypark_frances:yes"/>
     <property name="behav1" value="talk spyder_citypark_frances"/>
-    <property name="cond1" value="not variable_set citypark_frances:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_citypark_frances"/>
    </properties>
   </object>
   <object id="54" name="Create Bobette" type="event" x="256" y="272" width="16" height="16">
@@ -253,9 +252,8 @@
     <property name="act2" value="add_monster aardorn,10,spyder_citypark_bobette,5,10"/>
     <property name="act3" value="start_battle player,spyder_citypark_bobette"/>
     <property name="act4" value="char_talk spyder_citypark_bobette,post_battle_lose"/>
-    <property name="act5" value="set_variable citypark_bobette:yes"/>
     <property name="behav1" value="talk spyder_citypark_bobette"/>
-    <property name="cond1" value="not variable_set citypark_bobette:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_citypark_bobette"/>
    </properties>
   </object>
   <object id="56" name="Create Edith" type="event" x="560" y="272" width="16" height="16">
@@ -272,9 +270,8 @@
     <property name="act3" value="add_monster squabbit,8,spyder_citypark_edith,5,10"/>
     <property name="act4" value="start_battle player,spyder_citypark_edith"/>
     <property name="act5" value="char_talk spyder_citypark_edith,post_battle_lose"/>
-    <property name="act6" value="set_variable citypark_edith:yes"/>
     <property name="behav1" value="talk spyder_citypark_edith"/>
-    <property name="cond1" value="not variable_set citypark_edith:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_citypark_edith"/>
    </properties>
   </object>
   <object id="58" name="encounter" type="event" x="304" y="304" width="128" height="128">
@@ -482,9 +479,9 @@
     <property name="act5" value="add_monster aardorn,10,spyder_citypark_bobette,5,10"/>
     <property name="act6" value="start_battle player,spyder_citypark_bobette"/>
     <property name="act7" value="char_talk spyder_citypark_bobette,post_battle_lose"/>
-    <property name="act8" value="set_variable citypark_bobette:yes"/>
-    <property name="cond1" value="not variable_set citypark_bobette:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_citypark_bobette"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="85" name="Create Box1" type="event" x="256" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -180,7 +180,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_cotton_cafegoth"/>
     <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
-    <property name="cond1" value="is variable_set foughtincafe:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_cottoncafe_cayden"/>
    </properties>
   </object>
   <object id="30" name="Hillary Talk" type="event" x="176" y="112" width="16" height="16">
@@ -234,9 +234,8 @@
     <property name="act11" value="add_monster capiti,4,spyder_cottoncafe_cayden,17,10"/>
     <property name="act12" value="add_monster tweesher,4,spyder_cottoncafe_cayden,17,10"/>
     <property name="act20" value="start_battle player,spyder_cottoncafe_cayden"/>
-    <property name="act22" value="set_variable foughtincafe:yes"/>
     <property name="act23" value="translated_dialog spyder_lostfight"/>
-    <property name="cond1" value="not variable_set foughtincafe:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_cottoncafe_cayden"/>
     <property name="cond2" value="is variable_set cafebattle:yes"/>
    </properties>
   </object>
@@ -257,7 +256,7 @@
     <property name="act1" value="translated_dialog spyder_request_fight"/>
     <property name="act2" value="translated_dialog_choice yes:no,cafebattle"/>
     <property name="behav1" value="talk spyder_cottoncafe_cayden"/>
-    <property name="cond1" value="not variable_set foughtincafe:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_cottoncafe_cayden"/>
    </properties>
   </object>
   <object id="44" name="Create Barmaid - accessible" type="event" x="16" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -202,7 +202,7 @@
     <property name="act1" value="create_npc spyder_cottontown_monk,5,7"/>
     <property name="act2" value="char_wander spyder_cottontown_monk"/>
     <property name="cond1" value="not char_exists spyder_cottontown_monk"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="543" name="Talk monk" type="event" x="96" y="128" width="16" height="16">
@@ -346,7 +346,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_statue_orange,3,7"/>
     <property name="cond1" value="not char_exists spyder_statue_orange"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="578" name="Teleport to Omnichannel HQ" type="event" x="272" y="144" width="16" height="16">
@@ -403,28 +403,28 @@
    <properties>
     <property name="act1" value="create_npc spyder_statue_blue,4,9"/>
     <property name="cond1" value="not char_exists spyder_statue_blue"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="584" name="Create Statue Red" type="event" x="96" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_statue_red,6,9"/>
     <property name="cond1" value="not char_exists spyder_statue_red"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="585" name="Create Statue Grey" type="event" x="112" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_statue_grey,7,7"/>
     <property name="cond1" value="not char_exists spyder_statue_grey"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="586" name="Create Statue Green" type="event" x="80" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_statue_green,5,5"/>
     <property name="cond1" value="not char_exists spyder_statue_green"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="588" name="Create Brute" type="event" x="48" y="576" width="16" height="16">
@@ -503,7 +503,7 @@
     <property name="act0" value="translated_dialog spyder_confused1"/>
     <property name="act3" value="translated_dialog_choice yes:no,confusedchoice"/>
     <property name="behav1" value="talk spyder_confusedperson"/>
-    <property name="cond1" value="not variable_set confusedbattle"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_confusedperson"/>
    </properties>
   </object>
   <object id="597" name="Create confused" type="event" x="96" y="528" width="16" height="16">
@@ -518,7 +518,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_confused2"/>
     <property name="behav1" value="talk spyder_confusedperson"/>
-    <property name="cond1" value="is variable_set confusedbattle:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_confusedperson"/>
    </properties>
   </object>
   <object id="599" name="Battle confused" type="event" x="128" y="576" width="16" height="16">
@@ -527,8 +527,7 @@
     <property name="act3" value="add_monster capiti,2,spyder_confusedperson,5,10"/>
     <property name="act4" value="start_battle player,spyder_confusedperson"/>
     <property name="act5" value="translated_dialog spyder_confused2"/>
-    <property name="act6" value="set_variable confusedbattle:yes"/>
-    <property name="cond1" value="not variable_set confusedbattle:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_confusedperson"/>
     <property name="cond2" value="is variable_set confusedchoice:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_cotton_tunnel.yaml
+++ b/mods/tuxemon/maps/spyder_cotton_tunnel.yaml
@@ -159,7 +159,7 @@ events:
     behav:
     - talk spyder_cottontunnel_carlos
     conditions:
-    - is variable_set cottontunnelcarlos:yes
+    - is battle_outcome player,won,spyder_cottontunnel_carlos
     - is variable_set dragonscavedrokoro:yes
     type: event
   Raise Melee:
@@ -226,10 +226,10 @@ events:
     - add_monster legko,35,spyder_cottontunnel_carlos,5,10
     - start_battle player,spyder_cottontunnel_carlos
     - char_talk spyder_cottontunnel_carlos,post_battle_lose
-    - set_variable cottontunnelcarlos:yes
     conditions:
-    - not variable_set cottontunnelcarlos:yes
+    - not battle_outcome player,won,spyder_cottontunnel_carlos
     - is char_at player
+    - not char_defeated player
     - is variable_set dragonscavedrokoro:yes
     type: event
     x: 37

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -192,9 +192,9 @@
     <property name="act09" value="add_monster neutrito,35,spyder_datacenter_fermi,5,10"/>
     <property name="act10" value="start_battle player,spyder_datacenter_fermi"/>
     <property name="act11" value="char_talk spyder_datacenter_fermi,post_battle_lose"/>
-    <property name="act12" value="set_variable datacenterfermi:yes"/>
-    <property name="cond1" value="not variable_set datacenterfermi:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_datacenter_fermi"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="83" name="Create Onnes" type="event" x="208" y="224" width="16" height="16">
@@ -214,9 +214,9 @@
     <property name="act06" value="add_monster angrito,40,spyder_datacenter_onnes,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_onnes"/>
     <property name="act08" value="char_talk spyder_datacenter_onnes,post_battle_lose"/>
-    <property name="act09" value="set_variable datacenteronnes:yes"/>
-    <property name="cond1" value="not variable_set datacenteronnes:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_datacenter_onnes"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="85" name="Create Bayliss" type="event" x="208" y="64" width="16" height="16">
@@ -236,9 +236,9 @@
     <property name="act06" value="add_monster sadito,40,spyder_datacenter_bayliss,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_bayliss"/>
     <property name="act08" value="char_talk spyder_datacenter_bayliss,post_battle_lose"/>
-    <property name="act09" value="set_variable datacenterbayliss:yes"/>
-    <property name="cond1" value="not variable_set datacenterbayliss:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_datacenter_bayliss"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="87" name="Create Chomsky" type="event" x="144" y="64" width="16" height="16">
@@ -258,9 +258,9 @@
     <property name="act06" value="add_monster happito,40,spyder_datacenter_chomsky,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_chomsky"/>
     <property name="act08" value="char_talk spyder_datacenter_chomsky,post_battle_lose"/>
-    <property name="act09" value="set_variable datacenterchomsky:yes"/>
-    <property name="cond1" value="not variable_set datacenterchomsky:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_datacenter_chomsky"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="89" name="Create Lagrange" type="event" x="48" y="64" width="16" height="16">
@@ -280,9 +280,9 @@
     <property name="act06" value="add_monster neutrito,45,spyder_datacenter_lagrange,5,10"/>
     <property name="act07" value="start_battle player,spyder_datacenter_lagrange"/>
     <property name="act08" value="char_talk spyder_datacenter_lagrange,post_battle_lose"/>
-    <property name="act09" value="set_variable datacenterlagrange:yes"/>
-    <property name="cond1" value="not variable_set datacenterlagrange:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_datacenter_lagrange"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="91" name="Create Gold Pass" type="event" x="16" y="224" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dojo2.tmx
+++ b/mods/tuxemon/maps/spyder_dojo2.tmx
@@ -115,7 +115,7 @@
     <property name="act1" value="create_npc spyder_dojo_wan,13,9"/>
     <property name="act2" value="char_face spyder_dojo_wan,left"/>
     <property name="cond1" value="not char_exists spyder_dojo_wan"/>
-    <property name="cond2" value="not variable_set dojowan:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dojo_wan"/>
    </properties>
   </object>
   <object id="27" name="Talk Wan1" type="event" x="112" y="0" width="16" height="16">
@@ -123,12 +123,12 @@
     <property name="act1" value="translated_dialog spyder_dojo_wan3"/>
     <property name="behav1" value="talk spyder_dojo_wan"/>
     <property name="cond1" value="is variable_set wanintro:yes"/>
-    <property name="cond2" value="not variable_set dojoiroh:yes"/>
-    <property name="cond3" value="not variable_set dojoyangchen:yes"/>
-    <property name="cond4" value="not variable_set dojokataro:yes"/>
-    <property name="cond5" value="not variable_set dojosokka:yes"/>
-    <property name="cond6" value="not variable_set dojotoph:yes"/>
-    <property name="cond7" value="not variable_set dojowan:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dojo_iroh"/>
+    <property name="cond3" value="not battle_outcome player,won,spyder_dojo_yangchen"/>
+    <property name="cond4" value="not battle_outcome player,won,spyder_dojo_kataro"/>
+    <property name="cond5" value="not battle_outcome player,won,spyder_dojo_sokka"/>
+    <property name="cond6" value="not battle_outcome player,won,spyder_dojo_toph"/>
+    <property name="cond7" value="not battle_outcome player,won,spyder_dojo_wan"/>
    </properties>
   </object>
   <object id="28" name="Talk Iroh" type="event" x="128" y="0" width="16" height="16">
@@ -147,11 +147,10 @@
     <property name="act25" value="add_tech iid_slot_4,demiurge"/>
     <property name="act30" value="start_battle player,spyder_dojo_iroh"/>
     <property name="act31" value="char_talk spyder_dojo_iroh,post_battle_lose"/>
-    <property name="act32" value="set_variable dojoiroh:yes"/>
     <property name="act40" value="set_monster_health"/>
     <property name="act50" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_dojo_iroh"/>
-    <property name="cond1" value="not variable_set dojoiroh:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_iroh"/>
    </properties>
   </object>
   <object id="29" name="Talk Yangchen" type="event" x="144" y="0" width="16" height="16">
@@ -163,11 +162,10 @@
     <property name="act15" value="add_monster budaye,20,spyder_dojo_yangchen,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_yangchen"/>
     <property name="act17" value="char_talk spyder_dojo_yangchen,post_battle_lose"/>
-    <property name="act18" value="set_variable dojoyangchen:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_dojo_yangchen"/>
-    <property name="cond1" value="not variable_set dojoyangchen:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_yangchen"/>
    </properties>
   </object>
   <object id="30" name="Talk Kataro" type="event" x="160" y="0" width="16" height="16">
@@ -176,11 +174,10 @@
     <property name="act12" value="add_monster hydrone,20,spyder_dojo_kataro,5,10"/>
     <property name="act13" value="start_battle player,spyder_dojo_kataro"/>
     <property name="act14" value="char_talk spyder_dojo_kataro,post_battle_lose"/>
-    <property name="act15" value="set_variable dojokataro:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_dojo_kataro"/>
-    <property name="cond1" value="not variable_set dojokataro:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_kataro"/>
    </properties>
   </object>
   <object id="19" name="Talk Sokka" type="event" x="176" y="0" width="16" height="16">
@@ -192,11 +189,10 @@
     <property name="act15" value="add_monster grintrock,20,spyder_dojo_sokka,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_sokka"/>
     <property name="act17" value="char_talk spyder_dojo_sokka,post_battle_lose"/>
-    <property name="act18" value="set_variable dojosokka:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_dojo_sokka"/>
-    <property name="cond1" value="not variable_set dojosokka:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_sokka"/>
    </properties>
   </object>
   <object id="32" name="Talk Toph" type="event" x="192" y="0" width="16" height="16">
@@ -210,11 +206,10 @@
     <property name="act07" value="add_monster vivipere,20,spyder_dojo_toph,5,10"/>
     <property name="act08" value="start_battle player,spyder_dojo_toph"/>
     <property name="act09" value="char_talk spyder_dojo_toph,post_battle_lose"/>
-    <property name="act10" value="set_variable dojotoph:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_dojo_toph"/>
-    <property name="cond1" value="not variable_set dojotoph:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_toph"/>
    </properties>
   </object>
   <object id="38" name="Encounter" type="event" x="160" y="144" width="16" height="16">
@@ -250,15 +245,14 @@
     <property name="act34" value="lock_controls"/>
     <property name="act35" value="pathfind spyder_dojo_wan,9,9"/>
     <property name="act37" value="unlock_controls"/>
-    <property name="act38" value="set_variable dojowan:yes"/>
     <property name="behav1" value="talk spyder_dojo_wan"/>
     <property name="cond1" value="is variable_set wanintro:yes"/>
-    <property name="cond2" value="is variable_set dojoiroh:yes"/>
-    <property name="cond3" value="is variable_set dojoyangchen:yes"/>
-    <property name="cond4" value="is variable_set dojokataro:yes"/>
-    <property name="cond5" value="is variable_set dojosokka:yes"/>
-    <property name="cond6" value="is variable_set dojotoph:yes"/>
-    <property name="cond7" value="not variable_set dojowan:yes"/>
+    <property name="cond2" value="is battle_outcome player,won,spyder_dojo_iroh"/>
+    <property name="cond3" value="is battle_outcome player,won,spyder_dojo_yangchen"/>
+    <property name="cond4" value="is battle_outcome player,won,spyder_dojo_kataro"/>
+    <property name="cond5" value="is battle_outcome player,won,spyder_dojo_sokka"/>
+    <property name="cond6" value="is battle_outcome player,won,spyder_dojo_toph"/>
+    <property name="cond7" value="not battle_outcome player,won,spyder_dojo_wan"/>
    </properties>
   </object>
   <object id="33" name="Post Talk Iroh" type="event" x="128" y="16" width="16" height="16">
@@ -299,7 +293,7 @@
   <object id="39" name="Remove Wan" type="event" x="336" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="remove_npc spyder_dojo_wan"/>
-    <property name="cond1" value="is variable_set dojowan:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_dojo_wan"/>
    </properties>
   </object>
   <object id="40" name="Play Music" type="event" x="0" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dojo3.tmx
+++ b/mods/tuxemon/maps/spyder_dojo3.tmx
@@ -115,7 +115,7 @@
     <property name="act1" value="create_npc spyder_dojo_tu,13,9"/>
     <property name="act2" value="char_face spyder_dojo_tu,left"/>
     <property name="cond1" value="not char_exists spyder_dojo_tu"/>
-    <property name="cond2" value="not variable_set dojotu:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dojo_tu"/>
    </properties>
   </object>
   <object id="27" name="Talk Tu1" type="event" x="112" y="0" width="16" height="16">
@@ -123,12 +123,12 @@
     <property name="act1" value="translated_dialog spyder_dojo_tu3"/>
     <property name="behav1" value="talk spyder_dojo_tu"/>
     <property name="cond1" value="is variable_set tuintro:yes"/>
-    <property name="cond2" value="not variable_set dojosaturn:yes"/>
-    <property name="cond3" value="not variable_set dojohephastus:yes"/>
-    <property name="cond4" value="not variable_set dojohermes:yes"/>
-    <property name="cond5" value="not variable_set dojoorion:yes"/>
-    <property name="cond6" value="not variable_set dojoares:yes"/>
-    <property name="cond7" value="not variable_set dojotu:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dojo_saturn"/>
+    <property name="cond3" value="not battle_outcome player,won,spyder_dojo_hephastus"/>
+    <property name="cond4" value="not battle_outcome player,won,spyder_dojo_hermes"/>
+    <property name="cond5" value="not battle_outcome player,won,spyder_dojo_orion"/>
+    <property name="cond6" value="not battle_outcome player,won,spyder_dojo_ares"/>
+    <property name="cond7" value="not battle_outcome player,won,spyder_dojo_tu"/>
    </properties>
   </object>
   <object id="28" name="Talk Saturn" type="event" x="128" y="0" width="16" height="16">
@@ -140,13 +140,12 @@
     <property name="act15" value="add_monster sludgehog,30,spyder_dojo_saturn,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_saturn"/>
     <property name="act17" value="char_talk spyder_dojo_saturn,post_battle_lose"/>
-    <property name="act18" value="set_variable dojosaturn:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_all_in"/>
     <property name="act41" value="translated_dialog tm_all_in,,center,center,center"/>
     <property name="behav1" value="talk spyder_dojo_saturn"/>
-    <property name="cond1" value="not variable_set dojosaturn:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_saturn"/>
    </properties>
   </object>
   <object id="29" name="Talk Hephastus" type="event" x="144" y="0" width="16" height="16">
@@ -158,13 +157,12 @@
     <property name="act15" value="add_monster embra,30,spyder_dojo_hephastus,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_hephastus"/>
     <property name="act17" value="char_talk spyder_dojo_hephastus,post_battle_lose"/>
-    <property name="act18" value="set_variable dojohephastus:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_blade"/>
     <property name="act41" value="translated_dialog tm_blade,,center,center,center"/>
     <property name="behav1" value="talk spyder_dojo_hephastus"/>
-    <property name="cond1" value="not variable_set dojohephastus:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_hephastus"/>
    </properties>
   </object>
   <object id="19" name="Talk Hermes" type="event" x="160" y="0" width="16" height="16">
@@ -176,13 +174,12 @@
     <property name="act15" value="add_monster eaglace,30,spyder_dojo_hermes,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_hermes"/>
     <property name="act17" value="char_talk spyder_dojo_hermes,post_battle_lose"/>
-    <property name="act18" value="set_variable dojohermes:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_panjandrum"/>
     <property name="act41" value="translated_dialog tm_panjandrum,,center,center,center"/>
     <property name="behav1" value="talk spyder_dojo_hermes"/>
-    <property name="cond1" value="not variable_set dojohermes:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_hermes"/>
    </properties>
   </object>
   <object id="13" name="Talk Orion" type="event" x="176" y="0" width="16" height="16">
@@ -194,13 +191,12 @@
     <property name="act15" value="add_monster drashimi,30,spyder_dojo_orion,5,10"/>
     <property name="act16" value="start_battle player,spyder_dojo_orion"/>
     <property name="act17" value="char_talk spyder_dojo_orion,post_battle_lose"/>
-    <property name="act18" value="set_variable dojoorion:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_shadow_boxing"/>
     <property name="act41" value="translated_dialog tm_shadow_boxing,,center,center,center"/>
     <property name="behav1" value="talk spyder_dojo_orion"/>
-    <property name="cond1" value="not variable_set dojoorion:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_orion"/>
    </properties>
   </object>
   <object id="39" name="Talk Ares" type="event" x="192" y="0" width="16" height="16">
@@ -212,13 +208,12 @@
     <property name="act05" value="add_monster tourbidi,30,spyder_dojo_ares,5,10"/>
     <property name="act08" value="start_battle player,spyder_dojo_ares"/>
     <property name="act09" value="char_talk spyder_dojo_ares,post_battle_lose"/>
-    <property name="act10" value="set_variable dojoares:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="act40" value="add_item tm_scope"/>
     <property name="act41" value="translated_dialog tm_scope,,center,center,center"/>
     <property name="behav1" value="talk spyder_dojo_ares"/>
-    <property name="cond1" value="not variable_set dojoares:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_ares"/>
    </properties>
   </object>
   <object id="30" name="Encounter" type="event" x="160" y="144" width="16" height="16">
@@ -252,15 +247,14 @@
     <property name="act31" value="lock_controls"/>
     <property name="act32" value="pathfind spyder_dojo_tu,9,9"/>
     <property name="act34" value="unlock_controls"/>
-    <property name="act35" value="set_variable dojotu:yes"/>
     <property name="behav1" value="talk spyder_dojo_tu"/>
     <property name="cond1" value="is variable_set tuintro:yes"/>
-    <property name="cond2" value="is variable_set dojosaturn:yes"/>
-    <property name="cond3" value="is variable_set dojohephastus:yes"/>
-    <property name="cond4" value="is variable_set dojohermes:yes"/>
-    <property name="cond5" value="is variable_set dojoorion:yes"/>
-    <property name="cond6" value="is variable_set dojoares:yes"/>
-    <property name="cond7" value="not variable_set dojotu:yes"/>
+    <property name="cond2" value="is battle_outcome player,won,spyder_dojo_saturn"/>
+    <property name="cond3" value="is battle_outcome player,won,spyder_dojo_hephastus"/>
+    <property name="cond4" value="is battle_outcome player,won,spyder_dojo_hermes"/>
+    <property name="cond5" value="is battle_outcome player,won,spyder_dojo_orion"/>
+    <property name="cond6" value="is battle_outcome player,won,spyder_dojo_ares"/>
+    <property name="cond7" value="not battle_outcome player,won,spyder_dojo_tu"/>
    </properties>
   </object>
   <object id="32" name="Post Talk Saturn" type="event" x="128" y="16" width="16" height="16">
@@ -301,7 +295,7 @@
   <object id="37" name="Remove Tu" type="event" x="336" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="remove_npc spyder_dojo_tu"/>
-    <property name="cond1" value="is variable_set dojotu:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_dojo_tu"/>
    </properties>
   </object>
   <object id="38" name="Play Music" type="event" x="0" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dojo4.tmx
+++ b/mods/tuxemon/maps/spyder_dojo4.tmx
@@ -75,11 +75,10 @@
     <property name="act12" value="add_monster sampsage,35,spyder_dojo_thri,5,10"/>
     <property name="act13" value="add_monster sampsack,35,spyder_dojo_thri,5,10"/>
     <property name="act14" value="start_battle player,spyder_dojo_thri"/>
-    <property name="act15" value="set_variable dojothri:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
     <property name="behav1" value="talk spyder_dojo_thri"/>
-    <property name="cond7" value="not variable_set dojothri:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dojo_thri"/>
    </properties>
   </object>
   <object id="25" name="Talk Thri Choice" type="event" x="176" y="32" width="16" height="16">
@@ -89,7 +88,7 @@
     <property name="act15" value="set_variable dojothrichoice:yes"/>
     <property name="act20" value="set_monster_health"/>
     <property name="act30" value="set_monster_status"/>
-    <property name="cond1" value="is variable_set dojothri:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_dojo_thri"/>
     <property name="cond2" value="not variable_set dojothrichoice:yes"/>
    </properties>
   </object>
@@ -123,13 +122,13 @@
     <property name="act04" value="pathfind_to_char player,spyder_billie,down"/>
     <property name="act05" value="unlock_controls"/>
     <property name="act08" value="translated_dialog spyder_dojo_billie1"/>
-    <property name="act20" value="add_monster billie_choice,35,spyder_billie,5,10"/>
+    <property name="act20" value="add_monster billie_choice,34,spyder_billie,5,10"/>
     <property name="act21" value="set_monster_attribute add_monster,gender,male"/>
-    <property name="act22" value="add_monster eyesore,35,spyder_billie,5,10"/>
-    <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act24" value="add_monster cardiwing,35,spyder_billie,5,10"/>
+    <property name="act24" value="add_monster cardiwing,30,spyder_billie,5,10"/>
     <property name="act25" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act26" value="add_monster viviphyta,35,spyder_billie,5,10"/>
+    <property name="act22" value="add_monster eyesore,30,spyder_billie,5,10"/>
+    <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
+    <property name="act26" value="add_monster viviphyta,30,spyder_billie,5,10"/>
     <property name="act27" value="set_monster_attribute add_monster,gender,male"/>
     <property name="act30" value="start_battle player,spyder_billie"/>
     <property name="act40" value="translated_dialog spyder_dojo_billie2"/>

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -89,7 +89,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_mom4"/>
     <property name="behav1" value="talk spyder_papertown_mom"/>
-    <property name="cond1" value="is variable_set zoolanderdefeat:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_route3_zoolander"/>
     <property name="cond2" value="is variable_set spokenmom:yes"/>
     <property name="cond3" value="not variable_set captainreturns:yes"/>
    </properties>
@@ -118,7 +118,7 @@
     <property name="behav1" value="talk spyder_papertown_mom"/>
     <property name="cond1" value="is party_size player,greater_than,0"/>
     <property name="cond2" value="is variable_set spokenmom:yes"/>
-    <property name="cond3" value="not variable_set zoolanderdefeat:yes"/>
+    <property name="cond3" value="not battle_outcome player,won,spyder_route3_zoolander"/>
    </properties>
   </object>
   <object id="56" name="Go Outside" type="event" x="64" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -117,9 +117,8 @@
     <property name="act2" value="add_monster allagon,35,spyder_dragonscave_tomas,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_tomas"/>
     <property name="act4" value="char_talk spyder_dragonscave_tomas,post_battle_lose"/>
-    <property name="act6" value="set_variable dragonscavetomas:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_tomas"/>
-    <property name="cond1" value="not variable_set dragonscavetomas:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_tomas"/>
    </properties>
   </object>
   <object id="63" name="Create Lessa" type="event" x="256" y="320" width="16" height="16">
@@ -134,9 +133,8 @@
     <property name="act2" value="add_monster allagon,37,spyder_dragonscave_lessa,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_lessa"/>
     <property name="act4" value="char_talk spyder_dragonscave_lessa,post_battle_lose"/>
-    <property name="act6" value="set_variable dragonscavelessa:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_lessa"/>
-    <property name="cond1" value="not variable_set dragonscavelessa:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_lessa"/>
    </properties>
   </object>
   <object id="65" name="Create Cailin" type="event" x="112" y="416" width="16" height="16">
@@ -152,9 +150,8 @@
     <property name="act2" value="add_monster dragarbor,36,spyder_dragonscave_cailin,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_cailin"/>
     <property name="act4" value="char_talk spyder_dragonscave_cailin,post_battle_lose"/>
-    <property name="act6" value="set_variable dragonscavecailin:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_cailin"/>
-    <property name="cond1" value="not variable_set dragonscavecailin:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_cailin"/>
    </properties>
   </object>
   <object id="67" name="Create Griffin" type="event" x="112" y="608" width="16" height="16">
@@ -170,9 +167,8 @@
     <property name="act2" value="add_monster bigfin,35,spyder_dragonscave_griffin,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_griffin"/>
     <property name="act4" value="char_talk spyder_dragonscave_griffin,post_battle_lose"/>
-    <property name="act6" value="set_variable dragonscavegriffin:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_griffin"/>
-    <property name="cond1" value="not variable_set dragonscavegriffin:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_griffin"/>
    </properties>
   </object>
   <object id="69" name="Create Daenny" type="event" x="192" y="496" width="16" height="16">
@@ -188,9 +184,8 @@
     <property name="act2" value="add_monster eaglace,37,spyder_dragonscave_daenny,5,10"/>
     <property name="act3" value="start_battle player,spyder_dragonscave_daenny"/>
     <property name="act4" value="char_talk spyder_dragonscave_daenny,post_battle_lose"/>
-    <property name="act6" value="set_variable dragonscavedaenny:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_daenny"/>
-    <property name="cond1" value="not variable_set dragonscavedaenny:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_daenny"/>
    </properties>
   </object>
   <object id="71" name="Create Benden" type="event" x="64" y="240" width="16" height="16">
@@ -208,9 +203,8 @@
     <property name="act5" value="char_talk spyder_dragonscave_benden,post_battle_lose"/>
     <property name="act6" value="set_monster_health"/>
     <property name="act7" value="set_monster_status"/>
-    <property name="act8" value="set_variable dragonscavebenden:yes"/>
     <property name="behav1" value="talk spyder_dragonscave_benden"/>
-    <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="74" name="Get Drokoro" type="event" x="208" y="48" width="64" height="32">
@@ -247,22 +241,22 @@
    <properties>
     <property name="act1" value="create_npc spyder_dragonscave_ray,18,9"/>
     <property name="cond1" value="not char_exists spyder_dragonscave_ray"/>
-    <property name="cond2" value="not variable_set dragonscaveray:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_ray"/>
    </properties>
   </object>
   <object id="80" name="Create Lucille" type="event" x="64" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_dragonscave_lucille,4,4"/>
     <property name="cond1" value="not char_exists spyder_dragonscave_lucille"/>
-    <property name="cond2" value="not variable_set dragonscaveray:lucille"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_lucille"/>
    </properties>
   </object>
   <object id="82" name="Create Tru" type="event" x="160" y="96" width="16" height="16">
    <properties>
-    <property name="act1" value="create_npc spyder_dragonscave_tru,10,6"/>
-    <property name="act2" value="char_face spyder_dragonscave_tru,up"/>
-    <property name="cond1" value="not char_exists spyder_dragonscave_tru"/>
-    <property name="cond2" value="not variable_set dragonscavetru:yes"/>
+    <property name="act1" value="create_npc spyder_nimrod_tru,10,6"/>
+    <property name="act2" value="char_face spyder_nimrod_tru,up"/>
+    <property name="cond1" value="not char_exists spyder_nimrod_tru"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_nimrod_tru,2"/>
    </properties>
   </object>
   <object id="88" name="Benden Defeated" type="event" x="112" y="224" width="16" height="16">
@@ -273,7 +267,7 @@
     <property name="act4" value="char_face spyder_dragonscave_benden,right"/>
     <property name="act5" value="translated_dialog spyder_dragonscave_benden4"/>
     <property name="act6" value="set_variable dragonscavebenden2:yes"/>
-    <property name="cond1" value="is variable_set dragonscavebenden:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_dragonscave_benden"/>
     <property name="cond2" value="not variable_set dragonscavebenden2:yes"/>
    </properties>
   </object>
@@ -301,9 +295,9 @@
     <property name="act5" value="add_monster allagon,35,spyder_dragonscave_tomas,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_tomas"/>
     <property name="act7" value="char_talk spyder_dragonscave_tomas,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscavetomas:yes"/>
-    <property name="cond1" value="not variable_set dragonscavetomas:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_tomas"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="93" name="Talk Daenny" type="event" x="192" y="432" width="16" height="64">
@@ -315,9 +309,9 @@
     <property name="act5" value="add_monster eaglace,37,spyder_dragonscave_daenny,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_daenny"/>
     <property name="act7" value="char_talk spyder_dragonscave_daenny,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscavedaenny:yes"/>
-    <property name="cond1" value="not variable_set dragonscavedaenny:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_daenny"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="94" name="Talk Cailin" type="event" x="128" y="416" width="32" height="16">
@@ -329,9 +323,9 @@
     <property name="act5" value="add_monster dragarbor,36,spyder_dragonscave_cailin,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_cailin"/>
     <property name="act7" value="char_talk spyder_dragonscave_cailin,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscavecailin:yes"/>
-    <property name="cond1" value="not variable_set dragonscavecailin:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_cailin"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="95" name="Talk Lessa" type="event" x="256" y="336" width="16" height="48">
@@ -343,9 +337,9 @@
     <property name="act5" value="add_monster allagon,37,spyder_dragonscave_lessa,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_lessa"/>
     <property name="act7" value="char_talk spyder_dragonscave_lessa,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscavelessa:yes"/>
-    <property name="cond1" value="not variable_set dragonscavelessa:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_lessa"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="96" name="Talk Griffin" type="event" x="112" y="528" width="16" height="80">
@@ -357,9 +351,9 @@
     <property name="act5" value="add_monster bigfin,35,spyder_dragonscave_griffin,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_griffin"/>
     <property name="act7" value="char_talk spyder_dragonscave_griffin,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscavegriffin:yes"/>
-    <property name="cond1" value="not variable_set dragonscavegriffin:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_griffin"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="97" name="Talk Benden" type="event" x="80" y="240" width="16" height="16">
@@ -374,9 +368,9 @@
     <property name="act08" value="char_talk spyder_dragonscave_benden,post_battle_lose"/>
     <property name="act09" value="set_monster_health"/>
     <property name="act10" value="set_monster_status"/>
-    <property name="act11" value="set_variable dragonscavebenden:yes"/>
-    <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="98" name="Talk Ray" type="event" x="272" y="176" width="32" height="16">
@@ -388,25 +382,26 @@
     <property name="act5" value="add_monster ghosteeth,40,spyder_dragonscave_ray,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_ray"/>
     <property name="act7" value="char_talk spyder_dragonscave_ray,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscaveray:yes"/>
-    <property name="cond1" value="not variable_set dragonscaveray:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_ray"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="99" name="Talk Tru" type="event" x="160" y="64" width="16" height="16">
    <properties>
     <property name="act01" value="lock_controls"/>
-    <property name="act02" value="pathfind_to_char player,spyder_dragonscave_tru"/>
-    <property name="act03" value="char_talk spyder_dragonscave_tru,pre_battle"/>
+    <property name="act02" value="pathfind_to_char player,spyder_nimrod_tru"/>
+    <property name="act03" value="translated_dialog spyder_dragonscave_tru1"/>
     <property name="act04" value="unlock_controls"/>
-    <property name="act05" value="add_monster embazook,40,spyder_dragonscave_tru,5,10"/>
-    <property name="act06" value="add_monster arthrobolt,40,spyder_dragonscave_tru,5,10"/>
-    <property name="act07" value="add_monster hydrone,40,spyder_dragonscave_tru,5,10"/>
-    <property name="act08" value="start_battle player,spyder_dragonscave_tru"/>
-    <property name="act09" value="char_talk spyder_dragonscave_tru,post_battle_lose"/>
-    <property name="act10" value="set_variable dragonscavetru:yes"/>
-    <property name="cond1" value="not variable_set dragonscavetru:yes"/>
-    <property name="cond2" value="is char_at player"/>
+    <property name="act05" value="add_monster embazook,40,spyder_nimrod_tru,5,10"/>
+    <property name="act06" value="add_monster arthrobolt,40,spyder_nimrod_tru,5,10"/>
+    <property name="act07" value="add_monster hydrone,40,spyder_nimrod_tru,5,10"/>
+    <property name="act08" value="start_battle player,spyder_nimrod_tru"/>
+    <property name="act09" value="translated_dialog spyder_dragonscave_tru2"/>
+    <property name="cond1" value="is battle_outcome_count player,won,spyder_nimrod_tru,1"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_nimrod_tru,2"/>
+    <property name="cond3" value="is char_at player"/>
+    <property name="cond4" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="100" name="Talk Lucille" type="event" x="64" y="112" width="32" height="16">
@@ -418,9 +413,9 @@
     <property name="act5" value="add_monster coleorus,40,spyder_dragonscave_lucille,5,10"/>
     <property name="act6" value="start_battle player,spyder_dragonscave_lucille"/>
     <property name="act7" value="char_talk spyder_dragonscave_lucille,post_battle_lose"/>
-    <property name="act8" value="set_variable dragonscavelucille:yes"/>
-    <property name="cond1" value="not variable_set dragonscavelucille:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_lucille"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="101" name="Talk Mal" type="event" x="176" y="144" width="16" height="32">
@@ -453,7 +448,7 @@
   <object id="89" name="Encounters" type="event" x="16" y="208" width="16" height="16">
    <properties>
     <property name="act1" value="random_encounter spyder_dragonscave,0.6"/>
-    <property name="cond1" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
     <property name="cond2" value="is check_char_parameter player,moving,1"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -566,7 +566,7 @@
     <property name="act1" value="create_npc spyder_dryadsgrove_aquemini,34,15"/>
     <property name="act2" value="char_face spyder_dryadsgrove_aquemini,up"/>
     <property name="cond1" value="not char_exists spyder_dryadsgrove_aquemini"/>
-    <property name="cond2" value="not variable_set dryadsgroveaquemini:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dryadsgrove_aquemini"/>
    </properties>
   </object>
   <object id="209" name="Talk Aquemini" type="event" x="528" y="240" width="16" height="16">
@@ -577,9 +577,8 @@
     <property name="act4" value="add_monster noctalo,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_aquemini"/>
     <property name="act6" value="char_talk spyder_dryadsgrove_aquemini,post_battle_lose"/>
-    <property name="act7" value="set_variable dryadsgroveaquemini:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_aquemini"/>
-    <property name="cond1" value="not variable_set dryadsgroveaquemini:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_aquemini"/>
    </properties>
   </object>
   <object id="212" name="Get Volcoli" type="event" x="96" y="288" width="32" height="32">
@@ -598,7 +597,7 @@
     <property name="act1" value="create_npc spyder_dryadsgrove_ignatia,24,8"/>
     <property name="act2" value="char_face spyder_dryadsgrove_ignatia,right"/>
     <property name="cond1" value="not char_exists spyder_dryadsgrove_ignatia"/>
-    <property name="cond2" value="not variable_set dryadsgroveignatia:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dryadsgrove_ignatia"/>
    </properties>
   </object>
   <object id="214" name="Talk Ignatia" type="event" x="384" y="112" width="16" height="16">
@@ -609,16 +608,15 @@
     <property name="act4" value="add_monster criniotherme,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_ignatia"/>
     <property name="act6" value="char_talk spyder_dryadsgrove_ignatia,post_battle_lose"/>
-    <property name="act7" value="set_variable dryadsgroveignatia:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_ignatia"/>
-    <property name="cond1" value="not variable_set dryadsgroveignatia:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_ignatia"/>
    </properties>
   </object>
   <object id="215" name="Create Petra" type="event" x="240" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_dryadsgrove_petra,15,5"/>
     <property name="cond1" value="not char_exists spyder_dryadsgrove_petra"/>
-    <property name="cond2" value="not variable_set dryadsgrovepetra:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dryadsgrove_petra"/>
    </properties>
   </object>
   <object id="216" name="Talk Petra" type="event" x="240" y="64" width="16" height="16">
@@ -629,9 +627,8 @@
     <property name="act4" value="add_monster exapode,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_petra"/>
     <property name="act6" value="char_talk spyder_dryadsgrove_petra,post_battle_lose"/>
-    <property name="act7" value="set_variable dryadsgrovepetra:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_petra"/>
-    <property name="cond1" value="not variable_set dryadsgrovepetra:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_petra"/>
    </properties>
   </object>
   <object id="217" name="Create Sylvia" type="event" x="224" y="224" width="16" height="16">
@@ -639,7 +636,7 @@
     <property name="act1" value="create_npc spyder_dryadsgrove_sylvia,14,14"/>
     <property name="act2" value="char_wander spyder_dryadsgrove_sylvia"/>
     <property name="cond1" value="not char_exists spyder_dryadsgrove_sylvia"/>
-    <property name="cond2" value="not variable_set dryadsgrovesylvia:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dryadsgrove_sylvia"/>
    </properties>
   </object>
   <object id="218" name="Talk Sylvia" type="event" x="224" y="208" width="16" height="16">
@@ -650,9 +647,8 @@
     <property name="act4" value="add_monster narcileaf,50,spyder_dryadsgrove_sylvia,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_sylvia"/>
     <property name="act6" value="char_talk spyder_dryadsgrove_sylvia,post_battle_lose"/>
-    <property name="act7" value="set_variable dryadsgrovesylvia:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_sylvia"/>
-    <property name="cond1" value="not variable_set dryadsgrovesylvia:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_sylvia"/>
    </properties>
   </object>
   <object id="219" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
@@ -680,9 +676,9 @@
     <property name="act07" value="add_monster noctalo,50,spyder_dryadsgrove_aquemini,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_aquemini"/>
     <property name="act09" value="char_talk spyder_dryadsgrove_aquemini,post_battle_lose"/>
-    <property name="act10" value="set_variable dryadsgroveaquemini:yes"/>
-    <property name="cond1" value="not variable_set dryadsgroveaquemini:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_aquemini"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="221" name="Talk Ignatia" type="event" x="400" y="128" width="48" height="16">
@@ -696,9 +692,9 @@
     <property name="act07" value="add_monster criniotherme,50,spyder_dryadsgrove_ignatia,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_ignatia"/>
     <property name="act09" value="char_talk spyder_dryadsgrove_ignatia,post_battle_lose"/>
-    <property name="act10" value="set_variable dryadsgroveignatia:yes"/>
-    <property name="cond1" value="not variable_set dryadsgroveignatia:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_ignatia"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="222" name="Talk Petra" type="event" x="240" y="96" width="16" height="32">
@@ -712,16 +708,16 @@
     <property name="act07" value="add_monster exapode,50,spyder_dryadsgrove_petra,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_petra"/>
     <property name="act09" value="char_talk spyder_dryadsgrove_petra,post_battle_lose"/>
-    <property name="act10" value="set_variable dryadsgrovepetra:yes"/>
-    <property name="cond1" value="not variable_set dryadsgrovepetra:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_petra"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="225" name="Create Ferris" type="event" x="592" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_dryadsgrove_ferris,37,6"/>
     <property name="cond1" value="not char_exists spyder_dryadsgrove_ferris"/>
-    <property name="cond2" value="not variable_set dryadsgroveferris:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dryadsgrove_ferris"/>
    </properties>
   </object>
   <object id="226" name="Talk Ferris" type="event" x="592" y="80" width="16" height="16">
@@ -732,9 +728,8 @@
     <property name="act4" value="add_monster araignee,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act5" value="start_battle player,spyder_dryadsgrove_ferris"/>
     <property name="act6" value="char_talk spyder_dryadsgrove_ferris,post_battle_lose"/>
-    <property name="act7" value="set_variable dryadsgroveferris:yes"/>
     <property name="behav1" value="talk spyder_dryadsgrove_ferris"/>
-    <property name="cond1" value="not variable_set dryadsgroveferris:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_ferris"/>
    </properties>
   </object>
   <object id="227" name="Talk Ferris" type="event" x="592" y="112" width="16" height="32">
@@ -748,9 +743,9 @@
     <property name="act07" value="add_monster araignee,50,spyder_dryadsgrove_ferris,5,10"/>
     <property name="act08" value="start_battle player,spyder_dryadsgrove_ferris"/>
     <property name="act09" value="char_talk spyder_dryadsgrove_ferris,post_battle_lose"/>
-    <property name="act10" value="set_variable dryadsgroveferris:yes"/>
-    <property name="cond1" value="not variable_set dryadsgroveferris:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_dryadsgrove_ferris"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="253" name="Teleport to Routed 1" type="event" x="528" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="502">
+<map version="1.8" tiledversion="1.8.2" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="8" nextobjectid="504">
  <properties>
   <property name="east" value="route4"/>
   <property name="edges" value="clamped"/>
@@ -578,14 +578,14 @@
    <properties>
     <property name="act1" value="create_npc spyder_sign_flower1,6,16"/>
     <property name="cond1" value="not char_exists spyder_sign_flower1"/>
-    <property name="cond2" value="not variable_set nimrodtru:yes"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
    </properties>
   </object>
   <object id="479" name="Sign 2" type="event" x="112" y="256" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_sign_flower2,7,16"/>
     <property name="cond1" value="not char_exists spyder_sign_flower2"/>
-    <property name="cond2" value="not variable_set nimrodtru:yes"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
    </properties>
   </object>
   <object id="478" name="Sign Alert" type="event" x="96" y="256" width="32" height="16">
@@ -593,7 +593,20 @@
     <property name="act1" value="translated_dialog spyder_flower_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed K_RETURN"/>
-    <property name="cond3" value="not variable_set nimrodtru:yes"/>
+    <property name="cond3" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
+   </properties>
+  </object>
+  <object id="502" name="Create Enforcer" type="event" x="336" y="128" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_nimrod_bowie,19,10"/>
+    <property name="cond1" value="not char_exists spyder_nimrod_bowie"/>
+    <property name="cond2" value="not variable_set dojothrimonster:yes"/>
+   </properties>
+  </object>
+  <object id="503" name="Talk Enforcer" type="event" x="336" y="144" width="16" height="16">
+   <properties>
+    <property name="act1" value="translated_dialog spyder_flower_guard"/>
+    <property name="behav1" value="talk spyder_nimrod_bowie"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_greenwash.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash.tmx
@@ -75,11 +75,10 @@
     <property name="act21" value="char_talk spyder_greenwash_looten,post_battle_lose"/>
     <property name="act22" value="translated_dialog spyder_greenwash_looten3"/>
     <property name="act23" value="translated_dialog spyder_greenwash_looten4"/>
-    <property name="act40" value="set_variable gotaardant:yes"/>
     <property name="act50" value="add_item aardant"/>
     <property name="act51" value="translated_dialog aardant,,center,center,center"/>
     <property name="behav1" value="talk spyder_greenwash_looten"/>
-    <property name="cond1" value="not variable_set gotaardant:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_looten"/>
    </properties>
   </object>
   <object id="46" name="Teleport to Greenhouse" type="event" x="240" y="304" width="16" height="16">
@@ -104,7 +103,7 @@
     <property name="act2" value="char_face player,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is variable_set gotaardant:yes"/>
+    <property name="cond3" value="not battle_outcome player,won,spyder_greenwash_looten"/>
    </properties>
   </object>
   <object id="68" name="Teleport to Level 2" type="event" x="16" y="32" width="16" height="32">
@@ -140,9 +139,9 @@
     <property name="act07" value="add_monster tikorch,22,spyder_greenwash_chip,5,10"/>
     <property name="act08" value="start_battle player,spyder_greenwash_chip"/>
     <property name="act09" value="char_talk spyder_greenwash_chip,post_battle_lose"/>
-    <property name="act10" value="set_variable greenwashchip:yes"/>
-    <property name="cond1" value="not variable_set greenwashchip:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_chip"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="77" name="Talk Clarence" type="event" x="192" y="112" width="48" height="16">
@@ -155,9 +154,9 @@
     <property name="act6" value="add_monster cochini,23,spyder_greenwash_clarence,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_clarence"/>
     <property name="act8" value="char_talk spyder_greenwash_clarence,post_battle_lose"/>
-    <property name="act9" value="set_variable greenwashclarence:yes"/>
-    <property name="cond1" value="not variable_set greenwashclarence:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_clarence"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="78" name="Move Right" type="event" x="144" y="464" width="16" height="16">
@@ -184,9 +183,9 @@
     <property name="act07" value="char_talk spyder_greenwash_broer,post_battle_lose"/>
     <property name="act08" value="add_item potion"/>
     <property name="act09" value="translated_dialog potion,,center,center,center"/>
-    <property name="act10" value="set_variable greenwashbroer:yes"/>
-    <property name="cond1" value="not variable_set greenwashbroer:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_broer"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="82" name="Create Lewie" type="event" x="160" y="176" width="16" height="16">
@@ -205,9 +204,9 @@
     <property name="act5" value="add_monster agnite,26,spyder_greenwash_lewie,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_lewie"/>
     <property name="act7" value="char_talk spyder_greenwash_lewie,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashlewie:yes"/>
-    <property name="cond1" value="not variable_set greenwashlewie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_lewie"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="84" name="Create Morehouse" type="event" x="112" y="320" width="16" height="16">
@@ -227,9 +226,9 @@
     <property name="act6" value="add_monster eyesore,20,spyder_greenwash_morehouse,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_morehouse"/>
     <property name="act8" value="char_talk spyder_greenwash_morehouse,post_battle_lose"/>
-    <property name="act9" value="set_variable greenwashmorehouse:yes"/>
-    <property name="cond1" value="not variable_set greenwashmorehouse:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_morehouse"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="89" name="Post Talk Broer" type="event" x="160" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_greenhouse.tmx
@@ -224,9 +224,9 @@
     <property name="act6" value="add_monster cateye,22,spyder_greenwash_gregor,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_gregor"/>
     <property name="act8" value="char_talk spyder_greenwash_gregor,post_battle_lose"/>
-    <property name="act9" value="set_variable greenwashgregor:yes"/>
-    <property name="cond1" value="not variable_set greenwashgregor:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_gregor"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="93" name="Create Alex" type="event" x="80" y="224" width="16" height="16">
@@ -245,9 +245,9 @@
     <property name="act5" value="add_monster shybulb,25,spyder_greenwash_alex,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_alex"/>
     <property name="act7" value="char_talk spyder_greenwash_alex,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashalex:yes"/>
-    <property name="cond1" value="not variable_set greenwashalex:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_alex"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="95" name="Create Hunt" type="event" x="304" y="192" width="16" height="16">
@@ -267,9 +267,9 @@
     <property name="act6" value="add_monster propellercat,25,spyder_greenwash_hunt,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_hunt"/>
     <property name="act8" value="char_talk spyder_greenwash_hunt,post_battle_lose"/>
-    <property name="act9" value="set_variable greenwashhunt:yes"/>
-    <property name="cond1" value="not variable_set greenwashhunt:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_hunt"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="97" name="Talk Hunt" type="event" x="272" y="192" width="16" height="64">
@@ -282,9 +282,9 @@
     <property name="act6" value="add_monster propellercat,25,spyder_greenwash_hunt,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_hunt"/>
     <property name="act8" value="char_talk spyder_greenwash_hunt,post_battle_lose"/>
-    <property name="act9" value="set_variable greenwashhunt:yes"/>
-    <property name="cond1" value="not variable_set greenwashhunt:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_hunt"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="98" name="Create Lewis" type="event" x="288" y="128" width="16" height="16">
@@ -303,9 +303,9 @@
     <property name="act5" value="add_monster pharfan,24,spyder_greenwash_lewis,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_lewis"/>
     <property name="act7" value="char_talk spyder_greenwash_lewis,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashlewis:yes"/>
-    <property name="cond1" value="not variable_set greenwashlewis:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_lewis"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="101" name="Talk Lewis" type="event" x="256" y="48" width="16" height="32">
@@ -317,9 +317,9 @@
     <property name="act5" value="add_monster pharfan,24,spyder_greenwash_lewis,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_lewis"/>
     <property name="act7" value="char_talk spyder_greenwash_lewis,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashlewis:yes"/>
-    <property name="cond1" value="not variable_set greenwashlewis:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_lewis"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="102" name="Create Louis" type="event" x="112" y="48" width="16" height="16">
@@ -338,9 +338,9 @@
     <property name="act5" value="add_monster cateye,24,spyder_greenwash_louis,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_louis"/>
     <property name="act7" value="char_talk spyder_greenwash_louis,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashlouis:yes"/>
-    <property name="cond1" value="not variable_set greenwashlouis:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_louis"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="104" name="Create Firefighter" type="event" x="48" y="160" width="16" height="16">
@@ -372,9 +372,9 @@
     <property name="act5" value="add_monster narcileaf,25,spyder_greenwash_gluck,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_gluck"/>
     <property name="act7" value="char_talk spyder_greenwash_gluck,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashgluck:yes"/>
-    <property name="cond1" value="not variable_set greenwashgluck:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_gluck"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="108" name="Talk Gluck" type="event" x="464" y="176" width="32" height="16">
@@ -386,9 +386,9 @@
     <property name="act5" value="add_monster narcileaf,25,spyder_greenwash_gluck,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_gluck"/>
     <property name="act7" value="char_talk spyder_greenwash_gluck,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashgluck:yes"/>
-    <property name="cond1" value="not variable_set greenwashgluck:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_gluck"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="109" name="Post Talk Alex" type="event" x="144" y="208" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -131,9 +131,9 @@
     <property name="act5" value="add_monster cateye,22,spyder_greenwash_aissa,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_aissa"/>
     <property name="act7" value="char_talk spyder_greenwash_aissa,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashaissa:yes"/>
-    <property name="cond1" value="not variable_set greenwashaissa:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_aissa"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="93" name="Talk Dippel" type="event" x="80" y="112" width="16" height="32">
@@ -146,9 +146,9 @@
     <property name="act6" value="add_monster tikorch,22,spyder_greenwash_dippel,5,10"/>
     <property name="act7" value="start_battle player,spyder_greenwash_dippel"/>
     <property name="act8" value="char_talk spyder_greenwash_dippel,post_battle_lose"/>
-    <property name="act9" value="set_variable greenwashdippel:yes"/>
-    <property name="cond1" value="not variable_set greenwashdippel:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_dippel"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="94" name="Talk Moreau" type="event" x="208" y="400" width="32" height="16">
@@ -160,9 +160,9 @@
     <property name="act5" value="add_monster sclairus,26,spyder_greenwash_moreau,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_moreau"/>
     <property name="act7" value="char_talk spyder_greenwash_moreau,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashmoreau:yes"/>
-    <property name="cond1" value="not variable_set greenwashmoreau:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_moreau"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="108" name="Create Dempsey" type="event" x="32" y="256" width="16" height="16">
@@ -181,9 +181,9 @@
     <property name="act5" value="add_monster masknake,25,spyder_greenwash_dempsey,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_dempsey"/>
     <property name="act7" value="char_talk spyder_greenwash_dempsey,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashdempsey:yes"/>
-    <property name="cond1" value="not variable_set greenwashdempsey:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_dempsey"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="110" name="Create Heidenstam" type="event" x="80" y="352" width="16" height="16">
@@ -202,9 +202,9 @@
     <property name="act5" value="add_monster foofle,10,spyder_greenwash_heidenstam,5,10"/>
     <property name="act6" value="start_battle player,spyder_greenwash_heidenstam"/>
     <property name="act7" value="char_talk spyder_greenwash_heidenstam,post_battle_lose"/>
-    <property name="act8" value="set_variable greenwashheidenstam:yes"/>
-    <property name="cond1" value="not variable_set greenwashheidenstam:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_greenwash_heidenstam"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="112" name="Create Fossilisator" type="event" x="160" y="288" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -233,9 +233,9 @@
     <property name="act6" value="add_monster ghosteeth,22,spyder_mansion_gillette,5,10"/>
     <property name="act7" value="start_battle player,spyder_mansion_gillette"/>
     <property name="act8" value="char_talk spyder_mansion_gillette,post_battle_lose"/>
-    <property name="act9" value="set_variable mansiongillette:yes"/>
-    <property name="cond1" value="not variable_set mansiongillette:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_mansion_gillette"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="57" name="Talk Lucy" type="event" x="240" y="112" width="32" height="16">
@@ -248,9 +248,9 @@
     <property name="act6" value="add_monster budaye,15,spyder_mansion_lucy,5,10"/>
     <property name="act7" value="start_battle player,spyder_mansion_lucy"/>
     <property name="act8" value="char_talk spyder_mansion_lucy,post_battle_lose"/>
-    <property name="act9" value="set_variable mansionlucy:yes"/>
-    <property name="cond1" value="not variable_set mansionlucy:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_mansion_lucy"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="58" name="Talk Lyle" type="event" x="16" y="112" width="32" height="16">
@@ -263,9 +263,9 @@
     <property name="act6" value="add_monster shybulb,20,spyder_mansion_lyle,5,10"/>
     <property name="act7" value="start_battle player,spyder_mansion_lyle"/>
     <property name="act8" value="char_talk spyder_mansion_lyle,post_battle_lose"/>
-    <property name="act9" value="set_variable mansionlyle:yes"/>
-    <property name="cond1" value="not variable_set mansionlyle:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_mansion_lyle"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="63" name="Create Magician1" type="event" x="144" y="240" width="16" height="16">
@@ -313,7 +313,7 @@
     <property name="act3" value="translated_dialog mystery_tea,,center,center,center"/>
     <property name="act4" value="set_variable tealucy:yes"/>
     <property name="behav1" value="talk spyder_mansion_lucy"/>
-    <property name="cond1" value="is variable_set mansionlucy:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_mansion_lucy"/>
     <property name="cond2" value="not variable_set tealucy:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_mansion_basement.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_basement.tmx
@@ -154,9 +154,9 @@
     <property name="act6" value="add_monster elofly,22,spyder_basement_coralli,5,10"/>
     <property name="act7" value="start_battle player,spyder_basement_coralli"/>
     <property name="act8" value="char_talk spyder_basement_coralli,post_battle_lose"/>
-    <property name="act9" value="set_variable basementcoralli:yes"/>
-    <property name="cond1" value="not variable_set basementcoralli:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_basement_coralli"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="52" name="Talk Bobby" type="event" x="144" y="112" width="16" height="16">
@@ -168,9 +168,9 @@
     <property name="act5" value="add_monster capiti,26,spyder_basement_bobby,5,10"/>
     <property name="act6" value="start_battle player,spyder_basement_bobby"/>
     <property name="act7" value="char_talk spyder_basement_bobby,post_battle_lose"/>
-    <property name="act8" value="set_variable basementbobby:yes"/>
-    <property name="cond1" value="not variable_set basementbobby:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_basement_bobby"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="54" name="Talk Roger" type="event" x="304" y="272" width="16" height="48">
@@ -182,9 +182,9 @@
     <property name="act5" value="add_monster polyrock,22,spyder_basement_roger,5,10"/>
     <property name="act6" value="start_battle player,spyder_basement_roger"/>
     <property name="act7" value="char_talk spyder_basement_roger,post_battle_lose"/>
-    <property name="act8" value="set_variable basementroger:yes"/>
-    <property name="cond1" value="not variable_set basementroger:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_basement_roger"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="56" name="Talk Catholi" type="event" x="144" y="288" width="96" height="16">
@@ -197,9 +197,9 @@
     <property name="act6" value="add_monster rosarin,24,spyder_basement_catholi,5,10"/>
     <property name="act7" value="start_battle player,spyder_basement_catholi"/>
     <property name="act8" value="char_talk spyder_basement_catholi,post_battle_lose"/>
-    <property name="act9" value="set_variable basementcatholi:yes"/>
-    <property name="cond1" value="not variable_set basementcatholi:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_basement_catholi"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="58" name="Create Baller" type="event" x="336" y="176" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_mansion_top.tmx
+++ b/mods/tuxemon/maps/spyder_mansion_top.tmx
@@ -100,9 +100,9 @@
     <property name="act6" value="add_monster cardiwing,25,spyder_top_mickey,5,10"/>
     <property name="act7" value="start_battle player,spyder_top_mickey"/>
     <property name="act8" value="char_talk spyder_top_mickey,post_battle_lose"/>
-    <property name="act9" value="set_variable mansiontop_mickey:yes"/>
-    <property name="cond1" value="not variable_set mansiontop_mickey:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_top_mickey"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="33" name="Create Mickey" type="event" x="48" y="144" width="16" height="16">
@@ -152,9 +152,9 @@
     <property name="act07" value="add_monster k9,22,spyder_top_russell,5,10"/>
     <property name="act08" value="start_battle player,spyder_top_russell"/>
     <property name="act09" value="char_talk spyder_top_russell,post_battle_lose"/>
-    <property name="act10" value="set_variable mansiontop_russell:yes"/>
-    <property name="cond1" value="not variable_set mansiontop_russell:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_top_russell"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="45" name="Talk Ricardo" type="event" x="240" y="96" width="16" height="16">
@@ -167,9 +167,9 @@
     <property name="act6" value="add_monster squabbit,22,spyder_top_ricardo,5,10"/>
     <property name="act7" value="start_battle player,spyder_top_ricardo"/>
     <property name="act8" value="char_talk spyder_top_ricardo,post_battle_lose"/>
-    <property name="act9" value="set_variable mansiontop_ricardo:yes"/>
-    <property name="cond1" value="not variable_set mansiontop_ricardo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_top_ricardo"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="48" name="Talk Jackson" type="event" x="176" y="208" width="80" height="16">
@@ -181,9 +181,9 @@
     <property name="act5" value="add_monster viviteel,26,spyder_top_jackson,5,10"/>
     <property name="act6" value="start_battle player,spyder_top_jackson"/>
     <property name="act7" value="char_talk spyder_top_jackson,post_battle_lose"/>
-    <property name="act8" value="set_variable mansiontop_jackson:yes"/>
-    <property name="cond1" value="not variable_set mansiontop_jackson:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_top_jackson"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="49" name="Create Magician" type="event" x="80" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -92,7 +92,7 @@
     <property name="act1" value="create_npc spyder_nimrod_jake,7,19"/>
     <property name="act2" value="char_face spyder_nimrod_jake,right"/>
     <property name="cond1" value="not char_exists spyder_nimrod_jake"/>
-    <property name="cond2" value="not variable_set nimrodtru:yes"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
    </properties>
   </object>
   <object id="39" name="Talk Guard" type="event" x="96" y="272" width="16" height="16">
@@ -114,9 +114,8 @@
     <property name="act2" value="add_monster grimachin,25,spyder_nimrod_rebel,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_rebel"/>
     <property name="act4" value="char_talk spyder_nimrod_rebel,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodrebel:yes"/>
     <property name="behav1" value="talk spyder_nimrod_rebel"/>
-    <property name="cond1" value="not variable_set nimrodrebel:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_rebel"/>
    </properties>
   </object>
   <object id="42" name="Create Bowie" type="event" x="16" y="240" width="16" height="16">
@@ -132,9 +131,8 @@
     <property name="act3" value="add_monster embazook,35,spyder_nimrod_bowie,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_bowie"/>
     <property name="act5" value="char_talk spyder_nimrod_bowie,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodbowie:yes"/>
     <property name="behav1" value="talk spyder_nimrod_bowie"/>
-    <property name="cond1" value="not variable_set nimrodbowie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_bowie"/>
    </properties>
   </object>
   <object id="44" name="Create Tru" type="event" x="16" y="288" width="16" height="16">
@@ -155,11 +153,10 @@
     <property name="act07" value="start_battle player,spyder_nimrod_tru"/>
     <property name="act08" value="char_talk spyder_nimrod_tru,post_battle_lose"/>
     <property name="act09" value="translated_dialog spyder_nimrod_tru3"/>
-    <property name="act10" value="set_variable nimrodtru:yes"/>
     <property name="act11" value="pathfind spyder_nimrod_jake,0,17"/>
     <property name="act12" value="remove_npc spyder_nimrod_jake"/>
     <property name="behav1" value="talk spyder_nimrod_tru"/>
-    <property name="cond1" value="not variable_set nimrodtru:yes"/>
+    <property name="cond1" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
    </properties>
   </object>
   <object id="48" name="Teleport to  Flower City" type="event" x="0" y="256" width="16" height="48">
@@ -185,9 +182,9 @@
     <property name="act5" value="add_monster grimachin,25,spyder_nimrod_rebel,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_rebel"/>
     <property name="act7" value="char_talk spyder_nimrod_rebel,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodrebel:yes"/>
-    <property name="cond1" value="not variable_set nimrodrebel:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_rebel"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="54" name="Talk Tru" type="event" x="32" y="288" width="32" height="16">
@@ -204,10 +201,9 @@
     <property name="act10" value="start_battle player,spyder_nimrod_tru"/>
     <property name="act11" value="char_talk spyder_nimrod_tru,post_battle_lose"/>
     <property name="act12" value="translated_dialog spyder_nimrod_tru3"/>
-    <property name="act13" value="set_variable nimrodtru:yes"/>
     <property name="act14" value="pathfind spyder_nimrod_jake,0,17"/>
     <property name="act15" value="remove_npc spyder_nimrod_jake"/>
-    <property name="cond1" value="not variable_set nimrodtru:yes"/>
+    <property name="cond1" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
     <property name="cond2" value="is char_at player"/>
    </properties>
   </object>
@@ -221,9 +217,9 @@
     <property name="act6" value="add_monster embazook,35,spyder_nimrod_bowie,5,10"/>
     <property name="act7" value="start_battle player,spyder_nimrod_bowie"/>
     <property name="act8" value="char_talk spyder_nimrod_bowie,post_battle_lose"/>
-    <property name="act9" value="set_variable nimrodbowie:yes"/>
-    <property name="cond1" value="not variable_set nimrodbowie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_bowie"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="58" name="Post Talk Rebel" type="event" x="176" y="240" width="16" height="16">
@@ -244,7 +240,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_nimrod_tru3"/>
     <property name="behav1" value="talk spyder_nimrod_tru"/>
-    <property name="cond1" value="is battle_outcome player,won,spyder_nimrod_tru"/>
+    <property name="cond1" value="is battle_outcome_count player,won,spyder_nimrod_tru,1"/>
    </properties>
   </object>
   <object id="62" name="Play Music" type="event" x="0" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_nimrod_middle.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_middle.tmx
@@ -80,9 +80,8 @@
     <property name="act3" value="add_monster viviteel,25,spyder_nimrod_thatcher,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_thatcher"/>
     <property name="act5" value="char_talk spyder_nimrod_thatcher,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodthatcher:yes"/>
     <property name="behav1" value="talk spyder_nimrod_thatcher"/>
-    <property name="cond1" value="not variable_set nimrodthatcher:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_thatcher"/>
    </properties>
   </object>
   <object id="16" name="Create Honour" type="event" x="240" y="64" width="16" height="16">
@@ -99,9 +98,8 @@
     <property name="act3" value="add_monster sharpfin,20,spyder_nimrod_honour,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_honour"/>
     <property name="act5" value="char_talk spyder_nimrod_honour,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodhonour:yes"/>
     <property name="behav1" value="talk spyder_nimrod_honour"/>
-    <property name="cond1" value="not variable_set nimrodhonour:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_honour"/>
    </properties>
   </object>
   <object id="18" name="Create Antimony" type="event" x="64" y="176" width="16" height="16">
@@ -116,9 +114,8 @@
     <property name="act2" value="add_monster komodraw,30,spyder_nimrod_antimony,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_antimony"/>
     <property name="act4" value="char_talk spyder_nimrod_antimony,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodantimony:yes"/>
     <property name="behav1" value="talk spyder_nimrod_antimony"/>
-    <property name="cond1" value="not variable_set nimrodantimony:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_antimony"/>
    </properties>
   </object>
   <object id="20" name="Create Chrome Robo" type="event" x="144" y="176" width="16" height="16">
@@ -126,7 +123,7 @@
     <property name="act1" value="create_npc spyder_nimrod_chromerobo,9,11"/>
     <property name="act2" value="char_face spyder_nimrod_chromerobo,down"/>
     <property name="cond1" value="not char_exists spyder_nimrod_chromerobo"/>
-    <property name="cond2" value="not variable_set nimrodchromerobo_middle:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_nimrod_chromerobo"/>
    </properties>
   </object>
   <object id="21" name="Talk Chrome Robo" type="event" x="128" y="176" width="16" height="16">
@@ -135,10 +132,9 @@
     <property name="act2" value="add_monster chrome_robo,20,spyder_nimrod_chromerobo,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_chromerobo"/>
     <property name="act4" value="char_talk spyder_nimrod_chromerobo,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodchromerobo_middle:yes"/>
     <property name="act7" value="remove_npc spyder_nimrod_chromerobo"/>
     <property name="behav1" value="talk spyder_nimrod_chromerobo"/>
-    <property name="cond1" value="not variable_set nimrodchromerobo_middle:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_chromerobo"/>
    </properties>
   </object>
   <object id="24" name="Create Xeon" type="event" x="160" y="240" width="16" height="16">
@@ -146,17 +142,16 @@
     <property name="act1" value="create_npc spyder_nimrod_xeon,10,15"/>
     <property name="act2" value="char_face spyder_nimrod_xeon,up"/>
     <property name="cond1" value="not char_exists spyder_nimrod_xeon"/>
-    <property name="cond2" value="not variable_set nimrodxeon_middle:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_nimrod_xeon"/>
    </properties>
   </object>
   <object id="25" name="Talk Xeon" type="event" x="176" y="240" width="16" height="16">
    <properties>
     <property name="act3" value="start_battle player,spyder_nimrod_xeon"/>
     <property name="act4" value="char_talk spyder_nimrod_xeon,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodxeon_middle:yes"/>
     <property name="act7" value="remove_npc spyder_nimrod_xeon"/>
     <property name="behav1" value="talk spyder_nimrod_xeon"/>
-    <property name="cond1" value="not variable_set nimrodxeon_middle:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_xeon"/>
    </properties>
   </object>
   <object id="26" name="Create Argon" type="event" x="208" y="144" width="16" height="16">
@@ -172,9 +167,8 @@
     <property name="act2" value="add_monster chrome_robo,25,spyder_nimrod_argon,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_argon"/>
     <property name="act4" value="char_talk spyder_nimrod_argon,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodargon:yes"/>
     <property name="behav1" value="talk spyder_nimrod_argon"/>
-    <property name="cond1" value="not variable_set nimrodargon:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_argon"/>
    </properties>
   </object>
   <object id="29" name="Create Archer" type="event" x="48" y="208" width="16" height="16">
@@ -192,9 +186,8 @@
     <property name="act4" value="add_monster grimachin,20,spyder_nimrod_archer,5,10"/>
     <property name="act5" value="start_battle player,spyder_nimrod_archer"/>
     <property name="act6" value="char_talk spyder_nimrod_archer,post_battle_lose"/>
-    <property name="act7" value="set_variable nimrodarcher:yes"/>
     <property name="behav1" value="talk spyder_nimrod_archer"/>
-    <property name="cond1" value="not variable_set nimrodarcher:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_archer"/>
    </properties>
   </object>
   <object id="36" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -212,9 +205,9 @@
     <property name="act5" value="add_monster chrome_robo,25,spyder_nimrod_argon,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_argon"/>
     <property name="act7" value="char_talk spyder_nimrod_argon,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodargon:yes"/>
-    <property name="cond1" value="not variable_set nimrodargon:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_argon"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="38" name="Talk Honour" type="event" x="192" y="64" width="48" height="16">
@@ -227,9 +220,9 @@
     <property name="act6" value="add_monster sharpfin,20,spyder_nimrod_honour,5,10"/>
     <property name="act7" value="start_battle player,spyder_nimrod_honour"/>
     <property name="act8" value="char_talk spyder_nimrod_honour,post_battle_lose"/>
-    <property name="act9" value="set_variable nimrodhonour:yes"/>
-    <property name="cond1" value="not variable_set nimrodhonour:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_honour"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="40" name="Talk Xeon" type="event" x="160" y="176" width="16" height="64">
@@ -241,10 +234,10 @@
     <property name="act5" value="add_monster xeon,20,spyder_nimrod_xeon,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_xeon"/>
     <property name="act7" value="char_talk spyder_nimrod_xeon,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodxeon_middle:yes"/>
     <property name="act9" value="remove_npc spyder_nimrod_xeon"/>
-    <property name="cond1" value="not variable_set nimrodxeon_middle:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_xeon"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="41" name="Talk Chrome Robo" type="event" x="144" y="192" width="16" height="64">
@@ -256,10 +249,10 @@
     <property name="act5" value="add_monster chrome_robo,20,spyder_nimrod_chromerobo,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_chromerobo"/>
     <property name="act7" value="char_talk spyder_nimrod_chromerobo,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodchromerobo_middle:yes"/>
     <property name="act9" value="remove_npc spyder_nimrod_chromerobo"/>
-    <property name="cond1" value="not variable_set nimrodchromerobo_middle:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_chromerobo"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="42" name="Talk Archer" type="event" x="64" y="208" width="16" height="16">
@@ -273,9 +266,9 @@
     <property name="act07" value="add_monster grimachin,20,spyder_nimrod_archer,5,10"/>
     <property name="act08" value="start_battle player,spyder_nimrod_archer"/>
     <property name="act09" value="char_talk spyder_nimrod_archer,post_battle_lose"/>
-    <property name="act10" value="set_variable nimrodarcher:yes"/>
-    <property name="cond1" value="not variable_set nimrodarcher:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_archer"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="43" name="Talk Antimony" type="event" x="64" y="192" width="16" height="16">
@@ -287,9 +280,9 @@
     <property name="act5" value="add_monster komodraw,30,spyder_nimrod_antimony,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_antimony"/>
     <property name="act7" value="char_talk spyder_nimrod_antimony,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodantimony:yes"/>
-    <property name="cond1" value="not variable_set nimrodantimony:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_antimony"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="45" name="Post Talk Archer" type="event" x="64" y="256" width="16" height="16">
@@ -350,7 +343,7 @@
     <property name="act13" value="unlock_controls"/>
     <property name="act14" value="get_party_monster spyder_nimrod_argon"/>
     <property name="act15" value="remove_monster iid_slot_0"/>
-    <property name="cond1" value="is variable_set nimrodargon:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_nimrod_argon"/>
     <property name="cond2" value="not variable_set zircon_argon"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -95,9 +95,8 @@
     <property name="act2" value="add_monster av8r,25,spyder_nimrod_maverick,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_maverick"/>
     <property name="act4" value="char_talk spyder_nimrod_maverick,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodmaverick:yes"/>
     <property name="behav1" value="talk spyder_nimrod_maverick"/>
-    <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_maverick"/>
    </properties>
   </object>
   <object id="32" name="Create Justice" type="event" x="224" y="256" width="16" height="16">
@@ -114,9 +113,8 @@
     <property name="act3" value="add_monster ghosteeth,16,spyder_nimrod_justice,5,10"/>
     <property name="act4" value="start_battle player,spyder_nimrod_justice"/>
     <property name="act5" value="char_talk spyder_nimrod_justice,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodjustice:yes"/>
     <property name="behav1" value="talk spyder_nimrod_justice"/>
-    <property name="cond1" value="not variable_set nimrodjustice:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_justice"/>
    </properties>
   </object>
   <object id="34" name="Create Zircon" type="event" x="176" y="160" width="16" height="16">
@@ -131,9 +129,8 @@
     <property name="act2" value="add_monster dark_robo,25,spyder_nimrod_zircon,5,10"/>
     <property name="act3" value="start_battle player,spyder_nimrod_zircon"/>
     <property name="act4" value="char_talk spyder_nimrod_zircon,post_battle_lose"/>
-    <property name="act6" value="set_variable nimrodzircon:yes"/>
     <property name="behav1" value="talk spyder_nimrod_zircon"/>
-    <property name="cond1" value="not variable_set nimrodzircon:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_zircon"/>
    </properties>
   </object>
   <object id="38" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -152,9 +149,9 @@
     <property name="act6" value="add_monster ghosteeth,16,spyder_nimrod_justice,5,10"/>
     <property name="act7" value="start_battle player,spyder_nimrod_justice"/>
     <property name="act8" value="char_talk spyder_nimrod_justice,post_battle_lose"/>
-    <property name="act9" value="set_variable nimrodjustice:yes"/>
-    <property name="cond1" value="not variable_set nimrodjustice:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_justice"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="41" name="Talk Zircon" type="event" x="176" y="176" width="16" height="32">
@@ -166,9 +163,9 @@
     <property name="act5" value="add_monster dark_robo,25,spyder_nimrod_zircon,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_zircon"/>
     <property name="act7" value="char_talk spyder_nimrod_zircon,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodzircon:yes"/>
-    <property name="cond1" value="not variable_set nimrodzircon:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_zircon"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="42" name="Talk Maverick" type="event" x="144" y="128" width="32" height="16">
@@ -180,9 +177,9 @@
     <property name="act5" value="add_monster av8r,25,spyder_nimrod_maverick,5,10"/>
     <property name="act6" value="start_battle player,spyder_nimrod_maverick"/>
     <property name="act7" value="char_talk spyder_nimrod_maverick,post_battle_lose"/>
-    <property name="act8" value="set_variable nimrodmaverick:yes"/>
-    <property name="cond1" value="not variable_set nimrodmaverick:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_maverick"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="44" name="Create Mace" type="event" x="240" y="176" width="16" height="16">
@@ -203,9 +200,9 @@
     <property name="act07" value="add_monster komodraw,25,spyder_nimrod_mace,5,10"/>
     <property name="act08" value="start_battle player,spyder_nimrod_mace"/>
     <property name="act09" value="char_talk spyder_nimrod_mace,post_battle_lose"/>
-    <property name="act10" value="set_variable nimrodmace:yes"/>
-    <property name="cond1" value="not variable_set nimrodmace:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_mace"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="46" name="Talk Mace" type="event" x="240" y="192" width="16" height="16">
@@ -216,9 +213,8 @@
     <property name="act4" value="add_monster komodraw,25,spyder_nimrod_mace,5,10"/>
     <property name="act5" value="start_battle player,spyder_nimrod_mace"/>
     <property name="act6" value="char_talk spyder_nimrod_mace,post_battle_lose"/>
-    <property name="act7" value="set_variable nimrodmace:yes"/>
     <property name="behav1" value="talk spyder_nimrod_mace"/>
-    <property name="cond1" value="not variable_set nimrodmace:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_nimrod_mace"/>
    </properties>
   </object>
   <object id="47" name="Post Talk Justice" type="event" x="208" y="256" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -93,7 +93,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_william,9,4"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_william"/>
-    <property name="cond2" value="not variable_set omnichannelwilliam:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_william"/>
    </properties>
   </object>
   <object id="25" name="Talk William" type="event" x="144" y="48" width="16" height="16">
@@ -103,9 +103,8 @@
     <property name="act3" value="add_monster cardiwing,36,spyder_omnichannel_william,5,10"/>
     <property name="act4" value="start_battle player,spyder_omnichannel_william"/>
     <property name="act5" value="char_talk spyder_omnichannel_william,post_battle_lose"/>
-    <property name="act6" value="set_variable omnichannelwilliam:yes"/>
     <property name="behav1" value="talk spyder_omnichannel_william"/>
-    <property name="cond1" value="not variable_set omnichannelwilliam:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_william"/>
    </properties>
   </object>
   <object id="29" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -144,9 +143,9 @@
     <property name="act50" value="translated_dialog spyder_cottontown_enforcer2"/>
     <property name="act55" value="pathfind spyder_omnichannel_enforcer,2,12"/>
     <property name="act60" value="remove_npc spyder_omnichannel_enforcer"/>
-    <property name="act70" value="set_variable enforceromni:yes"/>
-    <property name="cond1" value="not variable_set enforceromni:yes"/>
-    <property name="cond3" value="is char_at player"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_enforcer"/>
+    <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="39" name="Create Maniac" type="event" x="32" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -97,7 +97,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_bettger,12,10"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_bettger"/>
-    <property name="cond2" value="not variable_set omnichannel2bettger:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_bettger"/>
    </properties>
   </object>
   <object id="25" name="Talk Schwartz" type="event" x="128" y="192" width="32" height="16">
@@ -110,9 +110,9 @@
     <property name="act6" value="add_monster strella,35,spyder_omnichannel_schwartz,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_schwartz"/>
     <property name="act8" value="char_talk spyder_omnichannel_schwartz,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannel2schwartz:yes"/>
-    <property name="cond1" value="not variable_set omnichannel2schwartz:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_schwartz"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="29" name="Create Schwartz" type="event" x="192" y="176" width="16" height="16">
@@ -120,7 +120,7 @@
     <property name="act1" value="create_npc spyder_omnichannel_schwartz,12,11"/>
     <property name="act2" value="char_face spyder_omnichannel_schwartz,up"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_schwartz"/>
-    <property name="cond2" value="not variable_set omnichannel2schwartz:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_schwartz"/>
    </properties>
   </object>
   <object id="30" name="Talk Bettger" type="event" x="112" y="176" width="32" height="16">
@@ -133,9 +133,9 @@
     <property name="act6" value="add_monster rabbitosaur,35,spyder_omnichannel_bettger,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_bettger"/>
     <property name="act8" value="char_talk spyder_omnichannel_bettger,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannel2bettger:yes"/>
-    <property name="cond1" value="not variable_set omnichannel2bettger:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_bettger"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="31" name="Create Tohei" type="event" x="64" y="304" width="16" height="16">
@@ -143,7 +143,7 @@
     <property name="act1" value="create_npc spyder_omnichannel_tohei,4,19"/>
     <property name="act2" value="char_face spyder_omnichannel_tohei,up"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_tohei"/>
-    <property name="cond2" value="not variable_set omnichannel2tohei:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_tohei"/>
    </properties>
   </object>
   <object id="32" name="Talk Tohei" type="event" x="64" y="256" width="32" height="16">
@@ -155,9 +155,9 @@
     <property name="act5" value="add_monster sludgehog,40,spyder_omnichannel_tohei,5,10"/>
     <property name="act6" value="start_battle player,spyder_omnichannel_tohei"/>
     <property name="act7" value="char_talk spyder_omnichannel_tohei,post_battle_lose"/>
-    <property name="act8" value="set_variable omnichannel2tohei:yes"/>
-    <property name="cond1" value="not variable_set omnichannel2tohei:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_tohei"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="36" name="Create Crane" type="event" x="176" y="48" width="16" height="16">
@@ -165,7 +165,7 @@
     <property name="act1" value="create_npc spyder_omnichannel_crane,11,3"/>
     <property name="act2" value="char_face spyder_omnichannel_crane,up"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_crane"/>
-    <property name="cond2" value="not variable_set omnichannel2crane:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_crane"/>
    </properties>
   </object>
   <object id="37" name="Talk Crane" type="event" x="128" y="96" width="32" height="16">
@@ -178,9 +178,9 @@
     <property name="act6" value="add_monster sharpfin,35,spyder_omnichannel_crane,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_crane"/>
     <property name="act8" value="char_talk spyder_omnichannel_crane,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannel2crane:yes"/>
-    <property name="cond1" value="not variable_set omnichannel2crane:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_crane"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="39" name="Create Dempsey" type="event" x="64" y="64" width="16" height="16">
@@ -188,7 +188,7 @@
     <property name="act1" value="create_npc spyder_omnichannel_dempsey,4,4"/>
     <property name="act2" value="char_face spyder_omnichannel_dempsey,up"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_dempsey"/>
-    <property name="cond2" value="not variable_set omnichannel2dempsey:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_dempsey"/>
    </properties>
   </object>
   <object id="40" name="Talk Dempsey" type="event" x="96" y="32" width="16" height="16">
@@ -201,9 +201,9 @@
     <property name="act6" value="add_monster squabbit,20,spyder_omnichannel_dempsey,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_dempsey"/>
     <property name="act8" value="char_talk spyder_omnichannel_dempsey,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannel2dempsey:yes"/>
-    <property name="cond1" value="not variable_set omnichannel2dempsey:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_dempsey"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="41" name="PC" type="event" x="16" y="272" width="32" height="16">

--- a/mods/tuxemon/maps/spyder_omnichannel3.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel3.tmx
@@ -92,21 +92,21 @@
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_carnegie,10,8"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_carnegie"/>
-    <property name="cond2" value="not variable_set omnichannelcarnegie:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_carnegie"/>
    </properties>
   </object>
   <object id="11" name="Create Byrne" type="event" x="192" y="288" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_byrne,12,18"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_byrne"/>
-    <property name="cond2" value="not variable_set omnichannelbyrne:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_byrne"/>
    </properties>
   </object>
   <object id="13" name="Create Strauss" type="event" x="48" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_strauss,3,2"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_strauss"/>
-    <property name="cond2" value="not variable_set omnichannelstrauss:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_omnichannel_strauss"/>
    </properties>
   </object>
   <object id="34" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -125,9 +125,9 @@
     <property name="act6" value="add_monster frondly,40,spyder_omnichannel_strauss,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_strauss"/>
     <property name="act8" value="char_talk spyder_omnichannel_strauss,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannelstrauss:yes"/>
-    <property name="cond1" value="not variable_set omnichannelstrauss:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_strauss"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="36" name="Talk Carnegie" type="event" x="160" y="192" width="16" height="16">
@@ -140,9 +140,9 @@
     <property name="act6" value="add_monster elostorm,38,spyder_omnichannel_carnegie,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_carnegie"/>
     <property name="act8" value="char_talk spyder_omnichannel_carnegie,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannelcarnegie:yes"/>
-    <property name="cond1" value="not variable_set omnichannelcarnegie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_carnegie"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="37" name="Talk Byrne" type="event" x="144" y="320" width="16" height="16">
@@ -155,9 +155,9 @@
     <property name="act6" value="add_monster jemuar,40,spyder_omnichannel_byrne,5,10"/>
     <property name="act7" value="start_battle player,spyder_omnichannel_byrne"/>
     <property name="act8" value="char_talk spyder_omnichannel_byrne,post_battle_lose"/>
-    <property name="act9" value="set_variable omnichannelbyrne:yes"/>
-    <property name="cond1" value="not variable_set omnichannelbyrne:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_omnichannel_byrne"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="48" name="Create Spyder Rookie" type="event" x="64" y="272" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_paper_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_paper_scoop.yaml
@@ -275,7 +275,7 @@ events:
     behav:
     - talk spyder_dante
     conditions:
-    - is variable_set zoolanderdefeat:yes
+    - is battle_outcome player,won,spyder_route3_zoolander
     - not variable_set omnichannelradioannounce:yes
     - is variable_set spokendante:yes
     type: event
@@ -295,7 +295,7 @@ events:
     behav:
     - talk spyder_dante
     conditions:
-    - is variable_set zoolanderdefeat:yes
+    - is battle_outcome player,won,spyder_route3_zoolander
     - is variable_set omnichannelradioannounce:yes
     - is variable_set spokendante:yes
     type: event
@@ -315,6 +315,6 @@ events:
     behav:
     - talk spyder_dante
     conditions:
-    - is variable_set zoolanderdefeat:yes
+    - is battle_outcome player,won,spyder_route3_zoolander
     - not variable_set spokendante:yes
     type: event

--- a/mods/tuxemon/maps/spyder_radiotower.tmx
+++ b/mods/tuxemon/maps/spyder_radiotower.tmx
@@ -70,7 +70,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_route3_zoolander,7,14"/>
     <property name="cond1" value="not char_exists spyder_route3_zoolander"/>
-    <property name="cond2" value="not variable_set omnichannelbeaverbrook:yes"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_omnichannel_beaverbrook,1"/>
    </properties>
   </object>
   <object id="20" name="Talk Zoolander" type="event" x="112" y="208" width="16" height="16">
@@ -83,7 +83,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_scoop_donald,11,14"/>
     <property name="cond1" value="not char_exists spyder_scoop_donald"/>
-    <property name="cond2" value="not variable_set omnichannelbeaverbrook:yes"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_omnichannel_beaverbrook,1"/>
    </properties>
   </object>
   <object id="22" name="Talk Donald" type="event" x="176" y="208" width="16" height="16">
@@ -96,7 +96,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_omnichannel_beaverbrook,9,12"/>
     <property name="cond1" value="not char_exists spyder_omnichannel_beaverbrook"/>
-    <property name="cond2" value="not variable_set omnichannelbeaverbrook:yes"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_omnichannel_beaverbrook,1"/>
    </properties>
   </object>
   <object id="27" name="Stop!" type="event" x="16" y="256" width="192" height="16">
@@ -132,11 +132,12 @@
     <property name="act85" value="char_face player,up"/>
     <property name="act86" value="translated_dialog spyder_omnichannel_beaverbrook2"/>
     <property name="act87" value="pathfind spyder_omnichannel_beaverbrook,9,4"/>
-    <property name="act90" value="set_variable omnichannelbeaverbrook:yes"/>
     <property name="act91" value="set_variable kernelquest:yes"/>
     <property name="act92" value="unlock_controls"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="not variable_set omnichannelbeaverbrook:yes"/>
+    <property name="cond1" value="is battle_outcome_count player,won,spyder_omnichannel_beaverbrook,0"/>
+    <property name="cond2" value="not battle_outcome_count player,won,spyder_omnichannel_beaverbrook,1"/>
+    <property name="cond3" value="is char_at player"/>
+    <property name="cond4" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="28" name="Create Worm" type="event" x="80" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -389,9 +389,8 @@
     <property name="act2" value="add_monster spighter,8,spyder_route2_roddick,5,10"/>
     <property name="act3" value="start_battle player,spyder_route2_roddick"/>
     <property name="act4" value="char_talk spyder_route2_roddick,post_battle_lose"/>
-    <property name="act5" value="set_variable route2roddick:yes"/>
     <property name="behav1" value="talk spyder_route2_roddick"/>
-    <property name="cond1" value="not variable_set route2roddick:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route2_roddick"/>
    </properties>
   </object>
   <object id="162" name="Talk marion" type="event" x="208" y="48" width="16" height="16">
@@ -401,9 +400,8 @@
     <property name="act3" value="add_monster aardorn,7,spyder_route2_marion,5,10"/>
     <property name="act4" value="start_battle player,spyder_route2_marion"/>
     <property name="act5" value="char_talk spyder_route2_marion,post_battle_lose"/>
-    <property name="act6" value="set_variable route2marion:yes"/>
     <property name="behav1" value="talk spyder_route2_marion"/>
-    <property name="cond1" value="not variable_set route2marion:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route2_marion"/>
    </properties>
   </object>
   <object id="163" name="Talk graf" type="event" x="224" y="48" width="16" height="16">
@@ -414,9 +412,8 @@
     <property name="act4" value="add_monster cataspike,5,spyder_route2_graf,5,10"/>
     <property name="act5" value="start_battle player,spyder_route2_graf"/>
     <property name="act6" value="char_talk spyder_route2_graf,post_battle_lose"/>
-    <property name="act7" value="set_variable route2graf:yes"/>
     <property name="behav1" value="talk spyder_route2_graf"/>
-    <property name="cond1" value="not variable_set route2graf:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route2_graf"/>
    </properties>
   </object>
   <object id="164" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -457,9 +454,9 @@
     <property name="act6" value="add_monster spighter,8,spyder_route2_roddick,5,10"/>
     <property name="act7" value="start_battle player,spyder_route2_roddick"/>
     <property name="act8" value="char_talk spyder_route2_roddick,post_battle_lose"/>
-    <property name="act9" value="set_variable route2roddick:yes"/>
-    <property name="cond1" value="not variable_set route2roddick:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route2_roddick"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="189" name="Talk marion" type="event" x="352" y="160" width="16" height="64">
@@ -473,9 +470,9 @@
     <property name="act7" value="add_monster aardorn,7,spyder_route2_marion,5,10"/>
     <property name="act8" value="start_battle player,spyder_route2_marion"/>
     <property name="act9" value="char_talk spyder_route2_marion,post_battle_lose"/>
-    <property name="act10" value="set_variable route2marion:yes"/>
-    <property name="cond1" value="not variable_set route2marion:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route2_marion"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="190" name="Talk graf" type="event" x="464" y="64" width="16" height="80">
@@ -490,9 +487,9 @@
     <property name="act08" value="add_monster cataspike,5,spyder_route2_graf,5,10"/>
     <property name="act09" value="start_battle player,spyder_route2_graf"/>
     <property name="act10" value="char_talk spyder_route2_graf,post_battle_lose"/>
-    <property name="act11" value="set_variable route2graf:yes"/>
-    <property name="cond1" value="not variable_set route2graf:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route2_graf"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="195" name="random battle35" type="event" x="512" y="128" width="112" height="32">

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -217,16 +217,15 @@
     <property name="act07" value="char_talk spyder_route3_zoolander,post_battle_lose"/>
     <property name="act08" value="add_item sledgehammer"/>
     <property name="act09" value="translated_dialog sledgehammer,,center,center,center"/>
-    <property name="act10" value="set_variable zoolanderdefeat:yes"/>
     <property name="behav1" value="talk spyder_route3_zoolander"/>
-    <property name="cond1" value="not variable_set zoolanderdefeat:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_zoolander"/>
    </properties>
   </object>
   <object id="594" name="Make Rookie" type="event" x="16" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route3_qqq,1,2"/>
     <property name="cond1" value="not char_exists spyder_route3_qqq"/>
-    <property name="cond2" value="not variable_set ambushedbyqqq:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_route3_qqq"/>
    </properties>
   </object>
   <object id="595" name="Rookie Talk" type="event" x="80" y="0" width="16" height="16">
@@ -235,11 +234,10 @@
     <property name="act2" value="add_monster cardiling,16,spyder_route3_qqq,5,10"/>
     <property name="act3" value="start_battle player,spyder_route3_qqq"/>
     <property name="act4" value="char_talk spyder_route3_qqq,post_battle_lose"/>
-    <property name="act6" value="set_variable ambushedbyqqq:yes"/>
     <property name="act7" value="pathfind spyder_route3_qqq,0,2"/>
     <property name="act8" value="remove_npc spyder_route3_qqq"/>
     <property name="behav1" value="talk spyder_route3_qqq"/>
-    <property name="cond1" value="not variable_set ambushedbyqqq:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_qqq"/>
    </properties>
   </object>
   <object id="596" name="Make Enforcer" type="event" x="256" y="144" width="16" height="16">
@@ -256,9 +254,8 @@
     <property name="act3" value="add_monster squabbit,12,spyder_route3_weaver,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_weaver"/>
     <property name="act5" value="char_talk spyder_route3_weaver,post_battle_lose"/>
-    <property name="act6" value="set_variable route3weaver:yes"/>
     <property name="behav1" value="talk spyder_route3_weaver"/>
-    <property name="cond1" value="not variable_set route3weaver:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_weaver"/>
    </properties>
   </object>
   <object id="598" name="encounter 3" type="event" x="80" y="496" width="16" height="48">
@@ -377,9 +374,8 @@
     <property name="act2" value="add_monster elofly,13,spyder_route3_novak,5,10"/>
     <property name="act3" value="start_battle player,spyder_route3_novak"/>
     <property name="act4" value="char_talk spyder_route3_novak,post_battle_lose"/>
-    <property name="act6" value="set_variable route3novak:yes"/>
     <property name="behav1" value="talk spyder_route3_novak"/>
-    <property name="cond1" value="not variable_set route3novak:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_novak"/>
    </properties>
   </object>
   <object id="613" name="Create Curie" type="event" x="480" y="496" width="16" height="16">
@@ -394,9 +390,8 @@
     <property name="act2" value="add_monster propellercat,13,spyder_route3_curie,5,10"/>
     <property name="act3" value="start_battle player,spyder_route3_curie"/>
     <property name="act4" value="char_talk spyder_route3_curie,post_battle_lose"/>
-    <property name="act6" value="set_variable route3curie:yes"/>
     <property name="behav1" value="talk spyder_route3_curie"/>
-    <property name="cond1" value="not variable_set route3curie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_curie"/>
    </properties>
   </object>
   <object id="615" name="Create Connor" type="event" x="304" y="32" width="16" height="16">
@@ -416,9 +411,8 @@
     <property name="act06" value="add_monster cataspike,8,spyder_route3_connor,5,10"/>
     <property name="act07" value="start_battle player,spyder_route3_connor"/>
     <property name="act08" value="char_talk spyder_route3_connor,post_battle_lose"/>
-    <property name="act09" value="set_variable route3connor:yes"/>
     <property name="behav1" value="talk spyder_route3_connor"/>
-    <property name="cond1" value="not variable_set route3connor:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_connor"/>
    </properties>
   </object>
   <object id="617" name="Create Wanda" type="event" x="512" y="272" width="16" height="16">
@@ -440,9 +434,8 @@
     <property name="act09" value="char_talk spyder_route3_wanda,post_battle_lose"/>
     <property name="act10" value="add_item fishing_rod"/>
     <property name="act11" value="translated_dialog fishing_rod,,center,center,center"/>
-    <property name="act12" value="set_variable route3wanda:yes"/>
     <property name="behav1" value="talk spyder_route3_wanda"/>
-    <property name="cond1" value="not variable_set route3wanda:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_wanda"/>
    </properties>
   </object>
   <object id="619" name="Create Twig" type="event" x="416" y="240" width="16" height="16">
@@ -456,7 +449,7 @@
    <properties>
     <property name="act2" value="translated_dialog spyder_route3_twig3"/>
     <property name="behav1" value="talk spyder_route3_twig"/>
-    <property name="cond1" value="is variable_set route3twig:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_route3_twig"/>
    </properties>
   </object>
   <object id="621" name="Talk Twig" type="event" x="416" y="224" width="16" height="16">
@@ -466,9 +459,8 @@
     <property name="act3" value="add_monster foofle,11,spyder_route3_twig,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_twig"/>
     <property name="act5" value="char_talk spyder_route3_twig,post_battle_lose"/>
-    <property name="act6" value="set_variable route3twig:yes"/>
     <property name="behav1" value="talk spyder_route3_twig"/>
-    <property name="cond1" value="not variable_set route3twig:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_twig"/>
    </properties>
   </object>
   <object id="622" name="Create Surat" type="event" x="128" y="272" width="16" height="16">
@@ -482,7 +474,7 @@
    <properties>
     <property name="act2" value="translated_dialog spyder_route3_surat3"/>
     <property name="behav1" value="talk spyder_route3_surat"/>
-    <property name="cond1" value="is variable_set route3surat:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_route3_surat"/>
    </properties>
   </object>
   <object id="624" name="Talk Surat" type="event" x="128" y="256" width="16" height="16">
@@ -492,9 +484,8 @@
     <property name="act3" value="add_monster foofle,12,spyder_route3_surat,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_surat"/>
     <property name="act5" value="char_talk spyder_route3_surat,post_battle_lose"/>
-    <property name="act6" value="set_variable route3surat:yes"/>
     <property name="behav1" value="talk spyder_route3_surat"/>
-    <property name="cond1" value="not variable_set route3surat:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_surat"/>
    </properties>
   </object>
   <object id="625" name="Create Roxby" type="event" x="240" y="288" width="16" height="16">
@@ -507,7 +498,7 @@
    <properties>
     <property name="act2" value="translated_dialog spyder_route3_roxby3"/>
     <property name="behav1" value="talk spyder_route3_roxby"/>
-    <property name="cond1" value="is variable_set route3roxby:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_route3_roxby"/>
    </properties>
   </object>
   <object id="627" name="Talk Roxby" type="event" x="224" y="288" width="16" height="16">
@@ -517,9 +508,8 @@
     <property name="act3" value="add_monster ignibus,13,spyder_route3_roxby,5,10"/>
     <property name="act4" value="start_battle player,spyder_route3_roxby"/>
     <property name="act5" value="char_talk spyder_route3_roxby,post_battle_lose"/>
-    <property name="act6" value="set_variable route3roxby:yes"/>
     <property name="behav1" value="talk spyder_route3_roxby"/>
-    <property name="cond1" value="not variable_set route3roxby:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_roxby"/>
    </properties>
   </object>
   <object id="628" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -566,9 +556,9 @@
     <property name="act6" value="add_monster squabbit,12,spyder_route3_weaver,5,10"/>
     <property name="act7" value="start_battle player,spyder_route3_weaver"/>
     <property name="act8" value="char_talk spyder_route3_weaver,post_battle_lose"/>
-    <property name="act9" value="set_variable route3weaver:yes"/>
-    <property name="cond1" value="not variable_set route3weaver:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_weaver"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="680" name="Talk Twig" type="event" x="384" y="240" width="32" height="16">
@@ -581,9 +571,9 @@
     <property name="act6" value="add_monster foofle,11,spyder_route3_twig,5,10"/>
     <property name="act7" value="start_battle player,spyder_route3_twig"/>
     <property name="act8" value="char_talk spyder_route3_twig,post_battle_lose"/>
-    <property name="act9" value="set_variable route3twig:yes"/>
-    <property name="cond1" value="not variable_set route3twig:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_twig"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="681" name="Talk Wanda" type="event" x="512" y="288" width="16" height="16">
@@ -602,9 +592,9 @@
     <property name="act12" value="char_talk spyder_route3_wanda,post_battle_lose"/>
     <property name="act13" value="add_item fishing_rod"/>
     <property name="act14" value="translated_dialog fishing_rod,,center,center,center"/>
-    <property name="act15" value="set_variable route3wanda:yes"/>
-    <property name="cond1" value="not variable_set route3wanda:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_wanda"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="682" name="Novak Talk" type="event" x="192" y="480" width="16" height="32">
@@ -616,9 +606,9 @@
     <property name="act5" value="add_monster elofly,13,spyder_route3_novak,5,10"/>
     <property name="act6" value="start_battle player,spyder_route3_novak"/>
     <property name="act7" value="char_talk spyder_route3_novak,post_battle_lose"/>
-    <property name="act8" value="set_variable route3novak:yes"/>
-    <property name="cond1" value="not variable_set route3novak:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_novak"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="684" name="Rookie Talk" type="event" x="16" y="48" width="16" height="16">
@@ -626,11 +616,11 @@
     <property name="act2" value="char_talk spyder_route3_qqq,pre_battle"/>
     <property name="act3" value="add_monster cardiling,16,spyder_route3_qqq,5,10"/>
     <property name="act4" value="char_talk spyder_route3_qqq,post_battle_lose"/>
-    <property name="act6" value="set_variable ambushedbyqqq:yes"/>
     <property name="act7" value="pathfind spyder_route3_qqq,0,2"/>
     <property name="act8" value="remove_npc spyder_route3_qqq"/>
-    <property name="cond1" value="not variable_set ambushedbyqqq:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route3_qqq"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="701" name="Create Miner 2" type="event" x="592" y="240" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route4.tmx
+++ b/mods/tuxemon/maps/spyder_route4.tmx
@@ -99,9 +99,8 @@
     <property name="act3" value="add_monster puparmor,16,spyder_route4_marshall,5,10"/>
     <property name="act4" value="start_battle player,spyder_route4_marshall"/>
     <property name="act5" value="char_talk spyder_route4_marshall,post_battle_lose"/>
-    <property name="act6" value="set_variable route4marshall:yes"/>
     <property name="behav1" value="talk spyder_route4_marshall"/>
-    <property name="cond1" value="not variable_set route4marshall:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_marshall"/>
    </properties>
   </object>
   <object id="49" name="encounter 3" type="event" x="128" y="48" width="32" height="176">
@@ -285,9 +284,8 @@
     <property name="act2" value="add_monster rabbitosaur,16,spyder_route4_roger,5,10"/>
     <property name="act3" value="start_battle player,spyder_route4_roger"/>
     <property name="act4" value="char_talk spyder_route4_roger,post_battle_lose"/>
-    <property name="act6" value="set_variable route4roger:yes"/>
     <property name="behav1" value="talk spyder_route4_roger"/>
-    <property name="cond1" value="not variable_set route4roger:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_roger"/>
    </properties>
   </object>
   <object id="72" name="Create Wulf" type="event" x="32" y="192" width="16" height="16">
@@ -304,9 +302,8 @@
     <property name="act4" value="add_monster shybulb,14,spyder_route4_wulf,5,10"/>
     <property name="act5" value="start_battle player,spyder_route4_wulf"/>
     <property name="act6" value="char_talk spyder_route4_wulf,post_battle_lose"/>
-    <property name="act7" value="set_variable route4wulf:yes"/>
     <property name="behav1" value="talk spyder_route4_wulf"/>
-    <property name="cond1" value="not variable_set route4wulf:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_wulf"/>
    </properties>
   </object>
   <object id="74" name="Create Rincewind" type="event" x="224" y="80" width="16" height="16">
@@ -323,9 +320,8 @@
     <property name="act3" value="add_monster k9,16,spyder_route4_rincewind,5,10"/>
     <property name="act4" value="start_battle player,spyder_route4_rincewind"/>
     <property name="act5" value="char_talk spyder_route4_rincewind,post_battle_lose"/>
-    <property name="act6" value="set_variable route4rincewind:yes"/>
     <property name="behav1" value="talk spyder_route4_rincewind"/>
-    <property name="cond1" value="not variable_set route4rincewind:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_rincewind"/>
    </properties>
   </object>
   <object id="76" name="Create Rosamund" type="event" x="192" y="480" width="16" height="16">
@@ -340,9 +336,8 @@
     <property name="act2" value="add_monster foofle,18,spyder_route4_rosamund,5,10"/>
     <property name="act3" value="start_battle player,spyder_route4_rosamund"/>
     <property name="act4" value="char_talk spyder_route4_rosamund,post_battle_lose"/>
-    <property name="act6" value="set_variable route4rosamund:yes"/>
     <property name="behav1" value="talk spyder_route4_rosamund"/>
-    <property name="cond1" value="not variable_set route4rosamund:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_rosamund"/>
    </properties>
   </object>
   <object id="78" name="Create Beck" type="event" x="48" y="320" width="16" height="16">
@@ -360,9 +355,8 @@
     <property name="act4" value="add_monster spighter,12,spyder_route4_beck,5,10"/>
     <property name="act5" value="start_battle player,spyder_route4_beck"/>
     <property name="act6" value="char_talk spyder_route4_beck,post_battle_lose"/>
-    <property name="act7" value="set_variable route4beck:yes"/>
     <property name="behav1" value="talk spyder_route4_beck"/>
-    <property name="cond1" value="not variable_set route4beck:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_beck"/>
    </properties>
   </object>
   <object id="81" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
@@ -389,9 +383,9 @@
     <property name="act6" value="add_monster puparmor,16,spyder_route4_marshall,5,10"/>
     <property name="act7" value="start_battle player,spyder_route4_marshall"/>
     <property name="act8" value="char_talk spyder_route4_marshall,post_battle_lose"/>
-    <property name="act9" value="set_variable route4marshall:yes"/>
-    <property name="cond1" value="not variable_set route4marshall:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_marshall"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="83" name="Talk Beck" type="event" x="64" y="320" width="32" height="16">
@@ -405,9 +399,9 @@
     <property name="act07" value="add_monster spighter,12,spyder_route4_beck,5,10"/>
     <property name="act08" value="start_battle player,spyder_route4_beck"/>
     <property name="act09" value="char_talk spyder_route4_beck,post_battle_lose"/>
-    <property name="act10" value="set_variable route4beck:yes"/>
-    <property name="cond1" value="not variable_set route4beck:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_beck"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="84" name="Talk Wulf" type="event" x="32" y="208" width="16" height="48">
@@ -421,9 +415,9 @@
     <property name="act07" value="add_monster shybulb,14,spyder_route4_wulf,5,10"/>
     <property name="act08" value="start_battle player,spyder_route4_wulf"/>
     <property name="act09" value="char_talk spyder_route4_wulf,post_battle_lose"/>
-    <property name="act10" value="set_variable route4wulf:yes"/>
-    <property name="cond1" value="not variable_set route4wulf:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_wulf"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="85" name="Talk Rosamund" type="event" x="192" y="496" width="16" height="16">
@@ -435,9 +429,9 @@
     <property name="act5" value="add_monster foofle,18,spyder_route4_rosamund,5,10"/>
     <property name="act6" value="start_battle player,spyder_route4_rosamund"/>
     <property name="act7" value="char_talk spyder_route4_rosamund,post_battle_lose"/>
-    <property name="act8" value="set_variable route4rosamund:yes"/>
-    <property name="cond1" value="not variable_set route4rosamund:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route4_rosamund"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="88" name="Billie" type="event" x="32" y="96" width="64" height="16">
@@ -454,8 +448,7 @@
     <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
     <property name="act24" value="add_monster eyesore,16,spyder_billie,5,10"/>
     <property name="act25" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act26" value="add_monster viviphyta,16,spyder_billie,5,10"/>
-    <property name="act27" value="set_monster_attribute add_monster,gender,male"/>
+    <property name="act26" value="set_monster_attribute add_monster,gender,male"/>
     <property name="act30" value="start_battle player,spyder_billie"/>
     <property name="act71" value="translated_dialog spyder_route4_billie2"/>
     <property name="act75" value="pathfind spyder_billie,0,4"/>

--- a/mods/tuxemon/maps/spyder_route5.tmx
+++ b/mods/tuxemon/maps/spyder_route5.tmx
@@ -237,9 +237,8 @@
     <property name="act2" value="add_monster capiti,20,spyder_route5_sara,5,10"/>
     <property name="act3" value="start_battle player,spyder_route5_sara"/>
     <property name="act4" value="char_talk spyder_route5_sara,post_battle_lose"/>
-    <property name="act6" value="set_variable route5sara:yes"/>
     <property name="behav1" value="talk spyder_route5_sara"/>
-    <property name="cond1" value="not variable_set route5sara:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_sara"/>
    </properties>
   </object>
   <object id="49" name="Stop! - Goliath" type="event" x="608" y="144" width="16" height="16">
@@ -252,16 +251,16 @@
     <property name="act46" value="char_talk spyder_route5_goliath,post_battle_lose"/>
     <property name="act50" value="pathfind spyder_route5_goliath,35,4"/>
     <property name="act80" value="remove_npc spyder_route5_goliath"/>
-    <property name="act90" value="set_variable route5goliath:yes"/>
-    <property name="cond1" value="is char_at player"/>
-    <property name="cond2" value="not variable_set route5goliath:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_goliath"/>
+    <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="50" name="Create Goliath" type="event" x="560" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="create_npc spyder_route5_goliath,35,5"/>
     <property name="cond1" value="not char_exists spyder_route5_goliath"/>
-    <property name="cond2" value="not variable_set route5goliath:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_route5_goliath"/>
    </properties>
   </object>
   <object id="53" name="Create Edith" type="event" x="304" y="224" width="16" height="16">
@@ -276,9 +275,8 @@
     <property name="act2" value="add_monster aardart,20,spyder_route5_edith,5,10"/>
     <property name="act3" value="start_battle player,spyder_route5_edith"/>
     <property name="act4" value="char_talk spyder_route5_edith,post_battle_lose"/>
-    <property name="act6" value="set_variable route5edith:yes"/>
     <property name="behav1" value="talk spyder_route5_edith"/>
-    <property name="cond1" value="not variable_set route5edith:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_edith"/>
    </properties>
   </object>
   <object id="55" name="Create Hunter" type="event" x="96" y="128" width="16" height="16">
@@ -296,9 +294,8 @@
     <property name="act4" value="add_monster elofly,16,spyder_route5_hunter,5,10"/>
     <property name="act5" value="start_battle player,spyder_route5_hunter"/>
     <property name="act6" value="char_talk spyder_route5_hunter,post_battle_lose"/>
-    <property name="act7" value="set_variable route5hunter:yes"/>
     <property name="behav1" value="talk spyder_route5_hunter"/>
-    <property name="cond1" value="not variable_set route5hunter:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_hunter"/>
    </properties>
   </object>
   <object id="57" name="Create Cleo" type="event" x="320" y="80" width="16" height="16">
@@ -314,9 +311,8 @@
     <property name="act3" value="add_monster memnomnom,20,spyder_route5_cleo,5,10"/>
     <property name="act4" value="start_battle player,spyder_route5_cleo"/>
     <property name="act5" value="char_talk spyder_route5_cleo,post_battle_lose"/>
-    <property name="act6" value="set_variable route5cleo:yes"/>
     <property name="behav1" value="talk spyder_route5_cleo"/>
-    <property name="cond1" value="not variable_set route5cleo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_cleo"/>
    </properties>
   </object>
   <object id="59" name="Create Tryphaena" type="event" x="288" y="80" width="16" height="16">
@@ -332,9 +328,8 @@
     <property name="act3" value="add_monster criniotherme,22,spyder_route5_tryphaena,5,10"/>
     <property name="act4" value="start_battle player,spyder_route5_tryphaena"/>
     <property name="act5" value="char_talk spyder_route5_tryphaena,post_battle_lose"/>
-    <property name="act6" value="set_variable route5tryphaena:yes"/>
     <property name="behav1" value="talk spyder_route5_tryphaena"/>
-    <property name="cond1" value="not variable_set route5tryphaena:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_tryphaena"/>
    </properties>
   </object>
   <object id="61" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
@@ -360,9 +355,9 @@
     <property name="act5" value="add_monster capiti,20,spyder_route5_sara,5,10"/>
     <property name="act6" value="start_battle player,spyder_route5_sara"/>
     <property name="act7" value="char_talk spyder_route5_sara,post_battle_lose"/>
-    <property name="act8" value="set_variable route5sara:yes"/>
-    <property name="cond1" value="not variable_set route5sara:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_sara"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="63" name="Talk Cleo" type="event" x="320" y="96" width="16" height="16">
@@ -375,9 +370,9 @@
     <property name="act6" value="add_monster memnomnom,20,spyder_route5_cleo,5,10"/>
     <property name="act7" value="start_battle player,spyder_route5_cleo"/>
     <property name="act8" value="char_talk spyder_route5_cleo,post_battle_lose"/>
-    <property name="act9" value="set_variable route5cleo:yes"/>
-    <property name="cond1" value="not variable_set route5cleo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_cleo"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="64" name="Talk Tryphaena" type="event" x="288" y="96" width="16" height="16">
@@ -390,9 +385,9 @@
     <property name="act6" value="add_monster criniotherme,22,spyder_route5_tryphaena,5,10"/>
     <property name="act7" value="start_battle player,spyder_route5_tryphaena"/>
     <property name="act8" value="char_talk spyder_route5_tryphaena,post_battle_lose"/>
-    <property name="act9" value="set_variable route5tryphaena:yes"/>
-    <property name="cond1" value="not variable_set route5tryphaena:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_tryphaena"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="65" name="Talk Edith" type="event" x="304" y="240" width="16" height="16">
@@ -404,9 +399,9 @@
     <property name="act5" value="add_monster aardart,20,spyder_route5_edith,5,10"/>
     <property name="act6" value="start_battle player,spyder_route5_edith"/>
     <property name="act7" value="char_talk spyder_route5_edith,post_battle_lose"/>
-    <property name="act8" value="set_variable route5edith:yes"/>
-    <property name="cond1" value="not variable_set route5edith:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route5_edith"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="68" name="Post Talk Sara" type="event" x="272" y="176" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route6.tmx
+++ b/mods/tuxemon/maps/spyder_route6.tmx
@@ -234,9 +234,8 @@
     <property name="act4" value="add_monster shybulb,30,spyder_route6_frances,5,10"/>
     <property name="act5" value="start_battle player,spyder_route6_frances"/>
     <property name="act6" value="char_talk spyder_route6_frances,post_battle_lose"/>
-    <property name="act7" value="set_variable route6frances:yes"/>
     <property name="behav1" value="talk spyder_route6_frances"/>
-    <property name="cond1" value="not variable_set route6frances:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_frances"/>
    </properties>
   </object>
   <object id="193" name="Create Ping" type="event" x="400" y="96" width="16" height="16">
@@ -253,9 +252,8 @@
     <property name="act3" value="add_monster foofle,30,spyder_route6_ping,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_ping"/>
     <property name="act5" value="char_talk spyder_route6_ping,post_battle_lose"/>
-    <property name="act6" value="set_variable route6ping:yes"/>
     <property name="behav1" value="talk spyder_route6_ping"/>
-    <property name="cond1" value="not variable_set route6ping:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_ping"/>
    </properties>
   </object>
   <object id="195" name="Create Richard" type="event" x="416" y="176" width="16" height="16">
@@ -272,9 +270,8 @@
     <property name="act3" value="add_monster pigabyte,30,spyder_route6_richard,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_richard"/>
     <property name="act5" value="char_talk spyder_route6_richard,post_battle_lose"/>
-    <property name="act6" value="set_variable route6richard:yes"/>
     <property name="behav1" value="talk spyder_route6_richard"/>
-    <property name="cond1" value="not variable_set route6richard:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_richard"/>
    </properties>
   </object>
   <object id="197" name="Create Blair" type="event" x="560" y="144" width="16" height="16">
@@ -291,9 +288,8 @@
     <property name="act3" value="add_monster grinflare,30,spyder_route6_blair,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_blair"/>
     <property name="act5" value="char_talk spyder_route6_blair,post_battle_lose"/>
-    <property name="act6" value="set_variable route6blair:yes"/>
     <property name="behav1" value="talk spyder_route6_blair"/>
-    <property name="cond1" value="not variable_set route6blair:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_blair"/>
    </properties>
   </object>
   <object id="199" name="Create Maxwell" type="event" x="160" y="80" width="16" height="16">
@@ -310,9 +306,8 @@
     <property name="act3" value="add_monster birdling,30,spyder_route6_maxwell,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_maxwell"/>
     <property name="act5" value="char_talk spyder_route6_maxwell,post_battle_lose"/>
-    <property name="act6" value="set_variable route6maxwell:yes"/>
     <property name="behav1" value="talk spyder_route6_maxwell"/>
-    <property name="cond1" value="not variable_set route6maxwell:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_maxwell"/>
    </properties>
   </object>
   <object id="201" name="Create Orion" type="event" x="336" y="96" width="16" height="16">
@@ -329,9 +324,8 @@
     <property name="act3" value="add_monster zunna,30,spyder_route6_orion,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_orion"/>
     <property name="act5" value="char_talk spyder_route6_orion,post_battle_lose"/>
-    <property name="act6" value="set_variable route6orion:yes"/>
     <property name="behav1" value="talk spyder_route6_orion"/>
-    <property name="cond1" value="not variable_set route6orion:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_orion"/>
    </properties>
   </object>
   <object id="203" name="Create Mungo" type="event" x="512" y="48" width="16" height="16">
@@ -347,9 +341,8 @@
     <property name="act2" value="add_monster noctula,20,spyder_route6_mungo,5,10"/>
     <property name="act3" value="start_battle player,spyder_route6_mungo"/>
     <property name="act4" value="char_talk spyder_route6_mungo,post_battle_lose"/>
-    <property name="act6" value="set_variable route6mungo:yes"/>
     <property name="behav1" value="talk spyder_route6_mungo"/>
-    <property name="cond1" value="not variable_set route6mungo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_mungo"/>
    </properties>
   </object>
   <object id="205" name="Create Rigel" type="event" x="448" y="256" width="16" height="16">
@@ -365,9 +358,8 @@
     <property name="act2" value="add_monster ignibus,30,spyder_route6_rigel,5,10"/>
     <property name="act3" value="start_battle player,spyder_route6_rigel"/>
     <property name="act4" value="char_talk spyder_route6_rigel,post_battle_lose"/>
-    <property name="act6" value="set_variable route6rigel:yes"/>
     <property name="behav1" value="talk spyder_route6_rigel"/>
-    <property name="cond1" value="not variable_set route6rigel:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_rigel"/>
    </properties>
   </object>
   <object id="207" name="Create Gunner" type="event" x="480" y="272" width="16" height="16">
@@ -375,7 +367,7 @@
     <property name="act1" value="create_npc spyder_route6_gunner,30,17"/>
     <property name="act2" value="char_face spyder_route6_gunner,up"/>
     <property name="cond1" value="not char_exists spyder_route6_gunner"/>
-    <property name="cond2" value="not variable_set route6gunner:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_route6_gunner"/>
    </properties>
   </object>
   <object id="208" name="Talk Gunner" type="event" x="464" y="272" width="16" height="16">
@@ -385,10 +377,9 @@
     <property name="act3" value="add_monster viviteel,20,spyder_route6_gunner,5,10"/>
     <property name="act4" value="start_battle player,spyder_route6_gunner"/>
     <property name="act5" value="char_talk spyder_route6_gunner,post_battle_lose"/>
-    <property name="act6" value="set_variable route6gunner:yes"/>
-    <property name="act90" value="pathfind spyder_route6_gunner,28,17"/>
+    <property name="act9" value="pathfind spyder_route6_gunner,28,17"/>
     <property name="behav1" value="talk spyder_route6_gunner"/>
-    <property name="cond1" value="not variable_set route6gunner:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_gunner"/>
    </properties>
   </object>
   <object id="210" name="Teleport to Candy Town" type="event" x="528" y="304" width="16" height="16">
@@ -431,9 +422,9 @@
     <property name="act6" value="add_monster birdling,30,spyder_route6_maxwell,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_maxwell"/>
     <property name="act8" value="char_talk spyder_route6_maxwell,post_battle_lose"/>
-    <property name="act9" value="set_variable route6maxwell:yes"/>
-    <property name="cond1" value="not variable_set route6maxwell:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_maxwell"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="214" name="Talk Orion" type="event" x="336" y="32" width="16" height="64">
@@ -446,9 +437,9 @@
     <property name="act6" value="add_monster zunna,30,spyder_route6_orion,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_orion"/>
     <property name="act8" value="char_talk spyder_route6_orion,post_battle_lose"/>
-    <property name="act9" value="set_variable route6orion:yes"/>
-    <property name="cond1" value="not variable_set route6orion:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_orion"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="215" name="Talk Richard" type="event" x="432" y="176" width="96" height="16">
@@ -461,9 +452,9 @@
     <property name="act6" value="add_monster pigabyte,30,spyder_route6_richard,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_richard"/>
     <property name="act8" value="char_talk spyder_route6_richard,post_battle_lose"/>
-    <property name="act9" value="set_variable route6richard:yes"/>
-    <property name="cond1" value="not variable_set route6richard:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_richard"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="216" name="Talk Blair" type="event" x="432" y="144" width="128" height="16">
@@ -476,9 +467,9 @@
     <property name="act6" value="add_monster grinflare,30,spyder_route6_blair,5,10"/>
     <property name="act7" value="start_battle player,spyder_route6_blair"/>
     <property name="act8" value="char_talk spyder_route6_blair,post_battle_lose"/>
-    <property name="act9" value="set_variable route6blair:yes"/>
-    <property name="cond1" value="not variable_set route6blair:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_blair"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="217" name="Talk Mungo" type="event" x="464" y="48" width="48" height="16">
@@ -490,9 +481,9 @@
     <property name="act5" value="add_monster noctula,20,spyder_route6_mungo,5,10"/>
     <property name="act6" value="start_battle player,spyder_route6_mungo"/>
     <property name="act7" value="char_talk spyder_route6_mungo,post_battle_lose"/>
-    <property name="act8" value="set_variable route6mungo:yes"/>
-    <property name="cond1" value="not variable_set route6mungo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_route6_mungo"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="223" name="Billie1" type="event" x="48" y="176" width="16" height="80">
@@ -503,13 +494,13 @@
     <property name="act04" value="pathfind_to_char player,spyder_billie"/>
     <property name="act05" value="unlock_controls"/>
     <property name="act08" value="translated_dialog spyder_route6_billie1"/>
-    <property name="act20" value="add_monster billie_choice,34,spyder_billie,5,10"/>
+    <property name="act20" value="add_monster billie_choice,35,spyder_billie,5,10"/>
     <property name="act21" value="set_monster_attribute add_monster,gender,male"/>
-    <property name="act22" value="add_monster cardiwing,30,spyder_billie,5,10"/>
-    <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act24" value="add_monster eyesore,30,spyder_billie,5,10"/>
+    <property name="act24" value="add_monster cardiwing,35,spyder_billie,5,10"/>
     <property name="act25" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act26" value="add_monster viviphyta,30,spyder_billie,5,10"/>
+    <property name="act22" value="add_monster eyesore,35,spyder_billie,5,10"/>
+    <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
+    <property name="act26" value="add_monster viviphyta,35,spyder_billie,5,10"/>
     <property name="act27" value="set_monster_attribute add_monster,gender,male"/>
     <property name="act30" value="start_battle player,spyder_billie"/>
     <property name="act71" value="translated_dialog spyder_route6_billie2"/>
@@ -546,13 +537,13 @@
     <property name="act06" value="char_face spyder_billie,down"/>
     <property name="act07" value="char_face player,up"/>
     <property name="act10" value="translated_dialog spyder_route6_billie1"/>
-    <property name="act20" value="add_monster billie_choice,34,spyder_billie,5,10"/>
+    <property name="act20" value="add_monster billie_choice,35,spyder_billie,5,10"/>
     <property name="act21" value="set_monster_attribute add_monster,gender,male"/>
-    <property name="act22" value="add_monster cardiwing,30,spyder_billie,5,10"/>
-    <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act24" value="add_monster eyesore,30,spyder_billie,5,10"/>
+    <property name="act24" value="add_monster cardiwing,35,spyder_billie,5,10"/>
     <property name="act25" value="set_monster_attribute add_monster,gender,female"/>
-    <property name="act26" value="add_monster viviphyta,30,spyder_billie,5,10"/>
+    <property name="act22" value="add_monster eyesore,35,spyder_billie,5,10"/>
+    <property name="act23" value="set_monster_attribute add_monster,gender,female"/>
+    <property name="act26" value="add_monster viviphyta,35,spyder_billie,5,10"/>
     <property name="act27" value="set_monster_attribute add_monster,gender,male"/>
     <property name="act30" value="start_battle player,spyder_billie"/>
     <property name="act71" value="translated_dialog spyder_route6_billie2"/>
@@ -561,36 +552,6 @@
     <property name="act90" value="set_variable route6billie:yes"/>
     <property name="cond1" value="not variable_set route6billie:yes"/>
     <property name="cond2" value="is char_at player"/>
-   </properties>
-  </object>
-  <object id="227" name="Billie Budaye" type="event" x="0" y="64" width="16" height="16">
-   <properties>
-    <property name="act1" value="set_variable billie_choice:bamboon"/>
-    <property name="cond1" value="is variable_set billie_choice:budaye"/>
-   </properties>
-  </object>
-  <object id="228" name="Billie Dollfin" type="event" x="16" y="64" width="16" height="16">
-   <properties>
-    <property name="act1" value="set_variable billie_choice:bigfin"/>
-    <property name="cond1" value="is variable_set billie_choice:dollfin"/>
-   </properties>
-  </object>
-  <object id="229" name="Billie Grintot" type="event" x="32" y="64" width="16" height="16">
-   <properties>
-    <property name="act1" value="set_variable billie_choice:grintrock"/>
-    <property name="cond1" value="is variable_set billie_choice:grintot"/>
-   </properties>
-  </object>
-  <object id="230" name="Billie Ignibus" type="event" x="48" y="64" width="16" height="16">
-   <properties>
-    <property name="act1" value="set_variable billie_choice:eruptibus"/>
-    <property name="cond1" value="is variable_set billie_choice:ignibus"/>
-   </properties>
-  </object>
-  <object id="231" name="Billie Memnomnom" type="event" x="0" y="80" width="16" height="16">
-   <properties>
-    <property name="act1" value="set_variable billie_choice:miaownolith"/>
-    <property name="cond1" value="is variable_set billie_choice:memnomnom"/>
    </properties>
   </object>
   <object id="236" name="Post Talk Maxwell" type="event" x="176" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routea.tmx
+++ b/mods/tuxemon/maps/spyder_routea.tmx
@@ -175,11 +175,10 @@
     <property name="act2" value="add_monster sapsnap,18,spyder_routea_vince,5,10"/>
     <property name="act3" value="start_battle player,spyder_routea_vince"/>
     <property name="act4" value="translated_dialog spyder_routea_vince4"/>
-    <property name="act5" value="set_variable routeavince:yes"/>
     <property name="behav1" value="talk spyder_routea_vince"/>
     <property name="cond1" value="is variable_set vincefirst:yes"/>
     <property name="cond2" value="is variable_set vincesecond:yes"/>
-    <property name="cond3" value="not variable_set routeavince:yes"/>
+    <property name="cond3" value="not battle_outcome player,won,spyder_routea_vince"/>
    </properties>
   </object>
   <object id="72" name="Create Doris" type="event" x="160" y="352" width="16" height="16">
@@ -199,9 +198,9 @@
     <property name="act6" value="add_monster trapsnap,14,spyder_routea_doris,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_doris"/>
     <property name="act8" value="char_talk spyder_routea_doris,post_battle_lose"/>
-    <property name="act9" value="set_variable routeadoris:yes"/>
-    <property name="cond1" value="not variable_set routeadoris:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_doris"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="74" name="Create Dagger" type="event" x="32" y="352" width="16" height="16">
@@ -220,9 +219,9 @@
     <property name="act5" value="add_monster cardiwing,16,spyder_routea_dagger,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_dagger"/>
     <property name="act7" value="char_talk spyder_routea_dagger,post_battle_lose"/>
-    <property name="act8" value="set_variable routeadagger:yes"/>
-    <property name="cond1" value="not variable_set routeadagger:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_dagger"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="76" name="Talk Doris" type="event" x="160" y="336" width="16" height="16">
@@ -235,9 +234,9 @@
     <property name="act6" value="add_monster trapsnap,14,spyder_routea_doris,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_doris"/>
     <property name="act8" value="char_talk spyder_routea_doris,post_battle_lose"/>
-    <property name="act9" value="set_variable routeadoris:yes"/>
-    <property name="cond1" value="not variable_set routeadoris:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_doris"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="77" name="Talk Dagger" type="event" x="48" y="352" width="16" height="16">
@@ -249,9 +248,9 @@
     <property name="act5" value="add_monster cardiwing,16,spyder_routea_dagger,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_dagger"/>
     <property name="act7" value="char_talk spyder_routea_dagger,post_battle_lose"/>
-    <property name="act8" value="set_variable routeadagger:yes"/>
-    <property name="cond1" value="not variable_set routeadagger:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_dagger"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="78" name="Create Koan" type="event" x="32" y="592" width="16" height="16">
@@ -271,9 +270,9 @@
     <property name="act6" value="add_monster budaye,12,spyder_routea_koan,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_koan"/>
     <property name="act8" value="char_talk spyder_routea_koan,post_battle_lose"/>
-    <property name="act9" value="set_variable routeakoan:yes"/>
-    <property name="cond1" value="not variable_set routeakoan:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_koan"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="80" name="Create Lexi" type="event" x="32" y="480" width="16" height="16">
@@ -292,9 +291,9 @@
     <property name="act6" value="add_monster katapill,14,spyder_routea_lexi,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_lexi"/>
     <property name="act8" value="char_talk spyder_routea_lexi,post_battle_lose"/>
-    <property name="act9" value="set_variable routealexi:yes"/>
-    <property name="cond1" value="not variable_set routealexi:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_lexi"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="82" name="Create Lotu" type="event" x="224" y="496" width="16" height="16">
@@ -314,9 +313,9 @@
     <property name="act6" value="add_monster tarpeur,14,spyder_routea_lotu,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_lotu"/>
     <property name="act8" value="char_talk spyder_routea_lotu,post_battle_lose"/>
-    <property name="act9" value="set_variable routealotu:yes"/>
-    <property name="cond1" value="not variable_set routealotu:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_lotu"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="84" name="Talk Connie" type="event" x="192" y="432" width="16" height="16">
@@ -329,9 +328,9 @@
     <property name="act6" value="add_monster bigfin,14,spyder_routea_connie,5,10"/>
     <property name="act7" value="start_battle player,spyder_routea_connie"/>
     <property name="act8" value="char_talk spyder_routea_connie,post_battle_lose"/>
-    <property name="act9" value="set_variable routeaconnie:yes"/>
-    <property name="cond1" value="not variable_set routeaconnie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_lotu"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="85" name="Create Connie" type="event" x="192" y="416" width="16" height="16">
@@ -355,9 +354,9 @@
     <property name="act5" value="add_monster katapill,16,spyder_routea_joe,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_joe"/>
     <property name="act7" value="char_talk spyder_routea_joe,post_battle_lose"/>
-    <property name="act8" value="set_variable routeajoe:yes"/>
-    <property name="cond1" value="not variable_set routeajoe:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_joe"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="88" name="Talk Joe2" type="event" x="224" y="544" width="16" height="32">
@@ -369,9 +368,9 @@
     <property name="act5" value="add_monster katapill,16,spyder_routea_joe,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_joe"/>
     <property name="act7" value="char_talk spyder_routea_joe,post_battle_lose"/>
-    <property name="act8" value="set_variable routeajoe:yes"/>
-    <property name="cond1" value="not variable_set routeajoe:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_joe"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="89" name="Create Rosy" type="event" x="176" y="272" width="16" height="16">
@@ -389,9 +388,9 @@
     <property name="act5" value="add_monster shammer,16,spyder_routea_rosy,5,10"/>
     <property name="act6" value="start_battle player,spyder_routea_rosy"/>
     <property name="act7" value="char_talk spyder_routea_rosy,post_battle_lose"/>
-    <property name="act8" value="set_variable routearosy:yes"/>
-    <property name="cond1" value="not variable_set routearosy:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routea_rosy"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="91" name="Create Maniac" type="event" x="96" y="240" width="16" height="16">
@@ -527,7 +526,7 @@
     <property name="behav1" value="talk spyder_routea_vince"/>
     <property name="cond1" value="is variable_set vincefirst:yes"/>
     <property name="cond2" value="is variable_set vincesecond:yes"/>
-    <property name="cond3" value="is variable_set routeavince:yes"/>
+    <property name="cond3" value="is battle_outcome player,won,spyder_routea_vince"/>
    </properties>
   </object>
   <object id="123" name="Post Talk Rosy" type="event" x="176" y="256" width="16" height="16">
@@ -562,7 +561,7 @@
    <properties>
     <property name="act1" value="char_talk spyder_routea_lotu,post_battle_lose"/>
     <property name="behav1" value="talk spyder_routea_lotu"/>
-    <property name="cond1" value="is variable_set routealotu:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_routea_lotu"/>
    </properties>
   </object>
   <object id="128" name="Create Nurse" type="event" x="80" y="432" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routeb.tmx
+++ b/mods/tuxemon/maps/spyder_routeb.tmx
@@ -118,9 +118,9 @@
     <property name="act07" value="add_monster tumblebee,40,spyder_routeb_cytherea,5,10"/>
     <property name="act08" value="start_battle player,spyder_routeb_cytherea"/>
     <property name="act09" value="char_talk spyder_routeb_cytherea,post_battle_lose"/>
-    <property name="act10" value="set_variable routebcytherea:yes"/>
-    <property name="cond1" value="not variable_set routebcytherea:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routeb_cytherea"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="74" name="Create Nephthys" type="event" x="80" y="368" width="16" height="16">
@@ -139,9 +139,9 @@
     <property name="act6" value="add_monster djinnbo,45,spyder_routeb_nephthys,5,10"/>
     <property name="act7" value="start_battle player,spyder_routeb_nephthys"/>
     <property name="act8" value="char_talk spyder_routeb_nephthys,post_battle_lose"/>
-    <property name="act9" value="set_variable routebnephthys:yes"/>
-    <property name="cond1" value="not variable_set routebnephthys:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routeb_nephthys"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="76" name="Create Sedna" type="event" x="256" y="272" width="16" height="16">
@@ -159,9 +159,9 @@
     <property name="act5" value="add_monster squabbit,40,spyder_routeb_sedna,5,10"/>
     <property name="act6" value="start_battle player,spyder_routeb_sedna"/>
     <property name="act7" value="char_talk spyder_routeb_sedna,post_battle_lose"/>
-    <property name="act8" value="set_variable routebsedna:yes"/>
-    <property name="cond1" value="not variable_set routebsedna:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routeb_sedna"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="78" name="Create Calypso" type="event" x="48" y="112" width="16" height="16">
@@ -182,9 +182,9 @@
     <property name="act07" value="add_monster sumchon,40,spyder_routeb_calypso,5,10"/>
     <property name="act08" value="start_battle player,spyder_routeb_calypso"/>
     <property name="act09" value="char_talk spyder_routeb_calypso,post_battle_lose"/>
-    <property name="act10" value="set_variable routebcalypso:yes"/>
-    <property name="cond1" value="not variable_set routebcalypso:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routeb_calypso"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="80" name="Play Music" type="event" x="0" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routec.tmx
+++ b/mods/tuxemon/maps/spyder_routec.tmx
@@ -63,9 +63,8 @@
     <property name="act2" value="add_monster manosting,24,spyder_searoutec_river,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_river"/>
     <property name="act4" value="char_talk spyder_searoutec_river,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecriver:yes"/>
     <property name="behav1" value="talk spyder_searoutec_river"/>
-    <property name="cond1" value="not variable_set searoutecriver:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_river"/>
    </properties>
   </object>
   <object id="203" name="Create Wade" type="event" x="224" y="176" width="16" height="16">
@@ -85,9 +84,8 @@
     <property name="act07" value="add_monster picc,20,spyder_searoutec_wade,5,10"/>
     <property name="act08" value="start_battle player,spyder_searoutec_wade"/>
     <property name="act09" value="char_talk spyder_searoutec_wade,post_battle_lose"/>
-    <property name="act10" value="set_variable searoutecwade:yes"/>
     <property name="behav1" value="talk spyder_searoutec_wade"/>
-    <property name="cond1" value="not variable_set searoutecwade:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_wade"/>
    </properties>
   </object>
   <object id="205" name="Create Gil" type="event" x="384" y="240" width="16" height="16">
@@ -104,9 +102,8 @@
     <property name="act5" value="add_monster nudimind,24,spyder_searoutec_gil,5,10"/>
     <property name="act6" value="start_battle player,spyder_searoutec_gil"/>
     <property name="act7" value="char_talk spyder_searoutec_gil,post_battle_lose"/>
-    <property name="act8" value="set_variable searoutecgil:yes"/>
     <property name="behav1" value="talk spyder_searoutec_gil"/>
-    <property name="cond1" value="not variable_set searoutecgil:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_gil"/>
    </properties>
   </object>
   <object id="207" name="Create Leek" type="event" x="480" y="160" width="16" height="16">
@@ -122,9 +119,8 @@
     <property name="act2" value="add_monster nudikill,27,spyder_searoutec_leek,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_leek"/>
     <property name="act4" value="char_talk spyder_searoutec_leek,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecleek:yes"/>
     <property name="behav1" value="talk spyder_searoutec_leek"/>
-    <property name="cond1" value="not variable_set searoutecleek:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_leek"/>
    </properties>
   </object>
   <object id="209" name="Create Beech" type="event" x="128" y="192" width="16" height="16">
@@ -140,9 +136,8 @@
     <property name="act2" value="add_monster nostray,26,spyder_searoutec_beech,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_beech"/>
     <property name="act4" value="char_talk spyder_searoutec_beech,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecbeech:yes"/>
     <property name="behav1" value="talk spyder_searoutec_beech"/>
-    <property name="cond1" value="not variable_set searoutecbeech:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_beech"/>
    </properties>
   </object>
   <object id="211" name="Create Rutherford" type="event" x="544" y="192" width="16" height="16">
@@ -158,9 +153,8 @@
     <property name="act2" value="add_monster incandesfin,26,spyder_searoutec_rutherford,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_rutherford"/>
     <property name="act4" value="char_talk spyder_searoutec_rutherford,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecrutherford:yes"/>
     <property name="behav1" value="talk spyder_searoutec_rutherford"/>
-    <property name="cond1" value="not variable_set searoutecrutherford:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_rutherford"/>
    </properties>
   </object>
   <object id="213" name="Create Carstair" type="event" x="400" y="96" width="16" height="16">
@@ -176,9 +170,8 @@
     <property name="act2" value="add_monster axolightl,24,spyder_searoutec_carstair,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_carstair"/>
     <property name="act4" value="char_talk spyder_searoutec_carstair,post_battle_lose"/>
-    <property name="act6" value="set_variable searouteccarstair:yes"/>
     <property name="behav1" value="talk spyder_searoutec_carstair"/>
-    <property name="cond1" value="not variable_set searouteccarstair:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_carstair"/>
    </properties>
   </object>
   <object id="215" name="Create Sandy" type="event" x="80" y="224" width="16" height="16">
@@ -195,9 +188,8 @@
     <property name="act4" value="add_monster bigfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act5" value="start_battle player,spyder_searoutec_sandy"/>
     <property name="act6" value="char_talk spyder_searoutec_sandy,post_battle_lose"/>
-    <property name="act7" value="set_variable searoutecsandy:yes"/>
     <property name="behav1" value="talk spyder_searoutec_sandy"/>
-    <property name="cond1" value="not variable_set searoutecsandy:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_sandy"/>
    </properties>
   </object>
   <object id="221" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
@@ -223,9 +215,9 @@
     <property name="act5" value="add_monster incandesfin,26,spyder_searoutec_rutherford,5,10"/>
     <property name="act6" value="start_battle player,spyder_searoutec_rutherford"/>
     <property name="act7" value="char_talk spyder_searoutec_rutherford,post_battle_lose"/>
-    <property name="act8" value="set_variable searoutecrutherford:yes"/>
-    <property name="cond1" value="not variable_set searoutecrutherford:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_rutherford"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="223" name="Talk Gil" type="event" x="384" y="256" width="16" height="32">
@@ -239,9 +231,9 @@
     <property name="act07" value="add_monster nudimind,24,spyder_searoutec_gil,5,10"/>
     <property name="act08" value="start_battle player,spyder_searoutec_gil"/>
     <property name="act09" value="char_talk spyder_searoutec_gil,post_battle_lose"/>
-    <property name="act10" value="set_variable searoutecgil:yes"/>
-    <property name="cond1" value="not variable_set searoutecgil:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_gil"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="226" name="Talk Sandy" type="event" x="80" y="240" width="16" height="48">
@@ -255,9 +247,9 @@
     <property name="act07" value="add_monster bigfin,22,spyder_searoutec_sandy,5,10"/>
     <property name="act08" value="start_battle player,spyder_searoutec_sandy"/>
     <property name="act09" value="char_talk spyder_searoutec_sandy,post_battle_lose"/>
-    <property name="act10" value="set_variable searoutecsandy:yes"/>
-    <property name="cond1" value="not variable_set searoutecsandy:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_sandy"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="229" name="Talk More" type="event" x="528" y="464" width="16" height="16">
@@ -270,9 +262,8 @@
     <property name="act6" value="add_monster bigfin,19,spyder_searoutec_more,5,10"/>
     <property name="act7" value="start_battle player,spyder_searoutec_more"/>
     <property name="act8" value="char_talk spyder_searoutec_more,post_battle_lose"/>
-    <property name="act9" value="set_variable searoutecmore:yes"/>
     <property name="behav1" value="talk spyder_searoutec_more"/>
-    <property name="cond1" value="not variable_set searoutecmore:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_more"/>
    </properties>
   </object>
   <object id="230" name="Talk More" type="event" x="544" y="480" width="64" height="16">
@@ -288,9 +279,9 @@
     <property name="act09" value="add_monster bigfin,19,spyder_searoutec_more,5,10"/>
     <property name="act10" value="start_battle player,spyder_searoutec_more"/>
     <property name="act11" value="char_talk spyder_searoutec_more,post_battle_lose"/>
-    <property name="act12" value="set_variable searoutecmore:yes"/>
-    <property name="cond1" value="not variable_set searoutecmore:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_more"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="231" name="Create More" type="event" x="528" y="480" width="16" height="16">
@@ -321,9 +312,8 @@
     <property name="act2" value="add_monster agnigon,36,spyder_searoutec_nigel,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_nigel"/>
     <property name="act4" value="char_talk spyder_searoutec_nigel,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecnigel:yes"/>
     <property name="behav1" value="talk spyder_searoutec_nigel"/>
-    <property name="cond1" value="not variable_set searoutecnigel:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_nigel"/>
     <property name="cond2" value="is variable_set hospitalcure:yes"/>
    </properties>
   </object>
@@ -338,7 +328,7 @@
    <properties>
     <property name="act2" value="translated_dialog spyder_searoutec_nigel3"/>
     <property name="behav1" value="talk spyder_searoutec_nigel"/>
-    <property name="cond1" value="not variable_set searoutecnigel:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_nigel"/>
     <property name="cond2" value="not variable_set hospitalcure:yes"/>
    </properties>
   </object>
@@ -381,9 +371,8 @@
     <property name="act2" value="add_monster medushock,22,spyder_searoutec_stafford,5,10"/>
     <property name="act3" value="start_battle player,spyder_searoutec_stafford"/>
     <property name="act4" value="char_talk spyder_searoutec_stafford,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecstafford:yes"/>
     <property name="behav1" value="talk spyder_searoutec_stafford"/>
-    <property name="cond1" value="not variable_set searoutecstafford:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_stafford"/>
    </properties>
   </object>
   <object id="264" name="Create Maurice" type="event" x="96" y="480" width="16" height="16">
@@ -400,9 +389,8 @@
     <property name="act3" value="add_monster fancair,22,spyder_searoutec_maurice,5,10"/>
     <property name="act4" value="start_battle player,spyder_searoutec_maurice"/>
     <property name="act5" value="char_talk spyder_searoutec_maurice,post_battle_lose"/>
-    <property name="act6" value="set_variable searoutecmaurice:yes"/>
     <property name="behav1" value="talk spyder_searoutec_maurice"/>
-    <property name="cond1" value="not variable_set searoutecmaurice:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_searoutec_maurice"/>
    </properties>
   </object>
   <object id="275" name="Teleport to Candy Port" type="event" x="0" y="480" width="16" height="128">

--- a/mods/tuxemon/maps/spyder_routee.tmx
+++ b/mods/tuxemon/maps/spyder_routee.tmx
@@ -122,10 +122,10 @@
     <property name="act6" value="add_monster windeye,35,spyder_routee_calliope,5,10"/>
     <property name="act7" value="start_battle player,spyder_routee_calliope"/>
     <property name="act8" value="char_talk spyder_routee_calliope,post_battle_lose"/>
-    <property name="act9" value="set_variable routeecalliope:yes"/>
-    <property name="cond1" value="not variable_set routeecalliope:yes"/>
-    <property name="cond2" value="is variable_set kernelquestbegin:yes"/>
-    <property name="cond3" value="is char_at player"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routee_calliope"/>
+    <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
+    <property name="cond4" value="is variable_set kernelquestbegin:yes"/>
    </properties>
   </object>
   <object id="82" name="Talk Calliope" type="event" x="96" y="192" width="32" height="16">
@@ -160,9 +160,9 @@
     <property name="act6" value="add_monster dinoflop,40,spyder_routee_aiolos,5,10"/>
     <property name="act7" value="start_battle player,spyder_routee_aiolos"/>
     <property name="act8" value="char_talk spyder_routee_aiolos,post_battle_lose"/>
-    <property name="act9" value="set_variable routeeaiolos:yes"/>
-    <property name="cond1" value="not variable_set routeeaiolos:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_routee_aiolos"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="87" name="Post Talk Calliope" type="event" x="128" y="224" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop1.tmx
+++ b/mods/tuxemon/maps/spyder_scoop1.tmx
@@ -79,9 +79,8 @@
     <property name="act3" value="add_monster picc,35,spyder_scoop_lanth,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_lanth"/>
     <property name="act5" value="translated_dialog spyder_scoop_lanth2"/>
-    <property name="act6" value="set_variable scooplanth:yes"/>
     <property name="behav1" value="talk spyder_scoop_lanth"/>
-    <property name="cond1" value="not variable_set scooplanth:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_lanth"/>
    </properties>
   </object>
   <object id="49" name="Create Paine" type="event" x="112" y="48" width="16" height="16">
@@ -97,9 +96,8 @@
     <property name="act3" value="add_monster cairfrey,30,spyder_scoop_paine,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_paine"/>
     <property name="act5" value="translated_dialog spyder_scoop_paine2"/>
-    <property name="act6" value="set_variable scooppaine:yes"/>
     <property name="behav1" value="talk spyder_scoop_paine"/>
-    <property name="cond1" value="not variable_set scooppaine:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_paine"/>
    </properties>
   </object>
   <object id="51" name="Create Rubid" type="event" x="208" y="160" width="16" height="16">
@@ -116,9 +114,8 @@
     <property name="act3" value="add_monster hatchling,30,spyder_scoop_rubid,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_rubid"/>
     <property name="act5" value="translated_dialog spyder_scoop_rubid2"/>
-    <property name="act6" value="set_variable scooprubid:yes"/>
     <property name="behav1" value="talk spyder_scoop_rubid"/>
-    <property name="cond1" value="not variable_set scooprubid:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_rubid"/>
    </properties>
   </object>
   <object id="53" name="Create Berys" type="event" x="304" y="64" width="16" height="16">
@@ -135,9 +132,8 @@
     <property name="act3" value="add_monster embazook,35,spyder_scoop_berys,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_berys"/>
     <property name="act5" value="translated_dialog spyder_scoop_berys2"/>
-    <property name="act6" value="set_variable scoopberys:yes"/>
     <property name="behav1" value="talk spyder_scoop_berys"/>
-    <property name="cond1" value="not variable_set scoopberys:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_berys"/>
    </properties>
   </object>
   <object id="55" name="Create Turner" type="event" x="32" y="144" width="16" height="16">
@@ -153,9 +149,8 @@
     <property name="act3" value="add_monster squabbit,30,spyder_scoop_turner,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_turner"/>
     <property name="act5" value="translated_dialog spyder_scoop_turner2"/>
-    <property name="act6" value="set_variable scoopturner:yes"/>
     <property name="behav1" value="talk spyder_scoop_turner"/>
-    <property name="cond1" value="not variable_set scoopturner:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_turner"/>
    </properties>
   </object>
   <object id="60" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -197,9 +192,9 @@
     <property name="act6" value="add_monster picc,35,spyder_scoop_lanth,5,10"/>
     <property name="act7" value="start_battle player,spyder_scoop_lanth"/>
     <property name="act8" value="translated_dialog spyder_scoop_lanth2"/>
-    <property name="act9" value="set_variable scooplanth:yes"/>
-    <property name="cond1" value="not variable_set scooplanth:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_lanth"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="66" name="Talk Berys" type="event" x="272" y="64" width="32" height="16">
@@ -212,9 +207,9 @@
     <property name="act6" value="add_monster embazook,35,spyder_scoop_berys,5,10"/>
     <property name="act7" value="start_battle player,spyder_scoop_berys"/>
     <property name="act8" value="translated_dialog spyder_scoop_berys2"/>
-    <property name="act9" value="set_variable scoopberys:yes"/>
-    <property name="cond1" value="not variable_set scoopberys:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_berys"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="67" name="Talk Turner" type="event" x="16" y="160" width="16" height="48">
@@ -227,9 +222,9 @@
     <property name="act6" value="add_monster squabbit,30,spyder_scoop_turner,5,10"/>
     <property name="act7" value="start_battle player,spyder_scoop_turner"/>
     <property name="act8" value="translated_dialog spyder_scoop_turner2"/>
-    <property name="act9" value="set_variable scoopturner:yes"/>
-    <property name="cond1" value="not variable_set scoopturner:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_turner"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="68" name="Talk Paine" type="event" x="96" y="64" width="16" height="32">
@@ -242,9 +237,9 @@
     <property name="act6" value="add_monster cairfrey,30,spyder_scoop_paine,5,10"/>
     <property name="act7" value="start_battle player,spyder_scoop_paine"/>
     <property name="act8" value="translated_dialog spyder_scoop_paine2"/>
-    <property name="act9" value="set_variable scooppaine:yes"/>
-    <property name="cond1" value="not variable_set scooppaine:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_paine"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="69" name="Talk Rubid" type="event" x="192" y="160" width="16" height="16">
@@ -257,9 +252,9 @@
     <property name="act6" value="add_monster hatchling,30,spyder_scoop_rubid,5,10"/>
     <property name="act7" value="start_battle player,spyder_scoop_rubid"/>
     <property name="act8" value="translated_dialog spyder_scoop_rubid2"/>
-    <property name="act9" value="set_variable scooprubid:yes"/>
-    <property name="cond1" value="not variable_set scooprubid:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_rubid"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="71" name="Post Talk Turner" type="event" x="32" y="128" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -124,9 +124,9 @@
     <property name="act5" value="add_monster possessun,40,spyder_scoop_alyssa,5,10"/>
     <property name="act6" value="start_battle player,spyder_scoop_alyssa"/>
     <property name="act7" value="translated_dialog spyder_scoop_alyssa2"/>
-    <property name="act8" value="set_variable scoopalyssa:yes"/>
-    <property name="cond1" value="not variable_set scoopalyssa:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_alyssa"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="27" name="Talk Taggart" type="event" x="96" y="144" width="16" height="48">
@@ -140,9 +140,9 @@
     <property name="act07" value="add_monster lapinou,30,spyder_scoop_taggart,5,10"/>
     <property name="act08" value="start_battle player,spyder_scoop_taggart"/>
     <property name="act09" value="translated_dialog spyder_scoop_taggart2"/>
-    <property name="act10" value="set_variable scooptaggart:yes"/>
-    <property name="cond1" value="not variable_set scooptaggart:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_taggart"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="28" name="Talk Donald" type="event" x="160" y="160" width="32" height="16">
@@ -156,9 +156,9 @@
     <property name="act07" value="add_monster zunna,35,spyder_scoop_donald,5,10"/>
     <property name="act08" value="start_battle player,spyder_scoop_donald"/>
     <property name="act09" value="translated_dialog spyder_scoop_donald2"/>
-    <property name="act10" value="set_variable scoopdonald:yes"/>
-    <property name="cond1" value="not variable_set scoopdonald:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_donald"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="33" name="Intro" type="event" x="160" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop4.tmx
+++ b/mods/tuxemon/maps/spyder_scoop4.tmx
@@ -82,7 +82,7 @@
     <property name="act1" value="create_npc spyder_scoop_orba,2,12"/>
     <property name="act2" value="char_face spyder_scoop_orba,left"/>
     <property name="cond1" value="not char_exists spyder_scoop_orba"/>
-    <property name="cond2" value="not variable_set scooporba:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_scoop_orba"/>
    </properties>
   </object>
   <object id="31" name="Talk Orba" type="event" x="48" y="192" width="16" height="16">
@@ -92,9 +92,8 @@
     <property name="act3" value="add_monster spighter,30,spyder_scoop_orba,5,10"/>
     <property name="act4" value="start_battle player,spyder_scoop_orba"/>
     <property name="act5" value="translated_dialog spyder_scoop_orba2"/>
-    <property name="act6" value="set_variable scooporba:yes"/>
     <property name="behav1" value="talk spyder_scoop_orba"/>
-    <property name="cond1" value="not variable_set scooporba:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_orba"/>
    </properties>
   </object>
   <object id="32" name="Create Haf" type="event" x="176" y="208" width="16" height="16">
@@ -289,9 +288,9 @@
     <property name="act07" value="add_monster abesnaki,35,spyder_scoop_arachne,5,10"/>
     <property name="act08" value="start_battle player,spyder_scoop_arachne"/>
     <property name="act09" value="translated_dialog spyder_scoop_arachne2"/>
-    <property name="act10" value="set_variable scooparachne:yes"/>
-    <property name="cond1" value="not variable_set scooparachne:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_arachne"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="57" name="Talk Weaver" type="event" x="112" y="112" width="16" height="32">
@@ -304,9 +303,9 @@
     <property name="act06" value="add_monster spighter,30,spyder_scoop_weaver,5,10"/>
     <property name="act07" value="start_battle player,spyder_scoop_weaver"/>
     <property name="act08" value="translated_dialog spyder_scoop_weaver2"/>
-    <property name="act09" value="set_variable scoopweaver:yes"/>
-    <property name="cond1" value="not variable_set scoopweaver:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_weaver"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="59" name="Post Talk Orba" type="event" x="32" y="224" width="16" height="16">
@@ -332,9 +331,8 @@
     <property name="act4" value="add_monster abesnaki,35,spyder_scoop_arachne,5,10"/>
     <property name="act5" value="start_battle player,spyder_scoop_arachne"/>
     <property name="act6" value="translated_dialog spyder_scoop_arachne2"/>
-    <property name="act7" value="set_variable scooparachne:yes"/>
     <property name="behav1" value="talk spyder_scoop_arachne"/>
-    <property name="cond1" value="not variable_set scooparachne:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_arachne"/>
    </properties>
   </object>
   <object id="62" name="Talk Arachne 2" type="event" x="176" y="96" width="16" height="16">
@@ -348,9 +346,9 @@
     <property name="act07" value="add_monster abesnaki,35,spyder_scoop_arachne,5,10"/>
     <property name="act08" value="start_battle player,spyder_scoop_arachne"/>
     <property name="act09" value="translated_dialog spyder_scoop_arachne2"/>
-    <property name="act10" value="set_variable scooparachne:yes"/>
-    <property name="cond1" value="not variable_set scooparachne:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_scoop_arachne"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_test_map.tmx
+++ b/mods/tuxemon/maps/spyder_test_map.tmx
@@ -80,7 +80,7 @@
    <properties>
     <property name="act1" value="create_npc spyder_statue_blue,4,9"/>
     <property name="cond1" value="not char_exists spyder_statue_blue"/>
-    <property name="cond2" value="not variable_set dragonscavebenden:yes"/>
+    <property name="cond2" value="not battle_outcome player,won,spyder_dragonscave_benden"/>
    </properties>
   </object>
   <object id="601" name="Create Cleo" type="event" x="272" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -373,7 +373,7 @@
     <property name="act13" value="remove_npc spyder_papertown_mom"/>
     <property name="act14" value="set_variable timbermom:yes"/>
     <property name="cond1" value="not variable_set timbermom:yes"/>
-    <property name="cond2" value="is variable_set scooparachne:yes"/>
+    <property name="cond2" value="is battle_outcome player,won,spyder_scoop_arachne"/>
    </properties>
   </object>
   <object id="376" name="Teleport to Walled Garden" type="event" x="512" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_walledgarden1.tmx
+++ b/mods/tuxemon/maps/spyder_timber_walledgarden1.tmx
@@ -126,9 +126,9 @@
     <property name="act07" value="add_monster sampsack,50,spyder_walled_fugger,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_fugger"/>
     <property name="act09" value="char_talk spyder_walled_fugger,post_battle_lose"/>
-    <property name="act10" value="set_variable walledfugger:yes"/>
-    <property name="cond1" value="not variable_set walledfugger:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_fugger"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="60" name="Create carnegie" type="event" x="16" y="48" width="16" height="16">
@@ -148,9 +148,9 @@
     <property name="act06" value="add_monster apeoro,55,spyder_walled_carnegie,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_carnegie"/>
     <property name="act08" value="char_talk spyder_walled_carnegie,post_battle_lose"/>
-    <property name="act09" value="set_variable walledcarnegie:yes"/>
-    <property name="cond1" value="not variable_set walledcarnegie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_carnegie"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="62" name="Create ford" type="event" x="80" y="96" width="16" height="16">
@@ -171,9 +171,9 @@
     <property name="act07" value="add_monster firomenis,50,spyder_walled_ford,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_ford"/>
     <property name="act09" value="char_talk spyder_walled_ford,post_battle_lose"/>
-    <property name="act10" value="set_variable walledford:yes"/>
-    <property name="cond1" value="not variable_set walledford:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_ford"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="64" name="Create girard" type="event" x="32" y="144" width="16" height="16">
@@ -194,9 +194,9 @@
     <property name="act07" value="add_monster komoduel,50,spyder_walled_girard,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_girard"/>
     <property name="act09" value="char_talk spyder_walled_girard,post_battle_lose"/>
-    <property name="act10" value="set_variable walledgirard:yes"/>
-    <property name="cond1" value="not variable_set walledgirard:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_girard"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="66" name="Create vanderbilt" type="event" x="160" y="96" width="16" height="16">
@@ -217,9 +217,9 @@
     <property name="act07" value="add_monster narcileaf,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_vanderbilt"/>
     <property name="act09" value="char_talk spyder_walled_vanderbilt,post_battle_lose"/>
-    <property name="act10" value="set_variable walledvanderbilt:yes"/>
-    <property name="cond1" value="not variable_set walledvanderbilt:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_vanderbilt"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="68" name="Talk ford" type="event" x="80" y="64" width="32" height="16">
@@ -233,9 +233,9 @@
     <property name="act07" value="add_monster firomenis,50,spyder_walled_ford,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_ford"/>
     <property name="act09" value="char_talk spyder_walled_ford,post_battle_lose"/>
-    <property name="act10" value="set_variable walledford:yes"/>
-    <property name="cond1" value="not variable_set walledford:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_ford"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="69" name="Talk vanderbilt" type="event" x="144" y="64" width="32" height="16">
@@ -249,9 +249,9 @@
     <property name="act07" value="add_monster narcileaf,50,spyder_walled_vanderbilt,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_vanderbilt"/>
     <property name="act09" value="char_talk spyder_walled_vanderbilt,post_battle_lose"/>
-    <property name="act10" value="set_variable walledvanderbilt:yes"/>
-    <property name="cond1" value="not variable_set walledvanderbilt:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_vanderbilt"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="70" name="Create astor" type="event" x="208" y="144" width="16" height="16">
@@ -272,9 +272,9 @@
     <property name="act07" value="add_monster selket,50,spyder_walled_astor,5,10"/>
     <property name="act08" value="start_battle player,spyder_walled_astor"/>
     <property name="act09" value="char_talk spyder_walled_astor,post_battle_lose"/>
-    <property name="act10" value="set_variable walledastor:yes"/>
-    <property name="cond1" value="not variable_set walledastor:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_astor"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="72" name="Post Talk astor" type="event" x="176" y="128" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_walledgarden2.tmx
+++ b/mods/tuxemon/maps/spyder_timber_walledgarden2.tmx
@@ -111,9 +111,9 @@
     <property name="act06" value="add_monster pyraminx,50,spyder_walled_osman,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_osman"/>
     <property name="act08" value="char_talk spyder_walled_osman,post_battle_lose"/>
-    <property name="act09" value="set_variable walledosman:yes"/>
-    <property name="cond1" value="not variable_set walledosman:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_osman"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="62" name="Create alexander" type="event" x="64" y="160" width="16" height="16">
@@ -133,9 +133,9 @@
     <property name="act06" value="add_monster eruptibus,50,spyder_walled_alexander,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_alexander"/>
     <property name="act08" value="char_talk spyder_walled_alexander,post_battle_lose"/>
-    <property name="act09" value="set_variable walledalexander:yes"/>
-    <property name="cond1" value="not variable_set walledalexander:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_alexander"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="64" name="Create musa" type="event" x="128" y="128" width="16" height="16">
@@ -162,9 +162,9 @@
     <property name="act06" value="add_monster grinflare,50,spyder_walled_musa,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_musa"/>
     <property name="act08" value="char_talk spyder_walled_musa,post_battle_lose"/>
-    <property name="act09" value="set_variable walledmusa:yes"/>
-    <property name="cond1" value="not variable_set walledmusa:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_musa"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="67" name="Talk augustus" type="event" x="64" y="128" width="16" height="16">
@@ -177,9 +177,9 @@
     <property name="act06" value="add_monster spycozeus,50,spyder_walled_augustus,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_augustus"/>
     <property name="act08" value="char_talk spyder_walled_augustus,post_battle_lose"/>
-    <property name="act09" value="set_variable walledaugustus:yes"/>
-    <property name="cond1" value="not variable_set walledaugustus:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_augustus"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="68" name="Create rufus" type="event" x="128" y="240" width="16" height="16">
@@ -199,9 +199,9 @@
     <property name="act06" value="add_monster frondly,50,spyder_walled_rufus,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_rufus"/>
     <property name="act08" value="char_talk spyder_walled_rufus,post_battle_lose"/>
-    <property name="act09" value="set_variable walledrufus:yes"/>
-    <property name="cond1" value="not variable_set walledrufus:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_rufus"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="70" name="Create crassus" type="event" x="112" y="176" width="16" height="16">
@@ -221,9 +221,9 @@
     <property name="act06" value="add_monster sharpfin,50,spyder_walled_crassus,5,10"/>
     <property name="act07" value="start_battle player,spyder_walled_crassus"/>
     <property name="act08" value="char_talk spyder_walled_crassus,post_battle_lose"/>
-    <property name="act09" value="set_variable walledcrassus:yes"/>
-    <property name="cond1" value="not variable_set walledcrassus:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_crassus"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="76" name="Talk midas" type="event" x="176" y="192" width="16" height="16">
@@ -241,10 +241,9 @@
     <property name="act40" value="char_talk spyder_walled_midas,post_battle_lose"/>
     <property name="act50" value="pathfind spyder_walled_midas,9,19"/>
     <property name="act60" value="remove_npc spyder_walled_midas"/>
-    <property name="act70" value="set_variable walledmidas:yes"/>
-    <property name="cond1" value="not variable_set walledmidas:yes"/>
-    <property name="cond2" value="is variable_set walledmusa:yes"/>
-    <property name="cond3" value="is variable_set walledaugustus:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_walled_midas"/>
+    <property name="cond2" value="is battle_outcome player,won,spyder_walled_musa"/>
+    <property name="cond3" value="is battle_outcome player,won,spyder_walled_augustus"/>
    </properties>
   </object>
   <object id="78" name="Talk Billie" type="event" x="192" y="192" width="16" height="16">
@@ -258,7 +257,7 @@
     <property name="act60" value="remove_npc spyder_billie"/>
     <property name="act70" value="set_variable walledbillie:yes"/>
     <property name="act99" value="unlock_controls"/>
-    <property name="cond1" value="is variable_set walledmidas:yes"/>
+    <property name="cond1" value="is battle_outcome player,won,spyder_walled_midas"/>
     <property name="cond2" value="not variable_set walledbillie:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_tunnel.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel.tmx
@@ -120,9 +120,8 @@
     <property name="act4" value="add_monster tourbidi,18,spyder_tunnelb_iris,5,10"/>
     <property name="act5" value="start_battle player,spyder_tunnelb_iris"/>
     <property name="act6" value="char_talk spyder_tunnelb_iris,post_battle_lose"/>
-    <property name="act7" value="set_variable tunnelbiris:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_iris"/>
-    <property name="cond1" value="not variable_set tunnelbiris:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_iris"/>
    </properties>
   </object>
   <object id="335" name="Create Greta" type="event" x="208" y="560" width="16" height="16">
@@ -142,9 +141,8 @@
     <property name="act07" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act08" value="start_battle player,spyder_tunnelb_greta"/>
     <property name="act09" value="char_talk spyder_tunnelb_greta,post_battle_lose"/>
-    <property name="act10" value="set_variable tunnelbgreta:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_greta"/>
-    <property name="cond1" value="not variable_set tunnelbgreta:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_greta"/>
    </properties>
   </object>
   <object id="337" name="Create Tommy" type="event" x="208" y="80" width="16" height="16">
@@ -160,9 +158,8 @@
     <property name="act2" value="add_monster zunna,22,spyder_tunnelb_tommy,5,10"/>
     <property name="act3" value="start_battle player,spyder_tunnelb_tommy"/>
     <property name="act4" value="char_talk spyder_tunnelb_tommy,post_battle_lose"/>
-    <property name="act6" value="set_variable tunnelbtommy:yes"/>
     <property name="behav1" value="talk spyder_tunnelb_tommy"/>
-    <property name="cond1" value="not variable_set tunnelbtommy:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_tommy"/>
    </properties>
   </object>
   <object id="341" name="Talk Greta" type="event" x="208" y="576" width="16" height="32">
@@ -179,9 +176,9 @@
     <property name="act10" value="add_monster foofle,16,spyder_tunnelb_greta,5,10"/>
     <property name="act11" value="start_battle player,spyder_tunnelb_greta"/>
     <property name="act12" value="char_talk spyder_tunnelb_greta,post_battle_lose"/>
-    <property name="act13" value="set_variable tunnelbgreta:yes"/>
-    <property name="cond1" value="not variable_set tunnelbgreta:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_greta"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="346" name="Teleport to Routee 1" type="event" x="304" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_tunnel_below.tmx
+++ b/mods/tuxemon/maps/spyder_tunnel_below.tmx
@@ -146,9 +146,9 @@
     <property name="act5" value="add_monster masknake,22,spyder_tunnelb_meitner,5,10"/>
     <property name="act6" value="start_battle player,spyder_tunnelb_meitner"/>
     <property name="act7" value="char_talk spyder_tunnelb_meitner,post_battle_lose"/>
-    <property name="act8" value="set_variable tunnelbmeitner:yes"/>
-    <property name="cond1" value="not variable_set tunnelbmeitner:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_meitner"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="51" name="Talk Lute" type="event" x="32" y="560" width="16" height="16">
@@ -163,9 +163,9 @@
     <property name="act08" value="add_monster strella,20,spyder_tunnelb_lute,5,10"/>
     <property name="act09" value="start_battle player,spyder_tunnelb_lute"/>
     <property name="act10" value="char_talk spyder_tunnelb_lute,post_battle_lose"/>
-    <property name="act11" value="set_variable tunnelblute:yes"/>
-    <property name="cond1" value="not variable_set tunnelblute:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_lute"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="52" name="Talk Beryll" type="event" x="144" y="512" width="16" height="32">
@@ -179,9 +179,9 @@
     <property name="act07" value="add_monster grintot,20,spyder_tunnelb_beryll,5,10"/>
     <property name="act08" value="start_battle player,spyder_tunnelb_beryll"/>
     <property name="act09" value="char_talk spyder_tunnelb_beryll,post_battle_lose"/>
-    <property name="act10" value="set_variable tunnelbberyll:yes"/>
-    <property name="cond1" value="not variable_set tunnelbberyll:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_tunnelb_beryll"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="42" name="Encounters" type="event" x="0" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -210,13 +210,12 @@
   <object id="56" name="Talk Morton" type="event" x="64" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_morton,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_morton"/>
-    <property name="act12" value="add_monster mrmoswitch,14,spyder_wayfarer1_morton,5,10"/>
+    <property name="act11" value="add_monster mrmoswitch,14,spyder_wayfarer1_morton,5,10"/>
+    <property name="act12" value="char_plague spyderbite,infected,spyder_wayfarer1_morton"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_morton"/>
     <property name="act14" value="char_talk spyder_wayfarer1_morton,post_battle_lose"/>
-    <property name="act16" value="set_variable wayfarer1morton:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_morton"/>
-    <property name="cond1" value="not variable_set wayfarer1morton:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_morton"/>
    </properties>
   </object>
   <object id="57" name="Create Jessie" type="event" x="80" y="240" width="16" height="16">
@@ -229,14 +228,13 @@
   <object id="58" name="Talk Jessie" type="event" x="64" y="240" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_jessie,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_jessie"/>
-    <property name="act12" value="add_monster lapinou,12,spyder_wayfarer1_jessie,5,10"/>
-    <property name="act13" value="add_monster cairfrey,12,spyder_wayfarer1_jessie,5,10"/>
+    <property name="act11" value="add_monster lapinou,12,spyder_wayfarer1_jessie,5,10"/>
+    <property name="act12" value="add_monster cairfrey,12,spyder_wayfarer1_jessie,5,10"/>
+    <property name="act13" value="char_plague spyderbite,infected,spyder_wayfarer1_jessie"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_jessie"/>
     <property name="act15" value="char_talk spyder_wayfarer1_jessie,post_battle_lose"/>
-    <property name="act16" value="set_variable wayfarer1jessie:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_jessie"/>
-    <property name="cond1" value="not variable_set wayfarer1jessie:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_jessie"/>
    </properties>
   </object>
   <object id="59" name="Create Nightshade" type="event" x="64" y="208" width="16" height="16">
@@ -248,14 +246,13 @@
   <object id="60" name="Talk Nightshade" type="event" x="48" y="208" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_nightshade,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_nightshade"/>
-    <property name="act12" value="add_monster lapinou,12,spyder_wayfarer1_nightshade,5,10"/>
-    <property name="act13" value="add_monster elofly,12,spyder_wayfarer1_nightshade,5,10"/>
+    <property name="act11" value="add_monster lapinou,12,spyder_wayfarer1_nightshade,5,10"/>
+    <property name="act12" value="add_monster elofly,12,spyder_wayfarer1_nightshade,5,10"/>
+    <property name="act13" value="char_plague spyderbite,infected,spyder_wayfarer1_nightshade"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_nightshade"/>
     <property name="act15" value="char_talk spyder_wayfarer1_nightshade,post_battle_lose"/>
-    <property name="act16" value="set_variable wayfarer1nightshade:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_nightshade"/>
-    <property name="cond1" value="not variable_set wayfarer1nightshade:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_nightshade"/>
    </properties>
   </object>
   <object id="61" name="Create Victor" type="event" x="208" y="32" width="16" height="16">
@@ -270,9 +267,8 @@
     <property name="act12" value="add_monster squabbit,14,spyder_wayfarer1_victor,5,10"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_victor"/>
     <property name="act14" value="char_talk spyder_wayfarer1_victor,post_battle_lose"/>
-    <property name="act16" value="set_variable wayfarer1victor:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_victor"/>
-    <property name="cond1" value="not variable_set wayfarer1victor:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_victor"/>
    </properties>
   </object>
   <object id="63" name="Create Morningstar" type="event" x="32" y="32" width="16" height="16">
@@ -284,14 +280,13 @@
   <object id="64" name="Talk Morningstar" type="event" x="16" y="32" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_morningstar,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_morningstar"/>
+    <property name="act11" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
     <property name="act12" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
-    <property name="act13" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
+    <property name="act13" value="char_plague spyderbite,infected,spyder_wayfarer1_morningstar"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_morningstar"/>
     <property name="act15" value="char_talk spyder_wayfarer1_morningstar,post_battle_lose"/>
-    <property name="act16" value="set_variable wayfarer1morningstar:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_morningstar"/>
-    <property name="cond1" value="not variable_set wayfarer1morningstar:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_morningstar"/>
    </properties>
   </object>
   <object id="71" name="Talk Morningstar" type="event" x="32" y="48" width="16" height="16">
@@ -300,14 +295,14 @@
     <property name="act02" value="pathfind_to_char player,spyder_wayfarer1_morningstar"/>
     <property name="act03" value="char_talk spyder_wayfarer1_morningstar,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
-    <property name="act05" value="char_plague spyderbite,infected,spyder_wayfarer1_morningstar"/>
+    <property name="act05" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
     <property name="act06" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
-    <property name="act07" value="add_monster cairfrey,12,spyder_wayfarer1_morningstar,5,10"/>
+    <property name="act07" value="char_plague spyderbite,infected,spyder_wayfarer1_morningstar"/>
     <property name="act08" value="start_battle player,spyder_wayfarer1_morningstar"/>
     <property name="act09" value="char_talk spyder_wayfarer1_morningstar,post_battle_lose"/>
-    <property name="act10" value="set_variable wayfarer1morningstar:yes"/>
-    <property name="cond1" value="not variable_set wayfarer1morningstar:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_morningstar"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="72" name="Talk Victor" type="event" x="176" y="32" width="32" height="16">
@@ -316,13 +311,13 @@
     <property name="act02" value="pathfind_to_char player,spyder_wayfarer1_victor"/>
     <property name="act03" value="char_talk spyder_wayfarer1_victor,pre_battle"/>
     <property name="act04" value="unlock_controls"/>
-    <property name="act05" value="char_plague spyderbite,infected,spyder_wayfarer1_victor"/>
-    <property name="act06" value="add_monster squabbit,14,spyder_wayfarer1_victor,5,10"/>
+    <property name="act05" value="add_monster squabbit,14,spyder_wayfarer1_victor,5,10"/>
+    <property name="act06" value="char_plague spyderbite,infected,spyder_wayfarer1_victor"/>
     <property name="act07" value="start_battle player,spyder_wayfarer1_victor"/>
     <property name="act08" value="char_talk spyder_wayfarer1_victor,post_battle_lose"/>
-    <property name="act09" value="set_variable wayfarer1victor:yes"/>
-    <property name="cond1" value="not variable_set wayfarer1victor:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_victor"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="75" name="Environment" type="event" x="16" y="0" width="16" height="16">
@@ -341,13 +336,12 @@
   <object id="77" name="Talk Ratcher" type="event" x="80" y="112" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_ratcher,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_ratcher"/>
-    <property name="act12" value="add_monster lapinou,14,spyder_wayfarer1_ratcher,5,10"/>
+    <property name="act11" value="add_monster lapinou,14,spyder_wayfarer1_ratcher,5,10"/>
+    <property name="act12" value="char_plague spyderbite,infected,spyder_wayfarer1_ratcher"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_ratcher"/>
     <property name="act14" value="char_talk spyder_wayfarer1_ratcher,post_battle_lose"/>
-    <property name="act15" value="set_variable wayfarer1ratcher:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_ratcher"/>
-    <property name="cond1" value="not variable_set wayfarer1ratcher:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_ratcher"/>
    </properties>
   </object>
   <object id="78" name="Create Bismuth" type="event" x="16" y="240" width="16" height="16">
@@ -360,13 +354,12 @@
   <object id="79" name="Talk Bismuth" type="event" x="16" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_bismuth,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_bismuth"/>
-    <property name="act12" value="add_monster hydrone,14,spyder_wayfarer1_bismuth,5,10"/>
+    <property name="act11" value="add_monster hydrone,14,spyder_wayfarer1_bismuth,5,10"/>
+    <property name="act12" value="char_plague spyderbite,infected,spyder_wayfarer1_bismuth"/>
     <property name="act13" value="start_battle player,spyder_wayfarer1_bismuth"/>
     <property name="act14" value="char_talk spyder_wayfarer1_bismuth,post_battle_lose"/>
-    <property name="act15" value="set_variable wayfarer1bismuth:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_bismuth"/>
-    <property name="cond1" value="not variable_set wayfarer1bismuth:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_bismuth"/>
    </properties>
   </object>
   <object id="82" name="Post Talk Jessie" type="event" x="112" y="224" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -121,14 +121,13 @@
   <object id="40" name="Talk Bravo" type="event" x="192" y="32" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_bravo,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_bravo"/>
-    <property name="act12" value="add_monster elofly,12,spyder_wayfarer1_bravo,5,10"/>
-    <property name="act13" value="add_monster flacono,12,spyder_wayfarer1_bravo,5,10"/>
+    <property name="act11" value="add_monster elofly,12,spyder_wayfarer1_bravo,5,10"/>
+    <property name="act12" value="add_monster flacono,12,spyder_wayfarer1_bravo,5,10"/>
+    <property name="act13" value="char_plague spyderbite,infected,spyder_wayfarer1_bravo"/>
     <property name="act14" value="start_battle player,spyder_wayfarer1_bravo"/>
     <property name="act15" value="char_talk spyder_wayfarer1_bravo,post_battle_lose"/>
-    <property name="act16" value="set_variable wayfarer1bravo:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_bravo"/>
-    <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_bravo"/>
    </properties>
   </object>
   <object id="41" name="Create James" type="event" x="144" y="112" width="16" height="16">
@@ -140,15 +139,14 @@
   <object id="42" name="Talk James" type="event" x="128" y="112" width="16" height="16">
    <properties>
     <property name="act10" value="char_talk spyder_wayfarer1_james,pre_battle"/>
-    <property name="act11" value="char_plague spyderbite,infected,spyder_wayfarer1_james"/>
-    <property name="act12" value="add_monster botbot,12,spyder_wayfarer1_james,5,10"/>
-    <property name="act13" value="add_monster picc,12,spyder_wayfarer1_james,5,10"/>
-    <property name="act14" value="add_monster b_ver_1,12,spyder_wayfarer1_james,5,10"/>
+    <property name="act11" value="add_monster botbot,12,spyder_wayfarer1_james,5,10"/>
+    <property name="act12" value="add_monster picc,12,spyder_wayfarer1_james,5,10"/>
+    <property name="act13" value="add_monster b_ver_1,12,spyder_wayfarer1_james,5,10"/>
+    <property name="act14" value="char_plague spyderbite,infected,spyder_wayfarer1_james"/>
     <property name="act15" value="start_battle player,spyder_wayfarer1_james"/>
     <property name="act16" value="char_talk spyder_wayfarer1_james,post_battle_lose"/>
-    <property name="act17" value="set_variable wayfarer1james:yes"/>
     <property name="behav1" value="talk spyder_wayfarer1_james"/>
-    <property name="cond1" value="not variable_set wayfarer1james:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_james"/>
    </properties>
   </object>
   <object id="43" name="Watch TV" type="event" x="176" y="96" width="32" height="16">
@@ -174,9 +172,9 @@
     <property name="act06" value="add_monster flacono,12,spyder_wayfarer1_bravo,5,10"/>
     <property name="act07" value="start_battle player,spyder_wayfarer1_bravo"/>
     <property name="act08" value="char_talk spyder_wayfarer1_bravo,post_battle_lose"/>
-    <property name="act09" value="set_variable wayfarer1bravo:yes"/>
-    <property name="cond1" value="not variable_set wayfarer1bravo:yes"/>
+    <property name="cond1" value="not battle_outcome player,won,spyder_wayfarer1_bravo"/>
     <property name="cond2" value="is char_at player"/>
+    <property name="cond3" value="not char_defeated player"/>
    </properties>
   </object>
   <object id="51" name="Post Talk James" type="event" x="128" y="128" width="16" height="16">

--- a/tuxemon/combat/utils.py
+++ b/tuxemon/combat/utils.py
@@ -142,50 +142,42 @@ def battlefield(session: Session, monster: Monster) -> None:
 
 def track_battles(
     session: Session,
-    output: str,
-    player: NPC,
-    players: Sequence[NPC],
+    output: OutputBattle,
+    character: NPC,
+    opponents: Sequence[NPC],
     turns: int,
     combat_type: CombatType,
     prize: int = 0,
 ) -> str:
     """
-    Tracks battles, fills variables and returns the message.
+    Records the outcome of a battle for a given character and returns a formatted message.
 
     Parameters:
-        session: Session
-        output: Output of the battle: won, lost, draw
-        player: The human player.
-        players: All the players (eg if player is winner, players are losers)
+        session: The current game session.
+        output: The result of the battle (won, lost, or draw).
+        character: The character whose battle result is being tracked.
+        opponents: The opposing characters in the battle.
         turns: Number of turns the battle lasted.
-        combat_type: Combat type (eg trainer, wild, horde).
-        prize: Amount of money (prize) after fighting.
+        combat_type: Type of combat (e.g., trainer, wild, horde).
+        prize: Amount of money awarded for winning (if applicable).
 
     Returns:
-        Message to display.
+        A formatted message describing the battle outcome.
     """
-    battle_outcomes = {
-        "won": OutputBattle.won.value,
-        "lost": OutputBattle.lost.value,
-        "draw": OutputBattle.draw.value,
-    }
-
-    if output not in battle_outcomes:
-        raise ValueError("Invalid battle output")
-
     location = session.client.get_map_name()
+    opponents = [op for op in opponents if op.slug != character.slug]
 
-    if output == "won":
+    if output == OutputBattle.won:
         return _handle_win(
-            session, player, players, turns, location, prize, combat_type
+            session, character, opponents, turns, location, prize, combat_type
         )
-    elif output == "lost":
+    elif output == OutputBattle.lost:
         return _handle_loss(
-            session, player, players, turns, location, combat_type
+            session, character, opponents, turns, location, combat_type
         )
     else:
         return _handle_draw(
-            session, player, players, turns, location, combat_type
+            session, character, opponents, turns, location, combat_type
         )
 
 
@@ -256,7 +248,7 @@ def _handle_loss(
 
         for winner in winners:
             loser.battle_handler.record_battle(
-                opponent=loser.slug,
+                opponent=winner.slug,
                 outcome=OutputBattle.lost,
                 steps=int(winner.steps),
                 location=location,
@@ -285,7 +277,7 @@ def _handle_draw(
             player.battle_handler.record_battle(
                 opponent=player_defeated.slug,
                 outcome=OutputBattle.draw,
-                steps=int(player.steps),
+                steps=int(player_defeated.steps),
                 location=location,
                 turns=turns,
             )

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -67,10 +67,6 @@ class TeleportFaintAction(EventAction):
 
         action = client.event_engine
 
-        if healing:
-            action.execute_action("set_monster_health")
-            action.execute_action("set_monster_status")
-
         action.execute_action(
             "transition_teleport",
             [
@@ -81,3 +77,7 @@ class TeleportFaintAction(EventAction):
                 self.rgb,
             ],
         )
+
+        if healing and session.client.get_map_name() == teleport.map_name:
+            action.execute_action("set_monster_health")
+            action.execute_action("set_monster_status")

--- a/tuxemon/event/conditions/battle_outcome_count.py
+++ b/tuxemon/event/conditions/battle_outcome_count.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from tuxemon.event import MapCondition, get_npc
+from tuxemon.event.eventcondition import EventCondition
+from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BattleOutcomeCountCondition(EventCondition):
+    """
+    Checks if a character has achieved a specific battle outcome a minimum number of times
+    against a specific opponent.
+
+    Script usage:
+        .. code-block::
+
+            is battle_outcome_count <fighter>,<outcome>,<opponent>,<count>
+
+    Script parameters:
+        fighter_slug: The slug of the battle participant (e.g., "player").
+        outcome: The desired battle outcome ("won", "lost", or "draw").
+        opponent_slug: The slug of the opponent (e.g., "npc_maple").
+        count: Minimum number of times the outcome must have occurred.
+
+    Example:
+        `is battle_outcome_count player,won,npc_maple,2`
+        Checks if the 'player' has won at least 2 times against 'npc_maple'.
+    """
+
+    name = "battle_outcome_count"
+
+    def test(self, session: Session, condition: MapCondition) -> bool:
+        try:
+            fighter, outcome, opponent, count_str = condition.parameters[:4]
+            required_count = int(count_str)
+        except (ValueError, IndexError) as e:
+            logger.error(
+                f"Invalid parameters for battle_outcome_count: {condition.parameters}"
+            )
+            return False
+
+        if outcome not in {"won", "lost", "draw"}:
+            logger.error(f"Invalid outcome '{outcome}'")
+            return False
+
+        character = get_npc(session, fighter)
+        if character is None or not character.battle_handler:
+            logger.error(
+                f"Character '{fighter}' not found or has no battle handler"
+            )
+            return False
+
+        actual_count = sum(
+            1
+            for battle in character.battle_handler.get_battles()
+            if battle.fighter == fighter
+            and battle.opponent == opponent
+            and battle.outcome.value == outcome
+        )
+
+        return actual_count >= required_count

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -127,6 +127,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
         visibility_map.update(self.combat_session.menu_visibility_map)
 
+        if self.enemy.combat.forfeit:
+            visibility_map["menu_forfeit"] = True
+
         for key, method_name in menu_map.items():
             callback = getattr(self, method_name)
             visible = visibility_map.get(key, False)

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -52,6 +52,7 @@ from tuxemon.combat.utils import (
 from tuxemon.db import (
     EffectPhase,
     ItemCategory,
+    OutputBattle,
 )
 from tuxemon.formula import config_combat
 from tuxemon.item.item import Item
@@ -231,17 +232,21 @@ class CombatState(CombatAnimations):
 
         elif phase == CombatPhase.DRAW_MATCH:
             message = self.track_battle_results(
-                "draw", c_session.defeated_players
+                OutputBattle.draw, c_session.defeated_players
             )
             if message:
                 self.process_combat_message(message)
 
         elif phase == CombatPhase.HAS_WINNER:
             message = self.track_battle_results(
-                "won", c_session.remaining_players, c_session.defeated_players
+                OutputBattle.won,
+                c_session.remaining_players,
+                c_session.defeated_players,
             )
             message += "\n" + self.track_battle_results(
-                "lost", c_session.defeated_players, c_session.remaining_players
+                OutputBattle.lost,
+                c_session.defeated_players,
+                c_session.remaining_players,
             )
             if message:
                 self.process_combat_message(message)
@@ -388,7 +393,7 @@ class CombatState(CombatAnimations):
 
     def track_battle_results(
         self,
-        result_type: str,
+        result_type: OutputBattle,
         players: Sequence[NPC],
         opponents: Optional[Sequence[NPC]] = None,
     ) -> str:
@@ -403,13 +408,13 @@ class CombatState(CombatAnimations):
             message += ("\n" if message else "") + track_battles(
                 session=self.session,
                 output=result_type,
-                player=player,
-                players=opponents if opponents else players,
+                character=player,
+                opponents=opponents if opponents else players,
                 turns=self.client.combat_session.turn,
                 combat_type=self.client.combat_session.combat_type,
                 prize=(
                     self.client.combat_session.prize
-                    if result_type == "won"
+                    if result_type == OutputBattle.won
                     else 0
                 ),
             )


### PR DESCRIPTION
PR fixes #2981 and introduces two key improvements:
* adds a new event condition `BattleOutcomeCountCondition` that checks whether a character has achieved a specific battle outcome a given number of times against an opponent. This is especially useful for handling repeat battles with NPCs without relying on multiple variables (`is battle_outcome_count <fighter>,<outcome>,<opponent>,<count>`)
* updates the `teleport_faint` event action to trigger healing **only after** the character has arrived at the destination map. This resolves the issue where the dialog box would briefly appear and close if the player lost to a trainer who initiated the battle by walking toward them.
* fixes a bug in battle tracking where the opponent slug was incorrectly recorded during losses and draws. This caused outcome-based conditions to fail when checking results against specific NPCs. The fix ensures accurate opponent attribution for all battle outcomes.
* removed duplicate Tru NPC from Dragon's Cave, the Nimrod Boss version will now be used exclusively to avoid redundancy (@Sanglorian)
* swapped Billie’s encounter parties between the Dojo and Route 6, the stronger team now appears at Route 6, balancing progression difficulty (@Sanglorian)
* added a gatekeeper NPC at Nimrod to prevent players from skipping Route A, the Mansion, and the Dojo, this blocker will disappear once the Dojo is completed (@Sanglorian)
* as a result, removed a duplicate `set_variable` from Route6 that was previously added to ensure Dojo completion