### PR TITLE
Fix Various

### DIFF
--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -15,6 +15,7 @@ from tuxemon.combat.utils import alive_party, battlefield, defeated
 from tuxemon.db import EffectPhase, TargetType
 from tuxemon.event import get_event_bus
 from tuxemon.locale import T
+from tuxemon.technique.technique import Technique
 from tuxemon.ui.combat_swap import SwapTracker
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
     from tuxemon.npc import NPC
     from tuxemon.session import Session
     from tuxemon.status.status import Status
-    from tuxemon.technique.technique import Technique
+
 logger = logging.getLogger(__name__)
 
 
@@ -300,7 +301,7 @@ class CombatSession:
     def get_message_swap(self, character: NPC, monster: Monster) -> str:
         """Determines and returns the appropriate alert message for combat start."""
         params = {"target": monster.name.upper()}
-        if self.combat_type is CombatType.TRAINER:
+        if self.combat_type in (CombatType.TRAINER, CombatType.MONSTER):
             params["user"] = character.name.upper()
             return T.format("combat_swap", params)
         elif self.combat_type is CombatType.HORDE:


### PR DESCRIPTION
PR fixes various small things

```
[2025-10-16 06:19:19,656] tuxemon.event.eventbus - ERROR - Error in event listener for 'monster_added' (_on_monster_added): Unexpected combat_type: CombatType.MONSTER
Traceback (most recent call last):
  File "/home/giorgio/Tuxemon/tuxemon/event/eventbus.py", line 112, in publish
    listener.callback(*args, **kwargs)
  File "/home/giorgio/Tuxemon/tuxemon/states/combat_state.py", line 987, in _on_monster_added
    self.handle_monster_entry(player, monster)
  File "/home/giorgio/Tuxemon/tuxemon/states/combat_state.py", line 358, in handle_monster_entry
    message = self.client.combat_session.get_message_swap(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/combat/session.py", line 309, in get_message_swap
    raise ValueError(f"Unexpected combat_type: {self.combat_type}")
ValueError: Unexpected combat_type: CombatType.MONSTER
```
this one, because it was missing `CombatType.MONSTER`
```
  File "/home/giorgio/Tuxemon/tuxemon/ai.py", line 319, in make_decision
    self.default_decision(ai)
  File "/home/giorgio/Tuxemon/tuxemon/ai.py", line 399, in default_decision
    ai.action_tech(technique, target)
  File "/home/giorgio/Tuxemon/tuxemon/ai.py", line 588, in action_tech
    technique = self.combat_session.pre_checking(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/combat/session.py", line 537, in pre_checking
    alt_technique = Technique.create(slug)
                    ^^^^^^^^^
NameError: name 'Technique' is not defined. Did you mean: 'technique'?
```
the error happened because the `Technique` class was imported inside the `if TYPE_CHECKING` block, so Python couldn’t actually see it at runtime, so `name 'Technique' is not defined`, just moving the import outside that block fixed it