### PR TITLE
Enhance `MonsterPlagueHandler` with Infection Logic and Configurable Plague Rules

### DIFF
--- a/mods/plagues.yaml
+++ b/mods/plagues.yaml
@@ -1,0 +1,45 @@
+# Plague configuration file
+# Each plague is defined by a unique slug and its properties.
+# Example:
+#   spyderbite:                          # Unique identifier for the plague
+#     spreadness: 0.125                  # Base chance (0.0–1.0) that the plague spreads when applied
+#     weight_range: [10.0, 200.0]        # Optional: (min_weight, max_weight) in kg
+#     height_range: [0.5, 2.0]           # Optional: (min_height, max_height) in meters
+#     type_weights:                      # Optional: weighted targeting by monster type
+#       serpent: 0.6                     # Serpent-type monsters are more likely to be infected
+#       poison: 0.4                      # Poison-type monsters are less likely
+#     shape_weights:                     # Optional: weighted targeting by monster shape
+#       brute: 0.7                       # Brute-shaped monsters are highly susceptible
+#       humanoid: 0.3                    # Humanoid-shaped monsters are less susceptible
+#     status_weights:                    # Optional: weighted targeting by monster status
+#       stuck: 0.8                       # Monsters that are stuck are more vulnerable
+#       poisoned: 0.2                    # Monsters already poisoned are less affected
+#     resistance_modifiers:              # Optional: resistance multipliers based on traits
+#       types:                           # Resistance by type
+#         fire: 0.5                      # Fire-type monsters resist this plague by 50%
+#       shapes:                          # Resistance by shape
+#         flier: 0.6                     # Winged monsters resist this plague by 40%
+#       statuses:                        # Resistance by status
+#         poisoned: 0.3                  # Monsters currently poisoned resist this plague by 70%
+#     inoculation:                       # Optional: inoculation-specific rules and requirements
+#       required_held_item: antidote     # Optional: monster must hold this item to be eligible
+#       eligible_types:                  # Optional: only these types can be inoculated
+#         - serpent
+#         - poison
+#       eligible_shapes:                 # Optional: only these shapes can be inoculated
+#         - humanoid
+#     message_spread_success: msgid1     # "{user} sneezed on {target}." — transmission attempt
+#     message_target_resists: msgid2     # "{target} wiped it off." — resisted infection
+#     message_minor_effect: msgid3       # "Ah ... Ah. {target} held in a sneeze." — minor symptom, no infection
+#     message_target_infected: msgid4    # "{target} begins to sniffle." — early symptom of successful infection
+#     cure:                              # Optional: cure configuration
+#       chance: 0.25                     # Chance (0.0–1.0) that the plague is cured when evaluated
+#       message_cured: msgid5            # "{target} looks healthier." — message shown when cured
+
+plagues:
+  spyderbite:
+    spreadness: 0.125
+    message_spread_success: combat_state_plague2
+    message_target_resists: combat_state_plague3
+    message_minor_effect: combat_state_plague1
+    message_target_infected: combat_state_plague0

--- a/mods/tuxemon/db/technique/spyderbite.json
+++ b/mods/tuxemon/db/technique/spyderbite.json
@@ -5,8 +5,7 @@
     {
       "type": "plague",
       "parameters": [
-        "spyderbite",
-        "0.125"
+        "spyderbite"
       ]
     }
   ],
@@ -35,5 +34,5 @@
   "tech_id": 0,
   "use_failure": "combat_miss",
   "use_success": null,
-  "use_tech": "combat_state_plague2"
+  "use_tech": "combat_used_x"
 }

--- a/tests/tuxemon/test_monster_plague_handler.py
+++ b/tests/tuxemon/test_monster_plague_handler.py
@@ -1,14 +1,24 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
+from unittest.mock import MagicMock, patch
 
 from tuxemon.db import PlagueType
-from tuxemon.monster_dir.plague import MonsterPlagueHandler
+from tuxemon.monster_dir.plague import (
+    MonsterPlagueHandler,
+    PlagueData,
+    config_plagues,
+)
 
 
-class TestMonsterPlagueHandler(unittest.TestCase):
+class TestPlagueHandlerCore(unittest.TestCase):
 
     def setUp(self):
+        self.plague_data = {
+            "plague1": PlagueData(spreadness=0.1),
+            "plague2": PlagueData(spreadness=0.2),
+        }
+        config_plagues.update(self.plague_data)
         self.handler = MonsterPlagueHandler()
 
     def test_init(self):
@@ -28,15 +38,16 @@ class TestMonsterPlagueHandler(unittest.TestCase):
             self.handler.get_plague_type("plague1"), PlagueType.inoculated
         )
 
-    def test_is_infected(self):
-        self.assertFalse(self.handler.is_infected())
-        self.handler.infect("plague1")
-        self.assertTrue(self.handler.is_infected())
-
     def test_remove_plague(self):
         self.handler.infect("plague1")
         self.handler.remove_plague("plague1")
         self.assertNotIn("plague1", self.handler.current_plagues)
+
+    def test_clear_plagues(self):
+        self.handler.infect("plague1")
+        self.handler.inoculate("plague2")
+        self.handler.clear_plagues()
+        self.assertEqual(self.handler.current_plagues, {})
 
     def test_has_plague(self):
         self.assertFalse(self.handler.has_plague("plague1"))
@@ -48,12 +59,14 @@ class TestMonsterPlagueHandler(unittest.TestCase):
         self.assertEqual(
             self.handler.get_plague_type("plague1"), PlagueType.infected
         )
-        self.assertIsNone(self.handler.get_plague_type("plague2"))
+        self.assertIsNone(
+            self.handler.get_plague_type("plague2")
+        )  # not yet infected or inoculated
 
-    def test_get_infected_slugs(self):
+    def test_is_infected(self):
+        self.assertFalse(self.handler.is_infected())
         self.handler.infect("plague1")
-        self.handler.inoculate("plague2")
-        self.assertEqual(self.handler.get_infected_slugs(), ["plague1"])
+        self.assertTrue(self.handler.is_infected())
 
     def test_is_infected_with(self):
         self.handler.infect("plague1")
@@ -65,8 +78,233 @@ class TestMonsterPlagueHandler(unittest.TestCase):
         self.assertTrue(self.handler.is_inoculated_against("plague1"))
         self.assertFalse(self.handler.is_inoculated_against("plague2"))
 
-    def test_clear_plagues(self):
+    def test_get_infected_slugs(self):
         self.handler.infect("plague1")
         self.handler.inoculate("plague2")
-        self.handler.clear_plagues()
-        self.assertEqual(self.handler.current_plagues, {})
+        self.assertEqual(self.handler.get_infected_slugs(), ["plague1"])
+
+
+class DummyMonster:
+    def __init__(
+        self,
+        name,
+        type_slugs,
+        shape_slug,
+        weight,
+        height,
+        status_slug=None,
+        plague_data=None,
+        held_item=None,
+    ):
+        self.name = name
+        self.types = MagicMock()
+        self.types.get_type_slugs = MagicMock(return_value=type_slugs)
+        self.shape = MagicMock()
+        self.shape.slug = shape_slug
+        self.weight = weight
+        self.height = height
+        self.status = MagicMock()
+        self.status.get_current_status = MagicMock(
+            return_value=MagicMock(slug=status_slug) if status_slug else None
+        )
+        self.held_item = held_item or MagicMock()
+        self.held_item.get_item = MagicMock(return_value=None)
+        self.plague = MonsterPlagueHandler(plague_data=plague_data or {})
+
+
+class TestMonsterPlagueInteraction(unittest.TestCase):
+
+    def setUp(self):
+        self.plague_data = {
+            "test_plague": PlagueData(
+                spreadness=1.0,
+                type_weights={"wood": 0.6, "poison": 0.4},
+                shape_weights={"brute": 0.7, "humanoid": 0.3},
+                resistance_modifiers={
+                    "types": {"fire": 0.5},
+                    "shapes": {"flier": 0.6},
+                    "statuses": {"flying": 0.3},
+                },
+                weight_range=(10.0, 200.0),
+                height_range=(0.5, 2.0),
+            )
+        }
+        config_plagues.update(self.plague_data)
+
+    def test_can_be_infected_by_excluded_by_type_weight(self):
+        monster = DummyMonster("FireBrute", ["fire"], "brute", 100.0, 1.5)
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertFalse(result)
+
+    def test_can_be_infected_by_excluded_by_shape_weight(self):
+        monster = DummyMonster("woodflier", ["wood"], "flier", 100.0, 1.5)
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertFalse(result)
+
+    def test_can_be_infected_by_excluded_by_weight_range(self):
+        monster = DummyMonster("Tinywood", ["wood"], "brute", 5.0, 1.5)
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertFalse(result)
+
+    def test_can_be_infected_by_excluded_by_height_range(self):
+        monster = DummyMonster("Tallwood", ["wood"], "brute", 100.0, 3.0)
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertFalse(result)
+
+    @patch("random.random", return_value=0.999)
+    def test_can_be_infected_by_with_resistance(self, mock_random):
+        monster = DummyMonster(
+            "Fireflier", ["fire"], "flier", 100.0, 1.5, "flying"
+        )
+        self.plague_data["test_plague"].type_weights = {"fire": 1.0}
+        self.plague_data["test_plague"].shape_weights = {"flier": 1.0}
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertFalse(result)
+
+    def test_can_be_infected_by_with_no_weights_defined(self):
+        plague = PlagueData(spreadness=1.0)
+        config_plagues["simple_plague"] = plague
+        monster = DummyMonster("AnyMonster", ["ghost"], "slimy", 100.0, 1.5)
+        result = monster.plague.can_be_infected_by(monster, "simple_plague")
+        self.assertTrue(result)
+
+    @patch("random.random", return_value=0.0)
+    def test_can_be_infected_by_when_already_infected_simple(
+        self, mock_random
+    ):
+        monster = DummyMonster("woodBrute", ["wood"], "brute", 100.0, 1.5)
+        monster.plague.infect("test_plague")
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertTrue(result)
+
+    @patch("random.random", return_value=0.0)
+    def test_can_be_infected_by_when_inoculated(self, _):
+        monster = DummyMonster(
+            "BugBrute",
+            ["bug"],
+            "brute",
+            100.0,
+            1.5,
+            "sleeping",
+            self.plague_data,
+        )
+        monster.plague.inoculate("test_plague")
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertFalse(result)
+
+    @patch("random.random", return_value=0.0)
+    def test_can_be_infected_by_when_already_infected(self, _):
+        monster = DummyMonster(
+            "woodBrute",
+            ["wood"],
+            "brute",
+            100.0,
+            1.5,
+            "sleeping",
+            self.plague_data,
+        )
+        monster.plague.infect("test_plague")
+        result = monster.plague.can_be_infected_by(monster, "test_plague")
+        self.assertTrue(result)
+
+    def test_try_inoculate_success(self):
+        inoc_plague = PlagueData(
+            spreadness=0.1,
+            inoculation={
+                "eligible_types": ["bug"],
+                "eligible_shapes": ["humanoid"],
+            },
+        )
+        config_plagues["inoc_plague"] = inoc_plague
+        monster = DummyMonster(
+            "BugHumanoid",
+            ["bug"],
+            "humanoid",
+            50.0,
+            1.0,
+            plague_data={"inoc_plague": inoc_plague},
+        )
+        result = monster.plague.try_inoculate(monster, "inoc_plague")
+        self.assertTrue(result)
+        self.assertTrue(monster.plague.is_inoculated_against("inoc_plague"))
+
+    def test_try_inoculate_ineligible_type(self):
+        inoc_plague = PlagueData(
+            spreadness=0.1,
+            inoculation={
+                "eligible_types": ["bug"],
+            },
+        )
+        config_plagues["inoc_plague"] = inoc_plague
+        monster = DummyMonster(
+            "FireMonster",
+            ["fire"],
+            "humanoid",
+            50.0,
+            1.0,
+            plague_data={"inoc_plague": inoc_plague},
+        )
+        result = monster.plague.try_inoculate(monster, "inoc_plague")
+        self.assertFalse(result)
+
+    def test_try_inoculate_ineligible_shape(self):
+        inoc_plague = PlagueData(
+            spreadness=0.1,
+            inoculation={
+                "eligible_shapes": ["humanoid"],
+            },
+        )
+        config_plagues["inoc_plague"] = inoc_plague
+        monster = DummyMonster(
+            "BugBrute",
+            ["bug"],
+            "brute",
+            50.0,
+            1.0,
+            plague_data={"inoc_plague": inoc_plague},
+        )
+        result = monster.plague.try_inoculate(monster, "inoc_plague")
+        self.assertFalse(result)
+
+    def test_try_inoculate_missing_required_item(self):
+        inoc_plague = PlagueData(
+            spreadness=0.1,
+            inoculation={
+                "required_held_item": "antidote",
+            },
+        )
+        config_plagues["inoc_plague"] = inoc_plague
+        monster = DummyMonster(
+            "BugHumanoid",
+            ["bug"],
+            "humanoid",
+            50.0,
+            1.0,
+            plague_data={"inoc_plague": inoc_plague},
+        )
+        monster.held_item.get_item = MagicMock(return_value=None)
+        result = monster.plague.try_inoculate(monster, "inoc_plague")
+        self.assertFalse(result)
+
+    def test_try_inoculate_with_required_item(self):
+        inoc_plague = PlagueData(
+            spreadness=0.1,
+            inoculation={
+                "required_held_item": "antidote",
+            },
+        )
+        config_plagues["inoc_plague"] = inoc_plague
+        item = MagicMock()
+        item.slug = "antidote"
+        monster = DummyMonster(
+            "BugHumanoid",
+            ["bug"],
+            "humanoid",
+            50.0,
+            1.0,
+            plague_data={"inoc_plague": inoc_plague},
+        )
+        monster.held_item.get_item = MagicMock(return_value=item)
+        result = monster.plague.try_inoculate(monster, "inoc_plague")
+        self.assertTrue(result)
+        self.assertTrue(monster.plague.is_inoculated_against("inoc_plague"))

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -15,6 +15,7 @@ from tuxemon.combat.utils import alive_party, battlefield, defeated
 from tuxemon.db import EffectPhase, TargetType
 from tuxemon.event import get_event_bus
 from tuxemon.locale import T
+from tuxemon.technique.technique import Technique
 from tuxemon.ui.combat_swap import SwapTracker
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
     from tuxemon.npc import NPC
     from tuxemon.session import Session
     from tuxemon.status.status import Status
-    from tuxemon.technique.technique import Technique
+
 logger = logging.getLogger(__name__)
 
 
@@ -532,15 +533,15 @@ class CombatSession:
             technique.target.get(target_type, False)
             for target_type in ["enemy_monster", "enemy_team", "enemy_trainer"]
         ):
-            infected_slugs = monster.plague.get_infected_slugs()
-            slug = random.choice(infected_slugs)
-            alt_technique = Technique.create(slug)
-            result = alt_technique.use(session, monster, target)
-            if result.success:
-                logger.debug(
-                    f"[Plague Override] {monster.name} switches to {alt_technique.slug}"
-                )
-                technique = alt_technique
+            slug = monster.plague.get_most_severe_plague_slug()
+            if slug:
+                alt_technique = Technique.create(slug)
+                result = alt_technique.use(session, monster, target)
+                if result.success:
+                    logger.debug(
+                        f"[Plague Override] {monster.name} switches to {alt_technique.slug}"
+                    )
+                    technique = alt_technique
         logger.debug(f"[PreCheck End] {monster.name} using {technique.slug}")
         return technique
 

--- a/tuxemon/core/effects/plague.py
+++ b/tuxemon/core/effects/plague.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -19,40 +18,34 @@ if TYPE_CHECKING:
 class PlagueEffect(CoreEffect):
     """
     Plague is an effect that can infect a monster with a specific disease,
-    with a configurable spreadness.
+    using a spreadness value defined in the external configuration file
+    `plagues.yaml`.
 
     Attributes:
-        plague_slug: The slug of the plague to apply.
-        spreadness: The chance of the plague spreading to the target monster.
+        plague_slug: The slug of the plague to apply. This is used to look up
+            the plague's properties, such as spreadness, from the config.
     """
 
     name = "plague"
     plague_slug: str
-    spreadness: float
 
     def apply_tech_target(
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
 
-        if random.random() < self.spreadness and (
-            target.plague.has_plague(self.plague_slug)
-            or not target.plague.is_inoculated_against(self.plague_slug)
-        ):
-            target.plague.infect(self.plague_slug)
-            success = True
-        else:
-            success = False
-
-        params = {"target": target.name.upper()}
-        extra = [
-            T.format(
-                (
-                    "combat_state_plague3"
-                    if target.plague.is_infected_with(self.plague_slug)
-                    else "combat_state_plague0"
-                ),
-                params,
+        success = target.plague.try_infect(target, self.plague_slug)
+        message_key = target.plague.get_combat_message_key(self.plague_slug)
+        params = {"target": target.name.upper(), "user": user.name.upper()}
+        extra = [T.format(message_key, params)]
+        plague_config = target.plague.get_plague_config(self.plague_slug)
+        if success and plague_config:
+            msgid = (
+                plague_config.message_spread_success or "combat_state_plague2"
             )
-        ]
+            tech.use_tech = T.translate(msgid)
+
+        cured, message = target.plague.try_cure(target, self.plague_slug)
+        if cured and message:
+            extra.append(T.format(message, params))
 
         return TechEffectResult(name=tech.name, success=success, extras=extra)

--- a/tuxemon/event/actions/char_plague.py
+++ b/tuxemon/event/actions/char_plague.py
@@ -9,6 +9,7 @@ from typing import Optional, final
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
+from tuxemon.tools import parse_flag
 
 logger = logging.getLogger(__name__)
 
@@ -29,28 +30,42 @@ class CharPlagueAction(EventAction):
         condition: Infected, inoculated, or None (removes the plague from the
             character, indicating a healthy state).
         character: Either "player" or character slug name (e.g. "npc_maple").
+        enforced_check: Optional string flag to enforce eligibility rules.
+            Accepts "true", "1", or "yes" (case-insensitive).
+            Default is False (eligibility is bypassed).
     """
 
     name = "char_plague"
     plague_slug: str
     condition: Optional[str] = None
     character: Optional[str] = None
+    enforced_check: Optional[str] = None
 
     def start(self, session: Session) -> None:
-        self.character = "player" if self.character is None else self.character
-        character = get_npc(session, self.character)
+        target = self.character or "player"
+        character = get_npc(session, target)
+
         if character is None:
             logger.error(f"{self.character} not found")
             return
 
+        enforce = parse_flag(self.enforced_check)
+
+        condition = self.condition.strip().lower() if self.condition else None
         for monster in character.monsters:
-            if self.condition is None:
+            if condition is None:
                 monster.plague.clear_plagues()
-            elif self.condition == "infected":
-                monster.plague.infect(self.plague_slug)
-            elif self.condition == "inoculated":
-                monster.plague.inoculate(self.plague_slug)
+            elif condition == "infected":
+                if enforce:
+                    monster.plague.try_infect(monster, self.plague_slug)
+                else:
+                    monster.plague.infect(self.plague_slug)
+            elif condition == "inoculated":
+                if enforce:
+                    monster.plague.try_inoculate(monster, self.plague_slug)
+                else:
+                    monster.plague.inoculate(self.plague_slug)
             else:
                 raise ValueError(
-                    f"{self.condition} must be 'infected' or 'inoculated'."
+                    f"Invalid plague condition '{self.condition}'. Must be 'infected' or 'inoculated'."
                 )

--- a/tuxemon/event/actions/set_monster_plague.py
+++ b/tuxemon/event/actions/set_monster_plague.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import TYPE_CHECKING, Optional, final
 from uuid import UUID
 
 from tuxemon.event import get_monster_by_iid
 from tuxemon.event.eventaction import EventAction
-from tuxemon.session import Session
+from tuxemon.tools import parse_flag
+
+if TYPE_CHECKING:
+    from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -30,12 +33,16 @@ class SetMonsterPlagueAction(EventAction):
         plague_slug: The slug of the plague to target.
         condition: Infected, inoculated, or None (removes the plague from the
             character, indicating a healthy state).
+        enforced_check: Optional string flag to enforce eligibility rules.
+            Accepts "true", "1", or "yes" (case-insensitive).
+            Default is False (eligibility is bypassed).
     """
 
     name = "set_monster_plague"
     variable: str
     plague_slug: str
     condition: Optional[str] = None
+    enforced_check: Optional[str] = None
 
     def start(self, session: Session) -> None:
         player = session.player
@@ -49,13 +56,22 @@ class SetMonsterPlagueAction(EventAction):
             logger.error("Monster not found")
             return
 
-        if self.condition is None:
+        enforce = parse_flag(self.enforced_check)
+
+        condition = self.condition.strip().lower() if self.condition else None
+        if condition is None:
             monster.plague.clear_plagues()
-        elif self.condition == "infected":
-            monster.plague.infect(self.plague_slug)
-        elif self.condition == "inoculated":
-            monster.plague.inoculate(self.plague_slug)
+        elif condition == "infected":
+            if enforce:
+                monster.plague.try_infect(monster, self.plague_slug)
+            else:
+                monster.plague.infect(self.plague_slug)
+        elif condition == "inoculated":
+            if enforce:
+                monster.plague.try_inoculate(monster, self.plague_slug)
+            else:
+                monster.plague.inoculate(self.plague_slug)
         else:
             raise ValueError(
-                f"{self.condition} must be 'infected' or 'inoculated'."
+                f"Invalid plague condition '{self.condition}'. Must be 'infected' or 'inoculated'."
             )

--- a/tuxemon/monster_dir/plague.py
+++ b/tuxemon/monster_dir/plague.py
@@ -3,14 +3,70 @@
 from __future__ import annotations
 
 import logging
+import random
 from collections.abc import Mapping
-from typing import Any, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
 
-from tuxemon.db import (
-    PlagueType,
-)
+import yaml
+from pydantic import BaseModel, Field
+
+from tuxemon.constants import paths
+from tuxemon.db import PlagueType
+from tuxemon.locale import T
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
 
 logger = logging.getLogger(__name__)
+
+
+def load_yaml(filepath: Path) -> Any:
+    try:
+        with filepath.open() as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:
+        logger.error(f"Config file not found: {filepath}")
+        raise
+    except yaml.YAMLError as exc:
+        logger.error(f"Error parsing YAML file: {exc}")
+        raise exc
+
+
+class InoculationData(BaseModel):
+    required_held_item: Optional[str] = None
+    eligible_types: Optional[list[str]] = None
+    eligible_shapes: Optional[list[str]] = None
+
+
+class CureData(BaseModel):
+    chance: float = 0.0
+    message_cured: Optional[str] = None
+
+
+class PlagueData(BaseModel):
+    spreadness: float
+    type_weights: dict[str, float] = Field(default_factory=dict)
+    shape_weights: dict[str, float] = Field(default_factory=dict)
+    status_weights: dict[str, float] = Field(default_factory=dict)
+    resistance_modifiers: dict[str, dict[str, float]] = Field(
+        default_factory=dict
+    )
+    weight_range: Optional[tuple[float, float]] = None
+    height_range: Optional[tuple[float, float]] = None
+    inoculation: Optional[InoculationData] = None
+    cure: Optional[CureData] = None
+    message_spread_success: Optional[str] = None
+    message_target_resists: Optional[str] = None
+    message_target_infected: Optional[str] = None
+    message_user_suppressed: Optional[str] = None
+
+
+config = load_yaml(paths.mods_folder / "plagues.yaml")
+plagues_raw = config["plagues"]
+config_plagues = {
+    name: PlagueData(**data) for name, data in plagues_raw.items()
+}
 
 
 class MonsterPlagueHandler:
@@ -19,19 +75,226 @@ class MonsterPlagueHandler:
     """
 
     def __init__(
-        self, plagues: Optional[dict[str, PlagueType]] = None
+        self,
+        plagues: Optional[dict[str, PlagueType]] = None,
+        plague_data: Optional[dict[str, PlagueData]] = None,
     ) -> None:
         self._plagues = plagues or {}
+        self.plague_data = plague_data or config_plagues
 
     @property
     def current_plagues(self) -> dict[str, PlagueType]:
         return self._plagues
 
     def infect(self, plague_slug: str) -> None:
+        if plague_slug not in self.plague_data:
+            logger.error(f"Unknown plague slug: {plague_slug}")
+            return
         self._plagues[plague_slug] = PlagueType.infected
 
     def inoculate(self, plague_slug: str) -> None:
+        if plague_slug not in self.plague_data:
+            logger.error(f"Unknown plague slug: {plague_slug}")
+            return
         self._plagues[plague_slug] = PlagueType.inoculated
+
+    def can_be_infected_by(self, monster: Monster, plague_slug: str) -> bool:
+        plague_config = self.get_plague_config(plague_slug)
+        if plague_config is None:
+            logger.error(f"Unknown plague slug: {plague_slug}")
+            return False
+
+        if not self.is_target_eligible(monster, plague_slug, plague_config):
+            logger.debug(
+                f"Monster '{monster.name}' is not eligible for plague '{plague_slug}'"
+            )
+            return False
+
+        can_be_infected = not self.is_inoculated_against(plague_slug)
+
+        type_slugs = monster.types.get_type_slugs()
+        type_weight = (
+            sum(plague_config.type_weights.get(t, 0.0) for t in type_slugs)
+            if type_slugs and plague_config.type_weights
+            else 1.0
+        )
+        shape_weight = plague_config.shape_weights.get(
+            monster.shape.slug, 1.0 if not plague_config.shape_weights else 0.0
+        )
+        modifier = type_weight * shape_weight
+
+        resistance = 1.0
+
+        # Type-based resistance
+        for t in type_slugs:
+            resistance *= plague_config.resistance_modifiers.get(
+                "types", {}
+            ).get(t, 1.0)
+
+        # Shape-based resistance
+        resistance *= plague_config.resistance_modifiers.get("shapes", {}).get(
+            monster.shape.slug, 1.0
+        )
+
+        # Status-based resistance
+        current_status = monster.status.get_current_status()
+        if current_status:
+            resistance *= plague_config.resistance_modifiers.get(
+                "statuses", {}
+            ).get(current_status.slug, 1.0)
+
+        final_chance = plague_config.spreadness * modifier * resistance
+        chance = random.random() < final_chance
+
+        logger.debug(
+            f"Plague check for monster '{monster.name}': slug={plague_slug}, "
+            f"spreadness={plague_config.spreadness}, modifier={modifier}, resistance={resistance}, "
+            f"final_chance={final_chance}, chance={chance}, can_be_infected={can_be_infected}"
+        )
+
+        return can_be_infected and chance
+
+    def is_target_eligible(
+        self, monster: Monster, plague_slug: str, plague_config: PlagueData
+    ) -> bool:
+        # Weight range check
+        if plague_config.weight_range:
+            min_w, max_w = plague_config.weight_range
+            if not (min_w <= monster.weight <= max_w):
+                logger.debug(
+                    f"Monster '{monster.name}' weight {monster.weight}kg is outside target range for plague '{plague_slug}': {plague_config.weight_range}"
+                )
+                return False
+
+        # Height range check
+        if plague_config.height_range:
+            min_h, max_h = plague_config.height_range
+            if not (min_h <= monster.height <= max_h):
+                logger.debug(
+                    f"Monster '{monster.name}' height {monster.height}m is outside target range for plague '{plague_slug}': {plague_config.height_range}"
+                )
+                return False
+
+        # Type weight check
+        if plague_config.type_weights:
+            type_weight = sum(
+                plague_config.type_weights.get(t, 0.0)
+                for t in monster.types.get_type_slugs()
+            )
+            if type_weight == 0.0:
+                logger.debug(
+                    f"Monster '{monster.name}' has no matching types for plague '{plague_slug}': {plague_config.type_weights}"
+                )
+                return False
+
+        # Shape weight check
+        if plague_config.shape_weights:
+            shape_weight = plague_config.shape_weights.get(
+                monster.shape.slug, 0.0
+            )
+            if shape_weight == 0.0:
+                logger.debug(
+                    f"Monster '{monster.name}' shape '{monster.shape.slug}' not in shape weights for plague '{plague_slug}': {plague_config.shape_weights}"
+                )
+                return False
+
+        return True
+
+    def try_infect(self, monster: Monster, plague_slug: str) -> bool:
+        """
+        Attempts to infect the given monster with the specified plague.
+        Returns True if infection occurred, False otherwise.
+        """
+        if self.is_infected_with(plague_slug):
+            return False
+
+        if self.can_be_infected_by(monster, plague_slug):
+            self.infect(plague_slug)
+            return True
+        return False
+
+    def is_inoculation_eligible(
+        self, monster: Monster, plague_slug: str, plague_config: PlagueData
+    ) -> bool:
+        """
+        Determines if the monster is eligible to be inoculated against the given plague.
+        Uses inoculation-specific rules from the plague config.
+        """
+        inoculation = plague_config.inoculation
+        if inoculation is None:
+            logger.debug(
+                f"No inoculation config found for plague '{plague_slug}'."
+            )
+            return False
+
+        # Check required held_item
+        held_item = monster.held_item.get_item()
+        if inoculation.required_held_item is not None:
+            if (
+                not held_item
+                or held_item.slug != inoculation.required_held_item
+            ):
+                logger.debug(
+                    f"Monster '{monster.name}' must hold item '{inoculation.required_held_item}' to be eligible for inoculation against '{plague_slug}', but is holding '{held_item.slug if held_item else 'none'}'."
+                )
+                return False
+
+        # Check eligible types
+        if inoculation.eligible_types:
+            if not any(
+                t in inoculation.eligible_types
+                for t in monster.types.get_type_slugs()
+            ):
+                logger.debug(
+                    f"Monster '{monster.name}' types {monster.types.get_type_slugs()} not eligible for inoculation against '{plague_slug}'."
+                )
+                return False
+
+        # Check eligible shapes
+        if inoculation.eligible_shapes:
+            if monster.shape.slug not in inoculation.eligible_shapes:
+                logger.debug(
+                    f"Monster '{monster.name}' shape '{monster.shape.slug}' not eligible for inoculation against '{plague_slug}'."
+                )
+                return False
+
+        return True
+
+    def try_inoculate(self, monster: Monster, plague_slug: str) -> bool:
+        """
+        Attempts to inoculate the given monster against the specified plague.
+        Returns True if inoculation occurred, False otherwise.
+        """
+        plague_config = self.get_plague_config(plague_slug)
+        if plague_config is None:
+            logger.error(f"Unknown plague slug: {plague_slug}")
+            return False
+
+        if self.is_inoculation_eligible(monster, plague_slug, plague_config):
+            self.inoculate(plague_slug)
+            return True
+
+        return False
+
+    def try_cure(
+        self, monster: Monster, plague_slug: str
+    ) -> tuple[bool, Optional[str]]:
+        """
+        Attempts to cure a monster of a specific plague based on its cure configuration.
+
+        Returns:
+            A tuple:
+            - True if the cure succeeds, False otherwise.
+            - A cured message if available and cure succeeds, else None.
+        """
+        plague_config = self.get_plague_config(plague_slug)
+        cure = plague_config.cure if plague_config else None
+        if not cure:
+            return False, None
+
+        success = random.random() < cure.chance
+        message = cure.message_cured if success else None
+        return success, message
 
     def is_infected(self) -> bool:
         return any(
@@ -67,6 +330,49 @@ class MonsterPlagueHandler:
 
     def clear_plagues(self) -> None:
         self._plagues.clear()
+
+    def get_most_severe_plague_slug(self) -> Optional[str]:
+        active = [
+            slug for slug in self._plagues if self.is_infected_with(slug)
+        ]
+        if not active:
+            return None
+        return max(active, key=lambda slug: self.plague_data[slug].spreadness)
+
+    def get_suppressed_symptom_message(
+        self, monster_name: str, plague_slug: str
+    ) -> Optional[str]:
+        """
+        Returns a suppressed symptom message if the monster is infected,
+        using dynamic message key from plague config.
+        """
+        if self.is_infected():
+            plague_config = self.get_plague_config(plague_slug)
+            if plague_config is None:
+                return None
+            message_key = (
+                plague_config.message_user_suppressed or "combat_state_plague1"
+            )
+            params = {"target": monster_name.upper()}
+            return T.format(message_key, params)
+        return None
+
+    def get_plague_config(self, plague_slug: str) -> Optional[PlagueData]:
+        return self.plague_data.get(plague_slug)
+
+    def get_combat_message_key(self, plague_slug: str) -> str:
+        plague_config = self.get_plague_config(plague_slug)
+        if plague_config is None:
+            return "combat_state_plague3"  # fallback
+
+        if self.is_infected_with(plague_slug):
+            return (
+                plague_config.message_target_infected or "combat_state_plague0"
+            )
+        else:
+            return (
+                plague_config.message_target_resists or "combat_state_plague3"
+            )
 
     def encode_plagues(self) -> dict[str, PlagueType]:
         return self._plagues.copy()

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -580,10 +580,13 @@ class CombatState(CombatAnimations):
                 user, target, result_tech.damage
             )
 
-            if user.plague.is_infected():
-                params = {"target": user.name.upper()}
-                m = T.format("combat_state_plague1", params)
-                message += "\n" + m
+            plague = user.plague.get_most_severe_plague_slug()
+            if plague:
+                m = user.plague.get_suppressed_symptom_message(
+                    user.name, plague
+                )
+                if m:
+                    message += "\n" + m
 
             if method.range != "special":
                 element_damage_key = config_combat.multiplier_map.get(


### PR DESCRIPTION
PR introduces a major upgrade to the `MonsterPlagueHandler` class by adding support for configurable plague behavior and infection logic. The goal is to make plague interactions more dynamic and data-driven, allowing monsters to be infected or inoculated based on detailed rules defined in external configuration files.

Key additions include:
- introduced `PlagueData` and `InoculationData` models using `pydantic` for structured plague configuration
- added YAML-based plague configuration loading from `plagues.yaml`, enabling modders to define plague behavior without changing code
- extended `MonsterPlagueHandler` to support:
  - infection attempts based on plague spreadness, type/shape/status weights, and resistance modifiers
  - inoculation eligibility checks based on held items, monster types, and shapes
  - infection and inoculation methods that respect plague-specific rules
- preserved backward compatibility with the original plague tracking logic