### PR TITLE
Support for Persistent Status Effects After Combat

### DIFF
--- a/mods/tuxemon/db/status/blinded.json
+++ b/mods/tuxemon/db/status/blinded.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/burn.json
+++ b/mods/tuxemon/db/status/burn.json
@@ -16,6 +16,7 @@
       "multiplier": 2.0
     }
   ],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/chargedup.json
+++ b/mods/tuxemon/db/status/chargedup.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/charging.json
+++ b/mods/tuxemon/db/status/charging.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/charmed.json
+++ b/mods/tuxemon/db/status/charmed.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/confused.json
+++ b/mods/tuxemon/db/status/confused.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/diehard.json
+++ b/mods/tuxemon/db/status/diehard.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/elementalshield.json
+++ b/mods/tuxemon/db/status/elementalshield.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/eliminated.json
+++ b/mods/tuxemon/db/status/eliminated.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "effects": [],
   "flip_axes": "",
   "icon": "gfx/ui/icons/status/icon_eliminated.png",

--- a/mods/tuxemon/db/status/enraged.json
+++ b/mods/tuxemon/db/status/enraged.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/exhausted.json
+++ b/mods/tuxemon/db/status/exhausted.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/faint.json
+++ b/mods/tuxemon/db/status/faint.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "neutral",
   "effects": [],
   "flip_axes": "",

--- a/mods/tuxemon/db/status/feedback.json
+++ b/mods/tuxemon/db/status/feedback.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/festering.json
+++ b/mods/tuxemon/db/status/festering.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/flinching.json
+++ b/mods/tuxemon/db/status/flinching.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/focused.json
+++ b/mods/tuxemon/db/status/focused.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/grabbed.json
+++ b/mods/tuxemon/db/status/grabbed.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "conditions": [
     {

--- a/mods/tuxemon/db/status/hardshell.json
+++ b/mods/tuxemon/db/status/hardshell.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/harpooned.json
+++ b/mods/tuxemon/db/status/harpooned.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/lifegift.json
+++ b/mods/tuxemon/db/status/lifegift.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "conditions": [
     {

--- a/mods/tuxemon/db/status/lifeleech.json
+++ b/mods/tuxemon/db/status/lifeleech.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "conditions": [
     {

--- a/mods/tuxemon/db/status/lockdown.json
+++ b/mods/tuxemon/db/status/lockdown.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/noddingoff.json
+++ b/mods/tuxemon/db/status/noddingoff.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/poison.json
+++ b/mods/tuxemon/db/status/poison.json
@@ -9,6 +9,7 @@
       "multiplier": 0.0
     }
   ],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/prickly.json
+++ b/mods/tuxemon/db/status/prickly.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/recover.json
+++ b/mods/tuxemon/db/status/recover.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/retaliate.json
+++ b/mods/tuxemon/db/status/retaliate.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/revenge.json
+++ b/mods/tuxemon/db/status/revenge.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/slow.json
+++ b/mods/tuxemon/db/status/slow.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/sniping.json
+++ b/mods/tuxemon/db/status/sniping.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "positive",
   "effects": [
     {

--- a/mods/tuxemon/db/status/softened.json
+++ b/mods/tuxemon/db/status/softened.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/spiky.json
+++ b/mods/tuxemon/db/status/spiky.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/stuck.json
+++ b/mods/tuxemon/db/status/stuck.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "conditions": [
     {

--- a/mods/tuxemon/db/status/wasting.json
+++ b/mods/tuxemon/db/status/wasting.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/mods/tuxemon/db/status/wild.json
+++ b/mods/tuxemon/db/status/wild.json
@@ -1,6 +1,7 @@
 {
   "animation": null,
   "modifiers": [],
+  "behaviors": {},
   "category": "negative",
   "effects": [
     {

--- a/tuxemon/core/effects/flinching.py
+++ b/tuxemon/core/effects/flinching.py
@@ -42,7 +42,7 @@ class FlinchingEffect(CoreEffect):
             skip = Technique.create(empty)
             tech = [skip]
             status.advance_round()
-            status.check_counter_expiry(session)
+            host.status.check_and_clear_use_expiry(session)
         return StatusEffectResult(
             name=status.name, success=True, techniques=tech
         )

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -375,6 +375,15 @@ class TechBehaviors(Behaviors):
     )
 
 
+class StatusBehaviors(Behaviors):
+    """Behaviors specific to statuses."""
+
+    persists_after_combat: bool = Field(
+        False,
+        description="Whether this status effect remains active after combat ends.",
+    )
+
+
 class DynamicMenuEntry(BaseModel):
     position: int
     label_key: str
@@ -1339,6 +1348,7 @@ class StatusModel(BaseModel, BaseLookupModel):
     table_name: ClassVar[str] = "status"
     slug: str = Field(..., description="The slug of the status")
     sort: TechSort = Field(..., description="The sort of status this is")
+    behaviors: StatusBehaviors
     icon: str = Field(..., description="The icon to use for the condition")
     conditions: Sequence[CommonCondition] = Field(
         [], description="Conditions that must be met"

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -623,7 +623,12 @@ class Monster:
         self.moves.full_recharge_moves()
 
         if not self.status.is_fainted:
-            self.status.remove_status()
+            current_status = self.status.get_current_status()
+            if (
+                current_status
+                and not current_status.behaviors.persists_after_combat
+            ):
+                self.status.remove_status()
 
         if self.is_fainted:
             self.current_hp = 0

--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -180,6 +180,18 @@ class MonsterStatusHandler:
     def remove_bonded_statuses(self) -> None:
         self.status = [sta for sta in self.get_statuses() if not sta.bond]
 
+    def check_and_clear_use_expiry(
+        self, session: Session, max_uses: int = 1
+    ) -> bool:
+        """
+        Checks if a status is expired by its use counter. If so, clears it.
+        """
+        current_status = self.get_current_status()
+        if current_status and current_status.is_use_expired(max_uses=max_uses):
+            self.clear_status(session)
+            return True
+        return False
+
     def encode_status(self) -> Sequence[Mapping[str, Any]]:
         return encode_status(self.status)
 

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -16,6 +16,7 @@ from tuxemon.db import (
     Range,
     ResponseStatus,
     StatModel,
+    StatusBehaviors,
     StatusModel,
     db,
 )
@@ -51,11 +52,12 @@ class Status:
         save_data: Optional[Mapping[str, Any]] = None,
     ) -> None:
         save_data = save_data or {}
+        self._host: Monster = host
+        self._steps: float = steps
 
         self._effect_applied: set[str] = set()
 
         self.instance_id: UUID = uuid4()
-        self.set_steps(steps)
         self.bond: bool = False
         self.counter: int = 0
         self.cond_id: int = 0
@@ -65,7 +67,6 @@ class Status:
         self.flip_axes: FlipAxes = FlipAxes.NONE
         self.gain_cond: str = ""
         self.icon: str = ""
-        self.set_host(host)
         self.linked_monster: Optional[Monster] = None
         self.name: str = ""
         self.nr_turn: int = 0
@@ -83,6 +84,7 @@ class Status:
         self.use_success: str = ""
         self.use_failure: str = ""
         self.modifiers: ModifiersHandler = ModifiersHandler()
+        self.behaviors: StatusBehaviors
         self.stat_modifiers: dict[str, StatModel] = {}
 
         self.core_assets = CoreAssetManager()
@@ -126,6 +128,7 @@ class Status:
         self.icon = results.icon
 
         self.modifiers = ModifiersHandler(results.modifiers)
+        self.behaviors = results.behaviors
         # monster stats
         self.stat_modifiers = results.stat_modifiers
 
@@ -167,21 +170,11 @@ class Status:
             f"[Status Counter] {self.slug} used {self.counter} times."
         )
 
-    def check_counter_expiry(
-        self, session: Session, max_uses: int = 1
-    ) -> None:
+    def is_use_expired(self, max_uses: int = 1) -> bool:
         """
         Checks if the status has reached its use-based expiration threshold.
-        If so, clears the status from the host.
         """
-        logger.debug(
-            f"[Status Expired] {self.slug} used {self.counter}/{max_uses} times."
-        )
-        if self.counter >= max_uses:
-            logger.debug(
-                f"[Status Expired] {self.slug} removed from {self.host.name} after {self.counter} uses."
-            )
-            self.host.status.clear_status(session)
+        return self.counter >= max_uses
 
     def validate_monster(self, session: Session, target: Monster) -> bool:
         """
@@ -191,11 +184,7 @@ class Status:
 
     def get_host(self) -> Monster:
         """Returns the monster associated with this status."""
-        return self.host
-
-    def set_host(self, monster: Monster) -> None:
-        """Sets the monster associated with this status."""
-        self.host = monster
+        return self._host
 
     def get_linked_monster(self) -> Optional[Monster]:
         """Returns the monster linked to this status effect."""
@@ -204,10 +193,6 @@ class Status:
     def set_linked_monster(self, monster: Monster) -> None:
         """Assigns a linked monster that benefits from this status."""
         self.linked_monster = monster
-
-    def set_steps(self, steps: float) -> None:
-        """Sets the steps."""
-        self.steps = steps
 
     def has_reached_duration(self) -> bool:
         """Checks if the status has reached or exceeded its duration."""


### PR DESCRIPTION
PR introduces support for status effects that can persist beyond the end of combat.

The changes includes:
- added a new base model `StatusBehaviors` class
- added a new boolean field `persists_after_combat` to the `StatusBehaviors` class
- this field is also included in the status JSON definition to allow configuration via data
- the default value for `persists_after_combat` is set to `False`, meaning status effects will continue to be removed after combat unless explicitly marked otherwise (`poisoned` will probably be marked later)
- updated the `end_combat` method to check this flag before removing a status, if `persists_after_combat` is `True`, the status will remain active after combat ends
- removed the old `check_counter_expiry` method from the `Status` class and introduced `is_use_expired` in `Status` to check use-based expiration without performing removal  
- added `check_and_clear_use_expiry` method in `MonsterStatusHandler` to encapsulate both the check and the removal logic and updated combat flow to use `check_and_clear_use_expiry` instead of directly checking or clearing status  
- centralized expiry logic in `MonsterStatusHandler`, keeping `Status` focused on state tracking, reason is separation of concerns