### PR TITLE
Fix bug that meant status removal for a negative status was based on the wrong indicator

### DIFF
--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -136,7 +136,7 @@ class MonsterStatusHandler:
             )
             if new_status.on_negative_status == ResponseStatus.replaced:
                 self.add_status(new_status)
-            elif new_status.on_positive_status == ResponseStatus.removed:
+            elif new_status.on_negative_status == ResponseStatus.removed:
                 self.remove_status()
         else:
             logger.debug(


### PR DESCRIPTION
Just correcting a small typo -- when a negative status tries to remove an existing status, that occurs based on the original status' "positive status" setting. 