### PR TITLE
Refactor `QuarantineAction` +  Enhance `MonsterPlagueHandler`

### DIFF
--- a/tuxemon/event/actions/quarantine.py
+++ b/tuxemon/event/actions/quarantine.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
-from typing import Optional, final
+from typing import TYPE_CHECKING, Optional, final
 
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
-from tuxemon.session import Session
+
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+    from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +29,7 @@ class QuarantineAction(EventAction):
     Parameters:
         character: Either "player" or npc slug name (e.g. "npc_maple").
         plague_slug: The slug of the plague to target.
-        value: "in" to quarantine infected monsters, "out" to release them.
+        action_type: "in" to quarantine infected monsters, "out" to release them.
         amount: (Optional, only for "out") The number of monsters to release
             randomly.
 
@@ -36,8 +39,66 @@ class QuarantineAction(EventAction):
     name = "quarantine"
     npc_slug: str
     plague_slug: str
-    value: str
+    action_type: str
     amount: Optional[int] = None
+
+    def _quarantine_in(self, character: NPC) -> None:
+        """Moves currently infected monsters from the party into the quarantine box."""
+        party = character.party
+        boxes = character.monster_boxes
+
+        if not boxes.has_box(self.name, "monster"):
+            boxes.create_box(self.name, "monster")
+
+        to_quarantine = [
+            mon
+            for mon in party.monsters
+            if mon.plague.has_plague(self.plague_slug)
+            and mon.plague.is_infected_with(self.plague_slug)
+        ]
+
+        for monster in to_quarantine:
+            # Inoculates the monster before moving it.
+            monster.plague.inoculate(self.plague_slug)
+
+            if party.transfer_monster_to_box(monster, self.name):
+                logger.info(f"{monster} has been quarantined")
+            else:
+                logger.warning(f"Failed to quarantine {monster}")
+
+    def _quarantine_out(self, character: NPC) -> None:
+        """Moves selected monsters from the quarantine box back to the party."""
+        party = character.party
+        boxes = character.monster_boxes
+
+        if not boxes.has_box(self.name, "monster"):
+            logger.info(f"Box {self.name} does not exist")
+            return
+
+        box_monsters = [
+            mon
+            for mon in boxes.get_monsters(self.name)
+            if mon.plague.has_plague(self.plague_slug)
+        ]
+
+        if not box_monsters:
+            logger.info(f"Box {self.name} is empty")
+            return
+
+        if self.amount is None or self.amount >= len(box_monsters):
+            to_release = box_monsters
+        else:
+            to_release = random.sample(box_monsters, self.amount)
+
+        for monster in to_release:
+            # Inoculates the monster before releasing it.
+            monster.plague.inoculate(self.plague_slug)
+
+            if party.transfer_monster_to_party(monster):
+                boxes.remove_monster_from(self.name, monster)
+                logger.info(f"{monster} has been inoculated and released")
+            else:
+                logger.warning(f"Failed to release {monster} to party")
 
     def start(self, session: Session) -> None:
         character = get_npc(session, self.npc_slug)
@@ -45,53 +106,13 @@ class QuarantineAction(EventAction):
             logger.error(f"{self.npc_slug} not found")
             return
 
-        party = character.party
-        boxes = character.monster_boxes
+        if self.action_type == "in":
+            self._quarantine_in(character)
 
-        if not boxes.has_box(self.name, "monster"):
-            boxes.create_box(self.name, "monster")
-
-        if self.value == "in":
-            plague = [
-                mon
-                for mon in party.monsters
-                if mon.plague.has_plague(self.plague_slug)
-                and mon.plague.is_infected_with(self.plague_slug)
-            ]
-            for monster in plague:
-                monster.plague.inoculate(self.plague_slug)
-                if party.transfer_monster_to_box(monster, self.name):
-                    logger.info(f"{monster} has been quarantined")
-                else:
-                    logger.warning(f"Failed to quarantine {monster}")
-
-        elif self.value == "out":
-            if not boxes.has_box(self.name, "monster"):
-                logger.info(f"Box {self.name} does not exist")
-                return
-
-            box_monsters = [
-                mon
-                for mon in boxes.get_monsters(self.name)
-                if mon.plague.has_plague(self.plague_slug)
-            ]
-            if not box_monsters:
-                logger.info(f"Box {self.name} is empty")
-                return
-
-            to_release = (
-                box_monsters
-                if self.amount is None or self.amount >= len(box_monsters)
-                else random.sample(box_monsters, self.amount)
-            )
-
-            for monster in to_release:
-                monster.plague.inoculate(self.plague_slug)
-                if party.transfer_monster_to_party(monster):
-                    boxes.remove_monster_from(self.name, monster)
-                    logger.info(f"{monster} has been inoculated and released")
-                else:
-                    logger.warning(f"Failed to release {monster} to party")
+        elif self.action_type == "out":
+            self._quarantine_out(character)
 
         else:
-            raise ValueError(f"{self.value} must be 'in' or 'out'")
+            raise ValueError(
+                f"Value '{self.action_type}' must be 'in' or 'out'"
+            )

--- a/tuxemon/monster_dir/plague.py
+++ b/tuxemon/monster_dir/plague.py
@@ -310,10 +310,7 @@ class MonsterPlagueHandler:
         return plague_slug in self._plagues
 
     def get_plague_type(self, plague_slug: str) -> Optional[PlagueType]:
-        type_str = self._plagues.get(plague_slug)
-        if type_str:
-            return PlagueType(type_str)
-        return None
+        return self._plagues.get(plague_slug)
 
     def get_infected_slugs(self) -> list[str]:
         return [
@@ -374,9 +371,22 @@ class MonsterPlagueHandler:
                 plague_config.message_target_resists or "combat_state_plague3"
             )
 
-    def encode_plagues(self) -> dict[str, PlagueType]:
-        return self._plagues.copy()
+    def encode_plagues(self) -> dict[str, str]:
+        return {
+            k: (v.value if isinstance(v, PlagueType) else str(v))
+            for k, v in self._plagues.items()
+        }
 
     def decode_plagues(self, json_data: Optional[Mapping[str, Any]]) -> None:
-        if json_data and "plague" in json_data:
-            self._plagues.update(json_data["plague"])
+        if not json_data or "plague" not in json_data:
+            return
+        for k, v in json_data["plague"].items():
+            if isinstance(v, str):
+                try:
+                    self._plagues[k] = PlagueType(v)
+                except ValueError:
+                    logger.warning(
+                        f"Unknown plague state '{v}' for '{k}' in save — skipping",
+                    )
+            else:
+                self._plagues[k] = v


### PR DESCRIPTION
PR refactors the `QuarantineAction` class to improve structure without changing its core functionality (follows #3204)

The following updates were made:
- split the logic for quarantining monsters into two private methods: `_quarantine_in` and `_quarantine_out`
- renamed the `value` field to `action_type` for clearer intent
- preserved all original behavior, including monster filtering, inoculation, transfer between party and box and logging

PR enhances `MonsterPlagueHandler`:
- `get_plague_type` returns stored Enum (no cast) and normalize on decode
- encode/decode, store enums as strings on save; convert strings to Enum on load with safe handling