### PR TITLE
Refactor Region Property Extraction Using Strategy Pattern

### DIFF
--- a/tests/tuxemon/test_collision_manager.py
+++ b/tests/tuxemon/test_collision_manager.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 from tuxemon import prepare
 from tuxemon.entity import Entity
 from tuxemon.map.collision_manager import CollisionManager
-from tuxemon.map.map import RegionProperties
 from tuxemon.map.map_manager import MapManager
+from tuxemon.map.map_region import RegionProperties
 from tuxemon.npc_manager import NPCManager
 
 

--- a/tests/tuxemon/test_map.py
+++ b/tests/tuxemon/test_map.py
@@ -9,7 +9,6 @@ from tuxemon.compat import Rect
 from tuxemon.db import Direction, Orientation
 from tuxemon.map.map import (
     angle_of_points,
-    direction_to_list,
     get_adjacent_position,
     get_coord_direction,
     get_coords,
@@ -720,57 +719,6 @@ class TestPairsFunction(unittest.TestCase):
     def test_none_direction(self):
         with self.assertRaises(ValueError):
             pairs(None)
-
-
-class TestDirectionToList(unittest.TestCase):
-    def test_empty_string_with_whitespace(self):
-        with self.assertRaises(ValueError):
-            direction_to_list("    ")
-
-    def test_empty_string(self):
-        with self.assertRaises(ValueError):
-            direction_to_list("")
-
-    def test_single_direction(self):
-        result = direction_to_list("up")
-        self.assertEqual(result, [Direction.up])
-
-    def test_multiple_direction(self):
-        result = direction_to_list("up,down,right")
-        self.assertEqual(len(result), 3)
-
-    def test_single_direction_with_whitespace(self):
-        result = direction_to_list("   up    ")
-        self.assertEqual(len(result), 1)
-
-    def test_mutiple_direction_with_whitespace(self):
-        result = direction_to_list("up   ,down  ,   right")
-        self.assertEqual(len(result), 3)
-
-    def test_repeated_directions(self):
-        result = direction_to_list("up,up,down,down")
-        self.assertEqual(len(result), 2)
-
-    def test_insensitive_duplicates(self):
-        result = direction_to_list("uP,dOWn")
-        self.assertEqual(len(result), 2)
-
-    def test_none_input(self):
-        result = direction_to_list(None)
-        self.assertEqual(result, [])
-
-    def test_very_long_string(self):
-        long_string = ",".join(["up"] * 100)
-        result = direction_to_list(long_string)
-        self.assertEqual(result, [Direction.up])
-
-    def test_unicode_characters(self):
-        with self.assertRaises(ValueError):
-            direction_to_list("ä, ü, up")
-
-    def test_invalid_direction(self):
-        with self.assertRaises(ValueError):
-            direction_to_list("invalid direction")
 
 
 class TestGetExplicitTileExits(unittest.TestCase):

--- a/tests/tuxemon/test_map_loader_pytmx.py
+++ b/tests/tuxemon/test_map_loader_pytmx.py
@@ -6,8 +6,8 @@ from operator import is_not
 from unittest.mock import Mock
 
 from tuxemon.db import Direction as Dir
-from tuxemon.map.map import RegionProperties as RP
 from tuxemon.map.map_loader import TMXMapLoader
+from tuxemon.map.map_region import RegionProperties as RP
 
 
 class TestTMXMapLoaderRegionTiles(unittest.TestCase):

--- a/tests/tuxemon/test_pathfinder.py
+++ b/tests/tuxemon/test_pathfinder.py
@@ -7,8 +7,9 @@ from tuxemon.boundary import BoundaryChecker
 from tuxemon.client import LocalPygameClient
 from tuxemon.db import Direction
 from tuxemon.map.collision_manager import CollisionManager
-from tuxemon.map.map import RegionProperties, dirs2
+from tuxemon.map.map import dirs2
 from tuxemon.map.map_manager import MapManager
+from tuxemon.map.map_region import RegionProperties
 from tuxemon.movement import Pathfinder
 from tuxemon.npc import NPC
 from tuxemon.npc_manager import NPCManager

--- a/tests/tuxemon/test_region_properties.py
+++ b/tests/tuxemon/test_region_properties.py
@@ -3,7 +3,12 @@
 import unittest
 
 from tuxemon.db import Direction
-from tuxemon.map.map import RegionProperties, extract_region_properties
+from tuxemon.map.map_region import (
+    PushEffect,
+    RegionProperties,
+    direction_to_list,
+    extract_region_properties,
+)
 
 
 class TestExtractRegionProperties(unittest.TestCase):
@@ -184,3 +189,190 @@ class TestExtractRegionProperties(unittest.TestCase):
         properties = {"enter_from": "up, @, left"}
         with self.assertRaises(ValueError):
             extract_region_properties(properties)
+
+    def test_push_tile_valid(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "right",
+            "push_strength": "2",
+        }
+        expected = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=[],
+            entity=None,
+            key="push_tile",
+            push_effect=PushEffect(Direction.right, 2),
+            speed_modifier=None,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_push_tile_missing_strength(self):
+        properties = {"key": "push_tile", "push_direction": "left"}
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_push_tile_zero_strength(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "up",
+            "push_strength": "0",
+        }
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_push_tile_invalid_direction(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "banana",
+            "push_strength": "3",
+        }
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_slide_with_speed_modifier(self):
+        properties = {"key": "slide", "speed_modifier": "1.5"}
+        expected = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=list(Direction),
+            entity=None,
+            key="slide",
+            push_effect=None,
+            speed_modifier=1.5,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_invalid_speed_modifier(self):
+        properties = {"speed_modifier": "fast"}
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_push_tile_with_speed_modifier(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "down",
+            "push_strength": "4",
+            "speed_modifier": "0.75",
+        }
+        expected = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=[],
+            entity=None,
+            key="push_tile",
+            push_effect=PushEffect(Direction.down, 4),
+            speed_modifier=0.75,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_push_strength_as_int(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "up",
+            "push_strength": 3,
+        }
+        expected = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=[],
+            entity=None,
+            key="push_tile",
+            push_effect=PushEffect(Direction.up, 3),
+            speed_modifier=None,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_push_strength_invalid_string(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "right",
+            "push_strength": "strong",
+        }
+        with self.assertRaises(ValueError):
+            extract_region_properties(properties)
+
+    def test_slide_with_unknown_keys(self):
+        properties = {
+            "key": "slide",
+            "speed_modifier": "1.2",
+            "unknown": "value",
+        }
+        expected = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=list(Direction),
+            entity=None,
+            key="slide",
+            push_effect=None,
+            speed_modifier=1.2,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+    def test_push_tile_defaults_when_enter_exit_missing(self):
+        properties = {
+            "key": "push_tile",
+            "push_direction": "up",
+            "push_strength": "1",
+        }
+        expected = RegionProperties(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            endure=[],
+            entity=None,
+            key="push_tile",
+            push_effect=PushEffect(Direction.up, 1),
+            speed_modifier=None,
+        )
+        self.assertEqual(extract_region_properties(properties), expected)
+
+
+class TestDirectionToList(unittest.TestCase):
+    def test_empty_string_with_whitespace(self):
+        with self.assertRaises(ValueError):
+            direction_to_list("    ")
+
+    def test_empty_string(self):
+        with self.assertRaises(ValueError):
+            direction_to_list("")
+
+    def test_single_direction(self):
+        result = direction_to_list("up")
+        self.assertEqual(result, [Direction.up])
+
+    def test_multiple_direction(self):
+        result = direction_to_list("up,down,right")
+        self.assertEqual(len(result), 3)
+
+    def test_single_direction_with_whitespace(self):
+        result = direction_to_list("   up    ")
+        self.assertEqual(len(result), 1)
+
+    def test_mutiple_direction_with_whitespace(self):
+        result = direction_to_list("up   ,down  ,   right")
+        self.assertEqual(len(result), 3)
+
+    def test_repeated_directions(self):
+        result = direction_to_list("up,up,down,down")
+        self.assertEqual(len(result), 2)
+
+    def test_insensitive_duplicates(self):
+        result = direction_to_list("uP,dOWn")
+        self.assertEqual(len(result), 2)
+
+    def test_none_input(self):
+        result = direction_to_list(None)
+        self.assertEqual(result, [])
+
+    def test_very_long_string(self):
+        long_string = ",".join(["up"] * 100)
+        result = direction_to_list(long_string)
+        self.assertEqual(result, [Direction.up])
+
+    def test_unicode_characters(self):
+        with self.assertRaises(ValueError):
+            direction_to_list("ä, ü, up")
+
+    def test_invalid_direction(self):
+        with self.assertRaises(ValueError):
+            direction_to_list("invalid direction")

--- a/tuxemon/map/collision_manager.py
+++ b/tuxemon/map/collision_manager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, DefaultDict, Optional, Union
 
 from tuxemon import prepare
 from tuxemon.db import Direction
-from tuxemon.map.map import RegionProperties
+from tuxemon.map.map_region import RegionProperties
 
 if TYPE_CHECKING:
 

--- a/tuxemon/map/map.py
+++ b/tuxemon/map/map.py
@@ -6,9 +6,8 @@ import logging
 from collections.abc import Generator, Mapping, Sequence
 from itertools import product
 from math import atan2, pi
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
-from tuxemon import prepare
 from tuxemon.camera.camera import project
 from tuxemon.compat.rect import ReadOnlyRect
 from tuxemon.db import Direction, Orientation
@@ -16,28 +15,12 @@ from tuxemon.math import Vector2, Vector3
 from tuxemon.tools import round_to_divisible
 
 if TYPE_CHECKING:
-    from tuxemon.entity import Entity
+    from tuxemon.map.map_region import RegionProperties
     from tuxemon.map.map_tuxemon import AbstractMap
-    from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
 
 RectTypeVar = TypeVar("RectTypeVar", bound=ReadOnlyRect)
-
-
-class PushEffect(NamedTuple):
-    direction: Direction
-    strength: int
-
-
-class RegionProperties(NamedTuple):
-    enter_from: Sequence[Direction]
-    exit_from: Sequence[Direction]
-    endure: Sequence[Direction]
-    entity: Optional[Union[NPC, Entity[Any]]] = None
-    key: Optional[str] = None
-    push_effect: Optional[PushEffect] = None
-    speed_modifier: Optional[float] = None
 
 
 # direction => vector
@@ -443,115 +426,6 @@ def orientation_by_angle(angle: float) -> Orientation:
         raise ValueError("A collision line must be aligned to an axis")
 
 
-def extract_region_properties(
-    properties: Mapping[str, Optional[str]],
-) -> Optional[RegionProperties]:
-    """
-    Given a dictionary from Tiled properties, return a dictionary
-    suitable for collision detection.
-
-    The function expects the input dictionary to contain keys from the following set:
-    {"enter_from", "exit_from", "endure", "key"}. The values for "enter_from", "exit_from",
-    and "endure" should be strings representing directions, while the value for "key"
-    should be a string representing a label.
-
-    If the input dictionary contains an "exit_from" key but no "enter_from" key, the
-    function will automatically calculate the "enter_from" directions based on the
-    "exit_from" directions.
-
-    If the input dictionary contains a "key" with the value "slide", the function will
-    set all movement directions to all possible directions.
-
-    Parameters:
-        properties: A dictionary from Tiled properties.
-
-    Returns:
-        A dictionary suitable for collision detection.
-
-    Raises:
-        ValueError: If the input dictionary contains an invalid value.
-    """
-    all_dirs = list(Direction)
-
-    if not properties:
-        return None
-
-    if not any(key.lower() in prepare.REGION_KEYS for key in properties):
-        return None
-
-    movements: dict[str, list[Direction]] = {
-        "enter_from": [],
-        "exit_from": [],
-        "endure": [],
-    }
-    label = None
-    push_direction = None
-    push_strength = 0
-    speed_modifier = None
-
-    for key, value in properties.items():
-        key = key.lower()
-        if key in ["enter_from", "exit_from", "endure"]:
-            if value == "":
-                raise ValueError(
-                    f"Invalid value for '{key}': cannot be an empty string"
-                )
-            directions = direction_to_list(value)
-            if directions is None:
-                raise ValueError(f"Invalid directions for '{key}': {value}")
-            movements[key] = directions
-        elif key == "key":
-            if value == "":
-                raise ValueError(
-                    f"Invalid value for 'key': cannot be an empty string"
-                )
-            label = value
-        elif key == "push_direction":
-            push_dir = direction_to_single(value)
-            if push_dir:
-                push_direction = push_dir
-        elif key == "push_strength":
-            if value:
-                push_strength = int(value)
-        elif key == "speed_modifier":
-            if value:
-                speed_modifier = float(value)
-                if not movements["enter_from"] and not movements["exit_from"]:
-                    movements["enter_from"] = all_dirs
-                    movements["exit_from"] = all_dirs
-
-    if movements["exit_from"] and not movements["enter_from"]:
-        movements["enter_from"] = sorted(
-            set(Direction) - set(movements["exit_from"]),
-            key=lambda d: all_dirs.index(d),
-        )
-
-    if label == "slide":
-        for key in movements:
-            movements[key] = all_dirs
-
-    push_effect = None
-    if label == "push_tile":
-        if push_direction is None or push_strength <= 0:
-            raise ValueError(
-                "'push_tile' key requires both 'push_direction' and 'push_strength'."
-            )
-        if not movements["enter_from"] and not movements["exit_from"]:
-            movements["enter_from"] = all_dirs
-            movements["exit_from"] = all_dirs
-        push_effect = PushEffect(
-            direction=push_direction, strength=push_strength
-        )
-
-    return RegionProperties(
-        **movements,
-        entity=None,
-        key=label,
-        push_effect=push_effect,
-        speed_modifier=speed_modifier,
-    )
-
-
 def get_coords_ext(
     tile: tuple[int, int], map_size: tuple[int, int], radius: int = 1
 ) -> list[tuple[int, int]]:
@@ -594,46 +468,6 @@ def get_coords_ext(
         )
 
     return list(coords)
-
-
-def direction_to_list(direction: Optional[str]) -> list[Direction]:
-    """
-    Splits direction string and returns a list with Direction/s
-
-    Parameters:
-        direction: str (eg. enter_from = "direction")
-
-    Returns:
-        List with Direction/s
-    """
-    if direction is None:
-        return []
-    return sorted(
-        [
-            Direction(d)
-            for d in {d.strip().lower() for d in direction.split(",")}
-        ]
-    )
-
-
-def direction_to_single(direction: Optional[str]) -> Optional[Direction]:
-    """
-    Converts a single direction string into a Direction object.
-
-    Parameters:
-        direction: Optional[str]
-
-    Returns:
-        A Direction object or None if input is invalid or empty.
-    """
-    if direction is None:
-        return None
-
-    cleaned = direction.strip().lower()
-    if not cleaned:
-        return None
-
-    return Direction(cleaned)
 
 
 def get_explicit_tile_exits(

--- a/tuxemon/map/map_loader.py
+++ b/tuxemon/map/map_loader.py
@@ -22,14 +22,13 @@ from tuxemon.event.eventparser import EventParser
 from tuxemon.graphics import scaled_image_loader
 from tuxemon.lib.bresenham import bresenham
 from tuxemon.map.map import (
-    RegionProperties,
     angle_of_points,
-    extract_region_properties,
     orientation_by_angle,
     point_to_grid,
     snap_rect,
     tiles_inside_rect,
 )
+from tuxemon.map.map_region import RegionProperties, extract_region_properties
 from tuxemon.map.map_tuxemon import TuxemonMap
 from tuxemon.tools import copy_dict_with_keys
 

--- a/tuxemon/map/map_manager.py
+++ b/tuxemon/map/map_manager.py
@@ -15,7 +15,7 @@ from tuxemon.db import Direction
 
 if TYPE_CHECKING:
     from tuxemon.event import EventObject
-    from tuxemon.map.map import RegionProperties
+    from tuxemon.map.map_region import RegionProperties
     from tuxemon.map.map_tuxemon import AbstractMap
 
 logger = logging.getLogger(__name__)

--- a/tuxemon/map/map_region.py
+++ b/tuxemon/map/map_region.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping, Sequence
+from enum import Enum
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+
+from tuxemon.db import Direction
+from tuxemon.prepare import REGION_KEYS
+
+if TYPE_CHECKING:
+    from tuxemon.entity import Entity
+
+logger = logging.getLogger(__name__)
+
+REGION_STRATEGIES: dict[RegionKey, type[RegionPropertiesStrategy]] = {}
+
+
+class RegionKey(str, Enum):
+    DEFAULT = "default"
+    SLIDE = "slide"
+    PUSH_TILE = "push_tile"
+
+
+class PushEffect(NamedTuple):
+    direction: Direction
+    strength: int
+
+
+class RegionProperties(NamedTuple):
+    enter_from: Sequence[Direction]
+    exit_from: Sequence[Direction]
+    endure: Sequence[Direction]
+    entity: Optional[Entity[Any]] = None
+    key: Optional[str] = None
+    push_effect: Optional[PushEffect] = None
+    speed_modifier: Optional[float] = None
+
+    def __str__(self) -> str:
+        return (
+            f"RegionProperties(key={self.key}, enter={self.enter_from}, exit={self.exit_from}, "
+            f"endure={self.endure}, push={self.push_effect}, speed={self.speed_modifier})"
+        )
+
+
+def register_region_strategy(
+    key: RegionKey,
+) -> Callable[
+    [type[RegionPropertiesStrategy]], type[RegionPropertiesStrategy]
+]:
+    """
+    Decorator to register a RegionPropertiesStrategy class with a specific RegionKey.
+    """
+
+    def decorator(
+        cls: type[RegionPropertiesStrategy],
+    ) -> type[RegionPropertiesStrategy]:
+        if not issubclass(cls, RegionPropertiesStrategy):
+            raise TypeError(
+                f"Class {cls.__name__} must inherit from RegionPropertiesStrategy."
+            )
+        if key in REGION_STRATEGIES:
+            logger.warning(
+                f"Overwriting existing strategy for key '{key.value}' "
+                f"({REGION_STRATEGIES[key].__name__} -> {cls.__name__})."
+            )
+        REGION_STRATEGIES[key] = cls
+        return cls
+
+    return decorator
+
+
+class RegionPropertiesStrategy(ABC):
+    """Abstract base class for all region property strategies."""
+
+    @classmethod
+    @abstractmethod
+    def create(cls, parsed_data: dict[str, Any]) -> Optional[RegionProperties]:
+        pass
+
+
+@register_region_strategy(RegionKey.DEFAULT)
+class DefaultTileStrategy(RegionPropertiesStrategy):
+    """
+    Handles the default behavior for map regions,
+    where directions are explicitly defined.
+    """
+
+    @classmethod
+    def create(cls, parsed_data: dict[str, Any]) -> RegionProperties:
+        return RegionProperties(
+            enter_from=parsed_data.get("enter_from", []),
+            exit_from=parsed_data.get("exit_from", []),
+            endure=parsed_data.get("endure", []),
+            entity=None,
+            key=parsed_data.get("key"),
+            push_effect=None,
+            speed_modifier=parsed_data.get("speed_modifier"),
+        )
+
+
+@register_region_strategy(RegionKey.SLIDE)
+class SlideTileStrategy(RegionPropertiesStrategy):
+    """
+    Handles the "slide" behavior, where all movements are allowed.
+    """
+
+    @classmethod
+    def create(cls, parsed_data: dict[str, Any]) -> RegionProperties:
+        all_dirs = list(Direction)
+        return RegionProperties(
+            enter_from=all_dirs,
+            exit_from=all_dirs,
+            endure=all_dirs,
+            entity=None,
+            key=RegionKey.SLIDE.value,
+            push_effect=None,
+            speed_modifier=parsed_data.get("speed_modifier"),
+        )
+
+
+@register_region_strategy(RegionKey.PUSH_TILE)
+class PushTileStrategy(RegionPropertiesStrategy):
+    """
+    Handles the "push_tile" behavior, applying a push effect
+    in a specific direction.
+    """
+
+    @classmethod
+    def create(cls, parsed_data: dict[str, Any]) -> RegionProperties:
+        push_direction = parsed_data.get("push_direction")
+        push_strength = parsed_data.get("push_strength", 0)
+
+        if push_direction is None or push_strength <= 0:
+            raise ValueError(
+                "'push_tile' key requires both 'push_direction' and a positive 'push_strength'."
+            )
+
+        all_dirs = list(Direction)
+        enter_from = parsed_data.get("enter_from") or all_dirs
+        exit_from = parsed_data.get("exit_from") or all_dirs
+
+        return RegionProperties(
+            enter_from=enter_from,
+            exit_from=exit_from,
+            endure=parsed_data.get("endure", []),
+            entity=None,
+            key=RegionKey.PUSH_TILE.value,
+            push_effect=PushEffect(push_direction, push_strength),
+            speed_modifier=parsed_data.get("speed_modifier"),
+        )
+
+
+def _parse_raw_properties(
+    properties: Mapping[str, Optional[str]],
+) -> Optional[dict[str, Any]]:
+    if not properties:
+        return None
+
+    keys_lower = {k.lower() for k in properties}
+    if not keys_lower & set(REGION_KEYS):
+        return None
+
+    parsed_data: dict[str, Any] = {
+        "enter_from": [],
+        "exit_from": [],
+        "endure": [],
+        "key": None,
+        "push_direction": None,
+        "push_strength": 0,
+        "speed_modifier": None,
+    }
+
+    for key, value in properties.items():
+        k = key.lower()
+        if k in ["enter_from", "exit_from", "endure"]:
+            if value == "":
+                raise ValueError(
+                    f"Invalid value for '{k}': cannot be an empty string"
+                )
+            parsed_data[k] = direction_to_list(value)
+        elif k == "key":
+            if not value:
+                raise ValueError("Invalid value for 'key': cannot be empty")
+            parsed_data["key"] = value.strip().lower()
+        elif k == "push_direction":
+            parsed_data["push_direction"] = direction_to_single(value)
+        elif k == "push_strength":
+            if value:
+                try:
+                    parsed_data["push_strength"] = int(value)
+                except ValueError:
+                    raise ValueError(
+                        f"Invalid push_strength '{value}': must be an integer."
+                    )
+        elif k == "speed_modifier":
+            if value:
+                try:
+                    parsed_data["speed_modifier"] = float(value)
+                except ValueError:
+                    raise ValueError(
+                        f"Invalid speed_modifier '{value}': must be a number."
+                    )
+        # Optional: collect unknown keys for logging/debugging
+
+    if parsed_data["exit_from"] and not parsed_data["enter_from"]:
+        all_dirs = list(Direction)
+        parsed_data["enter_from"] = sorted(
+            set(all_dirs) - set(parsed_data["exit_from"]),
+            key=lambda d: all_dirs.index(d),
+        )
+
+    return parsed_data
+
+
+def create_region_properties(
+    parsed_data: dict[str, Any],
+) -> Optional[RegionProperties]:
+    key_str = (parsed_data.get("key") or "").lower()
+    try:
+        key = RegionKey(key_str)
+    except ValueError:
+        key = RegionKey.DEFAULT
+
+    strategy_cls = REGION_STRATEGIES.get(key, DefaultTileStrategy)
+
+    # Note: If DefaultTileStrategy is registered, this fallback is technically
+    # redundant but harmless, and ensures a clean failure if someone deletes the
+    # default registration.
+
+    return strategy_cls.create(parsed_data)
+
+
+def extract_region_properties(
+    properties: Mapping[str, Optional[str]],
+) -> Optional[RegionProperties]:
+    """
+    Given a dictionary from Tiled properties, return a dictionary
+    suitable for collision detection.
+
+    The function expects the input dictionary to contain keys from the following set:
+    {"enter_from", "exit_from", "endure", "key"}. The values for "enter_from", "exit_from",
+    and "endure" should be strings representing directions, while the value for "key"
+    should be a string representing a label.
+
+    If the input dictionary contains an "exit_from" key but no "enter_from" key, the
+    function will automatically calculate the "enter_from" directions based on the
+    "exit_from" directions.
+
+    If the input dictionary contains a "key" with the value "slide", the function will
+    set all movement directions to all possible directions.
+
+    Parameters:
+        properties: A dictionary from Tiled properties.
+
+    Returns:
+        A RegionProperties NamedTuple suitable for collision detection.
+
+    Raises:
+        ValueError: If the input dictionary contains an invalid value.
+    """
+    parsed = _parse_raw_properties(properties)
+    if not parsed:
+        return None
+
+    region = create_region_properties(parsed)
+    if region is None:
+        logger.debug(
+            f"Region creation returned None for parsed data: {parsed}"
+        )
+        return None
+
+    return region
+
+
+def direction_to_list(direction: Optional[str]) -> list[Direction]:
+    if direction is None:
+        return []
+
+    cleaned = direction.strip()
+    if not cleaned:
+        raise ValueError("Direction string is empty or whitespace.")
+
+    try:
+        return sorted(
+            [
+                Direction(d)
+                for d in {d.strip().lower() for d in cleaned.split(",")}
+            ]
+        )
+    except ValueError as e:
+        raise ValueError(f"Invalid direction list: {direction}") from e
+
+
+def direction_to_single(direction: Optional[str]) -> Optional[Direction]:
+    if direction is None:
+        return None
+
+    cleaned = direction.strip()
+    if not cleaned:
+        raise ValueError("Direction string is empty or whitespace.")
+
+    try:
+        return Direction(cleaned.lower())
+    except ValueError as e:
+        raise ValueError(f"Invalid direction: {direction}") from e

--- a/tuxemon/map/map_tuxemon.py
+++ b/tuxemon/map/map_tuxemon.py
@@ -19,7 +19,7 @@ from tuxemon.locale import T
 if TYPE_CHECKING:
     from tuxemon.db import Direction
     from tuxemon.event import EventObject
-    from tuxemon.map.map import RegionProperties
+    from tuxemon.map.map_region import RegionProperties
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PR introduces a refactor of the `extract_region_properties` function by applying the strategy design pattern. The changes are aimed at separating behavior-specific logic from the main parsing flow and making it easier to support new region types in the future.

Changes introduced:
- added an abstract base class `RegionPropertiesStrategy` to define a common interface for region behavior strategies
- implemented three concrete strategy classes:
  - `DefaultTileStrategy` for standard directional behavior
  - `SlideTileStrategy` for regions labeled `"slide"` that allow movement in all directions
  - `PushTileStrategy` for `"push_tile"` regions that apply directional force
- refactored the original logic in `extract_region_properties`: moved raw property parsing into a helper function `_parse_raw_properties` and introduced `create_region_properties` to delegate instantiation to the appropriate strategy based on the `"key"` value
- improved validation and error handling: added type-safe parsing for `push_strength` and `speed_modifier` with clear error messages and ensured empty strings for directional keys and `"key"` raise exceptions
- preserved backward compatibility with existing behavior

---

once merged, another PR, add :
```
class BlockTileStrategy(RegionPropertiesStrategy):
    """
    Handles the "block" behavior, explicitly setting all movement lists to empty.
    """
    def create(self, parsed_data: dict[str, Any]) -> RegionProperties:
        return RegionProperties(
            enter_from=[],
            exit_from=[],
            endure=[],
            entity=None,
            key="block",  # Explicitly set the key for identification
            push_effect=None,
            speed_modifier=parsed_data.get("speed_modifier"),
        )
```
mass replace `<property name="enter_from" value=""/>` with `<property name="key" value="block"/>` (tileset.tsx)
