### PR TITLE
Refactor: Replace Accessor Methods with Properties in `Status`

### DIFF
--- a/tests/tuxemon/test_monster_status_handler.py
+++ b/tests/tuxemon/test_monster_status_handler.py
@@ -16,7 +16,7 @@ class TestMonsterStatusHandler(unittest.TestCase):
         self.monster = MagicMock(spec=Monster)
         self.monster.name = "Rockitten"
         self.status = MagicMock(slug="test")
-        self.status.get_host.return_value = self.monster
+        self.status.host = self.monster
         self.basic = MonsterStatusHandler()
         self.handler = MonsterStatusHandler([self.status])
         self.mock_item = MagicMock()
@@ -39,9 +39,9 @@ class TestMonsterStatusHandler(unittest.TestCase):
             category=CategoryStatus.positive,
             on_positive_status=ResponseStatus.replaced,
         )
-        status1.get_host.return_value = self.monster
+        status1.host = self.monster
         status2 = MagicMock(on_positive_status=ResponseStatus.replaced)
-        status2.get_host.return_value = self.monster
+        status2.host = self.monster
         self.monster.held_item = MagicMock(spec=MonsterItemHandler)
         self.monster.held_item.get_item.return_value = self.mock_item
         handler = MonsterStatusHandler([status1])
@@ -51,9 +51,9 @@ class TestMonsterStatusHandler(unittest.TestCase):
 
     def test_apply_status_remove(self):
         status1 = MagicMock(category=CategoryStatus.positive)
-        status1.get_host.return_value = self.monster
+        status1.host = self.monster
         status2 = MagicMock(on_positive_status=ResponseStatus.removed)
-        status2.get_host.return_value = self.monster
+        status2.host = self.monster
         self.monster.held_item = MagicMock(spec=MonsterItemHandler)
         self.monster.held_item.get_item.return_value = self.mock_item
         handler = MonsterStatusHandler([status1])

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -441,7 +441,7 @@ class CombatSession:
             for status in monster.status.get_statuses():
                 if len(self.remaining_players) > 1:
                     if status.validate_monster(session, monster):
-                        status.nr_turn += 1
+                        status.tick_turn()
                         self.enqueue_action(None, status, monster)
 
     def track_enemy_monsters(self, session: Session) -> None:

--- a/tuxemon/core/effects/burnt.py
+++ b/tuxemon/core/effects/burnt.py
@@ -41,7 +41,7 @@ class BurntEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         burnt: bool = False
-        host = status.get_host()
+        host = status.host
         params = {"target": host.name, "method": status.name}
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             damage = host.hp / self.divisor

--- a/tuxemon/core/effects/chargedup.py
+++ b/tuxemon/core/effects/chargedup.py
@@ -24,7 +24,7 @@ class ChargedUpEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         _statuses: list[Status] = []
         if status.has_phase(EffectPhase.PERFORM_TECH):
             host.status.clear_status(session)

--- a/tuxemon/core/effects/charging.py
+++ b/tuxemon/core/effects/charging.py
@@ -24,7 +24,7 @@ class ChargingEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         _statuses: list[Status] = []
         if status.has_phase(EffectPhase.PERFORM_TECH):
             host.status.clear_status(session)

--- a/tuxemon/core/effects/charmed.py
+++ b/tuxemon/core/effects/charmed.py
@@ -34,7 +34,7 @@ class CharmedEffect(CoreEffect):
             status.has_phase(EffectPhase.PRE_CHECKING)
             and random.random() > self.chance
         ):
-            user = status.get_host()
+            user = status.host
             action = session.client.combat_session.get_variable("action_tech")
             technique = Technique.create(str(action) or "skip")
             if any(

--- a/tuxemon/core/effects/confused.py
+++ b/tuxemon/core/effects/confused.py
@@ -36,7 +36,7 @@ class ConfusedEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         CONFUSED_KEY = self.name
-        host = status.get_host()
+        host = status.host
         var = session.client.combat_session.get_variable(CONFUSED_KEY)
 
         if not 0 <= self.chance <= 1:

--- a/tuxemon/core/effects/diehard.py
+++ b/tuxemon/core/effects/diehard.py
@@ -33,7 +33,7 @@ class DieHardEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         extra: list[str] = []
-        host = status.get_host()
+        host = status.host
         if status.has_phase(EffectPhase.CHECK_PARTY_HP):
             params = {"target": host.name.upper()}
             if host.current_hp == self.hp:

--- a/tuxemon/core/effects/elemental_shield.py
+++ b/tuxemon/core/effects/elemental_shield.py
@@ -35,7 +35,7 @@ class ElementalShieldBackEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
 
-        host = status.get_host()
+        host = status.host
 
         if not status.has_phase(EffectPhase.PERFORM_STATUS):
             return StatusEffectResult(name=status.name, success=False)

--- a/tuxemon/core/effects/exhausted.py
+++ b/tuxemon/core/effects/exhausted.py
@@ -25,7 +25,7 @@ class ExhaustedEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         _statuses: list[Status] = []
         if status.has_phase(EffectPhase.PERFORM_TECH):
             host.status.clear_status(session)

--- a/tuxemon/core/effects/feedback.py
+++ b/tuxemon/core/effects/feedback.py
@@ -34,7 +34,7 @@ class FeedBackEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
 
-        host = status.get_host()
+        host = status.host
 
         if not status.has_phase(EffectPhase.PERFORM_STATUS):
             return StatusEffectResult(name=status.name, success=False)

--- a/tuxemon/core/effects/flinching.py
+++ b/tuxemon/core/effects/flinching.py
@@ -32,7 +32,7 @@ class FlinchingEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         tech: list[Technique] = []
-        host = status.get_host()
+        host = status.host
         if (
             status.has_phase(EffectPhase.PRE_CHECKING)
             and random.random() > self.chance

--- a/tuxemon/core/effects/grabbed.py
+++ b/tuxemon/core/effects/grabbed.py
@@ -36,7 +36,7 @@ class GrabbedEffect(CoreEffect):
             raise ValueError("StuckEffect divisor must be non-zero.")
 
         done: bool = False
-        host = status.get_host()
+        host = status.host
         ranges = self.ranges.split(":")
         moves = [
             tech for tech in host.moves.get_moves() if tech.range in ranges

--- a/tuxemon/core/effects/harpooned.py
+++ b/tuxemon/core/effects/harpooned.py
@@ -29,7 +29,7 @@ class HarpoonedEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         if status.has_phase(EffectPhase.SWAP_MONSTER):
             damage = host.hp // self.divisor
             host.current_hp = max(0, host.current_hp - damage)

--- a/tuxemon/core/effects/lifegift.py
+++ b/tuxemon/core/effects/lifegift.py
@@ -36,8 +36,8 @@ class LifeGiftEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         lifegift: bool = False
-        host = status.get_host()
-        linked = status.get_linked_monster()
+        host = status.host
+        linked = status.linked_monster
         if (
             status.has_phase(EffectPhase.PERFORM_STATUS)
             and linked

--- a/tuxemon/core/effects/lifeleech.py
+++ b/tuxemon/core/effects/lifeleech.py
@@ -35,8 +35,8 @@ class LifeLeechEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         lifeleech: bool = False
-        host = status.get_host()
-        linked = status.get_linked_monster()
+        host = status.host
+        linked = status.linked_monster
         if (
             status.has_phase(EffectPhase.PERFORM_STATUS)
             and linked

--- a/tuxemon/core/effects/lockdown.py
+++ b/tuxemon/core/effects/lockdown.py
@@ -26,7 +26,7 @@ class LockdownEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         extra: list[str] = []
-        host = status.get_host()
+        host = status.host
         if status.has_phase(EffectPhase.ENQUEUE_ITEM):
             params = {"target": host.name.upper()}
             extra = [T.format("combat_state_lockdown_item", params)]

--- a/tuxemon/core/effects/noddingoff.py
+++ b/tuxemon/core/effects/noddingoff.py
@@ -37,7 +37,7 @@ class NoddingOffEffect(CoreEffect):
     ) -> StatusEffectResult:
         extra: list[str] = []
         tech: list[Technique] = []
-        host = status.get_host()
+        host = status.host
 
         if status.has_phase(EffectPhase.PRE_CHECKING) and status.on_tech_use:
             skip = Technique.create(status.on_tech_use)

--- a/tuxemon/core/effects/poisoned.py
+++ b/tuxemon/core/effects/poisoned.py
@@ -42,7 +42,7 @@ class PoisonedEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         poisoned: bool = False
-        host = status.get_host()
+        host = status.host
         params = {"target": host.name, "method": status.name}
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             damage = host.hp / self.divisor

--- a/tuxemon/core/effects/prickly.py
+++ b/tuxemon/core/effects/prickly.py
@@ -33,7 +33,7 @@ class PricklyBackEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
 
         if not status.has_phase(EffectPhase.PERFORM_STATUS):
             return StatusEffectResult(name=status.name, success=False)

--- a/tuxemon/core/effects/recover.py
+++ b/tuxemon/core/effects/recover.py
@@ -32,7 +32,7 @@ class RecoverEffect(CoreEffect):
     ) -> StatusEffectResult:
         extra: list[str] = []
         healing: bool = False
-        host = status.get_host()
+        host = status.host
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             heal = simple_recover(host, self.divisor)
             host.current_hp = min(host.hp, host.current_hp + heal)

--- a/tuxemon/core/effects/retaliate.py
+++ b/tuxemon/core/effects/retaliate.py
@@ -33,7 +33,7 @@ class RetaliateEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
 
         if not status.has_phase(EffectPhase.PERFORM_STATUS):
             return StatusEffectResult(name=status.name, success=False)

--- a/tuxemon/core/effects/revenge.py
+++ b/tuxemon/core/effects/revenge.py
@@ -32,7 +32,7 @@ class RevengeEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
 
         if not status.has_phase(EffectPhase.PERFORM_STATUS):
             return StatusEffectResult(name=status.name, success=False)

--- a/tuxemon/core/effects/spiky.py
+++ b/tuxemon/core/effects/spiky.py
@@ -29,7 +29,7 @@ class SpikyEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         if status.has_phase(EffectPhase.SWAP_MONSTER):
             damage = host.hp // self.divisor
             host.current_hp = max(0, host.current_hp - damage)

--- a/tuxemon/core/effects/statchange.py
+++ b/tuxemon/core/effects/statchange.py
@@ -73,7 +73,7 @@ class StatChangeEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         if (
             status.has_phase(EffectPhase.PERFORM_STATUS)
             and self.name not in status._effect_applied

--- a/tuxemon/core/effects/stuck.py
+++ b/tuxemon/core/effects/stuck.py
@@ -32,7 +32,7 @@ class StuckEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         if self.divisor == 0:
             raise ValueError("StuckEffect divisor must be non-zero.")
 

--- a/tuxemon/core/effects/swap_out_lock.py
+++ b/tuxemon/core/effects/swap_out_lock.py
@@ -74,7 +74,7 @@ class SwapOutLockEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        host = status.get_host()
+        host = status.host
         combat_session = session.client.combat_session
         persistent = self.method == "persistent"
 

--- a/tuxemon/core/effects/wasting.py
+++ b/tuxemon/core/effects/wasting.py
@@ -30,7 +30,7 @@ class WastingEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         done: bool = False
-        host = status.get_host()
+        host = status.host
         if (
             status.has_phase(EffectPhase.PERFORM_STATUS)
             and not host.is_fainted

--- a/tuxemon/core/effects/wild.py
+++ b/tuxemon/core/effects/wild.py
@@ -38,7 +38,7 @@ class WildEffect(CoreEffect):
             status.has_phase(EffectPhase.PRE_CHECKING)
             and random.random() > self.chance
         ):
-            user = status.get_host()
+            user = status.host
             empty = status.on_tech_use
             assert empty
             skip = Technique.create(empty)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1373,6 +1373,10 @@ class StatusModel(BaseModel, BaseLookupModel):
     duration: int = Field(
         0, description="How many turns the status is supposed to last"
     )
+    step_interval: int = Field(
+        0,
+        description="The number of steps between out-of-battle effect triggers.",
+    )
     modifiers: list[Modifier] = Field(..., description="Various modifiers")
 
     # Optional fields

--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -71,7 +71,7 @@ class MonsterStatusHandler:
         ensuring proper transitions between statuses based on their category and
         interaction rules.
         """
-        host = new_status.get_host()
+        host = new_status.host
         logger.debug(
             f"Trying to apply status '{new_status.slug}' to monster '{host.name}'."
         )

--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -91,7 +91,7 @@ class MonsterStatusHandler:
         if current_status is None:
             logger.debug("No current status, applying new status directly.")
             self.add_status(new_status)
-            new_status.nr_turn = 1
+            new_status.tick_turn()
             new_status.use(session, EffectPhase.ON_START)
             return StatusApplyResult(applied=True)
 
@@ -99,12 +99,7 @@ class MonsterStatusHandler:
             logger.debug(
                 f"Monster already has status '{new_status.slug}', skipping."
             )
-            current_status.stack_level = min(
-                current_status.stack_level + 1, Status.MAX_STACKS
-            )
-            logger.debug(
-                f"Stacking status '{new_status.slug}': now at {current_status.stack_level}/{Status.MAX_STACKS}."
-            )
+            current_status.stack()
             return StatusApplyResult(
                 applied=False,
                 blocked_by=current_status.name,
@@ -116,7 +111,7 @@ class MonsterStatusHandler:
         )
         current_status.use(session, EffectPhase.ON_END)
 
-        new_status.nr_turn = 1
+        new_status.tick_turn()
         logger.debug(
             f"Starting new status '{new_status.slug}' with ON_START phase."
         )

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -55,6 +55,7 @@ class Status:
         self._host: Monster = host
         self._steps: float = steps
         self._linked_monster: Optional[Monster] = None
+        self._nr_turn: int = 0
 
         self._effect_applied: set[str] = set()
 
@@ -69,11 +70,11 @@ class Status:
         self.gain_cond: str = ""
         self.icon: str = ""
         self.name: str = ""
-        self.nr_turn: int = 0
         self.duration: int = 0
         self.phase: EffectPhase = EffectPhase.DEFAULT
         self.range: Range = Range.melee
         self.stack_level: int = 1
+        self.step_interval: int = 0
         self.on_positive_status: Optional[ResponseStatus] = None
         self.on_negative_status: Optional[ResponseStatus] = None
         self.on_tech_use: Optional[str] = None
@@ -119,6 +120,10 @@ class Status:
         """Returns the monster linked to this status effect."""
         return self._linked_monster
 
+    @property
+    def nr_turn(self) -> int:
+        return self._nr_turn
+
     def load(self, slug: str) -> None:
         """
         Loads and sets this status's attributes from the status
@@ -143,6 +148,7 @@ class Status:
 
         self.modifiers = ModifiersHandler(results.modifiers)
         self.behaviors = results.behaviors
+        self.step_interval = results.step_interval
         # monster stats
         self.stat_modifiers = results.stat_modifiers
 
@@ -202,11 +208,11 @@ class Status:
 
     def has_reached_duration(self) -> bool:
         """Checks if the status has reached or exceeded its duration."""
-        return self.nr_turn >= self.duration > 0
+        return self._nr_turn >= self.duration > 0
 
     def has_exceeded_duration(self) -> bool:
         """Checks if the status has lasted beyond its intended duration."""
-        return self.nr_turn > self.duration
+        return self._nr_turn > self.duration
 
     def use(self, session: Session, phase: EffectPhase) -> StatusEffectResult:
         """
@@ -218,6 +224,33 @@ class Status:
             source=self,
         )
         return result
+
+    def tick_turn(self) -> None:
+        """
+        Advance the turn counter for this status.
+        Only increments nr_turn if the status has a defined duration (> 0).
+        """
+        if self.duration > 0:
+            self._nr_turn += 1
+            logger.debug(
+                f"[Status Duration] {self.slug} turn {self._nr_turn} "
+                f"of {self.duration} at stack {self.stack_level}."
+            )
+
+    def stack(self) -> None:
+        """
+        Increments the status stack level up to MAX_STACKS and
+        resets the turn counter (nr_turn) and the use counter (counter)
+        to refresh the duration and uses.
+        """
+        old_stack = self.stack_level
+        self.stack_level = min(old_stack + 1, self.MAX_STACKS)
+        self._nr_turn = 0
+        self.counter = 0
+        logger.debug(
+            f"Status '{self.slug}' stacked from {old_stack} to {self.stack_level}. "
+            f"Duration/Uses refreshed."
+        )
 
     def get_state(self) -> Mapping[str, Any]:
         """

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -54,6 +54,7 @@ class Status:
         save_data = save_data or {}
         self._host: Monster = host
         self._steps: float = steps
+        self._linked_monster: Optional[Monster] = None
 
         self._effect_applied: set[str] = set()
 
@@ -67,7 +68,6 @@ class Status:
         self.flip_axes: FlipAxes = FlipAxes.NONE
         self.gain_cond: str = ""
         self.icon: str = ""
-        self.linked_monster: Optional[Monster] = None
         self.name: str = ""
         self.nr_turn: int = 0
         self.duration: int = 0
@@ -104,6 +104,20 @@ class Status:
         method = cls(host, steps, save_data)
         method.load(slug)
         return method
+
+    @property
+    def host(self) -> Monster:
+        """Returns the monster associated with this status."""
+        return self._host
+
+    @property
+    def steps(self) -> float:
+        return self._steps
+
+    @property
+    def linked_monster(self) -> Optional[Monster]:
+        """Returns the monster linked to this status effect."""
+        return self._linked_monster
 
     def load(self, slug: str) -> None:
         """
@@ -182,17 +196,9 @@ class Status:
         """
         return self.condition_handler.validate(session=session, target=target)
 
-    def get_host(self) -> Monster:
-        """Returns the monster associated with this status."""
-        return self._host
-
-    def get_linked_monster(self) -> Optional[Monster]:
-        """Returns the monster linked to this status effect."""
-        return self.linked_monster
-
     def set_linked_monster(self, monster: Monster) -> None:
         """Assigns a linked monster that benefits from this status."""
-        self.linked_monster = monster
+        self._linked_monster = monster
 
     def has_reached_duration(self) -> bool:
         """Checks if the status has reached or exceeded its duration."""


### PR DESCRIPTION
waiting
- [x] #3216

PR removes the `get_host` and `get_linked_monster` methods from the `Status` class and replaces them with two read-only properties: `host` and `linked_monster`. The `linked_monster` attribute is now stored privately as `self._linked_monster`, mirroring the existing private storage of `host`. Both are exposed via `@property` decorators to improve clarity and encapsulation. Setters are intentionally omitted, as assignment is handled through a dedicated method.