### PR TITLE
 Refactor: Replace `get_current_status` Method with `current_status` Property

### DIFF
--- a/tests/tuxemon/test_monster_plague_handler.py
+++ b/tests/tuxemon/test_monster_plague_handler.py
@@ -104,7 +104,7 @@ class DummyMonster:
         self.weight = weight
         self.height = height
         self.status = MagicMock()
-        self.status.get_current_status = MagicMock(
+        self.status.current_status = MagicMock(
             return_value=MagicMock(slug=status_slug) if status_slug else None
         )
         self.held_item = held_item or MagicMock()

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -429,7 +429,7 @@ class CombatSession:
                 held_item = monster.held_item.get_item()
                 if held_item:
                     held_item.use(session, player, monster)
-                status = monster.status.get_current_status()
+                status = monster.status.current_status
                 if status:
                     status.use(session, EffectPhase.ON_DECISION)
 
@@ -499,12 +499,12 @@ class CombatSession:
 
         phase = EffectPhase.SWAP_MONSTER
 
-        entry_status = monster.status.get_current_status()
+        entry_status = monster.status.current_status
         if entry_status:
             entry_status.use(session, phase)
 
         if removed:
-            exit_status = removed.status.get_current_status()
+            exit_status = removed.status.current_status
             if exit_status:
                 exit_status.use(session, phase)
 
@@ -524,7 +524,7 @@ class CombatSession:
         or other conditions that change the chosen technique.
         """
         logger.debug(f"[PreCheck Start] {monster.name} using {technique.slug}")
-        status = monster.status.get_current_status()
+        status = monster.status.current_status
         if status:
             result_status = status.use(session, EffectPhase.PRE_CHECKING)
             if result_status.techniques:
@@ -556,7 +556,7 @@ class CombatSession:
         )
 
         status_result = None
-        status = user.status.get_current_status()
+        status = user.status.current_status
         if status:
             status_result = status.use(session, EffectPhase.PERFORM_TECH)
             if status_result.statuses:
@@ -578,7 +578,7 @@ class CombatSession:
         )
 
         if target:
-            status = target.status.get_current_status()
+            status = target.status.current_status
             if result.success and status:
                 status.use(session, EffectPhase.PERFORM_ITEM)
         return result

--- a/tuxemon/core/effects/remove.py
+++ b/tuxemon/core/effects/remove.py
@@ -48,7 +48,7 @@ class RemoveEffect(CoreEffect):
                 objectives, user, target
             )
             for monster in monsters:
-                current_status = monster.status.get_current_status()
+                current_status = monster.status.current_status
                 if self.status == "all":
                     monster.status.clear_status(session)
                 elif (

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -636,7 +636,7 @@ def calculate_status_modifier(item: Item, target: Monster) -> float:
     config = config_capdev.items.get(item.slug)
     status_modifier = config_capdev.status_modifier
 
-    status = target.status.get_current_status()
+    status = target.status.current_status
     if config is None or status is None:
         return status_modifier
 

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -594,7 +594,7 @@ class Monster:
         self.moves.full_recharge_moves()
 
         if not self.status.is_fainted:
-            current_status = self.status.get_current_status()
+            current_status = self.status.current_status
             if (
                 current_status
                 and not current_status.behaviors.persists_after_combat
@@ -604,7 +604,7 @@ class Monster:
         if self.is_fainted:
             self.current_hp = 0
             self.status.apply_faint(self)
-            current = self.status.get_current_status()
+            current = self.status.current_status
             if current:
                 current.use(session, EffectPhase.ON_FAINT)
 

--- a/tuxemon/monster_dir/filter.py
+++ b/tuxemon/monster_dir/filter.py
@@ -77,7 +77,7 @@ class MonsterFilter:
         self.clear_filters()
         self.add_filter(
             lambda monster: (
-                (status := monster.status.get_current_status()) is not None
+                (status := monster.status.current_status) is not None
                 and status.slug == status_slug
             )
         )

--- a/tuxemon/monster_dir/plague.py
+++ b/tuxemon/monster_dir/plague.py
@@ -137,7 +137,7 @@ class MonsterPlagueHandler:
         )
 
         # Status-based resistance
-        current_status = monster.status.get_current_status()
+        current_status = monster.status.current_status
         if current_status:
             resistance *= plague_config.resistance_modifiers.get(
                 "statuses", {}

--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -43,7 +43,8 @@ class MonsterStatusHandler:
     def is_fainted(self) -> bool:
         return self.has_status("faint")
 
-    def get_current_status(self) -> Optional[Status]:
+    @property
+    def current_status(self) -> Optional[Status]:
         if not self.status:
             return None
         return self.status[0]
@@ -87,7 +88,7 @@ class MonsterStatusHandler:
                 blocked_reason=BlockedReason.IMMUNE_BY_ITEM,
             )
 
-        current_status = self.get_current_status()
+        current_status = self.current_status
         if current_status is None:
             logger.debug("No current status, applying new status directly.")
             self.add_status(new_status)
@@ -160,7 +161,7 @@ class MonsterStatusHandler:
 
     def clear_status(self, session: Session) -> None:
         """Clears the current status effect for monsters in combat."""
-        current_status = self.get_current_status()
+        current_status = self.current_status
         if current_status:
             current_status.use(session, EffectPhase.ON_END)
             self.status.clear()
@@ -186,7 +187,7 @@ class MonsterStatusHandler:
         """
         Checks if a status is expired by its use counter. If so, clears it.
         """
-        current_status = self.get_current_status()
+        current_status = self.current_status
         if current_status and current_status.is_use_expired(max_uses=max_uses):
             self.clear_status(session)
             return True

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -158,7 +158,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         Cause player to run from the wild encounters.
         """
         run = Technique.create("menu_run")
-        status = self.monster.status.get_current_status()
+        status = self.monster.status.current_status
         message = status.name.lower() if status else ""
         if not run.validate_monster(self.session, self.monster):
             params = {
@@ -179,7 +179,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         def swap_it(menuitem: MenuItem[Monster]) -> None:
             added = menuitem.game_object
             swap = Technique.create("swap")
-            status = self.monster.status.get_current_status()
+            status = self.monster.status.current_status
             message = status.name.lower() if status else ""
             if not swap.validate_monster(self.session, self.monster):
                 params = {
@@ -269,7 +269,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             target = menu_item.game_object
 
             # check target status
-            status = target.status.get_current_status()
+            status = target.status.current_status
             if status:
                 result_status = status.use(
                     self.session, EffectPhase.ENQUEUE_ITEM

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -869,7 +869,7 @@ class CombatState(CombatAnimations):
         Parameters:
             monster: Monster that was defeated.
         """
-        status = monster.status.get_current_status()
+        status = monster.status.current_status
         if status:
             result_status = status.use(
                 self.session, EffectPhase.CHECK_PARTY_HP


### PR DESCRIPTION
waiting
- [x] #3216

PR removes the `get_current_status` method from the `Status` class and introduces a read-only `current_status` property in its place. The property directly returns the current status value.