### PR TITLE
Clearer language for when Nodding Off condition ends "X wakes up!"

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1848,7 +1848,7 @@ msgid "combat_state_dozing_get"
 msgstr "{target} is asleep."
 
 msgid "combat_state_dozing_end"
-msgstr "{target} dozes off!"
+msgstr "{target} wakes up!"
 
 msgid "combat_state_enraged_get"
 msgstr "{target} is enraged."


### PR DESCRIPTION
End of dozing dialogue referred to "X dozes off!" - which implies the monster is still asleep. This clarifies by changing it to "X wakes up!"