### PR TITLE
No XP if monster is at max XP - stops divide by zero crash

### DIFF
--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -199,7 +199,6 @@ class Monster:
         """Progress toward the next level as a percentage (0.0 to 1.0)."""
         return self.experience_handler.experience_progress_percent
 
-
     @property
     def armour(self) -> int:
         return self.base_stats.armour

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -195,6 +195,12 @@ class Monster:
         return self.experience_handler.got_experience
 
     @property
+    def experience_progress_percent(self) -> float:
+        """Progress toward the next level as a percentage (0.0 to 1.0)."""
+        return self.experience_handler.experience_progress_percent
+
+
+    @property
     def armour(self) -> int:
         return self.base_stats.armour
 

--- a/tuxemon/monster_dir/experience.py
+++ b/tuxemon/monster_dir/experience.py
@@ -102,12 +102,18 @@ class MonsterExperience:
     def experience_progress_percent(self) -> float:
         """The monster's progress toward the next level (0.0 to 1.0)."""
         if self.is_maxed_out:
-            return 1.0
+            return 1.0  # Maxed out, so progress is full.
+
         earned = self.experience_current_level
         required = self.experience_for_next_level
+
         if required <= 0:
-            return 0.0  # Should only happen if level formula is non-monotonic
-        return earned / required
+            return 0.0  # Avoid dividing by zero or negative XP requirements.
+
+        progress = earned / required
+
+        # Clamp between 0.0 and 1.0 to keep visuals sane.
+        return max(0.0, min(1.0, progress))
 
     def set_level(self, level: int) -> None:
         """

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -308,32 +308,12 @@ class CombatAnimations(Menu[None], ABC):
             transition="out_quint",
         )
 
-    def calculate_bar_value(
-        self, total_experience: int, xp_start: int, xp_end: int
-    ) -> float:
-        """
-        Calculates normalized bar progress as a float between 0.0 and 1.0.
-        Prevents overflow/underflow visually.
-        """
-        if xp_end <= xp_start:
-            # Guard against invalid or max-level ranges where the denominator
-            # would be zero or negative.
-            if total_experience >= max(xp_start, xp_end):
-                return 1.0
-            return 0.0
-        return max(
-            0.0, min(1.0, (total_experience - xp_start) / (xp_end - xp_start))
-        )
 
     def animate_exp(self, monster: Monster) -> None:
         exp_bar = self.bars.get_exp_bar(monster)
 
         # Calculate the correct XP bar value for the current level
-        value_for_new_level = self.calculate_bar_value(
-            total_experience=monster.total_experience,
-            xp_start=monster.experience_required(),
-            xp_end=monster.experience_required(1),
-        )
+        value_for_new_level = monster.experience_progress_percent
 
         # Check if this monster should animate level-up transition
         if self.monsters_just_leveled_up.get(monster.slug, False):

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -315,6 +315,12 @@ class CombatAnimations(Menu[None], ABC):
         Calculates normalized bar progress as a float between 0.0 and 1.0.
         Prevents overflow/underflow visually.
         """
+        if xp_end <= xp_start:
+            # Guard against invalid or max-level ranges where the denominator
+            # would be zero or negative.
+            if total_experience >= max(xp_start, xp_end):
+                return 1.0
+            return 0.0
         return max(
             0.0, min(1.0, (total_experience - xp_start) / (xp_end - xp_start))
         )

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -308,7 +308,6 @@ class CombatAnimations(Menu[None], ABC):
             transition="out_quint",
         )
 
-
     def animate_exp(self, monster: Monster) -> None:
         exp_bar = self.bars.get_exp_bar(monster)
 


### PR DESCRIPTION
I used the cheats to get a team of level 99 monsters, and crashed because the game tried to divide by 0 (the amount of XP "needed" for the monster).

I believe this should fix it. 