### PR TITLE
Map Event Handling Refactor

### DIFF
--- a/tuxemon/event/actions/load_yaml.py
+++ b/tuxemon/event/actions/load_yaml.py
@@ -49,5 +49,5 @@ class LoadYamlAction(EventAction):
         else:
             raise ValueError(f"{yaml_path} doesn't exist")
 
-        client.map_manager.events = _events
-        client.map_manager.inits = _inits
+        client.map_manager.set_events(_events)
+        client.map_manager.set_inits(_inits)

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -132,7 +132,7 @@ class EventEngine:
             self.running_events[map_event.id] = token
 
             if map_event in self.session.client.map_manager.inits:
-                self.session.client.map_manager.inits.remove(map_event)
+                self.session.client.map_manager.remove_init(map_event)
 
     def process_map_event(self, map_event: EventObject) -> None:
         """

--- a/tuxemon/map/map_manager.py
+++ b/tuxemon/map/map_manager.py
@@ -62,26 +62,9 @@ class MapManager:
 
     def __init__(self) -> None:
         """Initializes the manager state with no map loaded."""
-        self.events: Sequence[EventObject] = []
-        self.inits: list[EventObject] = []
         self.current_map: Optional[AbstractMap] = None
         self.maps: dict[str, Any] = {}
         self._map_type_slug: Optional[str] = None
-
-    def load_map(self, map_data: AbstractMap) -> None:
-        """Loads a new map, sets properties, and resets relevant events."""
-        self.current_map = map_data
-
-        self.events = map_data.events
-        self.inits = list(map_data.inits)
-        self.maps = map_data.maps
-
-        self._map_type_slug = map_data.map_type
-
-        if map_data.map_type not in MAP_TYPES:
-            logger.warning(
-                f"Invalid map type '{map_data.map_type}', defaulting to 'notype'."
-            )
 
     @property
     def map_slug(self) -> str:
@@ -154,6 +137,48 @@ class MapManager:
             f"Invalid or missing map type slug '{self._map_type_slug}', defaulting to 'notype'."
         )
         return MapType(name="notype")
+
+    @property
+    def events(self) -> Sequence[EventObject]:
+        return self.current_map.events if self.current_map else []
+
+    @property
+    def inits(self) -> Sequence[EventObject]:
+        return self.current_map.inits if self.current_map else []
+
+    def load_map(self, map_data: AbstractMap) -> None:
+        """Loads a new map, sets properties, and resets relevant events."""
+        self.current_map = map_data
+        self.maps = map_data.maps
+        self._map_type_slug = map_data.map_type
+
+        map_data.add_events([])
+        map_data.add_inits([])
+
+        if map_data.map_type not in MAP_TYPES:
+            logger.warning(
+                f"Invalid map type '{map_data.map_type}', defaulting to 'notype'."
+            )
+
+    def set_events(self, new_events: Sequence[EventObject]) -> None:
+        if self.current_map:
+            self.current_map.add_events(new_events)
+
+    def set_inits(self, new_inits: Sequence[EventObject]) -> None:
+        if self.current_map:
+            self.current_map.add_inits(new_inits)
+
+    def remove_event(self, event: EventObject) -> None:
+        if self.current_map:
+            updated = list(self.current_map.events)
+            updated.remove(event)
+            self.current_map.add_events(updated)
+
+    def remove_init(self, event: EventObject) -> None:
+        if self.current_map:
+            updated = list(self.current_map.inits)
+            updated.remove(event)
+            self.current_map.add_inits(updated)
 
     def get_map_filepath(self) -> Optional[str]:
         """Returns the filepath of the current map."""

--- a/tuxemon/map/map_tuxemon.py
+++ b/tuxemon/map/map_tuxemon.py
@@ -88,11 +88,11 @@ class AbstractMap(ABC):
 
     @property
     @abstractmethod
-    def events(self) -> Sequence[Any]: ...
+    def events(self) -> Sequence[EventObject]: ...
 
     @property
     @abstractmethod
-    def inits(self) -> Sequence[Any]: ...
+    def inits(self) -> Sequence[EventObject]: ...
 
     @property
     @abstractmethod
@@ -135,6 +135,14 @@ class AbstractMap(ABC):
 
     @abstractmethod
     def reload_tiles(self) -> None: ...
+
+    @abstractmethod
+    def add_events(self, new_events: Sequence[EventObject]) -> None:
+        """Append new events to the existing events list."""
+
+    @abstractmethod
+    def add_inits(self, new_inits: Sequence[EventObject]) -> None:
+        """Append new init events to the existing inits list."""
 
 
 class TuxemonMap(AbstractMap):


### PR DESCRIPTION
PR improves how map events and initialization actions are accessed and modified through `AbstractMap` and `MapManager`.

Changes in `AbstractMap`:
- added read-only properties: `events: Sequence[EventObject]` and `inits: Sequence[EventObject]`
- added abstract methods: `add_events`, `add_inits`, `remove_events` and `remove_inits`

Changes in `MapManager`:
- added read-only properties: `events: Sequence[EventObject]` and `inits: Sequence[EventObject]`
- updated `load_map()` to reset events and inits using `add_events([])` and `add_inits([])`
- added methods for explicit mutation: `set_events`, `set_inits`, `remove_events`, `remove_inits`