### PR TITLE
Prevent movement over tiles occupied by entities regardless of `enter_from` rules

### DIFF
--- a/tuxemon/movement.py
+++ b/tuxemon/movement.py
@@ -368,6 +368,10 @@ class Pathfinder:
         if tile_data is None:
             return False
 
+        # Check if tile is blocked by entity
+        if tile_data.entity is not None:
+            return False
+
         # Check if the reversed direction is in the tile's allowed entry directions.
         return pairs(direction) in tile_data.enter_from
 


### PR DESCRIPTION
PR fixes a movement bug introduced after changes to `RegionProperties`. Previously, if a tile had an `enter_from` rule set and was also occupied by an entity (e.g. a character or NPC), it was still possible to walk over that tile. This behavior was incorrect — entities should always block movement regardless of directional allowances.

The fix ensures that any tile containing an entity is treated as non-traversable, overriding `enter_from` permissions. This restores expected collision behavior and prevents unintended pathfinding through occupied tiles.

This issue was observed after checking PR #3239, where multiple `add_collision` calls were introduced without any accompanying explanation or rationale.