### PR TITLE
Visual Indicator for `SinkState` Activation

### DIFF
--- a/tuxemon/states/sink.py
+++ b/tuxemon/states/sink.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import ClassVar, Optional
 
+from pygame.draw import circle
+from pygame.surface import Surface
+
 from tuxemon.platform.events import PlayerInput
+from tuxemon.prepare import RED_COLOR
 from tuxemon.state.state import State
 
 
@@ -16,3 +20,15 @@ class SinkState(State):
 
     def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
         return None
+
+    def draw(self, surface: Surface) -> None:
+        indicator_size = 30  # pixels
+        # Position: bottom-right corner with a small margin
+        x = surface.get_width() - indicator_size - 8
+        y = surface.get_height() - indicator_size - 8
+        circle(
+            surface,
+            RED_COLOR,
+            (x + indicator_size // 2, y + indicator_size // 2),
+            indicator_size // 2,
+        )


### PR DESCRIPTION
PR introduces a small red circle rendered in the bottom-right corner of the screen (visible in the attached video) to signal that the screen is currently locked and player input is disabled. This visual cue appears when the `SinkState` is active, providing immediate feedback to modders and developers. It addresses a common issue where the lock state might remain in the stack unnoticed, potentially causing confusion or unintended behavior. With this addition, the presence of the input-blocking state becomes clearly visible, improving debugging and modding workflows.


https://github.com/user-attachments/assets/fbecd6f1-249c-4915-bc7c-51c13ffe6039

