### PR TITLE
Refactor Gamepad Input Handling with Strategy Pattern + Replace dict-based config with Pydantic models and validation

### DIFF
--- a/tests/tuxemon/test_config.py
+++ b/tests/tuxemon/test_config.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import io
+import threading
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import pygame
+import yaml
+
+from tuxemon.config import (
+    ControlsConfig,
+    InputConfig,
+    LoggingConfig,
+    TuxemonConfig,
+    TuxemonFullConfig,
+)
+
+
+def write_yaml(dir_path: Path, data) -> Path:
+    p = dir_path / "tuxemon.yaml"
+    p.write_text(yaml.safe_dump(data))
+    return p
+
+
+class TestTuxemonConfig(unittest.TestCase):
+    def test_defaults_load_when_no_file(self):
+        cfg = TuxemonConfig(config_path=None)
+        self.assertIsNotNone(cfg.config_model)
+        self.assertEqual(cfg.resolution, (1280, 720))
+        self.assertEqual(cfg.dialog_speed, "slow")
+
+    def test_load_partial_yaml_merges_with_defaults(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            partial = {
+                "display": {"resolution_x": 800},
+                "gameplay": {"music_volume": 0.75},
+            }
+            path = write_yaml(td, partial)
+            cfg = TuxemonConfig(config_path=path)
+            self.assertEqual(cfg.resolution[0], 800)
+            self.assertAlmostEqual(cfg.music_volume, 0.75)
+            self.assertEqual(cfg.resolution[1], 720)
+            self.assertEqual(cfg.dialog_speed, "slow")
+
+    def test_invalid_enum_falls_back_to_defaults_and_reports(self):
+        with (
+            TemporaryDirectory() as td,
+            mock.patch("sys.stdout", new_callable=io.StringIO) as fake_out,
+        ):
+            td = Path(td)
+            bad = {
+                "gameplay": {"dialog_speed": "ultra_fast"},
+                "display": {"fps": 120},
+            }
+            path = write_yaml(td, bad)
+            cfg = TuxemonConfig(config_path=path)
+            output = fake_out.getvalue()
+            self.assertIn("Configuration validation failed", output)
+            self.assertEqual(cfg.dialog_speed, "slow")
+            self.assertEqual(cfg.fps, 60.0)
+
+    def test_volume_clamping_and_validation(self):
+        data = TuxemonFullConfig().model_dump()
+        data["gameplay"]["sound_volume"] = -1.0
+        data["gameplay"]["music_volume"] = 2.0
+        model = TuxemonFullConfig.model_validate(data)
+        self.assertEqual(model.gameplay.sound_volume, 0.0)
+        self.assertEqual(model.gameplay.music_volume, 1.0)
+
+    def test_update_locale_writes_font_fields(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            cfg_path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=cfg_path)
+
+            cfg.update_locale("zh_CN")
+            self.assertEqual(cfg.config_model.game.locale, "zh_CN")
+            self.assertIn("SourceHanSerifCN", cfg.config_model.game.font_file)
+            self.assertIn(
+                "SourceHanSerifCN", cfg.config_model.game.thin_font_file
+            )
+
+            cfg.update_locale("ja")
+            self.assertIn("SourceHanSerifJP", cfg.config_model.game.font_file)
+
+            cfg.update_locale("en_US")
+            self.assertEqual(
+                cfg.config_model.game.font_file, "PressStart2P.ttf"
+            )
+
+    def test_reset_controls_to_default(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            cfg_path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=cfg_path)
+
+            cfg.input.update_key("up", "w")
+            self.assertEqual(cfg.config_model.controls.up, "w")
+            cfg.reset_controls_to_default()
+            self.assertEqual(cfg.config_model.controls, ControlsConfig())
+            self.assertIn(None, cfg.input.keyboard_button_map)
+
+    def test_reload_config_applies_changes(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=path)
+            new = base.copy()
+            new["display"]["resolution_x"] = 640
+            path.write_text(yaml.safe_dump(new))
+            cfg.reload_config()
+            self.assertEqual(cfg.resolution[0], 640)
+
+    def test_save_load_roundtrip_full(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            cfg_path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=cfg_path)
+
+            cfg.config_model.display.resolution_x = 999
+            cfg.config_model.game.locale = "ja"
+            cfg.config_model.gameplay.sound_volume = 0.33
+            cfg.config_model.graphics.menu_sound = "new_sound"
+            cfg.config_model.player.player_runrate = 9.99
+            cfg.save_config()
+
+            cfg2 = TuxemonConfig(config_path=cfg_path)
+            self.assertEqual(cfg2.config_model.display.resolution_x, 999)
+            self.assertEqual(cfg2.config_model.game.locale, "ja")
+            self.assertAlmostEqual(
+                cfg2.config_model.gameplay.sound_volume, 0.33
+            )
+            self.assertEqual(
+                cfg2.config_model.graphics.menu_sound, "new_sound"
+            )
+            self.assertAlmostEqual(
+                cfg2.config_model.player.player_runrate, 9.99
+            )
+
+    def test_concurrent_read_write_race(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            cfg_path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=cfg_path)
+
+            stop = threading.Event()
+
+            def writer():
+                i = 0
+                while not stop.is_set():
+                    cfg.config_model.display.resolution_x = 1000 + (i % 100)
+                    cfg.save_config()
+                    i += 1
+                    time.sleep(0.001)
+
+            def reader():
+                while not stop.is_set():
+                    try:
+                        cfg.reload_config()
+                    except Exception as e:
+                        stop.set()
+                        raise
+
+            t_w = threading.Thread(target=writer)
+            t_r = threading.Thread(target=reader)
+            t_w.start()
+            t_r.start()
+            time.sleep(0.2)
+            stop.set()
+            t_w.join()
+            t_r.join()
+
+            self.assertIsInstance(cfg.resolution[0], int)
+
+    def test_save_config_without_path_raises(self):
+        cfg = TuxemonConfig(config_path=None)
+        cfg.config_model.display.resolution_x = 42
+        with self.assertRaises(RuntimeError):
+            cfg.save_config()
+
+    def test_reload_config_when_file_removed_raises(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=path)
+            path.unlink()
+            with self.assertRaises(RuntimeError):
+                cfg.reload_config()
+
+    def test_logging_config_parsing_multiple_loggers(self):
+        data = TuxemonFullConfig().model_dump()
+        data["logging"] = {
+            "loggers": "states.combat, event , neteria.client",
+            "debug_logging": True,
+            "debug_level": "info",
+            "dump_to_file": False,
+            "file_keep_max": 3,
+        }
+        model = TuxemonFullConfig.model_validate(data)
+        log_cfg = LoggingConfig(model)
+        self.assertIn("states.combat", log_cfg.loggers)
+        self.assertIn("neteria.client", log_cfg.loggers)
+        self.assertIn("event", log_cfg.loggers)
+
+    def test_inputconfig_keyboard_mapping_respects_controls(self):
+        base = TuxemonFullConfig().model_dump()
+        base["controls"]["up"] = "w"
+        base["controls"]["down"] = "s"
+        model = TuxemonFullConfig.model_validate(base)
+        input_cfg = InputConfig(model)
+
+        self.assertIn(None, input_cfg.keyboard_button_map)
+        if hasattr(pygame, "K_w"):
+            self.assertIn(
+                getattr(pygame, "K_w"), input_cfg.keyboard_button_map
+            )
+
+    def test_update_control_and_reload(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            base = TuxemonFullConfig().model_dump()
+            cfg_path = write_yaml(td, base)
+            cfg = TuxemonConfig(config_path=cfg_path)
+
+            cfg.update_control("up", pygame.K_w)
+            self.assertEqual(
+                cfg.config_model.controls.up, pygame.key.name(pygame.K_w)
+            )
+            cfg2 = TuxemonConfig(config_path=cfg_path)
+            self.assertEqual(
+                cfg2.config_model.controls.up, pygame.key.name(pygame.K_w)
+            )

--- a/tests/tuxemon/test_events_platformpygame.py
+++ b/tests/tuxemon/test_events_platformpygame.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
+from typing import Optional
 from unittest.mock import Mock
 
 import pygame as pg
@@ -13,11 +14,28 @@ from tuxemon.platform.events import PlayerInput
 from tuxemon.platform.platform_pygame.events import (
     HORIZONTAL_AXIS,
     VERTICAL_AXIS,
+    InputMappingStrategy,
     PygameGamepadInput,
     PygameKeyboardInput,
     PygameMouseInput,
     PygameTouchOverlayInput,
 )
+
+
+class MockMapping(InputMappingStrategy):
+    def map_button(self, raw_button_id: int):
+        return TestPygameGamepadInput.event_map.get(raw_button_id)
+
+    def map_axis(self, axis_id: int, value: float):
+        if axis_id == HORIZONTAL_AXIS:
+            button = buttons.RIGHT if value > 0 else buttons.LEFT
+        elif axis_id == VERTICAL_AXIS:
+            button = buttons.DOWN if value > 0 else buttons.UP
+        else:
+            return (None, False)
+
+        pressed = abs(value) > 0.2
+        return (button, pressed)
 
 
 class TestPygameGamepadInput(unittest.TestCase):
@@ -36,9 +54,8 @@ class TestPygameGamepadInput(unittest.TestCase):
             14: buttons.DOWN,
             7: buttons.START,
         }
-        cls.gamepad_input = PygameGamepadInput(
-            event_map=cls.event_map, deadzone=0.2
-        )
+        strategy = MockMapping()
+        cls.gamepad_input = PygameGamepadInput(strategy)
         cls.gamepad_input.press = Mock()
         cls.gamepad_input.release = Mock()
 
@@ -50,10 +67,6 @@ class TestPygameGamepadInput(unittest.TestCase):
         self.__class__.gamepad_input.press.reset_mock()
         self.__class__.gamepad_input.release.reset_mock()
 
-    def test_is_within_deadzone(self):
-        self.assertTrue(self.gamepad_input.is_within_deadzone(0.1))
-        self.assertFalse(self.gamepad_input.is_within_deadzone(0.3))
-
     def test_handle_button_press(self):
         self.gamepad_input.handle_button(buttons.A, True)
         self.gamepad_input.press.assert_called_once_with(buttons.A, 0.0)
@@ -64,44 +77,106 @@ class TestPygameGamepadInput(unittest.TestCase):
 
     def test_check_button_press(self):
         event = Event(pg.JOYBUTTONDOWN, button=0)
-        self.gamepad_input.check_button(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.press.assert_called_once_with(buttons.A, 0.0)
 
     def test_check_button_release(self):
         event = Event(pg.JOYBUTTONUP, button=0)
-        self.gamepad_input.check_button(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.release.assert_called_once_with(buttons.A)
 
-    def test_check_axis_horizontal_right(self):
+    def test_axis_horizontal_right(self):
         event = Event(pg.JOYAXISMOTION, axis=HORIZONTAL_AXIS, value=0.5)
-        self.gamepad_input.check_axis(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.press.assert_called_with(buttons.RIGHT, 0.5)
 
-    def test_check_axis_horizontal_left(self):
+    def test_axis_horizontal_left(self):
         event = Event(pg.JOYAXISMOTION, axis=HORIZONTAL_AXIS, value=-0.5)
-        self.gamepad_input.check_axis(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.press.assert_called_with(buttons.LEFT, 0.5)
 
-    def test_check_axis_vertical_down(self):
+    def test_axis_vertical_down(self):
         event = Event(pg.JOYAXISMOTION, axis=VERTICAL_AXIS, value=0.5)
-        self.gamepad_input.check_axis(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.press.assert_called_with(buttons.DOWN, 0.5)
 
-    def test_check_axis_vertical_up(self):
+    def test_axis_vertical_up(self):
         event = Event(pg.JOYAXISMOTION, axis=VERTICAL_AXIS, value=-0.5)
-        self.gamepad_input.check_axis(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.press.assert_called_with(buttons.UP, 0.5)
 
-    def test_check_axis_deadzone(self):
+    def test_axis_event_within_deadzone(self):
+        self.gamepad_input.axis_state[HORIZONTAL_AXIS] = -1
         event = Event(pg.JOYAXISMOTION, axis=HORIZONTAL_AXIS, value=0.1)
-        self.gamepad_input.check_axis(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.release.assert_any_call(buttons.LEFT)
-        self.gamepad_input.release.assert_any_call(buttons.RIGHT)
 
+        self.gamepad_input.axis_state[VERTICAL_AXIS] = -1
         event = Event(pg.JOYAXISMOTION, axis=VERTICAL_AXIS, value=0.1)
-        self.gamepad_input.check_axis(event)
+        self.gamepad_input.process_event(event)
         self.gamepad_input.release.assert_any_call(buttons.UP)
-        self.gamepad_input.release.assert_any_call(buttons.DOWN)
+
+    def test_check_button_ignores_non_button_event(self):
+        event = Event(pg.JOYAXISMOTION, axis=HORIZONTAL_AXIS, value=0.5)
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_not_called()
+        self.gamepad_input.release.assert_not_called()
+
+    def test_hat_motion_left_right(self):
+        self.gamepad_input.hat_state = (0, 0)
+
+        event = Event(pg.JOYHATMOTION, value=(-1, 0))
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_any_call(buttons.LEFT, 0.0)
+
+        self.gamepad_input.press.reset_mock()
+        self.gamepad_input.release.reset_mock()
+
+        event = Event(pg.JOYHATMOTION, value=(1, 0))
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.release.assert_any_call(buttons.LEFT)
+        self.gamepad_input.press.assert_any_call(buttons.RIGHT, 0.0)
+
+    def test_hat_motion_up_down(self):
+        event = Event(pg.JOYHATMOTION, value=(0, -1))
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_any_call(buttons.UP, 0.0)
+
+        event = Event(pg.JOYHATMOTION, value=(0, 1))
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_any_call(buttons.DOWN, 0.0)
+
+    def test_hat_release(self):
+        self.gamepad_input.hat_state = (-1, 0)
+        event = Event(pg.JOYHATMOTION, value=(0, 0))
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.release.assert_any_call(buttons.LEFT)
+
+    def test_axis_direction_change(self):
+        self.gamepad_input.axis_state[HORIZONTAL_AXIS] = 1
+        event = Event(pg.JOYAXISMOTION, axis=HORIZONTAL_AXIS, value=-0.6)
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.release.assert_any_call(buttons.RIGHT)
+        self.gamepad_input.press.assert_any_call(buttons.LEFT, 0.6)
+
+    def test_unknown_button(self):
+        event = Event(pg.JOYBUTTONDOWN, button=99)  # not in map
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_not_called()
+        self.gamepad_input.release.assert_not_called()
+
+    def test_unknown_axis(self):
+        event = Event(pg.JOYAXISMOTION, axis=99, value=0.5)
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_not_called()
+        self.gamepad_input.release.assert_not_called()
+
+    def test_axis_no_change(self):
+        self.gamepad_input.axis_state[HORIZONTAL_AXIS] = 1
+        event = Event(pg.JOYAXISMOTION, axis=HORIZONTAL_AXIS, value=0.6)
+        self.gamepad_input.process_event(event)
+        self.gamepad_input.press.assert_not_called()
+        self.gamepad_input.release.assert_not_called()
 
 
 class TestPygameMouseInput(unittest.TestCase):

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -4,146 +4,235 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import pygame
 import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from tuxemon.animation import Animation
-from tuxemon.constants import paths
-from tuxemon.constants.dialog_speed import DIALOG_SPEED_PROFILES
 from tuxemon.platform.const import buttons, events
 
 Animation.default_transition = "out_quint"
 
 
+class DisplayConfig(BaseModel):
+    """Configuration for the game display."""
+
+    resolution_x: int = 1280
+    resolution_y: int = 720
+    splash: bool = True
+    fullscreen: bool = False
+    fps: float = 60.0
+    vsync: bool = True
+    show_fps: bool = False
+    scaling: bool = True
+    collision_map: bool = False
+    large_gui: bool = False
+    window_caption: str = "Tuxemon"
+
+
+class GameConfig(BaseModel):
+    """General game and system configuration."""
+
+    data: str = "tuxemon"
+    cli_enabled: bool = False
+    net_controller_enabled: bool = False
+    dev_tools: bool = False
+    recompile_translations: bool = True
+    skip_titlescreen: bool = False
+    compress_save: Optional[str] = None
+    save_prefix: str = "slot"
+    save_extension: str = "save"
+    save_method: str = "json"
+    locale: str = "en_US"
+    translation_mode: str = "none"
+    font_file: str = "PressStart2P.ttf"
+    language_font: str = "PressStart2P.ttf"
+    thin_font_file: str = "Pizel.ttf"
+
+
+class GameplayConfig(BaseModel):
+    """Configuration for gameplay mechanics. Includes validation for volume and enums."""
+
+    items_consumed_on_failure: bool = True
+    encounter_rate_modifier: float = 1.0
+    dialog_speed: Literal["slow", "medium", "fast", "max"] = "slow"
+    unit_measure: Literal["metric", "imperial"] = "metric"
+    hemisphere: Literal["northern", "southern"] = "northern"
+    sound_volume: float = 0.2
+    music_volume: float = 0.5
+    combat_click_to_continue: bool = False
+
+    @field_validator("sound_volume", "music_volume")
+    def validate_volume(cls, v: float) -> float:
+        return max(0.0, min(v, 1.0))
+
+
+class GraphicsConfig(BaseModel):
+    dialog_box_style: str = "default"
+    menu_border: str = "gfx/borders/borders.png"
+    menu_cursor: str = "gfx/arrow.png"
+    menu_sound: str = "sound_menu_select"
+
+
+class PlayerConfig(BaseModel):
+    animation_speed: float = 0.15
+    player_walkrate: float = 3.75
+    player_runrate: float = 7.35
+
+
+class ControlsConfig(BaseModel):
+    up: str = "up"
+    down: str = "down"
+    left: str = "left"
+    right: str = "right"
+    a: str = "return"
+    b: str = "rshift, lshift"
+    back: str = "escape"
+    backspace: str = "backspace"
+
+
+class ControllerConfigModel(BaseModel):
+    type: Optional[str] = None
+    overlay: bool = False
+    transparency: int = 45
+    hide_mouse: bool = True
+    show_input_visualizer: bool = False
+
+
+class LoggingConfigModel(BaseModel):
+    loggers: str = "all"
+    debug_logging: bool = True
+    debug_level: Literal["debug", "info", "warning", "error", "critical"] = (
+        "error"
+    )
+    dump_to_file: bool = False
+    file_keep_max: int = 5
+
+
+class TuxemonFullConfig(BaseModel):
+    display: DisplayConfig = Field(default_factory=DisplayConfig)
+    game: GameConfig = Field(default_factory=GameConfig)
+    gameplay: GameplayConfig = Field(default_factory=GameplayConfig)
+    graphics: GraphicsConfig = Field(default_factory=GraphicsConfig)
+    player: PlayerConfig = Field(default_factory=PlayerConfig)
+    controls: ControlsConfig = Field(default_factory=ControlsConfig)
+    controller: ControllerConfigModel = Field(
+        default_factory=ControllerConfigModel
+    )
+    logging: LoggingConfigModel = Field(default_factory=LoggingConfigModel)
+
+
 class TuxemonConfig:
     """
-    Handles loading of the config file for the primary game and map editor.
-
-    Do not forget to edit the default configuration specified below!
+    Handles loading of the config file for the primary game and map editor,
+    leveraging Pydantic for robust data validation.
     """
 
+    config_model: TuxemonFullConfig
+
     def __init__(self, config_path: Optional[Path] = None) -> None:
-        # Default configuration dictionary
-        self.config = generate_default_config()
         self.config_path = config_path
 
-        # Load customized configuration if the YAML file exists
+        config_data: dict[str, Any] = TuxemonFullConfig().model_dump()
+
         if config_path and config_path.exists():
             with config_path.open() as yaml_file:
-                loaded_config = yaml.safe_load(yaml_file)
+                loaded_config = yaml.safe_load(yaml_file) or {}
 
-            # Merge only existing sections while keeping defaults
-            for category, defaults in self.config.items():
-                if category in loaded_config:
+            for category, defaults in config_data.items():
+                if category in loaded_config and isinstance(defaults, dict):
                     defaults.update(loaded_config[category])
+                elif category in loaded_config:
+                    config_data[category] = loaded_config[category]
 
-        self.load_config()
+        try:
+            self.config_model = TuxemonFullConfig.model_validate(config_data)
+        except ValidationError as e:
+            print(
+                f"Configuration validation failed. Falling back to defaults: {e}"
+            )
+            self.config_model = (
+                TuxemonFullConfig()
+            )  # Fallback to clean defaults
 
-        # Initialize other components
-        self.input = InputConfig(self.config)
-        self.controller = ControllerConfig(self.config)
-        self.logging = LoggingConfig(self.config)
-        self.locale = LocaleConfig(self.config)
+        self.load_config_attributes()
 
-        # not configurable from the file yet
+        self.input: InputConfig = InputConfig(self.config_model)
+        self.logging: LoggingConfig = LoggingConfig(self.config_model)
+        self.locale: LocaleConfig = LocaleConfig(self.config_model)
+        self.controller: ControllerConfig = ControllerConfig(self.config_model)
         self.mods = ["tuxemon"]
-        assert all(mod in paths.mods_subfolders for mod in self.mods)
 
     def save_config(self) -> None:
-        """Saves the configuration to a YAML file."""
+        """Saves the configuration from the Pydantic model to a YAML file."""
         if not self.config_path:
             raise RuntimeError("No path specified for saving configuration.")
+
+        config_dict = self.config_model.model_dump()
+
         with self.config_path.open("w") as yaml_file:
             yaml.dump(
-                self.config, yaml_file, default_flow_style=False, indent=4
+                config_dict, yaml_file, default_flow_style=False, indent=4
             )
 
-    def load_config(self) -> None:
+    def load_config_attributes(self) -> None:
+        """Assigns Pydantic model values to easy-access instance attributes."""
         # [display]
-        display = self.config["display"]
-        self.resolution: tuple[int, int] = (
-            display["resolution_x"],
-            display["resolution_y"],
+        display = self.config_model.display
+        self.resolution = (
+            display.resolution_x,
+            display.resolution_y,
         )
-        self.splash: bool = display["splash"]
-        self.fullscreen: bool = display["fullscreen"]
-        self.fps: float = display["fps"]
-        self.vsync: bool = display["vsync"]
-        self.show_fps: bool = display["show_fps"]
-        self.scaling: bool = display["scaling"]
-        self.collision_map: bool = display["collision_map"]
-        self.large_gui: bool = display["large_gui"]
-        self.window_caption: str = display["window_caption"]
+        self.splash = display.splash
+        self.fullscreen = display.fullscreen
+        self.fps = display.fps
+        self.vsync = display.vsync
+        self.show_fps = display.show_fps
+        self.scaling = display.scaling
+        self.collision_map = display.collision_map
+        self.large_gui = display.large_gui
+        self.window_caption = display.window_caption
 
         # [game]
-        game = self.config["game"]
-        self.data: str = game["data"]
-        self.cli: bool = game["cli_enabled"]
-        self.net_controller_enabled: bool = game["net_controller_enabled"]
-        self.dev_tools: bool = game["dev_tools"]
-        self.recompile_translations: bool = game["recompile_translations"]
-        self.skip_titlescreen: bool = game["skip_titlescreen"]
-        self.compress_save: Optional[str] = game["compress_save"] or None
-        self.save_prefix: str = game["save_prefix"]
-        self.save_extension: str = game["save_extension"]
-        self.save_method: str = game["save_method"]
-
-        thin_font_file = game.get("thin_font_file")
-        if game["locale"] == "zh_CN":
-            thin_font_file = "SourceHanSerifCN-Bold.otf"
-        elif game["locale"] == "ja":
-            thin_font_file = "SourceHanSerifJP-Bold.otf"
-        else:
-            thin_font_file = "Pizel.ttf"
-
-        game["thin_font_file"] = thin_font_file
+        game = self.config_model.game
+        self.data = game.data
+        self.cli = game.cli_enabled
+        self.net_controller_enabled = game.net_controller_enabled
+        self.dev_tools = game.dev_tools
+        self.recompile_translations = game.recompile_translations
+        self.skip_titlescreen = game.skip_titlescreen
+        self.compress_save = game.compress_save
+        self.save_prefix = game.save_prefix
+        self.save_extension = game.save_extension
+        self.save_method = game.save_method
 
         # [gameplay]
-        gameplay = self.config["gameplay"]
-        self.items_consumed_on_failure: bool = gameplay[
-            "items_consumed_on_failure"
-        ]
-        self.encounter_rate_modifier: float = gameplay[
-            "encounter_rate_modifier"
-        ]
-        self.dialog_speed: str = gameplay["dialog_speed"]
-        if self.dialog_speed not in DIALOG_SPEED_PROFILES:
-            raise ValueError(
-                f"Invalid value for dialog_speed. Allowed: {', '.join(DIALOG_SPEED_PROFILES.keys())}"
-            )
-        self.unit_measure: str = gameplay["unit_measure"]
-        if self.unit_measure not in ("metric", "imperial"):
-            raise ValueError(
-                "Invalid value for unit_measure. Allowed: 'metric', 'imperial'"
-            )
-        self.hemisphere: str = gameplay["hemisphere"]
-        if self.hemisphere not in ("northern", "southern"):
-            raise ValueError(
-                "Invalid value for hemisphere. Allowed: 'northern', 'southern'"
-            )
+        gameplay = self.config_model.gameplay
+        self.items_consumed_on_failure = gameplay.items_consumed_on_failure
+        self.encounter_rate_modifier = gameplay.encounter_rate_modifier
 
-        sound_volume = float(gameplay["sound_volume"])
-        self.sound_volume: float = max(0.0, min(sound_volume, 1.0))
-        music_volume = float(gameplay["music_volume"])
-        self.music_volume: float = max(0.0, min(music_volume, 1.0))
-        self.combat_click_to_continue: bool = gameplay[
-            "combat_click_to_continue"
-        ]
+        self.dialog_speed = gameplay.dialog_speed
+        self.unit_measure = gameplay.unit_measure
+        self.hemisphere = gameplay.hemisphere
+
+        self.sound_volume = gameplay.sound_volume
+        self.music_volume = gameplay.music_volume
+        self.combat_click_to_continue = gameplay.combat_click_to_continue
 
         # [graphics]
-        graphics = self.config["graphics"]
-        self.dialog_box_style: str = graphics["dialog_box_style"]
-        self.menu_border: str = graphics["menu_border"]
-        self.menu_cursor: str = graphics["menu_cursor"]
-        self.menu_sound: str = graphics["menu_sound"]
+        graphics = self.config_model.graphics
+        self.dialog_box_style = graphics.dialog_box_style
+        self.menu_border = graphics.menu_border
+        self.menu_cursor = graphics.menu_cursor
+        self.menu_sound = graphics.menu_sound
 
         # [player]
-        player = self.config["player"]
-        self.player_animation_speed: float = player["animation_speed"]
-        self.player_walkrate: float = player["player_walkrate"]
-        self.player_runrate: float = player["player_runrate"]
+        player = self.config_model.player
+        self.animation_speed = player.animation_speed
+        self.player_walkrate = player.player_walkrate
+        self.player_runrate = player.player_runrate
 
     def reload_config(self) -> None:
         if not self.config_path or not self.config_path.exists():
@@ -152,30 +241,33 @@ class TuxemonConfig:
             )
 
         with self.config_path.open() as yaml_file:
-            self.config.update(yaml.safe_load(yaml_file))
-        self.load_config()
-        self.input.config = self.config
-        self.input.reload_input_map()
+            loaded_config = yaml.safe_load(yaml_file) or {}
 
-        self.locale.slug = self.config["game"]["locale"]
-        self.locale.translation_mode = self.config["game"]["translation_mode"]
-        self.locale.font_file = self.config["game"]["language_font"]
-        self.locale.thin_font_file = self.config["game"].get(
-            "thin_font_file", "Pizel.ttf"
-        )
+        current_config = self.config_model.model_dump()
+        for category, defaults in current_config.items():
+            if category in loaded_config and isinstance(defaults, dict):
+                defaults.update(loaded_config[category])
+            elif category in loaded_config:
+                current_config[category] = loaded_config[category]
+
+        self.config_model = TuxemonFullConfig.model_validate(current_config)
+
+        self.load_config_attributes()
+
+        self.input.reload_input_map()
+        self.locale.slug = self.config_model.game.locale
+        self.locale.translation_mode = self.config_model.game.translation_mode
+        self.locale.font_file = self.config_model.game.language_font
+        self.locale.thin_font_file = self.config_model.game.thin_font_file
 
     def update_attribute(
-        self, section: str, attribute: str, value: str
+        self, section: str, attribute: str, value: Any
     ) -> None:
         """
-        Updates the attribute's value in the tuxemon.yaml.
-
-        Parameters:
-            section: the section (eg. gameplay)
-            attribute: the attribute (eg. dialog_speed)
-            value: the value (eg slow or max)
+        Updates the attribute's value in the Pydantic model and saves/reloads.
         """
-        self.config[section][attribute] = value
+        sub_model = getattr(self.config_model, section)
+        setattr(sub_model, attribute, value)
         self.save_config()
         self.reload_config()
 
@@ -185,20 +277,27 @@ class TuxemonConfig:
         self.reload_config()
 
     def update_locale(self, value: str) -> None:
-        self.config["game"]["locale"] = value
-        self.locale.slug = value
+        """Handles locale update and derived font file changes."""
+
+        # Set the base locale value on the Pydantic model
+        self.config_model.game.locale = value
+
+        # Apply the derived font logic
         if value == "zh_CN":
-            self.locale.font_file = "SourceHanSerifCN-Bold.otf"
+            font_file = "SourceHanSerifCN-Bold.otf"
             thin_font = "SourceHanSerifCN-Bold.otf"
         elif value == "ja":
-            self.locale.font_file = "SourceHanSerifJP-Bold.otf"
+            font_file = "SourceHanSerifJP-Bold.otf"
             thin_font = "SourceHanSerifJP-Bold.otf"
         else:
-            self.locale.font_file = "PressStart2P.ttf"
+            font_file = "PressStart2P.ttf"
             thin_font = "Pizel.ttf"
-        self.locale.thin_font_file = thin_font
-        self.config["game"]["language_font"] = self.locale.font_file
-        self.config["game"]["thin_font_file"] = thin_font
+
+        # Update the font attributes on the Pydantic model
+        self.config_model.game.language_font = font_file
+        self.config_model.game.font_file = font_file
+        self.config_model.game.thin_font_file = thin_font
+
         self.save_config()
         self.reload_config()
 
@@ -211,31 +310,31 @@ class TuxemonConfig:
 class ControllerConfig:
     """Handles controller-related configurations."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
-        controller = config["controller"]
-        self.type: Optional[str] = controller.get("type")
-        self.overlay: bool = controller["overlay"]
-        self.transparency: int = controller["transparency"]
-        self.hide_mouse: bool = controller["hide_mouse"]
-        self.show_input_visualizer: bool = controller["show_input_visualizer"]
+    def __init__(self, config_model: TuxemonFullConfig) -> None:
+        controller = config_model.controller
+        self.type = controller.type
+        self.overlay = controller.overlay
+        self.transparency = controller.transparency
+        self.hide_mouse = controller.hide_mouse
+        self.show_input_visualizer = controller.show_input_visualizer
 
 
 class LocaleConfig:
     """Handles locale-related configurations."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
-        game = config["game"]
-        self.slug: str = game["locale"]
-        self.translation_mode: str = game["translation_mode"]
-        self.font_file: str = game["font_file"]
-        self.thin_font_file: str = game.get("thin_font_file")
+    def __init__(self, config_model: TuxemonFullConfig) -> None:
+        game = config_model.game
+        self.slug = game.locale
+        self.translation_mode = game.translation_mode
+        self.font_file = game.font_file
+        self.thin_font_file = game.thin_font_file
 
 
 class InputConfig:
     """Handles input-related configurations."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
-        self.config = config
+    def __init__(self, config_model: TuxemonFullConfig) -> None:
+        self.config_model = config_model
         self.keyboard_button_map = self._get_custom_pygame_keyboard_controls()
 
     def _get_custom_pygame_keyboard_controls(
@@ -245,48 +344,46 @@ class InputConfig:
         Returns a dictionary mapping pygame key constants to custom button values.
         """
         custom_controls: dict[Optional[int], int] = {None: events.UNICODE}
-        for key, values in self.config["controls"].items():
+
+        for key, values in self.config_model.controls.model_dump().items():
             key = key.upper()
             button_value: Optional[int] = getattr(buttons, key, None)
             event_value: Optional[int] = getattr(events, key, None)
+
+            internal_value = (
+                button_value if button_value is not None else event_value
+            )
+            if internal_value is None:
+                continue
+
             for each in values.split(", "):
                 each = each.lower() if len(each) == 1 else each.upper()
                 pygame_value: Optional[int] = getattr(
                     pygame, "K_" + each, None
                 )
-                if pygame_value is not None and button_value is not None:
-                    custom_controls[pygame_value] = button_value
-                elif pygame_value is not None and event_value is not None:
-                    custom_controls[pygame_value] = event_value
+                if pygame_value is not None:
+                    custom_controls[pygame_value] = internal_value
+
         return custom_controls
 
     def update_key(self, value: str, key_name: str) -> None:
-        self.config["controls"][value] = key_name
+        """Updates a key binding on the Pydantic controls model."""
+        setattr(self.config_model.controls, value, key_name)
         self.reload_input_map()
 
     def reload_input_map(self) -> None:
         self.keyboard_button_map = self._get_custom_pygame_keyboard_controls()
 
     def reset_to_default(self) -> None:
-        default_controls = {
-            "up": "up",
-            "down": "down",
-            "left": "left",
-            "right": "right",
-            "a": "return",
-            "b": "rshift, lshift",
-            "back": "escape",
-            "backspace": "backspace",
-        }
-        for button, key in default_controls.items():
-            self.config["controls"][button] = key
+        """Resets the controls section to the defaults defined in the ControlsConfig model."""
+        self.config_model.controls = ControlsConfig()
         self.reload_input_map()
 
 
 class LoggingConfig:
     """Handles logging-related configurations."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config_model: TuxemonFullConfig) -> None:
         # [logging]
         # Log levels can be: debug, info, warning, error, or critical
         # Setting loggers to "all" will enable debug logging for all modules.
@@ -294,98 +391,10 @@ class LoggingConfig:
         #     states.combat, states.world, event,
         #     neteria.server, neteria.client, neteria.core
         # Comma-separated list of which modules to enable logging on
-        log = config["logging"]
-        loggers_str: str = log["loggers"]
+        log = config_model.logging
+        loggers_str: str = log.loggers
         self.loggers = loggers_str.replace(" ", "").split(",")
-        self.debug_logging: bool = log["debug_logging"]
-        self.debug_level: str = log["debug_level"]
-        self.log_to_file: bool = log["dump_to_file"]
-        self.log_keep_max: int = log["file_keep_max"]
-
-
-def generate_default_config() -> dict[str, Any]:
-    """
-    Generate a config from defaults.
-
-    When making game changes, do not forget to edit this config!
-
-    Returns:
-        Mapping of default values.
-    """
-    return {
-        "display": {
-            "resolution_x": 1280,
-            "resolution_y": 720,
-            "splash": True,
-            "fullscreen": False,
-            "fps": 60.0,
-            "vsync": True,
-            "show_fps": False,
-            "scaling": True,
-            "collision_map": False,
-            "large_gui": False,
-            "window_caption": "Tuxemon",
-        },
-        "game": {
-            "data": "tuxemon",
-            "cli_enabled": False,
-            "net_controller_enabled": False,
-            "dev_tools": False,
-            "recompile_translations": True,
-            "skip_titlescreen": False,
-            "compress_save": None,
-            "save_prefix": "slot",
-            "save_extension": "save",
-            "save_method": "json",
-            "locale": "en_US",
-            "translation_mode": "none",
-            "font_file": "PressStart2P.ttf",
-            "language_font": "PressStart2P.ttf",
-            "thin_font_file": "Pizel.ttf",
-        },
-        "gameplay": {
-            "items_consumed_on_failure": True,
-            "encounter_rate_modifier": 1.0,
-            "dialog_speed": "slow",
-            "unit_measure": "metric",
-            "hemisphere": "northern",
-            "sound_volume": 0.2,
-            "music_volume": 0.5,
-            "combat_click_to_continue": False,
-        },
-        "graphics": {
-            "dialog_box_style": "default",
-            "menu_border": "gfx/borders/borders.png",
-            "menu_cursor": "gfx/arrow.png",
-            "menu_sound": "sound_menu_select",
-        },
-        "player": {
-            "animation_speed": 0.15,
-            "player_walkrate": 3.75,
-            "player_runrate": 7.35,
-        },
-        "controls": {
-            "up": "up",
-            "down": "down",
-            "left": "left",
-            "right": "right",
-            "a": "return",
-            "b": "rshift, lshift",
-            "back": "escape",
-            "backspace": "backspace",
-        },
-        "controller": {
-            "type": None,
-            "overlay": False,
-            "transparency": 45,
-            "hide_mouse": True,
-            "show_input_visualizer": False,
-        },
-        "logging": {
-            "loggers": "all",
-            "debug_logging": True,
-            "debug_level": "error",
-            "dump_to_file": False,
-            "file_keep_max": 5,
-        },
-    }
+        self.debug_logging = log.debug_logging
+        self.debug_level = log.debug_level
+        self.log_to_file = log.dump_to_file
+        self.log_keep_max = log.file_keep_max

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -209,11 +209,12 @@ class ControllerConfig:
     """Handles controller-related configurations."""
 
     def __init__(self, config: dict[str, Any]) -> None:
-        display = config["display"]
-        self.overlay: bool = display["controller_overlay"]
-        self.transparency: int = display["controller_transparency"]
-        self.hide_mouse: bool = display["hide_mouse"]
-        self.show_input_visualizer: bool = display["show_input_visualizer"]
+        controller = config["controller"]
+        self.type: Optional[str] = controller.get("type")
+        self.overlay: bool = controller["overlay"]
+        self.transparency: int = controller["transparency"]
+        self.hide_mouse: bool = controller["hide_mouse"]
+        self.show_input_visualizer: bool = controller["show_input_visualizer"]
 
 
 class LocaleConfig:
@@ -232,8 +233,6 @@ class InputConfig:
 
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
-        self.gamepad_deadzone: float = 0.25
-        self.gamepad_button_map = None
         self.keyboard_button_map = self._get_custom_pygame_keyboard_controls()
 
     def _get_custom_pygame_keyboard_controls(
@@ -323,10 +322,6 @@ def generate_default_config() -> dict[str, Any]:
             "collision_map": False,
             "large_gui": False,
             "window_caption": "Tuxemon",
-            "controller_overlay": False,
-            "controller_transparency": 45,
-            "hide_mouse": True,
-            "show_input_visualizer": False,
         },
         "game": {
             "data": "tuxemon",
@@ -372,6 +367,13 @@ def generate_default_config() -> dict[str, Any]:
             "b": "rshift, lshift",
             "back": "escape",
             "backspace": "backspace",
+        },
+        "controller": {
+            "type": None,
+            "overlay": False,
+            "transparency": 45,
+            "hide_mouse": True,
+            "show_input_visualizer": False,
         },
         "logging": {
             "loggers": "all",

--- a/tuxemon/platform/input_manager.py
+++ b/tuxemon/platform/input_manager.py
@@ -12,11 +12,14 @@ from tuxemon.platform.combo_detector import ComboManager
 from tuxemon.platform.input_history import InputHistory
 from tuxemon.platform.input_visualizer import InputVisualizer
 from tuxemon.platform.platform_pygame.events import (
+    InputMappingStrategy,
+    PlayStationMapping,
     PygameEventQueueHandler,
     PygameGamepadInput,
     PygameKeyboardInput,
     PygameMouseInput,
     PygameTouchOverlayInput,
+    XboxMapping,
 )
 from tuxemon.prepare import SCREEN_SIZE
 
@@ -76,12 +79,23 @@ class InputManager:
         """
         Sets up the gamepad input device.
         """
-        if self.input.gamepad_button_map:
-            gamepad = PygameGamepadInput(
-                self.input.gamepad_button_map, self.input.gamepad_deadzone
-            )
+        if self.controller.type:
+            strategy = self._get_mapping_strategy(self.controller.type)
+            gamepad = PygameGamepadInput(strategy)
             self.event_queue.add_input(0, gamepad)
-            logger.info("Gamepad set up successfully")
+            logger.info(
+                f"{self.controller.type.capitalize()} gamepad set up successfully"
+            )
+
+    def _get_mapping_strategy(
+        self, controller_type: str
+    ) -> InputMappingStrategy:
+        if controller_type == "xbox":
+            return XboxMapping()
+        elif controller_type == "ps4":
+            return PlayStationMapping()
+        else:
+            raise ValueError(f"Unsupported controller type: {controller_type}")
 
     def setup_controller_overlay(self) -> None:
         """

--- a/tuxemon/platform/input_manager.py
+++ b/tuxemon/platform/input_manager.py
@@ -47,7 +47,7 @@ class InputManager:
         self.setup_inputs()
         self.combo_manager = ComboManager()
         self.input_visualizer = InputVisualizer(SCREEN_SIZE)
-        self.show_visualizer = config.controller.show_input_visualizer
+        self.show_visualizer = self.controller.show_input_visualizer
 
     def setup_inputs(self) -> None:
         """

--- a/tuxemon/platform/platform_pygame/events.py
+++ b/tuxemon/platform/platform_pygame/events.py
@@ -1,5 +1,8 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from collections.abc import Generator, Mapping
 from typing import Any, ClassVar, Optional, TypedDict
@@ -18,6 +21,8 @@ from tuxemon.platform.events import (
 )
 from tuxemon.session import local_session
 from tuxemon.ui.draw import blit_alpha
+
+logger = logging.getLogger(__name__)
 
 HORIZONTAL_AXIS = 0
 VERTICAL_AXIS = 1
@@ -71,6 +76,74 @@ class PygameEventQueueHandler(EventQueueHandler):
                 yield from player_input.get_events()
 
 
+class InputMappingStrategy:
+    def map_button(self, raw_button_id: int) -> Optional[int]:
+        raise NotImplementedError
+
+    def map_axis(
+        self, axis_id: int, value: float
+    ) -> tuple[Optional[int], bool]:
+        raise NotImplementedError
+
+
+class XboxMapping(InputMappingStrategy):
+    def map_button(self, raw_button_id: int) -> Optional[int]:
+        return {
+            0: buttons.A,
+            1: buttons.B,
+            6: buttons.BACK,
+            7: buttons.START,
+            11: buttons.LEFT,
+            12: buttons.RIGHT,
+            13: buttons.UP,
+            14: buttons.DOWN,
+        }.get(raw_button_id)
+
+    def map_axis(
+        self, axis_id: int, value: float
+    ) -> tuple[Optional[int], bool]:
+        if axis_id == HORIZONTAL_AXIS:
+            return (
+                buttons.RIGHT if value > 0 else buttons.LEFT,
+                abs(value) > 0.25,
+            )
+        elif axis_id == VERTICAL_AXIS:
+            return (
+                buttons.DOWN if value > 0 else buttons.UP,
+                abs(value) > 0.25,
+            )
+        return (None, False)
+
+
+class PlayStationMapping(InputMappingStrategy):
+    def map_button(self, raw_button_id: int) -> Optional[int]:
+        return {
+            1: buttons.A,  # Cross
+            2: buttons.B,  # Circle
+            8: buttons.BACK,
+            9: buttons.START,
+            14: buttons.LEFT,
+            15: buttons.RIGHT,
+            12: buttons.UP,
+            13: buttons.DOWN,
+        }.get(raw_button_id)
+
+    def map_axis(
+        self, axis_id: int, value: float
+    ) -> tuple[Optional[int], bool]:
+        if axis_id == HORIZONTAL_AXIS:
+            return (
+                buttons.RIGHT if value > 0 else buttons.LEFT,
+                abs(value) > 0.2,
+            )
+        elif axis_id == VERTICAL_AXIS:
+            return (
+                buttons.DOWN if value > 0 else buttons.UP,
+                abs(value) > 0.2,
+            )
+        return (None, False)
+
+
 class PygameEventHandler(InputHandler[Event]):
     """
     Input handler of Pygame events.
@@ -92,43 +165,11 @@ class PygameGamepadInput(PygameEventHandler):
             almost impossible.
     """
 
-    # Xbox 360 Controller buttons:
-    # A = 0    Start = 7    D-Up = 13
-    # B = 1    Back = 6     D-Down = 14
-    # X = 2                 D-Left = 11
-    # Y = 3                 D-Right = 12
-    #
-    default_input_map = {
-        0: buttons.A,
-        1: buttons.B,
-        6: buttons.BACK,
-        11: buttons.LEFT,
-        12: buttons.RIGHT,
-        13: buttons.UP,
-        14: buttons.DOWN,
-        7: buttons.START,
-    }
-    DEADZONE: float = 0.25
-
-    def __init__(
-        self,
-        event_map: Optional[Mapping[Optional[int], int]] = None,
-        deadzone: float = DEADZONE,
-    ) -> None:
-        super().__init__(event_map)
-        self.deadzone = deadzone
-
-    def is_within_deadzone(self, value: float) -> bool:
-        """
-        Checks if the axis value is within the deadzone.
-
-        Parameters:
-            value: The axis value.
-
-        Returns:
-            True if the value is within the deadzone, False otherwise.
-        """
-        return abs(value) < self.deadzone
+    def __init__(self, mapping_strategy: InputMappingStrategy):
+        super().__init__({})
+        self.mapping = mapping_strategy
+        self.hat_state = (0, 0)
+        self.axis_state = {HORIZONTAL_AXIS: 0, VERTICAL_AXIS: 0}
 
     def handle_button(
         self, button: int, pressed: bool, value: float = 0.0
@@ -141,6 +182,9 @@ class PygameGamepadInput(PygameEventHandler):
             pressed: True if the button is pressed, False if released.
             value: The analog value of the button (optional, defaults to 0.0).
         """
+        logger.debug(
+            f"{'Pressed' if pressed else 'Released'} {button} with value {value}"
+        )
         if pressed:
             self.press(button, value)
         else:
@@ -155,7 +199,7 @@ class PygameGamepadInput(PygameEventHandler):
         """
         self.check_button(input_event)
         self.check_hat(input_event)
-        self.check_axis(input_event)
+        self.handle_axis_event(input_event)
 
     def check_button(self, pg_event: Event) -> None:
         """
@@ -164,11 +208,10 @@ class PygameGamepadInput(PygameEventHandler):
         Parameters:
             pg_event: The pygame event.
         """
-        try:
-            button = self.event_map[pg_event.button]
-            self.handle_button(button, pg_event.type == pg.JOYBUTTONDOWN)
-        except (KeyError, AttributeError):
-            pass
+        if pg_event.type in (pg.JOYBUTTONDOWN, pg.JOYBUTTONUP):
+            button = self.mapping.map_button(pg_event.button)
+            if button is not None:
+                self.handle_button(button, pg_event.type == pg.JOYBUTTONDOWN)
 
     def check_hat(self, pg_event: Event) -> None:
         """
@@ -179,20 +222,26 @@ class PygameGamepadInput(PygameEventHandler):
         """
         if pg_event.type == pg.JOYHATMOTION:
             x, y = pg_event.value
-            self.handle_button(buttons.LEFT, x == -1)
-            self.handle_button(buttons.RIGHT, x == 1)
-            # Note: y axis is inverted
-            self.handle_button(buttons.DOWN, y == 1)
-            # Note: y axis is inverted
-            self.handle_button(buttons.UP, y == -1)
-            if x == 0:
-                self.handle_button(buttons.LEFT, False)
-                self.handle_button(buttons.RIGHT, False)
-            if y == 0:
-                self.handle_button(buttons.UP, False)
-                self.handle_button(buttons.DOWN, False)
+            prev_x, prev_y = self.hat_state
+            self.hat_state = (x, y)
 
-    def check_axis(self, pg_event: Event) -> None:
+            if x != prev_x:
+                self.handle_button(buttons.LEFT, x == -1)
+                self.handle_button(buttons.RIGHT, x == 1)
+                if prev_x == -1 and x != -1:
+                    self.handle_button(buttons.LEFT, False)
+                if prev_x == 1 and x != 1:
+                    self.handle_button(buttons.RIGHT, False)
+
+            if y != prev_y:
+                self.handle_button(buttons.DOWN, y == 1)
+                self.handle_button(buttons.UP, y == -1)
+                if prev_y == 1 and y != 1:
+                    self.handle_button(buttons.DOWN, False)
+                if prev_y == -1 and y != -1:
+                    self.handle_button(buttons.UP, False)
+
+    def handle_axis_event(self, pg_event: Event) -> None:
         """
         Checks for axis motion events.
 
@@ -204,23 +253,36 @@ class PygameGamepadInput(PygameEventHandler):
 
     def _handle_axis(self, axis: int, value: float) -> None:
         """Handles axis motion events."""
-        if self.is_within_deadzone(value):
-            if axis == HORIZONTAL_AXIS:
-                self.handle_button(buttons.LEFT, False)
-                self.handle_button(buttons.RIGHT, False)
-            elif axis == VERTICAL_AXIS:
-                self.handle_button(buttons.UP, False)
-                self.handle_button(buttons.DOWN, False)
+        button, pressed = self.mapping.map_axis(axis, value)
+        if button is None:
             return
 
-        if axis == HORIZONTAL_AXIS:
+        # Determine direction: -1 (negative), 1 (positive), 0 (neutral)
+        direction = 0
+        if pressed:
+            direction = 1 if value > 0 else -1
+
+        # If direction hasn't changed, do nothing
+        if self.axis_state[axis] == direction:
+            return
+
+        # Release previous direction
+        if self.axis_state[axis] == -1:
             self.handle_button(
-                buttons.RIGHT if value > 0 else buttons.LEFT, True, abs(value)
+                buttons.LEFT if axis == HORIZONTAL_AXIS else buttons.UP, False
             )
-        elif axis == VERTICAL_AXIS:
+        elif self.axis_state[axis] == 1:
             self.handle_button(
-                buttons.DOWN if value > 0 else buttons.UP, True, abs(value)
+                buttons.RIGHT if axis == HORIZONTAL_AXIS else buttons.DOWN,
+                False,
             )
+
+        # Press new direction if applicable
+        if direction != 0:
+            self.handle_button(button, True, abs(value))
+
+        # Update state
+        self.axis_state[axis] = direction
 
 
 class PygameKeyboardInput(PygameEventHandler):

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -50,19 +50,22 @@ def _setup_user_environment() -> config.TuxemonConfig:
         logger.critical(f"Failed to create user directories: {e}")
         raise
 
-    config.generate_default_config()
     loaded_config = config.TuxemonConfig(paths.USER_CONFIG_PATH)
 
     try:
         with paths.USER_CONFIG_PATH.open("w") as fp:
             yaml.dump(
-                loaded_config.config, fp, default_flow_style=False, indent=4
+                loaded_config.config_model.model_dump(),
+                fp,
+                default_flow_style=False,
+                indent=4,
             )
         logger.info(
             f"Configuration loaded and saved to {paths.USER_CONFIG_PATH}"
         )
     except Exception as e:
         logger.error(f"Failed to save config: {e}")
+
     return loaded_config
 
 


### PR DESCRIPTION
waiting
- [x] #3248

PR introduces a more flexible and extensible approach to gamepad input handling by implementing the Strategy Pattern. The changes improve controller support and simplify future integration of additional gamepad types.

Changes:
- introduced `InputMappingStrategy` interface to abstract button and axis mapping logic
- added two concrete mapping strategies:
  - `XboxMapping` for Xbox 360 controller layout
  - `PlayStationMapping` for PlayStation controller layout
- refactored `PygameGamepadInput` to use `InputMappingStrategy` instead of a static `event_map`
- removed `default_input_map` and `deadzone` from `PygameGamepadInput` in favor of strategy-specific logic
- updated axis handling to track directional state and avoid redundant press/release events
- improved hat switch handling to compare previous and current states for accurate input transitions
- added debug logging to `handle_button` for better traceability of input events

Replace dict-based config with Pydantic models and validation

Changes:
- replaced the old dict-based configuration system with Pydantic models to provide strict typing, validation and clearer defaults.
- introduced individual config models (`DisplayConfig`, `GameConfig`, `GameplayConfig`, `GraphicsConfig`, `PlayerConfig`, `ControlsConfig`, `ControllerConfigModel`, `LoggingConfigModel`) and a top-level `TuxemonFullConfig`
- updated `TuxemonConfig` to load `YAML` into the Pydantic model, validate it and fall back to defaults if validation fails

Let’s be honest, our old dict-based config setup was like trying to plug a USB socket into a puddle and hoping for Wi-Fi. It worked, kind of, until it didn’t, and then you were neck-deep in cryptic key errors and silent failures that made you question your life choices. Switching to Pydantic is like finally getting out of that swamp and wiring things properly: you get strict typing, validation that actually tells you when things are broken, and defaults that don’t randomly vanish like your will to debug YAML at 2.69am. Plus, it still plays nice with legacy configs, so you’re not burning down the past, just building something that doesn’t collapse when you sneeze.