### PR TITLE
Refactor `SaveData` to Pydantic Models and Improve Save System Flexibility

### DIFF
--- a/tests/tuxemon/test_battles_handler.py
+++ b/tests/tuxemon/test_battles_handler.py
@@ -6,6 +6,7 @@ import unittest
 from tuxemon.battle import Battle
 from tuxemon.db import OutputBattle
 from tuxemon.entity_dir.battle import BattlesHandler
+from tuxemon.save_state import NPCState
 
 
 class TestBattlesHandler(unittest.TestCase):
@@ -174,15 +175,15 @@ class TestBattlesHandler(unittest.TestCase):
         self.handler.record_battle("npc", OutputBattle.won)
         encoded = self.handler.encode_battle()
         new_handler = BattlesHandler("player")
-        new_handler.decode_battle({"battles": encoded})
+        new_handler.decode_battle(NPCState(battles=encoded))
         self.assertEqual(len(new_handler.get_battles()), 1)
         self.assertEqual(
             new_handler.get_battles()[0].outcome, OutputBattle.won
         )
 
     def test_decode_battle_with_legacy_placeholder(self):
-        legacy_data = {
-            "battles": [
+        legacy_data = NPCState(
+            battles=[
                 {
                     "fighter": "player",
                     "opponent": "player",
@@ -191,7 +192,7 @@ class TestBattlesHandler(unittest.TestCase):
                     "instance_id": "1234567890abcdef1234567890abcdef",
                 }
             ]
-        }
+        )
         handler = BattlesHandler("hero")
         handler.decode_battle(legacy_data)
         battle = handler.get_battles()[0]
@@ -199,7 +200,7 @@ class TestBattlesHandler(unittest.TestCase):
         self.assertEqual(battle.opponent, "hero")
 
     def test_decode_battle_empty(self):
-        self.handler.decode_battle({})
+        self.handler.decode_battle(NPCState(battles=[]))
         self.assertEqual(len(self.handler.get_battles()), 0)
 
     def test_record_battle_with_location_and_turns(self):

--- a/tuxemon/boxes.py
+++ b/tuxemon/boxes.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC
+    from tuxemon.save_state import NPCState
 
 logger = logging.getLogger(__name__)
 
@@ -385,13 +386,13 @@ class ItemBoxes(BoxCollection):
             for box_id, items in self.item_boxes.items()
         }
 
-    def load(self, save_data: Mapping[str, Any]) -> None:
+    def load(self, save_data: NPCState) -> None:
         """
         Loads the item boxes from a saved state.
         """
+        item_boxes = save_data.item_boxes or {}
         self.item_boxes = {
-            box_id: decode_items(items)
-            for box_id, items in save_data.get("item_boxes", {}).items()
+            box_id: decode_items(items) for box_id, items in item_boxes.items()
         }
 
         for box_id, items in self.item_boxes.items():
@@ -563,15 +564,14 @@ class MonsterBoxes(BoxCollection):
             for box_id, monsters in self.monster_boxes.items()
         }
 
-    def load(self, char: NPC, save_data: Mapping[str, Any]) -> None:
+    def load(self, char: NPC, save_data: NPCState) -> None:
         """
         Loads the monster boxes from a saved state.
         """
         self.monster_boxes = {}
 
-        for box_id, encoded_monsters in save_data.get(
-            "monster_boxes", {}
-        ).items():
+        monster_boxes = save_data.monster_boxes or {}
+        for box_id, encoded_monsters in monster_boxes.items():
             monsters = decode_monsters(encoded_monsters)
             monster_count = len(monsters)
             logger.debug(

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -86,6 +86,9 @@ class TuxemonConfig:
         self.recompile_translations: bool = game["recompile_translations"]
         self.skip_titlescreen: bool = game["skip_titlescreen"]
         self.compress_save: Optional[str] = game["compress_save"] or None
+        self.save_prefix: str = game["save_prefix"]
+        self.save_extension: str = game["save_extension"]
+        self.save_method: str = game["save_method"]
 
         thin_font_file = game.get("thin_font_file")
         if game["locale"] == "zh_CN":
@@ -336,6 +339,9 @@ def generate_default_config() -> dict[str, Any]:
             "recompile_translations": True,
             "skip_titlescreen": False,
             "compress_save": None,
+            "save_prefix": "slot",
+            "save_extension": "save",
+            "save_method": "json",
             "locale": "en_US",
             "translation_mode": "none",
             "font_file": "PressStart2P.ttf",

--- a/tuxemon/entity.py
+++ b/tuxemon/entity.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar
 from uuid import UUID, uuid4
 
 from tuxemon.db import Direction
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from tuxemon.session import Session
 
 
-SaveDict = TypeVar("SaveDict", bound=Mapping[str, Any])
+SaveDict = TypeVar("SaveDict")
 
 
 class EntityState(Enum):

--- a/tuxemon/entity_dir/bag.py
+++ b/tuxemon/entity_dir/bag.py
@@ -14,6 +14,7 @@ from tuxemon.item.item import decode_items, encode_items
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
     from tuxemon.npc import NPC
+    from tuxemon.save_state import NPCState
 
 
 logger = logging.getLogger(__name__)
@@ -153,6 +154,6 @@ class BagHandler:
     def encode_items(self) -> Sequence[Mapping[str, Any]]:
         return encode_items(self._items)
 
-    def decode_items(self, json_data: Optional[Mapping[str, Any]]) -> None:
-        if json_data and "items" in json_data:
-            self._items = [itm for itm in decode_items(json_data["items"])]
+    def decode_items(self, json_data: Optional[NPCState]) -> None:
+        if json_data and json_data.items is not None:
+            self._items = [itm for itm in decode_items(json_data.items)]

--- a/tuxemon/entity_dir/battle.py
+++ b/tuxemon/entity_dir/battle.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Mapping, Sequence
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from tuxemon.battle import Battle, decode_battle, encode_battle
 from tuxemon.db import OutputBattle
+
+if TYPE_CHECKING:
+    from tuxemon.save_state import NPCState
 
 logger = logging.getLogger(__name__)
 
@@ -133,15 +136,17 @@ class BattlesHandler:
         """Serializes battles into a savable format."""
         return encode_battle(self._battles)
 
-    def decode_battle(self, json_data: Optional[Mapping[str, Any]]) -> None:
+    def decode_battle(self, json_data: Optional[NPCState]) -> None:
         """Deserializes and loads battles from saved data."""
-        if json_data and "battles" in json_data:
-            decoded = decode_battle(json_data["battles"])
+        if json_data is None or json_data.battles is None:
+            return
 
-            for battle in decoded:
-                if battle.fighter == LEGACY_PLACEHOLDER:
-                    battle.fighter = self.character
-                if battle.opponent == LEGACY_PLACEHOLDER:
-                    battle.opponent = self.character
+        decoded = decode_battle(json_data.battles)
 
-            self._battles = decoded
+        for battle in decoded:
+            if battle.fighter == LEGACY_PLACEHOLDER:
+                battle.fighter = self.character
+            if battle.opponent == LEGACY_PLACEHOLDER:
+                battle.opponent = self.character
+
+        self._battles = decoded

--- a/tuxemon/entity_dir/party.py
+++ b/tuxemon/entity_dir/party.py
@@ -15,6 +15,7 @@ from tuxemon.monster import Monster, decode_monsters, encode_monsters
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
+    from tuxemon.save_state import NPCState
 
 logger = logging.getLogger(__name__)
 
@@ -470,8 +471,8 @@ class PartyHandler:
     def encode_party(self) -> Sequence[Mapping[str, Any]]:
         return encode_monsters(self._monsters)
 
-    def decode_party(self, json_data: Optional[Mapping[str, Any]]) -> None:
+    def decode_party(self, json_data: Optional[NPCState]) -> None:
         self.clear_party()
-        if json_data and "monsters" in json_data:
-            for mon in decode_monsters(json_data["monsters"]):
+        if json_data and json_data.monsters is not None:
+            for mon in decode_monsters(json_data.monsters):
                 self.add_monster(mon, self.party_size)

--- a/tuxemon/entity_dir/routing.py
+++ b/tuxemon/entity_dir/routing.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import yaml
 
 from tuxemon.constants.paths import mods_folder
 from tuxemon.prepare import KENNEL
+
+if TYPE_CHECKING:
+    from tuxemon.save_state import NPCState
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +83,8 @@ class RoutingPolicy:
         return self.name
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> str:
-        name = data.get("routing_policy")
+    def from_dict(cls, data: NPCState) -> str:
+        name = data.routing_policy
 
         if not isinstance(name, str) or not name:
             logger.warning(

--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -50,42 +50,46 @@ class LoadGameAction(EventAction):
         index = 4 if self.index is None else self.index + 1
 
         client.map_loader.clear_cache()
-
         logger.info("Loading!")
-        save_data = save.load(index)
-        if save_data:
-            try:
-                old_world = client.get_state_by_name(WorldState)
-                # when game is loaded from world menu
-                client.remove_state_by_name("LoadMenuState")
-                client.pop_state(old_world)
-                client.remove_state_by_name("WorldMenuState")
-            except ValueError:
-                # when game is loaded from the start menu
-                client.remove_state_by_name("LoadMenuState")
-                # avoid crash save and load same action
-                if self.index is not None:
-                    client.remove_state_by_name("StartState")
 
-            slug = save_data["npc_state"].get("player_slug", PLAYER_NPC)
-            save_data["npc_state"]["player_slug"] = slug
-            Player.create(session, slug=slug)
+        save_path = save.get_save_path(index)
+        save_data = save.load(save_path)
+        if not save_data:
+            return
 
-            map_path = fetch_asset(
-                "maps", save_data["npc_state"]["current_map"]
-            )
-            client.push_state("WorldState", session=session, map_name=map_path)
+        try:
+            old_world = client.get_state_by_name(WorldState)
+            client.remove_state_by_name("LoadMenuState")
+            client.pop_state(old_world)
+            client.remove_state_by_name("WorldMenuState")
+        except ValueError:
+            client.remove_state_by_name("LoadMenuState")
+            if self.index is not None:
+                client.remove_state_by_name("StartState")
 
-            session.load_state(save_data)
+        npc_state = save_data.npc_state
+        if npc_state is None:
+            logger.error("Save data missing NPC state.")
+            return
 
-            # teleport the player to the correct position using an event
-            # engine action
-            client.current_music.stop()
-            tele_x, tele_y = save_data["npc_state"]["tile_pos"]
-            params = [
-                "player",
-                save_data["npc_state"]["current_map"],
-                tele_x,
-                tele_y,
-            ]
-            client.event_engine.execute_action("teleport", params)
+        slug = npc_state.player_slug or PLAYER_NPC
+        npc_state.player_slug = slug
+        Player.create(session, slug=slug)
+
+        if npc_state.current_map is None:
+            logger.error("Save data missing current map.")
+            return
+
+        map_path = fetch_asset("maps", npc_state.current_map)
+        client.push_state("WorldState", session=session, map_name=map_path)
+
+        session.load_state(save_data)
+
+        if npc_state.tile_pos is None:
+            logger.error("Save data missing tile position.")
+            return
+
+        tele_x, tele_y = npc_state.tile_pos
+        params = ["player", npc_state.current_map, tele_x, tele_y]
+        client.current_music.stop()
+        client.event_engine.execute_action("teleport", params)

--- a/tuxemon/money/controller.py
+++ b/tuxemon/money/controller.py
@@ -30,7 +30,7 @@ class MoneyController:
 
     def load(self, save_data: NPCState) -> None:
         """Recreates money manager from saved data."""
-        self.money_manager = decode_money(save_data["money"])
+        self.money_manager = decode_money(save_data.money or {})
 
     def transfer_money_to(self, amount: int, recipient: NPC) -> None:
         self.money_manager.remove_money(amount)

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from tuxemon.boxes import ItemBoxes, MonsterBoxes
 from tuxemon.db import DialogueProfile, Direction, NpcModel, db
@@ -23,6 +23,7 @@ from tuxemon.mission.manager import MissionManager
 from tuxemon.money.controller import MoneyController
 from tuxemon.monster import Monster
 from tuxemon.monster_dir.evolution_registry import EvolutionRegistry
+from tuxemon.prepare import PLAYER_NPC
 from tuxemon.relationship import (
     Relationships,
     decode_relationships,
@@ -148,7 +149,7 @@ class NPC(Entity[NPCState]):
             Dictionary containing all the information about the npc.
         """
 
-        state: NPCState = {
+        state: dict[str, Any] = {
             "current_map": session.client.get_map_name(),
             "facing": self.facing.value,
             "game_variables": self._variables.get_player_state(),
@@ -173,7 +174,7 @@ class NPC(Entity[NPCState]):
             "evolution_registry": self.evolution_registry.encode_registry(),
             "routing_policy": self.party.routing_policy.to_dict(),
         }
-        return state
+        return NPCState(**state)
 
     def set_state(self, session: Session, save_data: NPCState) -> None:
         """
@@ -183,36 +184,38 @@ class NPC(Entity[NPCState]):
             session: Game session.
             save_data: Data used to recreate the NPC.
         """
-        self.set_facing(Direction(save_data.get("facing", "down")))
-        self._variables.set_player_state(save_data["game_variables"])
-        self.tuxepedia = decode_tuxepedia(save_data["tuxepedia"])
-        self.relationships = decode_relationships(save_data["relationships"])
+        self.set_facing(Direction(save_data.facing or "down"))
+        self._variables.set_player_state(save_data.game_variables)
+        self.tuxepedia = decode_tuxepedia(save_data.tuxepedia)
+        self.relationships = decode_relationships(save_data.relationships)
         self.battle_handler.decode_battle(save_data)
         self.bag.decode_items(save_data)
         self.party.decode_party(save_data)
-        self.mission_controller.decode_missions(save_data.get("missions"))
-        self.slug = save_data["player_slug"]
-        self.name = save_data["player_name"]
-        self.steps = save_data["player_steps"]
+        self.mission_controller.decode_missions(save_data.missions)
+        self.slug = save_data.player_slug or PLAYER_NPC
+        self.name = save_data.player_name or "Player"
+        self.steps = save_data.player_steps or 0.0
         self.money_controller.load(save_data)
         self.unlocked_letters = decode_cipher(save_data)
-        self.evolution_registry.decode_registry(
-            save_data.get("evolution_registry", {})
-        )
+        self.evolution_registry.decode_registry(save_data.evolution_registry)
         self.monster_boxes.load(self, save_data)
         self.item_boxes.load(save_data)
 
         self.teleport_faint = TeleportFaint.from_dict(save_data)
 
-        self.tracker = decode_tracking(save_data.get("tracker", {}))
-        self.step_tracker = decode_steps(save_data.get("step_tracker", {}))
+        self.tracker = decode_tracking(save_data.tracker)
+        self.step_tracker = decode_steps(save_data.step_tracker)
         self.party.routing_policy_name = RoutingPolicy.from_dict(save_data)
 
-        _template = save_data["template"]
-        self.template.slug = _template["slug"]
-        self.template.sprite_name = _template["sprite_name"]
-        self.template.combat_front = _template["combat_front"]
-        self.sprite_controller.load_sprites(self.template)
+        if save_data.template:
+            self.template.slug = save_data.template.get("slug", "")
+            self.template.sprite_name = save_data.template.get(
+                "sprite_name", ""
+            )
+            self.template.combat_front = save_data.template.get(
+                "combat_front", ""
+            )
+            self.sprite_controller.load_sprites(self.template)
 
     def pathfind(self, destination: tuple[int, int]) -> None:
         self.path_controller.start_path(destination)

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -294,10 +294,6 @@ elif CONFIG.scaling:
 else:
     SCALE = 1
 
-# Reference user save dir
-SAVE_PATH = paths.USER_GAME_SAVE_DIR / "slot"
-SAVE_METHOD = "JSON"
-# SAVE_METHOD = "CBOR"
 
 DEV_TOOLS = CONFIG.dev_tools
 

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -14,10 +14,12 @@ from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
+import yaml
 from pygame.image import tobytes
 from pygame.surface import Surface
 
 from tuxemon import prepare
+from tuxemon.constants import paths
 from tuxemon.save_state import TIME_FORMAT, SaveData
 from tuxemon.save_upgrader import SAVE_VERSION, upgrade_save
 
@@ -27,7 +29,7 @@ if TYPE_CHECKING:
 try:
     import cbor
 except ImportError:
-    prepare.SAVE_METHOD = "JSON"
+    prepare.CONFIG.save_method = "json"
 
 
 T = TypeVar("T")
@@ -40,8 +42,9 @@ config = prepare.CONFIG
 
 
 class SaveMethod(Enum):
-    JSON = "JSON"
-    CBOR = "CBOR"
+    JSON = "json"
+    CBOR = "cbor"
+    YAML = "yaml"
 
     @classmethod
     def from_string(cls, method_str: str) -> SaveMethod:
@@ -74,26 +77,16 @@ def get_save_data(session: Session) -> SaveData:
     world_state = session.world.get_state(session)
     session_state = session.get_state()
 
-    return {
-        "screenshot": b64encode(tobytes(screenshot, "RGB")).decode(),
-        "screenshot_width": screenshot.get_width(),
-        "screenshot_height": screenshot.get_height(),
-        "time": datetime.now().strftime(TIME_FORMAT),
-        "version": SAVE_VERSION,
-        "npc_state": npc_state,
-        "world_state": world_state,
-        "session_state": session_state,
-    }
-
-
-def _get_save_extension() -> str:
-    save_format = config.compress_save
-    return "save" if save_format is None else f"csave.{save_format}"
-
-
-def get_save_path(slot: int) -> Path:
-    extension = _get_save_extension()
-    return prepare.SAVE_PATH.parent / f"slot{slot}.{extension}"
+    return SaveData(
+        screenshot=b64encode(tobytes(screenshot, "RGB")).decode(),
+        screenshot_width=screenshot.get_width(),
+        screenshot_height=screenshot.get_height(),
+        time=datetime.now().strftime(TIME_FORMAT),
+        version=SAVE_VERSION,
+        npc_state=npc_state,
+        world_state=world_state,
+        session_state=session_state,
+    )
 
 
 def save_action(
@@ -134,7 +127,7 @@ def save_action(
 
 
 def dump_data(
-    obj: Any,
+    obj: SaveData,
     path: Path,
     save_method: SaveMethod,
     compress_save: Optional[str] = None,
@@ -145,14 +138,22 @@ def dump_data(
         file: Any,
         serializer_kwargs: Mapping[str, Any],
     ) -> None:
+        serializable_obj = obj.model_dump()
         if save_method == SaveMethod.JSON:
-            json.dump(obj, file, **serializer_kwargs)
+            json.dump(serializable_obj, file, **serializer_kwargs)
         elif save_method == SaveMethod.CBOR:
-            cbor.dump(obj, file, **serializer_kwargs)
+            cbor.dump(serializable_obj, file, **serializer_kwargs)
+        elif save_method == SaveMethod.YAML:
+            yaml.dump(
+                serializable_obj,
+                file,
+                default_flow_style=False,
+                **serializer_kwargs,
+            )
         else:
             raise ValueError(f"Unsupported save method: {save_method}")
 
-    mode = "wt" if save_method == SaveMethod.JSON else "wb"
+    mode = "wt" if save_method in {SaveMethod.JSON, SaveMethod.YAML} else "wb"
 
     return save_action(
         path=path,
@@ -183,25 +184,39 @@ def load_data(
         compression_tool = importlib.import_module(compress_save)
         open_function = compression_tool.open
 
-    mode = "rt" if save_method == SaveMethod.JSON else "rb"
+    mode = "rt" if save_method in {SaveMethod.JSON, SaveMethod.YAML} else "rb"
 
     with open_function(
         path,
         mode=mode,
-        encoding="utf-8" if save_method == SaveMethod.JSON else None,
+        encoding=(
+            "utf-8"
+            if save_method in {SaveMethod.JSON, SaveMethod.YAML}
+            else None
+        ),
         **compression_kwargs,
     ) as file:
         if save_method == SaveMethod.JSON:
             return json.load(file, **serializer_kwargs)
         elif save_method == SaveMethod.CBOR:
             return cbor.load(file, **serializer_kwargs)
+        elif save_method == SaveMethod.YAML:
+            return yaml.safe_load(file)
         else:
             raise ValueError(f"Unsupported save method: {save_method}")
 
 
 def open_save_file(save_path: Path) -> Optional[dict[str, Any]]:
-    current_save_method = SaveMethod.from_string(prepare.SAVE_METHOD)
+    """
+    Opens and decodes the save file from disk.
 
+    Parameters:
+        save_path: Path to the save file.
+
+    Returns:
+        Raw dictionary of save data, or None if the file is missing or corrupted.
+    """
+    current_save_method = SaveMethod.from_string(config.save_method)
     package: dict[str, Any] = {}
 
     try:
@@ -220,22 +235,34 @@ def open_save_file(save_path: Path) -> Optional[dict[str, Any]]:
         return None
 
 
-def save(save_data: SaveData, slot: int) -> None:
+def get_save_path(
+    slot: int, prefix: Optional[str] = None, extension: Optional[str] = None
+) -> Path:
+    extension = config.save_extension if extension is None else extension
+    prefix = config.save_prefix if prefix is None else prefix
+    final_extension = (
+        extension
+        if config.compress_save is None
+        else f"c{extension}.{config.compress_save}"
+    )
+    return paths.USER_GAME_SAVE_DIR / f"{prefix}{slot}.{final_extension}"
+
+
+def save(save_data: SaveData, save_path: Path) -> None:
     """
     Saves the current game state to a file using gzip compressed JSON.
 
     Parameters:
         save_data: The data to save.
-        slot: The save slot to save the data to.
+        save_path: The full path where the save file should be written.
     """
-    save_path = get_save_path(slot)
     save_path_tmp = save_path.with_suffix(save_path.suffix + ".tmp")
     json_kwargs = {
         "indent": 4,
         "separators": (",", ": "),
     }
 
-    current_save_method = SaveMethod.from_string(prepare.SAVE_METHOD)
+    current_save_method = SaveMethod.from_string(config.save_method)
     logger.info(f"Saving data to save file: {save_path}")
 
     dump_data(
@@ -254,23 +281,24 @@ def save(save_data: SaveData, slot: int) -> None:
     os.replace(save_path_tmp.as_posix(), save_path.as_posix())
 
 
-def load(slot: int) -> Optional[SaveData]:
+def load(save_path: Path) -> Optional[SaveData]:
     """
     Loads game state data from a save file.
 
     Parameters:
-        slot: The save slot to load game data from.
+        save_path: The full path to the save file to load.
 
     Returns:
-        Dictionary containing game data to load.
+        A SaveData object containing the loaded game state, or None if
+        the file doesn't exist.
     """
-    save_path = get_save_path(slot)
-    save_data = open_save_file(save_path)
+    raw_data = open_save_file(save_path)
 
-    if save_data is None:
+    if raw_data is None:
         # File not found; it probably wasn't ever created, so don't panic
         return None
-    return upgrade_save(save_data)
+    upgraded_data = upgrade_save(raw_data)
+    return SaveData(**upgraded_data)
 
 
 def get_index_of_latest_save() -> Optional[int]:

--- a/tuxemon/save_state.py
+++ b/tuxemon/save_state.py
@@ -2,56 +2,62 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import Any, TypedDict
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
 
 TIME_FORMAT = "%Y-%m-%d %H:%M"
 
 
-class SaveData(TypedDict, total=False):
-    screenshot: str
-    screenshot_width: int
-    screenshot_height: int
-    time: str
-    version: int
-    npc_state: NPCState
-    world_state: WorldSave
-    session_state: SessionSave
+class WorldSave(BaseModel):
+    factions_manager: dict[str, Any] = Field(default_factory=dict)
+    menu_flags: dict[str, bool] = Field(default_factory=dict)
 
 
-class WorldSave(TypedDict, total=False):
-    factions_manager: dict[str, Any]
-    menu_flags: dict[str, bool]
+class SessionSave(BaseModel):
+    uuid: Optional[str] = Field(default=None)
+    start_time: Optional[str] = Field(default=None)
+    duration: Optional[float] = Field(default=None)
+    total_playtime: Optional[float] = Field(default=None)
 
 
-class SessionSave(TypedDict, total=False):
-    uuid: str
-    start_time: str
-    duration: float
-    total_playtime: float
+class NPCState(BaseModel):
+    current_map: Optional[str] = Field(default=None)
+    facing: Optional[str] = Field(default=None)
+    game_variables: dict[str, Any] = Field(default_factory=dict)
+    battles: list[Mapping[str, Any]] = Field(default_factory=list)
+    tuxepedia: dict[str, Any] = Field(default_factory=dict)
+    relationships: dict[str, Any] = Field(default_factory=dict)
+    money: dict[str, Any] = Field(default_factory=dict)
+    template: dict[str, Any] = Field(default_factory=dict)
+    missions: list[Mapping[str, Any]] = Field(default_factory=list)
+    items: list[Mapping[str, Any]] = Field(default_factory=list)
+    monsters: list[Mapping[str, Any]] = Field(default_factory=list)
+    player_name: Optional[str] = Field(default=None)
+    player_slug: Optional[str] = Field(default=None)
+    player_steps: Optional[float] = Field(default=None)
+    monster_boxes: dict[str, list[Mapping[str, Any]]] = Field(
+        default_factory=dict
+    )
+    item_boxes: dict[str, list[Mapping[str, Any]]] = Field(
+        default_factory=dict
+    )
+    tile_pos: Optional[tuple[int, int]] = Field(default=None)
+    teleport_faint: dict[str, Any] = Field(default_factory=dict)
+    tracker: dict[str, Any] = Field(default_factory=dict)
+    step_tracker: dict[str, Any] = Field(default_factory=dict)
+    unlocked_letters: dict[str, Any] = Field(default_factory=dict)
+    evolution_registry: dict[str, Any] = Field(default_factory=dict)
+    routing_policy: Optional[str] = Field(default=None)
 
 
-class NPCState(TypedDict, total=False):
-    current_map: str
-    facing: str
-    game_variables: dict[str, Any]
-    battles: Sequence[Mapping[str, Any]]
-    tuxepedia: Mapping[str, Any]
-    relationships: Mapping[str, Any]
-    money: Mapping[str, Any]
-    template: dict[str, Any]
-    missions: Sequence[Mapping[str, Any]]
-    items: Sequence[Mapping[str, Any]]
-    monsters: Sequence[Mapping[str, Any]]
-    player_name: str
-    player_slug: str
-    player_steps: float
-    monster_boxes: dict[str, Sequence[Mapping[str, Any]]]
-    item_boxes: dict[str, Sequence[Mapping[str, Any]]]
-    tile_pos: tuple[int, int]
-    teleport_faint: Mapping[str, Any]
-    tracker: Mapping[str, Any]
-    step_tracker: Mapping[str, Any]
-    unlocked_letters: Mapping[str, Any]
-    evolution_registry: Mapping[str, Any]
-    routing_policy: str
+class SaveData(BaseModel):
+    screenshot: Optional[str] = Field(default=None)
+    screenshot_width: Optional[int] = Field(default=None)
+    screenshot_height: Optional[int] = Field(default=None)
+    time: Optional[str] = Field(default=None)
+    version: Optional[int] = Field(default=None)
+    npc_state: Optional[NPCState] = Field(default=None)
+    world_state: Optional[WorldSave] = Field(default=None)
+    session_state: Optional[SessionSave] = Field(default=None)

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from tuxemon import db
 from tuxemon.locale import T
 
-if TYPE_CHECKING:
-    from tuxemon.save_state import SaveData
 logger = logging.getLogger(__name__)
 
 """
@@ -107,10 +105,15 @@ VERSION_UPGRADES: dict[int, Callable[[dict[str, Any]], None]] = {
 }
 
 
-def upgrade_save(save_data: dict[str, Any]) -> SaveData:
+def upgrade_save(save_data: dict[str, Any]) -> dict[str, Any]:
     """
-    Updates savegame if necessary.
-    This function can modify the passed save data.
+    Updates savegame data if necessary.
+
+    Parameters:
+        save_data: Raw dictionary of save data.
+
+    Returns:
+        Upgraded dictionary ready to be converted into a SaveData model.
     """
     if "npc_state" not in save_data:
         save_data = update_save_data(save_data)
@@ -124,7 +127,7 @@ def upgrade_save(save_data: dict[str, Any]) -> SaveData:
     save_data["version"] = SAVE_VERSION
     apply_field_migrations(save_data)
     apply_universal_fixes(save_data["npc_state"])
-    return save_data  # type: ignore[return-value]
+    return save_data
 
 
 def update_save_data(old_save_data: dict[str, Any]) -> dict[str, Any]:

--- a/tuxemon/session.py
+++ b/tuxemon/session.py
@@ -40,7 +40,7 @@ class AbstractSession(ABC, Generic[ClientType]):
         self._client: Optional[ClientType] = None
         self._world: Optional[WorldState] = None
         self._player: Optional[Player] = None
-        self._session_state: SessionSave = {}
+        self._session_state: SessionSave = SessionSave()
 
     @property
     @abstractmethod
@@ -96,17 +96,17 @@ class AbstractSession(ABC, Generic[ClientType]):
         self._total_playtime += current_duration
         self._start_timestamp = time.time()
 
-        return {
-            "uuid": self._uuid.hex,
-            "start_time": self._start_time.strftime(TIME_FORMAT),
-            "duration": current_duration,
-            "total_playtime": self._total_playtime,
-        }
+        return SessionSave(
+            uuid=self._uuid.hex,
+            start_time=self._start_time.strftime(TIME_FORMAT),
+            duration=current_duration,
+            total_playtime=self._total_playtime,
+        )
 
     def set_state(self, save_data: SessionSave) -> None:
         """Restores session-level state from saved data."""
         self._session_state = save_data
-        self._total_playtime = save_data.get("total_playtime", 0.0)
+        self._total_playtime = save_data.total_playtime or 0.0
 
 
 class Session(AbstractSession["LocalPygameClient"]):
@@ -135,18 +135,19 @@ class Session(AbstractSession["LocalPygameClient"]):
 
     def load_state(self, save_data: SaveData) -> None:
         """
-        Loads the player, world, and other session-level states from a saved game dictionary.
+        Loads the player, world, and other session-level states from a saved game model.
         """
-        self.player.set_state(self, save_data.get("npc_state", NPCState()))
-        self.world.set_state(self, save_data.get("world_state", WorldSave()))
-        self.set_state(save_data.get("session_state", SessionSave()))
+        self.player.set_state(self, save_data.npc_state or NPCState())
+        self.world.set_state(self, save_data.world_state or WorldSave())
+        self.set_state(save_data.session_state or SessionSave())
 
     def save_state(self, index: int, slot: int) -> SaveData:
         """
         Saves the player, world, and other session-level states to a dictionary.
         """
         save_data = save.get_save_data(self)
-        save.save(save_data, index)
+        save_path = save.get_save_path(index)
+        save.save(save_data, save_path)
         save.slot_number = slot
 
         return save_data

--- a/tuxemon/states/save_menu.py
+++ b/tuxemon/states/save_menu.py
@@ -84,7 +84,8 @@ class SaveMenuState(PopUpMenu[None]):
         slot_image = Surface(rect.size, SRCALPHA)
 
         # Load the save data
-        save_data = save.load(slot_num)
+        save_path = save.get_save_path(slot_num)
+        save_data = save.load(save_path)
         if not save_data:
             logger.critical(f"Save data not found for slot {slot_num}.")
             raise RuntimeError(
@@ -102,21 +103,22 @@ class SaveMenuState(PopUpMenu[None]):
         return slot_image
 
     def _get_thumbnail(self, save_data: SaveData, rect: Rect) -> Surface:
-        if "screenshot" in save_data:
-            screenshot = b64decode(save_data["screenshot"])
-            size = (
-                save_data["screenshot_width"],
-                save_data["screenshot_height"],
-            )
+        if (
+            save_data.screenshot is not None
+            and save_data.screenshot_width is not None
+            and save_data.screenshot_height is not None
+        ):
+            screenshot = b64decode(save_data.screenshot)
+            size = (save_data.screenshot_width, save_data.screenshot_height)
             thumb_image = frombuffer(screenshot, size, "RGB").convert()
             thumb_rect = thumb_image.get_rect().fit(rect)
             return smoothscale(thumb_image, thumb_rect.size)
-        else:
-            thumb_rect = rect.copy()
-            thumb_rect.width //= 5
-            thumb_image = Surface(thumb_rect.size)
-            thumb_image.fill(prepare.WHITE_COLOR)
 
+        # Fallback thumbnail if screenshot data is missing or incomplete
+        thumb_rect = rect.copy()
+        thumb_rect.width //= 5
+        thumb_image = Surface(thumb_rect.size)
+        thumb_image.fill(prepare.WHITE_COLOR)
         return thumb_image
 
     def _draw_slot_text(
@@ -134,18 +136,20 @@ class SaveMenuState(PopUpMenu[None]):
         )
 
         x = int(rect.width * 0.5)
-        draw_text(
-            slot_image,
-            save_data["npc_state"]["player_name"],
-            (x, 0, 500, 500),
-            font=self.font,
-        )
-        draw_text(
-            slot_image,
-            save_data["time"],
-            (x, 50, 500, 500),
-            font=self.font,
-        )
+        if save_data.npc_state and save_data.npc_state.player_name:
+            draw_text(
+                slot_image,
+                save_data.npc_state.player_name,
+                (x, 0, 500, 500),
+                font=self.font,
+            )
+        if save_data.time:
+            draw_text(
+                slot_image,
+                save_data.time,
+                (x, 50, 500, 500),
+                font=self.font,
+            )
 
     def save(self) -> None:
         self.client.event_engine.execute_action(
@@ -194,7 +198,8 @@ class SaveMenuState(PopUpMenu[None]):
             menu = MenuOptions(options)
             open_choice_dialog(self.client, menu, escape_key_exits=True)
 
-        save_data = save.load(self.selected_index + 1)
+        save_path = save.get_save_path(self.selected_index + 1)
+        save_data = save.load(save_path)
         if save_data:
             ask_confirmation()
         else:

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -67,21 +67,18 @@ class WorldState(State):
             self.client.set_renderer(renderer or NullRenderer())
 
     def get_state(self, session: Session) -> WorldSave:
-        """Returns a dictionary of the World to be saved."""
-        state: WorldSave = {
-            "factions_manager": self.faction_manager.set_state(
+        """Returns a WorldSave model representing the current world state."""
+        return WorldSave(
+            factions_manager=self.faction_manager.set_state(
                 self.client.npc_manager
             ),
-            "menu_flags": self.menu_manager.menu_flags.export(),
-        }
-        return state
+            menu_flags=self.menu_manager.menu_flags.export(),
+        )
 
     def set_state(self, session: Session, save_data: WorldSave) -> None:
         """Recreates the World from the provided saved data."""
-        self.faction_manager.get_state(save_data.get("factions_manager", {}))
-        self.menu_manager.menu_flags.import_flags(
-            save_data.get("menu_flags", {})
-        )
+        self.faction_manager.get_state(save_data.factions_manager)
+        self.menu_manager.menu_flags.import_flags(save_data.menu_flags)
 
     def register_input_handlers(self) -> None:
         self.input_handler = WorldInputHandler(

--- a/tuxemon/teleporter.py
+++ b/tuxemon/teleporter.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from tuxemon.movement import MovementManager
     from tuxemon.npc import NPC
     from tuxemon.npc_manager import NPCManager
+    from tuxemon.save_state import NPCState
     from tuxemon.state.manager import StateManager
 
 logger = logging.getLogger(__name__)
@@ -30,8 +31,8 @@ class TeleportFaint:
     y: int = 0
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> TeleportFaint:
-        raw = data.get("teleport_faint")
+    def from_dict(cls, data: NPCState) -> TeleportFaint:
+        raw = data.teleport_faint
 
         if raw is None:
             return cls()

--- a/tuxemon/ui/cipher_processor.py
+++ b/tuxemon/ui/cipher_processor.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from tuxemon.save_state import NPCState
 
 logger = logging.getLogger(__name__)
 
@@ -56,15 +59,19 @@ class CipherProcessor:
 
 
 def encode_cipher(unlocked_letters: set[str]) -> Mapping[str, Any]:
-    return {"unlocked_letters": list(unlocked_letters)}
+    return {
+        "unlocked_letters": {
+            letter.upper(): True for letter in unlocked_letters
+        }
+    }
 
 
-def decode_cipher(save_data: Mapping[str, Any]) -> set[str]:
+def decode_cipher(save_data: NPCState) -> set[str]:
     try:
-        letters = save_data.get("unlocked_letters", [])
+        letter_dict = save_data.unlocked_letters or {}
         return {
             str(letter).upper()
-            for letter in letters
+            for letter in letter_dict
             if isinstance(letter, str)
             and len(letter) == 1
             and letter.isalpha()


### PR DESCRIPTION
PR introduces several improvements to the save system, focusing on data structure clarity, serialization flexibility and configuration usability.

`TypedDict` was holding things together with duct tape and good intentions. Every time we added a new field, it felt like we were playing Jenga with our type safety, one wrong move and the whole tower wobbled. Switching to Pydantic is like trading in a cardboard sword for a steel one: same shape, but now it actually works in battle.

Changes included:
- replaced all `TypedDict` definitions for `SaveData`, `NPCState`, `WorldSave`, and `SessionSave` with `pydantic.BaseModel` classes, this allows for built-in validation, default values, and easier serialization/deserialization and optional fields are now explicitly marked using `Optional[...]` and `Field(default=None)` or `Field(default_factory=...)`
- updated the `save()` and `dump_data()` functions to use `.model_dump()` from Pydantic for serialization
- added support for YAML as a save format alongside JSON and CBOR, the save method can now be selected via `config.save_method` instead of modifying `prepare.py`
- introduced flexible filename generation via `get_save_path()`: we can now configure the filename prefix (`slot`, `save`, etc.) and extension (`save`, `backup`, etc.) through `config.save_prefix` and `config.save_extension` compression-aware extensions like `csave.gz` are automatically handled
- removed dependency on `prepare.SAVE_METHOD` and replaced it with `config.save_method` for consistency with other save-related settings