### PR TITLE
Refactor `RegionProperties` to Dataclass and Streamline `CollisionManager` with Immutable Updates

### DIFF
--- a/tests/tuxemon/test_collision_manager.py
+++ b/tests/tuxemon/test_collision_manager.py
@@ -79,32 +79,6 @@ class TestCollisionManager(unittest.TestCase):
         self.collision_manager.remove_collision((0, 0))
         self.assertNotIn((0, 0), self.map_manager.collision_map)
 
-    def test_add_collision_label(self):
-        collision_map = {
-            (0, 0): RegionProperties([], [], [], None, "label1"),
-            (1, 1): RegionProperties([], [], [], None, "label2"),
-        }
-        self.map_manager.collision_map = collision_map
-        self.collision_manager.add_collision_label("label1")
-        self.assertEqual(self.map_manager.collision_map[(0, 0)].key, "label1")
-        self.assertEqual(self.map_manager.collision_map[(1, 1)].key, "label2")
-
-    def test_add_collision_position(self):
-        self.map_manager.collision_map = {}
-        self.collision_manager.add_collision_position("label1", (0, 0))
-        self.assertIn((0, 0), self.map_manager.collision_map)
-        self.assertEqual(self.map_manager.collision_map[(0, 0)].key, "label1")
-
-    def test_remove_collision_label(self):
-        collision_map = {
-            (0, 0): RegionProperties([], [], [], None, "label1"),
-            (1, 1): RegionProperties([], [], [], None, "label2"),
-        }
-        self.map_manager.collision_map = collision_map
-        self.collision_manager.remove_collision_label("label1")
-        self.assertEqual(self.map_manager.collision_map[(0, 0)].key, "label1")
-        self.assertEqual(self.map_manager.collision_map[(1, 1)].key, "label2")
-
     def test_get_collision_map(self):
         self.map_manager.collision_map = {
             (0, 0): RegionProperties([], [], [], None, "label1")

--- a/tuxemon/event/actions/add_collision.py
+++ b/tuxemon/event/actions/add_collision.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.event.eventaction import EventAction
+from tuxemon.map.map_region import RegionProperties
 from tuxemon.session import Session
 
 
@@ -36,7 +37,13 @@ class AddCollisionAction(EventAction):
 
     def start(self, session: Session) -> None:
         client = session.client.collision_manager
-        if self.x and self.y:
-            client.add_collision_position(self.label, (self.x, self.y))
+        region = RegionProperties().with_overrides(key=self.label)
+
+        if self.x is not None and self.y is not None:
+            client._map_manager.collision_map[(self.x, self.y)] = region
         else:
-            client.add_collision_label(self.label)
+            coords = client.check_collision_zones(
+                client._map_manager.collision_map, self.label
+            )
+            for coord in coords:
+                client._map_manager.collision_map[coord] = region

--- a/tuxemon/event/actions/remove_collision.py
+++ b/tuxemon/event/actions/remove_collision.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon.db import Direction
 from tuxemon.event.eventaction import EventAction
+from tuxemon.map.map_region import RegionProperties
 from tuxemon.session import Session
 
 
@@ -29,4 +31,13 @@ class RemoveCollisionAction(EventAction):
     label: str
 
     def start(self, session: Session) -> None:
-        session.client.collision_manager.remove_collision_label(self.label)
+        region = RegionProperties().with_overrides(
+            enter_from=list(Direction),
+            exit_from=list(Direction),
+            key=self.label,
+        )
+        coords = session.client.collision_manager.check_collision_zones(
+            session.client.map_manager.collision_map, self.label
+        )
+        for coord in coords:
+            session.client.map_manager.collision_map[coord] = region

--- a/tuxemon/map/collision_manager.py
+++ b/tuxemon/map/collision_manager.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any, DefaultDict, Optional, Union
 
 from tuxemon import prepare
-from tuxemon.db import Direction
 from tuxemon.map.map_region import RegionProperties
 
 if TYPE_CHECKING:
@@ -136,26 +135,12 @@ class CollisionManager:
             pos: The X, Y coordinates (as floats) indicating the entity's position.
         """
         coords = (int(pos[0]), int(pos[1]))
-        region = self._map_manager.collision_map.get(coords)
-
-        enter_from = region.enter_from if region else []
-        exit_from = region.exit_from if region else []
-        endure = region.endure if region else []
-        key = region.key if region else None
-        push_effect = region.push_effect if region else None
-        speed_modifier = region.speed_modifier if region else None
-
-        prop = RegionProperties(
-            enter_from=enter_from,
-            exit_from=exit_from,
-            endure=endure,
-            entity=entity,
-            key=key,
-            push_effect=push_effect,
-            speed_modifier=speed_modifier,
+        region = (
+            self._map_manager.collision_map.get(coords) or RegionProperties()
         )
-
-        self._map_manager.collision_map[coords] = prop
+        self._map_manager.collision_map[coords] = region.with_overrides(
+            entity=entity
+        )
 
     def remove_collision(self, tile_pos: tuple[int, int]) -> None:
         """
@@ -169,57 +154,12 @@ class CollisionManager:
             return  # Nothing to remove
 
         if region.enter_from or region.exit_from or region.endure:
-            prop = RegionProperties(
-                enter_from=region.enter_from,
-                exit_from=region.exit_from,
-                endure=region.endure,
-                key=region.key,
-                push_effect=region.push_effect,
-                speed_modifier=region.speed_modifier,
+            self._map_manager.collision_map[tile_pos] = region.with_overrides(
+                entity=None
             )
-            self._map_manager.collision_map[tile_pos] = prop
         else:
             # Remove region
             del self._map_manager.collision_map[tile_pos]
-
-    def add_collision_label(self, label: str) -> None:
-        coords = self.check_collision_zones(
-            self._map_manager.collision_map, label
-        )
-        properties = RegionProperties(
-            enter_from=[],
-            exit_from=[],
-            endure=[],
-            key=label,
-        )
-        if coords:
-            for coord in coords:
-                self._map_manager.collision_map[coord] = properties
-
-    def add_collision_position(
-        self, label: str, position: tuple[int, int]
-    ) -> None:
-        properties = RegionProperties(
-            enter_from=[],
-            exit_from=[],
-            endure=[],
-            key=label,
-        )
-        self._map_manager.collision_map[position] = properties
-
-    def remove_collision_label(self, label: str) -> None:
-        properties = RegionProperties(
-            enter_from=list(Direction),
-            exit_from=list(Direction),
-            endure=[],
-            key=label,
-        )
-        coords = self.check_collision_zones(
-            self._map_manager.collision_map, label
-        )
-        if coords:
-            for coord in coords:
-                self._map_manager.collision_map[coord] = properties
 
     def get_collision_map(self) -> CollisionMap:
         """
@@ -237,7 +177,7 @@ class CollisionManager:
         """
         collision_dict: DefaultDict[
             tuple[int, int], Optional[RegionProperties]
-        ] = defaultdict(lambda: RegionProperties([], [], [], None, None))
+        ] = defaultdict(RegionProperties)
 
         # Get all the NPCs' tile positions
         for npc in self._npc_manager.get_all_entities():
@@ -273,33 +213,10 @@ class CollisionManager:
         Returns:
             A RegionProperties object representing the collision state.
         """
-        region: Optional[RegionProperties] = (
-            self._map_manager.collision_map.get(coords)
+        region = (
+            self._map_manager.collision_map.get(coords) or RegionProperties()
         )
-
-        enter_from = region.enter_from if region else []
-        exit_from = region.exit_from if region else []
-        endure = region.endure if region else []
-        push_effect = region.push_effect if region else None
-        speed_modifier = region.speed_modifier if region else None
-        key = region.key if region else None
-
         if isinstance(entity_or_label, str):
-            return RegionProperties(
-                enter_from=enter_from,
-                exit_from=exit_from,
-                endure=endure,
-                key=entity_or_label,
-                push_effect=push_effect,
-                speed_modifier=speed_modifier,
-            )
+            return region.with_overrides(key=entity_or_label)
         else:
-            return RegionProperties(
-                enter_from=enter_from,
-                exit_from=exit_from,
-                endure=endure,
-                entity=entity_or_label,
-                key=key,
-                push_effect=push_effect,
-                speed_modifier=speed_modifier,
-            )
+            return region.with_overrides(entity=entity_or_label)

--- a/tuxemon/map/map_region.py
+++ b/tuxemon/map/map_region.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from tuxemon.db import Direction
 from tuxemon.prepare import REGION_KEYS
@@ -25,19 +26,59 @@ class RegionKey(str, Enum):
     PUSH_TILE = "push_tile"
 
 
-class PushEffect(NamedTuple):
+@dataclass(frozen=True)
+class PushEffect:
     direction: Direction
     strength: int
 
 
-class RegionProperties(NamedTuple):
-    enter_from: Sequence[Direction]
-    exit_from: Sequence[Direction]
-    endure: Sequence[Direction]
-    entity: Optional[Entity[Any]] = None
-    key: Optional[str] = None
-    push_effect: Optional[PushEffect] = None
-    speed_modifier: Optional[float] = None
+@dataclass(frozen=True)
+class RegionProperties:
+    enter_from: Sequence[Direction] = field(
+        default_factory=list,
+        metadata={
+            "description": "Directions from which an entity can enter this region."
+        },
+    )
+    exit_from: Sequence[Direction] = field(
+        default_factory=list,
+        metadata={
+            "description": "Directions from which an entity can exit this region."
+        },
+    )
+    endure: Sequence[Direction] = field(
+        default_factory=list,
+        metadata={
+            "description": "Directions from which an entity can remain in this region."
+        },
+    )
+    entity: Optional[Entity[Any]] = field(
+        default=None,
+        metadata={
+            "description": "Optional entity associated with this region."
+        },
+    )
+    key: Optional[str] = field(
+        default=None,
+        metadata={
+            "description": "Region behavior key (e.g., 'slide', 'push_tile')."
+        },
+    )
+    push_effect: Optional[PushEffect] = field(
+        default=None,
+        metadata={
+            "description": "Push effect applied when entering this region."
+        },
+    )
+    speed_modifier: Optional[float] = field(
+        default=None,
+        metadata={
+            "description": "Multiplier for movement speed within this region."
+        },
+    )
+
+    def with_overrides(self, **kwargs: Any) -> RegionProperties:
+        return replace(self, **kwargs)
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
PR introduces a cohesive refactor to the region and collision handling system.

`RegionProperties` refactor:
- converted `RegionProperties` and `PushEffect` from `NamedTuple` to `@dataclass(frozen=True)`
- added field-level `metadata` to `RegionProperties`: enhances documentation and introspection for tooling and developers.
- introduced `with_overrides()` method: allows clean, immutable updates using `dataclasses.replace`.

`CollisionManager`:
- updated all usages of `RegionProperties` to leverage the new dataclass structure
- Replaced manual reconstruction of region objects with `with_overrides()` for clarity and immutability
- simplified logic in methods like `add_collision`, `remove_collision` and `_get_region_properties`
- updated default behavior in `get_collision_map()` to use `defaultdict(RegionProperties)`: guarantees fallback region objects are properly initialized
- removed redundant field unpacking and reconstruction logic in favor of concise overrides