### PR TITLE
Standardize `EventAction` lifecycle with `on_start` and `dt` support

### DIFF
--- a/tests/tuxemon/test_event_action.py
+++ b/tests/tuxemon/test_event_action.py
@@ -15,7 +15,7 @@ class TestActionContextManager(unittest.TestCase):
 
     def test_context_manager_enter(self):
         with ActionContextManager(self.mock_action, self.mock_session):
-            self.mock_action.start.assert_called_once()
+            self.mock_action.on_start.assert_called_once()
 
     def test_context_manager_exit(self):
         with ActionContextManager(self.mock_action, self.mock_session):

--- a/tuxemon/event/actions/access_pc.py
+++ b/tuxemon/event/actions/access_pc.py
@@ -62,7 +62,7 @@ class AccessPCAction(EventAction):
             "PCState", character=character, menu_builder=menu_builder
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("PCState")
         except ValueError:

--- a/tuxemon/event/actions/breeding.py
+++ b/tuxemon/event/actions/breeding.py
@@ -56,7 +56,7 @@ class BreedingAction(EventAction):
         menu.is_valid_entry = self.validate  # type: ignore[assignment]
         menu.on_menu_selection = self.set_var  # type: ignore[assignment]
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("MonsterMenuState")
         except ValueError:

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -48,7 +48,7 @@ class ChangeStateAction(EventAction):
 
         self.client.push_state(self.state_name)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name(self.state_name)
         except ValueError:

--- a/tuxemon/event/actions/char_move.py
+++ b/tuxemon/event/actions/char_move.py
@@ -77,7 +77,7 @@ class CharMoveAction(EventAction):
         else:
             logger.error("No valid path was generated")
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         if self.character is None:
             self.stop()
             return

--- a/tuxemon/event/actions/char_patrol.py
+++ b/tuxemon/event/actions/char_patrol.py
@@ -74,7 +74,7 @@ class CharPatrolAction(EventAction):
             logger.error(f"Failed to parse patrol path: {e}")
             return
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         if not self.character or not self.patrol_points:
             self.stop()
             return

--- a/tuxemon/event/actions/char_talk.py
+++ b/tuxemon/event/actions/char_talk.py
@@ -78,7 +78,7 @@ class CharTalkAction(EventAction):
         text = TextFormatter.replace_text(session, line, T)
         open_dialog(client=session.client, text=[T.translate(text)])
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("DialogState")
         except ValueError:

--- a/tuxemon/event/actions/choice_item.py
+++ b/tuxemon/event/actions/choice_item.py
@@ -62,7 +62,7 @@ class ChoiceItemAction(EventAction):
 
         session.client.push_state("ChoiceItem", menu=MenuOptions(options))
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("ChoiceItem")
         except ValueError:

--- a/tuxemon/event/actions/choice_monster.py
+++ b/tuxemon/event/actions/choice_monster.py
@@ -62,7 +62,7 @@ class ChoiceMonsterAction(EventAction):
 
         session.client.push_state("ChoiceMonster", menu=MenuOptions(options))
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("ChoiceMonster")
         except ValueError:

--- a/tuxemon/event/actions/choice_npc.py
+++ b/tuxemon/event/actions/choice_npc.py
@@ -62,7 +62,7 @@ class ChoiceNpcAction(EventAction):
 
         session.client.push_state("ChoiceNpc", menu=MenuOptions(options))
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("ChoiceNpc")
         except ValueError:

--- a/tuxemon/event/actions/cipher_dialog.py
+++ b/tuxemon/event/actions/cipher_dialog.py
@@ -111,7 +111,7 @@ class CipherDialogAction(EventAction):
             custom_rect=None,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("DialogState")
         except ValueError:

--- a/tuxemon/event/actions/crafting_station.py
+++ b/tuxemon/event/actions/crafting_station.py
@@ -63,7 +63,7 @@ class CraftingStationAction(EventAction):
             method=self.method,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("CraftMenuState")
         except ValueError:

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -121,7 +121,7 @@ class DojoMethodAction(EventAction):
 
             open_choice_dialog(session.client, MenuOptions(menu_options))
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("DialogState")
         except ValueError:

--- a/tuxemon/event/actions/fade_in.py
+++ b/tuxemon/event/actions/fade_in.py
@@ -16,7 +16,7 @@ from tuxemon.states.world_state import WorldState
 @dataclass
 class FadeInAction(EventAction):
     """
-    Fade in.
+    Fade in and block until the fade duration has completed.
 
     Script usage:
         .. code-block::
@@ -34,15 +34,19 @@ class FadeInAction(EventAction):
     name = "fade_in"
     trans_time: Optional[float] = None
     rgb: Optional[str] = None
+    elapsed: float = 0.0
 
     def start(self, session: Session) -> None:
-        pass
-
-    def update(self, session: Session) -> None:
         world = session.client.get_state_by_name(WorldState)
-        _time = TRANS_TIME if self.trans_time is None else self.trans_time
-        rgb: ColorLike = BLACK_COLOR
+        self._time = TRANS_TIME if self.trans_time is None else self.trans_time
+        self._rgb: ColorLike = BLACK_COLOR
         if self.rgb:
-            rgb = string_to_colorlike(self.rgb)
-        world.transition_manager.fade_in(_time, rgb)
-        self.stop()
+            self._rgb = string_to_colorlike(self.rgb)
+
+        world.transition_manager.fade_in(self._time, self._rgb)
+        self.elapsed = 0.0
+
+    def update(self, session: Session, dt: float) -> None:
+        self.elapsed += dt
+        if self.elapsed >= self._time:
+            self.stop()

--- a/tuxemon/event/actions/fade_out.py
+++ b/tuxemon/event/actions/fade_out.py
@@ -16,7 +16,7 @@ from tuxemon.states.world_state import WorldState
 @dataclass
 class FadeOutAction(EventAction):
     """
-    Fade out.
+    Fade out and block until the fade duration has completed.
 
     Script usage:
         .. code-block::
@@ -34,15 +34,19 @@ class FadeOutAction(EventAction):
     name = "fade_out"
     trans_time: Optional[float] = None
     rgb: Optional[str] = None
+    elapsed: float = 0.0
 
     def start(self, session: Session) -> None:
-        pass
-
-    def update(self, session: Session) -> None:
         world = session.client.get_state_by_name(WorldState)
-        _time = TRANS_TIME if self.trans_time is None else self.trans_time
-        rgb: ColorLike = BLACK_COLOR
+        self._time = TRANS_TIME if self.trans_time is None else self.trans_time
+        self._rgb: ColorLike = BLACK_COLOR
         if self.rgb:
-            rgb = string_to_colorlike(self.rgb)
-        world.transition_manager.fade_out(_time, rgb)
-        self.stop()
+            self._rgb = string_to_colorlike(self.rgb)
+
+        world.transition_manager.fade_out(self._time, self._rgb)
+        self.elapsed = 0.0
+
+    def update(self, session: Session, dt: float) -> None:
+        self.elapsed += dt
+        if self.elapsed >= self._time:
+            self.stop()

--- a/tuxemon/event/actions/get_pending_moves.py
+++ b/tuxemon/event/actions/get_pending_moves.py
@@ -88,7 +88,7 @@ class GetPendingMovesAction(EventAction):
 
         session.client.event_data.pop("check_max_tech", None)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("TechniqueMenuState")
         except ValueError:

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -161,7 +161,7 @@ class GetPlayerMonsterAction(EventAction):
         ):
             menu.escape_key_exits = False
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("MonsterMenuState")
         except ValueError:

--- a/tuxemon/event/actions/input_variable.py
+++ b/tuxemon/event/actions/input_variable.py
@@ -61,7 +61,7 @@ class InputVariableAction(EventAction):
             escape_key_exits=_escape,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("InputMenu")
         except ValueError:

--- a/tuxemon/event/actions/open_journal.py
+++ b/tuxemon/event/actions/open_journal.py
@@ -63,7 +63,7 @@ class OpenJournalAction(EventAction):
             reveal=True,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("JournalInfoState")
         except ValueError:

--- a/tuxemon/event/actions/park_experience.py
+++ b/tuxemon/event/actions/park_experience.py
@@ -48,7 +48,7 @@ class ParkExperienceAction(EventAction):
 
         self.client.push_state("ParkState", session=session)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         if self.option == "stop":
             try:
                 session.client.get_state_by_name("ParkState")

--- a/tuxemon/event/actions/pathfind.py
+++ b/tuxemon/event/actions/pathfind.py
@@ -38,7 +38,7 @@ class PathfindAction(EventAction):
         destination = (self.tile_pos_x, self.tile_pos_y)
         self.moving_entity.pathfind(destination)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         assert self.moving_entity
         if not (self.moving_entity.moving or self.moving_entity.path):
             self.stop()

--- a/tuxemon/event/actions/pathfind_to_char.py
+++ b/tuxemon/event/actions/pathfind_to_char.py
@@ -82,7 +82,7 @@ class PathfindToCharAction(EventAction):
 
         self.moving_entity.pathfind(final_destination)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         assert self.moving_entity
         if not (self.moving_entity.moving or self.moving_entity.path):
             self.stop()

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -124,7 +124,7 @@ class RandomBattleAction(EventAction):
             "play_music", [env.battle_music], True
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("CombatState")
         except ValueError:

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -128,7 +128,7 @@ class RandomEncounterAction(EventAction):
             "play_music", [environment.battle_music], True
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_queued_state_by_name("CombatState")
         except ValueError:

--- a/tuxemon/event/actions/random_horde.py
+++ b/tuxemon/event/actions/random_horde.py
@@ -141,7 +141,7 @@ class RandomHordeAction(EventAction):
             "play_music", [environment.battle_music], True
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_queued_state_by_name("CombatState")
         except ValueError:

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -62,7 +62,7 @@ class RenameMonsterAction(EventAction):
             char_limit=prepare.PLAYER_NAME_LIMIT,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("InputMenu")
         except ValueError:

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -46,7 +46,7 @@ class RenamePlayerAction(EventAction):
             random=bool(self.random),
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("InputMenu")
         except ValueError:

--- a/tuxemon/event/actions/screen_transition.py
+++ b/tuxemon/event/actions/screen_transition.py
@@ -16,7 +16,8 @@ from tuxemon.states.world_state import WorldState
 @dataclass
 class ScreenTransitionAction(EventAction):
     """
-    Initiate a screen transition.
+    Initiate a screen transition that blocks until both fade out and fade in
+    are complete.
 
     Script usage:
         .. code-block::
@@ -34,20 +35,26 @@ class ScreenTransitionAction(EventAction):
     name = "screen_transition"
     trans_time: Optional[float] = None
     rgb: Optional[str] = None
+    elapsed: float = 0.0
 
     def start(self, session: Session) -> None:
-        pass
-
-    def update(self, session: Session) -> None:
+        self._fade_in_triggered = False
         world = session.client.get_state_by_name(WorldState)
-        _time = TRANS_TIME if self.trans_time is None else self.trans_time
-        rgb: ColorLike = BLACK_COLOR
+        self._time = TRANS_TIME if self.trans_time is None else self.trans_time
+        self._rgb: ColorLike = BLACK_COLOR
         if self.rgb:
-            rgb = string_to_colorlike(self.rgb)
+            self._rgb = string_to_colorlike(self.rgb)
 
-        def fade_in() -> None:
-            world.transition_manager.fade_in(_time, rgb)
+        world.transition_manager.fade_out(self._time, self._rgb)
+        self.elapsed = 0.0
 
-        world.transition_manager.fade_out(_time, rgb)
-        world.task(fade_in, interval=_time)
-        self.stop()
+    def update(self, session: Session, dt: float) -> None:
+        self.elapsed += dt
+        world = session.client.get_state_by_name(WorldState)
+
+        if self.elapsed >= self._time and not self._fade_in_triggered:
+            world.transition_manager.fade_in(self._time, self._rgb)
+            self._fade_in_triggered = True
+
+        if self.elapsed >= 2 * self._time:
+            self.stop()

--- a/tuxemon/event/actions/show_monster.py
+++ b/tuxemon/event/actions/show_monster.py
@@ -57,7 +57,7 @@ class ShowMonsterAction(EventAction):
         params = {"monster": monster, "source": self.name}
         self.client.push_state("MonsterInfoState", kwargs=params)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("MonsterInfoState")
         except ValueError:

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -138,7 +138,7 @@ class SpawnMonsterAction(EventAction):
         msg = T.format("got_new_tuxemon", {"monster_name": child.name})
         open_dialog(session.client, [msg])
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("DialogState")
         except ValueError:

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -91,7 +91,7 @@ class StartBattleAction(EventAction):
             "play_music", [filename], True
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("CombatState")
         except ValueError:

--- a/tuxemon/event/actions/start_double_battle.py
+++ b/tuxemon/event/actions/start_double_battle.py
@@ -99,7 +99,7 @@ class StartDoubleBattleAction(EventAction):
             "play_music", [filename], True
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("CombatState")
         except ValueError:

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -105,7 +105,7 @@ class TranslatedDialogAction(EventAction):
             custom_rect=None,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("DialogState")
         except ValueError:

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -67,7 +67,7 @@ class TranslatedDialogChoiceAction(EventAction):
             escape_key_exits=True,
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_state_by_name("ChoiceState")
         except ValueError:

--- a/tuxemon/event/actions/tune_radio.py
+++ b/tuxemon/event/actions/tune_radio.py
@@ -86,7 +86,7 @@ class TuneRadioAction(EventAction):
         else:
             self.client.push_state("NuPhoneRadioMenu", character=character)
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         if not any(
             state.name in {"NuPhoneRadioMenu", "NuPhoneRadioTuner"}
             for state in session.client.active_states

--- a/tuxemon/event/actions/wait.py
+++ b/tuxemon/event/actions/wait.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from typing import final
 
@@ -14,7 +13,7 @@ from tuxemon.session import Session
 @dataclass
 class WaitAction(EventAction):
     """
-    Block event chain for some time.
+    Block the event chain for a given duration.
 
     Script usage:
         .. code-block::
@@ -22,17 +21,19 @@ class WaitAction(EventAction):
             wait <seconds>
 
     Script parameters:
-        seconds: Time in seconds for the event engine to wait for.
-
+        seconds: Duration in seconds for the event engine to wait.
+                The wait is measured using accumulated delta time (dt)
+                from the game loop, not wall clock time.
     """
 
     name = "wait"
     seconds: float
+    elapsed: float = 0.0
 
-    # TODO: use event loop time, not wall clock
     def start(self, session: Session) -> None:
-        self.finish_time = time.time() + self.seconds
+        self.elapsed = 0.0
 
-    def update(self, session: Session) -> None:
-        if time.time() >= self.finish_time:
+    def update(self, session: Session, dt: float) -> None:
+        self.elapsed += dt
+        if self.elapsed >= self.seconds:
             self.stop()

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -115,7 +115,7 @@ class WildEncounterAction(EventAction):
             "play_music", [environment.battle_music], True
         )
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         try:
             session.client.get_queued_state_by_name("CombatState")
         except ValueError:

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -36,7 +37,7 @@ class ActionContextManager:
         if self.action.cancelled:
             logger.warning("Event is cancelled, not starting")
         else:
-            self.action.start(self.session)
+            self.action.on_start(self.session)
         return self.action
 
     def __exit__(
@@ -171,11 +172,16 @@ class EventAction(ABC):
             logger.debug("Action is cancelled, not running")
             return
         try:
+            last_time = time.perf_counter()
             while not self.done and not self.cancelled:
                 if self._skip:
                     return
-                else:
-                    self.update(session)
+
+                now = time.perf_counter()
+                dt = now - last_time
+                last_time = now
+
+                self.update(session, dt)
         except Exception as e:
             logger.error(f"Error running action: {e}")
             raise
@@ -192,27 +198,27 @@ class EventAction(ABC):
     @abstractmethod
     def start(self, session: Session) -> None:
         """
-        Called only once, when the action is started.
+        Called only once by EventAction.on_start().
+        Subclasses must implement their unique initialization logic here.
+        """
 
-        For all actions, you will need to override this method.
-
-        For actions that only need to run one frame you can simply
-        put all the code here.  If the action will need to run over
-        several frames, you can init your action here, then override
-        the update method.
+    def on_start(self, session: Session) -> None:
+        """
+        Protocol method: Called once when the action is started.
+        Handles cancellation checks and calls the abstract start()
+        method for subclass logic.
         """
         if self.cancelled:
-            logger.debug("Action is cancelled, not starting")
+            logger.debug(f"Action is cancelled, not starting")
             self.stop()
             return
         try:
-            # start the action
-            pass
+            self.start(session)
         except Exception as e:
             logger.error(f"Error starting action: {e}")
             raise
 
-    def update(self, session: Session) -> None:
+    def update(self, session: Session, dt: float) -> None:
         """
         Called once per frame while action is running.
 

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -285,7 +285,7 @@ class EventEngine:
                     )
                 return
 
-            if not self.process_running_event(running_event):
+            if not self.process_running_event(running_event, dt):
                 # Event is complete or failed; mark it as completed
                 running_event.complete()
 
@@ -299,7 +299,9 @@ class EventEngine:
         for event_id in to_remove:
             self.running_events.pop(event_id, None)
 
-    def process_running_event(self, running_event: RunningEvent) -> bool:
+    def process_running_event(
+        self, running_event: RunningEvent, dt: float
+    ) -> bool:
         """
         Processes a single running event by handling its current or next action.
 
@@ -351,7 +353,7 @@ class EventEngine:
 
             # with add_error_context(e.map_event, e.current_action,
             # self.session):
-            current_action.update(self.session)
+            current_action.update(self.session, dt)
 
             if current_action.done:
                 # action finished, so continue and do the next one,
@@ -394,7 +396,7 @@ class EventEngine:
 
         # start the action
         # with add_error_context(e.map_event, next_action, self.session):
-        action.start(self.session)
+        action.on_start(self.session)
         running_event.current_action = action
         return True
 


### PR DESCRIPTION
PR introduces improvements to the event action system to make timing and lifecycle handling more consistent.

- added a new `on_start` method to event actions, this provides a dedicated hook for initialization logic when an action begins and it separates setup from the `update` loop, making actions easier to reason about
- updated the `update` method signature across event actions, the method now receives a `dt` (delta time) parameter and this allows actions to measure elapsed time in a frame‑rate independent way, rather than relying on wall clock time
- refactored `WaitAction`, it now accumulates `dt` to track elapsed time and this ensures the wait duration is consistent regardless of frame rate or pauses
- refactored `ScreenTransitionAction`, it now blocks until both fade out and fade in are complete and the action uses `dt` to measure the total transition time, ensuring predictable behavior in event chains
- refactored `FadeInAction` and `FadeOutAction`, both actions now accumulate `dt` and block until their fade duration has finished and this makes them consistent with other time‑based actions and ensures event chains wait for the fade to complete