### PR TITLE
Add active effect tracking and staged update support for techniques, items, and statuses

### DIFF
--- a/mods/fishing.yaml
+++ b/mods/fishing.yaml
@@ -1,27 +1,31 @@
 # Fishing Config Format
 # Each key is the slug of a fishing item (e.g., "fishing_rod", "neptune", "poseidon")
 # Fields:
-#   trigger: float                  # Probability of triggering a fishing encounter (0.0–1.0)
-#   lower_bound: int            # Minimum level of the fished monster
-#   upper_bound: int            # Maximum level of the fished monster
-#   exp_req_mod: float          # Experience modifier for the encounter
-#   stages: list[str]            # Allowed monster stages (e.g., basic, stage1, stage2, standalone)
-#   stage_weights: dict[str, float]   # Optional: weight per stages (e.g., basic: 0.5)
-#   shapes: list[str]            # Allowed monster shapes (e.g., piscine, polliwog)
-#   shape_weights: dict[str, float]   # Weight per shapes
-#   types: list[str]             # Allowed monster types (e.g., water, electric)
-#   type_weights: dict[str, float]    # Weight per types
-#   tags: list[str]              # Required monster tags (e.g., aquatic, rare)
-#   tag_shape: dict[str, float]       # Weight per tags
-#   animation_color: list[int]  # RGB color for animation (e.g., [0, 105, 148])
+#   trigger: float                   # Probability of triggering a fishing encounter (0.0–1.0)
+#   level_bounds: tuple[int, int]    # Minimum level, Maximum level of the fished monster
+#   exp_req_mod: float               # Experience modifier for the encounter
+#   failure_dialog: str              # Mandatory dialog key when no monster is caught
+#   cast_time: float                 # Duration of CAST stage
+#   wait_time: float                 # Duration of WAIT stage
+#   bite_time: float                 # Duration of BITE stage
+#   encounter_time: float            # Duration of ENCOUNTER stage
+#   stages: list[str]                # Allowed monster stages (e.g., basic, stage1, stage2, standalone)
+#   stage_weights: dict[str, float]  # Optional: weight per stage
+#   shapes: list[str]                # Allowed monster shapes (e.g., piscine, polliwog)
+#   shape_weights: dict[str, float]  # Weight per shape
+#   types: list[str]                 # Allowed monster types (e.g., water, electric)
+#   type_weights: dict[str, float]   # Weight per type
+#   tags: list[str]                  # Required monster tags (e.g., aquatic, rare)
+#   tag_shape: dict[str, float]      # Weight per tag
+#   animation_color: list[int]       # RGB color for animation (e.g., [0, 105, 148])
 #   environment: dict[str, str]      # Battle background by time of day (default/night)
 #   held_items: dict[str, float]     # Weighted held items (e.g., lure: 0.5, pearl: 0.5)
 
 fishing_rod:
   trigger: 0.6
-  lower_bound: 5
-  upper_bound: 15
+  level_bounds: [5, 15]
   exp_req_mod: 2.0
+  failure_dialog: fishing_rod_failure
   stages:
     - basic
   shapes:
@@ -38,9 +42,9 @@ fishing_rod:
 
 neptune:
   trigger: 0.8
-  lower_bound: 10
-  upper_bound: 25
+  level_bounds: [10, 25]
   exp_req_mod: 2.0
+  failure_dialog: fishing_rod_failure
   stages:
     - basic
     - stage1
@@ -58,9 +62,9 @@ neptune:
 
 poseidon:
   trigger: 0.95
-  lower_bound: 15
-  upper_bound: 40
+  level_bounds: [15, 40]
   exp_req_mod: 2.0
+  failure_dialog: fishing_rod_failure
   stages:
     - stage2
     - stage1

--- a/mods/trap.yaml
+++ b/mods/trap.yaml
@@ -1,0 +1,16 @@
+example_trap:
+  expire_time: 30.0        # Maximum time (in seconds) the trap/fishing rod remains active before expiring
+  max_distance: 8          # Maximum distance (in tiles) the player can move away before the trap expires
+  trigger_chance: 0.6      # Probability (0–1) that the trap/fishing rod will successfully trigger an encounter
+  failure_dialog: "trap_failed"     # Dialog key shown if the trap is sprung but no monster is caught
+  success_dialog: "trap_triggered"  # Dialog key shown when the trap successfully catches a monster
+  level_bounds: [2, 5]     # Minimum and maximum monster level range for encounters (randomly chosen between 2–5)
+  weight_bounds: [10.0, 200.0]      # Optional minimum and maximum monster body weight in kilograms allowed for encounters
+  stages: ["basic", "stage1"]       # Allowed monster evolutionary stages that can be selected
+  stage_weights:            # Weight modifiers for stage selection (higher = more likely)
+    basic: 1.0
+    advanced: 0.5
+  shapes: ["hunter", "varmint"]     # Allowed monster shapes/types (taxonomy categories)
+  shape_weights:            # Weight modifiers for shape selection
+    hunter: 1.0
+    varmint: 0.8

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -9238,6 +9238,12 @@ msgstr "The water ripples, but nothing bites."
 msgid "bivouac_success"
 msgstr "The bivouac restored your team's strength!"
 
+msgid "trap_failed"
+msgstr "The trap snaps shut, yet the earth falls silent."
+
+msgid "trap_triggered"
+msgstr "The trap springs, and a creature emerges from below."
+
 msgid "itsswimmingtime"
 msgstr "Do you want to swim?"
 

--- a/tests/tuxemon/test_core_processor.py
+++ b/tests/tuxemon/test_core_processor.py
@@ -39,11 +39,21 @@ class TestEffectProcessor(unittest.TestCase):
         result = self.processor.process_tech(
             self.session, self.technique, self.user, self.target
         )
-
         self.assertTrue(result.success)
         self.assertEqual(result.damage, 15)
         self.assertEqual(result.element_multiplier, 1.5)
         self.assertListEqual(result.extras, ["Burn"])
+
+    def test_process_tech_failure(self):
+        self.tech_effect.apply_tech_target.return_value.success = False
+        result = self.processor.process_tech(
+            self.session, self.technique, self.user, self.target
+        )
+        self.assertFalse(result.success)
+
+    def test_update_calls_effects(self):
+        self.processor.update(self.session, dt=0.1)
+        self.tech_effect.update.assert_called_once_with(self.session, 0.1)
 
 
 class TestEffectProcessorItem(unittest.TestCase):
@@ -64,10 +74,20 @@ class TestEffectProcessorItem(unittest.TestCase):
         result = self.processor.process_item(
             self.session, self.item, self.target
         )
-
         self.assertTrue(result.success)
         self.assertEqual(result.num_shakes, 3)
         self.assertListEqual(result.extras, ["Healing Boost"])
+
+    def test_process_item_failure(self):
+        self.item_effect.apply_item_target.return_value.success = False
+        result = self.processor.process_item(
+            self.session, self.item, self.target
+        )
+        self.assertFalse(result.success)
+
+    def test_update_calls_effects(self):
+        self.processor.update(self.session, dt=0.2)
+        self.item_effect.update.assert_called_once_with(self.session, 0.2)
 
 
 class TestEffectProcessorStatus(unittest.TestCase):
@@ -90,11 +110,14 @@ class TestEffectProcessorStatus(unittest.TestCase):
 
     def test_process_status(self):
         result = self.processor.process_status(self.session, self.status)
-
         self.assertTrue(result.success)
         self.assertListEqual(result.statuses, ["Poisoned"])
         self.assertListEqual(result.techniques, ["Weaken"])
         self.assertListEqual(result.extras, ["Extended Duration"])
+
+    def test_update_calls_effects(self):
+        self.processor.update(self.session, dt=0.3)
+        self.status_effect.update.assert_called_once_with(self.session, 0.3)
 
 
 class TestConditionProcessor(unittest.TestCase):
@@ -114,28 +137,24 @@ class TestConditionProcessor(unittest.TestCase):
     def test_condition_passes_with_op(self):
         self.core_condition.is_expected = True
         self.core_condition.test_with_monster.return_value = True
-
         processor = ConditionProcessor(conditions=[self.core_condition])
         self.assertTrue(processor.validate(self.session, self.target_monster))
 
     def test_condition_fails_with_op(self):
         self.core_condition.is_expected = True
         self.core_condition.test_with_monster.return_value = False
-
         processor = ConditionProcessor(conditions=[self.core_condition])
         self.assertFalse(processor.validate(self.session, self.target_monster))
 
     def test_condition_passes_without_op(self):
         self.core_condition.is_expected = False
         self.core_condition.test_with_monster.return_value = False
-
         processor = ConditionProcessor(conditions=[self.core_condition])
         self.assertTrue(processor.validate(self.session, self.target_monster))
 
     def test_condition_fails_without_op(self):
         self.core_condition.is_expected = False
         self.core_condition.test_with_monster.return_value = True
-
         processor = ConditionProcessor(conditions=[self.core_condition])
         self.assertFalse(processor.validate(self.session, self.target_monster))
 
@@ -147,33 +166,29 @@ class TestConditionProcessor(unittest.TestCase):
     def test_multiple_conditions_all_pass(self):
         self.core_condition.is_expected = True
         self.core_condition.test_with_monster.return_value = True
-
         another_condition = MagicMock(spec=CoreCondition)
         another_condition.is_expected = True
         another_condition.test_with_monster.return_value = True
-
         processor = ConditionProcessor(
-            conditions=[self.core_condition, another_condition]
+            [self.core_condition, another_condition]
         )
         self.assertTrue(processor.validate(self.session, self.target_monster))
 
     def test_multiple_conditions_one_fails(self):
         self.core_condition.is_expected = True
         self.core_condition.test_with_monster.return_value = True
-
         another_condition = MagicMock(spec=CoreCondition)
         another_condition.is_expected = True
         another_condition.test_with_monster.return_value = False
-
         processor = ConditionProcessor(
-            conditions=[self.core_condition, another_condition]
+            [self.core_condition, another_condition]
         )
         self.assertFalse(processor.validate(self.session, self.target_monster))
 
     def test_method_invocation_count(self):
         self.core_condition.is_expected = True
         self.core_condition.test_with_monster.return_value = True
-        processor = ConditionProcessor(conditions=[self.core_condition])
+        processor = ConditionProcessor([self.core_condition])
         processor.validate(self.session, self.target_monster)
         self.core_condition.test_with_monster.assert_called_once_with(
             self.session, self.target_monster

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -42,8 +42,11 @@ from tuxemon.world.weather import WorldWeatherManager
 
 if TYPE_CHECKING:
     from tuxemon.config import TuxemonConfig
+    from tuxemon.item.item import Item
     from tuxemon.platform.events import PlayerInput
     from tuxemon.state.queue import QueuedState
+    from tuxemon.status.status import Status
+    from tuxemon.technique.technique import Technique
     from tuxemon.ui.cipher_processor import CipherProcessor
 
 StateType = TypeVar("StateType", bound=State)
@@ -66,6 +69,9 @@ class BaseClient(ABC):
 
     def __init__(self, config: TuxemonConfig) -> None:
         self.config = config
+        self.active_techniques: list[Technique] = []
+        self.active_items: list[Item] = []
+        self.active_statuses: list[Status] = []
 
         self.event_bus = get_event_bus()
         self.state_repository = StateRepository()
@@ -193,6 +199,21 @@ class BaseClient(ABC):
         self.state_manager.update(time_delta)
         if self.state_manager.current_state is None:
             self.state = ClientState.EXITING
+
+        for tech in list(self.active_techniques):
+            tech.effect_handler.update(local_session, time_delta)
+            if tech.effect_handler.is_finished():
+                self.active_techniques.remove(tech)
+
+        for item in list(self.active_items):
+            item.effect_handler.update(local_session, time_delta)
+            if item.effect_handler.is_finished():
+                self.active_items.remove(item)
+
+        for status in list(self.active_statuses):
+            status.effect_handler.update(local_session, time_delta)
+            if status.effect_handler.is_finished():
+                self.active_statuses.remove(status)
 
     def get_map_name(self) -> str:
         """

--- a/tuxemon/core/core_effect.py
+++ b/tuxemon/core/core_effect.py
@@ -47,6 +47,12 @@ class CoreEffect:
     def __post_init__(self) -> None:
         cast_dataclass_parameters(self)
 
+    def update(self, session: Session, dt: float) -> None:
+        pass
+
+    def is_finished(self) -> bool:
+        return True
+
     def apply_globally(self, session: Session) -> EffectResult:
         return EffectResult()
 

--- a/tuxemon/core/core_processor.py
+++ b/tuxemon/core/core_processor.py
@@ -34,6 +34,29 @@ class EffectProcessor:
     def __init__(self, effects: Sequence[PluginObject]) -> None:
         self.effects = effects
 
+    def update(self, session: Session, dt: float) -> None:
+        if not self.effects:
+            return
+        for effect in self.effects:
+            if isinstance(effect, CoreEffect):
+                effect.update(session, dt)
+        self.prune_finished()
+
+    def is_finished(self) -> bool:
+        if not self.effects:
+            return True
+        for effect in self.effects:
+            if isinstance(effect, CoreEffect) and not effect.is_finished():
+                return False
+        return True
+
+    def prune_finished(self) -> None:
+        self.effects = [
+            effect
+            for effect in self.effects
+            if not (isinstance(effect, CoreEffect) and effect.is_finished())
+        ]
+
     def process_globally(
         self,
         session: Session,

--- a/tuxemon/core/effects/bivouac.py
+++ b/tuxemon/core/effects/bivouac.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
@@ -10,6 +11,13 @@ from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
     from tuxemon.session import Session
+
+
+class BivouacStage(Enum):
+    SETUP = 1
+    REST = 2
+    HEAL = 3
+    DONE = 4
 
 
 @dataclass
@@ -20,8 +28,41 @@ class BivouacEffect(CoreEffect):
     """
 
     name = "bivouac"
+    stage: BivouacStage = BivouacStage.SETUP
+    _elapsed: float = 0.0
+    _duration: float = 0.0
+    _finished: bool = False
 
     def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
-        session.client.event_engine.execute_action("set_monster_health")
-        session.client.event_engine.execute_action("set_monster_status")
+        self.session = session
+        self.item = item
+        self.stage = BivouacStage.SETUP
+        self._elapsed = 0.0
+        self._duration = 1.5
         return ItemEffectResult(name=item.name, success=True)
+
+    def update(self, session: Session, dt: float) -> None:
+        session.client.movement_manager.lock_controls(session.player)
+        self._elapsed += dt
+
+        if (
+            self.stage == BivouacStage.SETUP
+            and self._elapsed >= self._duration
+        ):
+            self.stage = BivouacStage.REST
+            self._elapsed = 0.0
+            self._duration = 3.0
+
+        elif (
+            self.stage == BivouacStage.REST and self._elapsed >= self._duration
+        ):
+            self.stage = BivouacStage.HEAL
+            self._elapsed = 0.0
+            session.client.event_engine.execute_action("set_monster_health")
+            session.client.event_engine.execute_action("set_monster_status")
+            session.client.movement_manager.unlock_controls(session.player)
+            self.stage = BivouacStage.DONE
+            self._finished = True
+
+    def is_finished(self) -> bool:
+        return self._finished

--- a/tuxemon/core/effects/drone.py
+++ b/tuxemon/core/effects/drone.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
@@ -12,6 +13,15 @@ if TYPE_CHECKING:
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
     from tuxemon.session import Session
+
+
+class DroneStage(Enum):
+    LAUNCH = 1
+    TRAVEL = 2
+    ARRIVAL = 3
+    SWAP = 4
+    RETURN = 5
+    DONE = 6
 
 
 @dataclass
@@ -24,25 +34,75 @@ class DroneEffect(CoreEffect):
     """
 
     name = "drone"
+    stage: DroneStage = DroneStage.LAUNCH
+    _elapsed: float = 0.0
+    _duration: float = 0.0
+    _finished: bool = False
 
     def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
+        self.session = session
+        self.item = item
+        self.stage = DroneStage.LAUNCH
+        self._elapsed = 0.0
+        self._duration = 1.0
+        return ItemEffectResult(name=item.name, success=True)
 
-        def on_party_monster_selected(monster: Monster) -> None:
+    def update(self, session: Session, dt: float) -> None:
+        session.client.movement_manager.lock_controls(session.player)
+        if self.stage == DroneStage.DONE:
+            return
+
+        self._elapsed += dt
+
+        if self.stage == DroneStage.LAUNCH and self._elapsed >= self._duration:
+            self.stage = DroneStage.TRAVEL
+            self._elapsed = 0.0
+            self._duration = 2.0
+
+        elif (
+            self.stage == DroneStage.TRAVEL and self._elapsed >= self._duration
+        ):
+            self.stage = DroneStage.ARRIVAL
+            self._elapsed = 0.0
+            self._duration = 0.5
+
+        elif (
+            self.stage == DroneStage.ARRIVAL
+            and self._elapsed >= self._duration
+        ):
+            size = session.player.monster_boxes.get_box_size(KENNEL, "monster")
+            if size == 0:
+                self._finished = True
+                self.stage = DroneStage.DONE
+                return
+
+            def on_party_monster_selected(monster: Monster) -> None:
+                session.client.push_state(
+                    "MonsterTakeState",
+                    box_name=KENNEL,
+                    character=session.player,
+                    swap_target=monster,
+                )
+                self.stage = DroneStage.RETURN
+                self._elapsed = 0.0
+                self._duration = 1.5
+
             session.client.push_state(
-                "MonsterTakeState",
+                "MonsterDropOff",
                 box_name=KENNEL,
                 character=session.player,
-                swap_target=monster,
+                on_selection=on_party_monster_selected,
             )
+            self.stage = DroneStage.SWAP
+            self._elapsed = 0.0
+            self._duration = 0.0  # waiting for user input
 
-        size = session.player.monster_boxes.get_box_size(KENNEL, "monster")
-        if size == 0:
-            return ItemEffectResult(name=item.name)
+        elif (
+            self.stage == DroneStage.RETURN and self._elapsed >= self._duration
+        ):
+            session.client.movement_manager.unlock_controls(session.player)
+            self.stage = DroneStage.DONE
+            self._finished = True
 
-        session.client.push_state(
-            "MonsterDropOff",
-            box_name=KENNEL,
-            character=session.player,
-            on_selection=on_party_monster_selected,
-        )
-        return ItemEffectResult(name=item.name, success=True)
+    def is_finished(self) -> bool:
+        return self._finished

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,8 +27,8 @@ lookup_cache: dict[str, MonsterModel] = {}
 @dataclass
 class ActionConfig:
     trigger: float = 0.0
-    lower_bound: int = 0
-    upper_bound: int = 0
+    level_bounds: tuple[int, int] = (0, 0)
+    failure_dialog: str = "fishing_rod_failure"
     stages: list[str] = field(default_factory=list)
     stage_weights: dict[str, float] = field(default_factory=dict)
     shapes: list[str] = field(default_factory=list)
@@ -39,14 +40,18 @@ class ActionConfig:
     animation_color: list[int] = field(default_factory=list)
     environment: dict[str, str] = field(default_factory=dict)
     held_items: dict[str, float] = field(default_factory=dict)
-    exp_req_mod: list[float] = field(default_factory=list)
+    exp_req_mod: float | None = None
+    cast_time: float = 1.0
+    wait_time: float = 2.0
+    bite_time: float = 1.0
+    encounter_time: float = 0.5
 
     def validate_parameters(self) -> None:
         if not (0 <= self.trigger <= 1):
             raise ValueError("Trigger must be between 0 and 1 inclusive.")
-        if self.lower_bound < 0 or self.upper_bound < 0:
+        if self.level_bounds[0] < 0 or self.level_bounds[1] < 0:
             raise ValueError("Bounds must be non-negative.")
-        if self.lower_bound > self.upper_bound:
+        if self.level_bounds[0] > self.level_bounds[1]:
             raise ValueError("Lower bound cannot exceed upper bound.")
 
 
@@ -76,18 +81,29 @@ class Loader:
         return cls._config_fishing
 
 
+class FishingStage(Enum):
+    CAST = 1
+    WAIT = 2
+    BITE = 3
+    ENCOUNTER = 4
+    DONE = 5
+
+
 @dataclass
 class FishingEffect(CoreEffect):
     """This effect triggers fishing."""
 
     name = "fishing"
+    stage: FishingStage = FishingStage.CAST
+    _elapsed: float = 0.0
+    _duration: float = 0.0
+    _pending_encounter: tuple[str, int] | None = None
+    _trigger_next_frame: bool = False
 
     def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
         if not lookup_cache:
             _lookup_monsters()
 
-        self.player = session.player
-        self.client = session.client
         fishing_configs = Loader.get_config_fishing(f"{self.name}.yaml")
 
         self._fish: ActionConfig = fishing_configs[item.slug]
@@ -97,13 +113,88 @@ class FishingEffect(CoreEffect):
 
         if monster_slugs and random.random() <= self._fish.trigger:
             mon_slug = monster_slugs[0]
-            level = random.randint(
-                self._fish.lower_bound, self._fish.upper_bound
-            )
-            self._trigger_fishing_encounter(mon_slug, level)
-            return ItemEffectResult(name=item.name, success=True)
+            low, high = self._fish.level_bounds
+            level = random.randint(low, high)
+            self._pending_encounter = (mon_slug, level)
 
-        return ItemEffectResult(name=item.name)
+        self.stage = FishingStage.CAST
+        self._elapsed = 0.0
+        self._duration = self._fish.cast_time
+        return ItemEffectResult(name=item.name, success=True)
+
+    def update(self, session: Session, dt: float) -> None:
+        session.client.movement_manager.lock_controls(session.player)
+        if self.stage == FishingStage.DONE:
+            return
+
+        self._elapsed += dt
+
+        if self.stage == FishingStage.CAST and self._elapsed >= self._duration:
+            self.stage = FishingStage.WAIT
+            self._elapsed = 0.0
+            self._duration = self._fish.wait_time
+
+        elif (
+            self.stage == FishingStage.WAIT and self._elapsed >= self._duration
+        ):
+            self.stage = FishingStage.BITE
+            self._elapsed = 0.0
+            self._duration = self._fish.bite_time
+
+        elif (
+            self.stage == FishingStage.BITE and self._elapsed >= self._duration
+        ):
+            if self._pending_encounter:
+                self._trigger_next_frame = True
+            self.stage = FishingStage.ENCOUNTER
+            self._elapsed = 0.0
+            self._duration = self._fish.encounter_time
+
+        elif (
+            self.stage == FishingStage.ENCOUNTER
+            and self._elapsed >= self._duration
+        ):
+            if self._trigger_next_frame and self._pending_encounter:
+                mon_slug, level = self._pending_encounter
+                exp_req_mod = self._fish.exp_req_mod
+                environment = (
+                    self._fish.environment.get("night")
+                    if session.player.game_variables.get("stage_of_day")
+                    == "night"
+                    else self._fish.environment.get("default")
+                )
+                rgb = ":".join(map(str, self._fish.animation_color))
+                held_item = None
+                if self._fish.held_items:
+                    items, weights = zip(*self._fish.held_items.items())
+                    held_item = random.choices(items, weights=weights, k=1)[0]
+
+                session.client.event_engine.execute_action(
+                    "wild_encounter",
+                    [
+                        mon_slug,
+                        level,
+                        exp_req_mod,
+                        None,
+                        environment,
+                        rgb,
+                        held_item,
+                    ],
+                    True,
+                )
+                self._pending_encounter = None
+                self._trigger_next_frame = False
+            else:
+                dialog_key = self._fish.failure_dialog
+                session.client.event_engine.execute_action(
+                    "translated_dialog", [dialog_key], True
+                )
+                logger.info("Fishing attempt ended with no catch.")
+            session.client.movement_manager.unlock_controls(session.player)
+            self.stage = FishingStage.DONE
+
+    def is_finished(self) -> bool:
+        return self.stage == FishingStage.DONE
 
     def _get_fishing_monsters(self) -> list[str]:
         """Return a list of monster slugs based on config filters and weighted selection."""
@@ -151,31 +242,9 @@ class FishingEffect(CoreEffect):
         return shape_weight * stage_weight * type_weight * tag_weight
 
     def _trigger_fishing_encounter(self, mon_slug: str, level: int) -> None:
-        """Trigger a fishing encounter with environment, color, held item, and exp modifier."""
-        environment = (
-            self._fish.environment.get("night")
-            if self.player.game_variables.get("stage_of_day") == "night"
-            else self._fish.environment.get("default")
-        )
-
-        rgb = ":".join(map(str, self._fish.animation_color))
-
-        held_item = None
-        if self._fish.held_items:
-            items, weights = zip(*self._fish.held_items.items())
-            held_item = random.choices(items, weights=weights, k=1)[0]
-
-        logger.debug(
-            f"Selected monster: {mon_slug}, level: {level}, held_item: {held_item}"
-        )
-
-        exp_req_mod = self._fish.exp_req_mod
-
-        self.client.event_engine.execute_action(
-            "wild_encounter",
-            [mon_slug, level, exp_req_mod, None, environment, rgb, held_item],
-            True,
-        )
+        """Prepare a fishing encounter (store slug + level only)."""
+        self._pending_encounter = (mon_slug, level)
+        self._trigger_next_frame = True
 
 
 def _lookup_monsters() -> None:

--- a/tuxemon/core/effects/trap.py
+++ b/tuxemon/core/effects/trap.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+import random
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from tuxemon.constants import paths
+from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
+from tuxemon.db import MonsterModel, db
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+lookup_cache: dict[str, MonsterModel] = {}
+
+
+@dataclass
+class TrapConfig:
+    expire_time: float | None = None
+    max_distance: int | None = None
+    trigger_chance: float | None = None
+    failure_dialog: str = "trap_failed"
+    success_dialog: str = "trap_triggered"
+    level_bounds: tuple[int, int] = (0, 0)
+    weight_bounds: tuple[float, float] | None = None
+    stages: list[str] = field(default_factory=list)
+    stage_weights: dict[str, float] = field(default_factory=dict)
+    shapes: list[str] = field(default_factory=list)
+    shape_weights: dict[str, float] = field(default_factory=dict)
+    types: list[str] = field(default_factory=list)
+    type_weights: dict[str, float] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    tag_weights: dict[str, float] = field(default_factory=dict)
+
+    def validate_parameters(self) -> None:
+        if self.expire_time and self.expire_time < 0:
+            raise ValueError("Expire time must be non-negative.")
+        if self.max_distance and self.max_distance < 0:
+            raise ValueError("Max distance must be non-negative.")
+        if self.trigger_chance and not (0 <= self.trigger_chance <= 1):
+            raise ValueError("Trigger chance must be between 0 and 1.")
+        if self.level_bounds[0] < 0 or self.level_bounds[1] < 0:
+            raise ValueError("Bounds must be non-negative.")
+        if self.level_bounds[0] > self.level_bounds[1]:
+            raise ValueError("Lower bound cannot exceed upper bound.")
+        if self.weight_bounds:
+            low, high = self.weight_bounds
+            if low < 0 or high < 0:
+                raise ValueError("Weight bounds must be non-negative.")
+            if low > high:
+                raise ValueError(
+                    "Lower weight bound cannot exceed upper bound."
+                )
+
+
+def _lookup_monsters() -> None:
+    global lookup_cache
+    lookup_cache = {
+        mon_name: result
+        for mon_name in db.database["monster"]
+        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
+    }
+
+
+def load_yaml(filepath: Path) -> Any:
+    try:
+        with filepath.open() as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:
+        logger.error(f"Config file not found: {filepath}")
+        raise
+    except yaml.YAMLError as exc:
+        logger.error(f"Error parsing YAML file: {exc}")
+        raise exc
+
+
+class Loader:
+    _config_trap: dict[str, TrapConfig] = {}
+
+    @classmethod
+    def get_config_trap(cls, filename: str) -> dict[str, TrapConfig]:
+        yaml_path = paths.mods_folder / filename
+        if not cls._config_trap:
+            raw_map = load_yaml(yaml_path)
+            cls._config_trap = {
+                key: TrapConfig(**item) for key, item in raw_map.items()
+            }
+        return cls._config_trap
+
+
+class TrapStage(Enum):
+    SETUP = 1
+    ARMED = 2
+    TRIGGERED = 3
+    RESOLVE = 4
+    DONE = 5
+
+
+@dataclass
+class TrapEffect(CoreEffect):
+    name = "trap"
+    stage: TrapStage = TrapStage.SETUP
+    _elapsed: float = 0.0
+    _duration: float = 0.0
+    _finished: bool = False
+    _pending_encounter: tuple[str, int] | None = None
+
+    def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
+        if not lookup_cache:
+            _lookup_monsters()
+        trap_configs = Loader.get_config_trap("trap.yaml")
+        self._trap: TrapConfig = trap_configs[item.slug]
+        self._trap.validate_parameters()
+
+        self.stage = TrapStage.SETUP
+        self._elapsed = 0.0
+        self._duration = 1.0
+        self._origin_map = session.client.get_map_name()
+        self._origin_pos = session.player.tile_pos
+        return ItemEffectResult(name=item.name, success=True)
+
+    def update(self, session: Session, dt: float) -> None:
+        self._elapsed += dt
+
+        if self.stage == TrapStage.SETUP and self._elapsed >= self._duration:
+            self.stage = TrapStage.ARMED
+            self._elapsed = 0.0
+
+        elif self.stage == TrapStage.ARMED:
+            if session.client.get_map_name() != self._origin_map:
+                self._expire(session)
+            elif self._trap.max_distance and (
+                self._distance(session.player.tile_pos, self._origin_pos)
+                > self._trap.max_distance
+            ):
+                self._expire(session)
+            elif (
+                self._trap.expire_time
+                and self._elapsed >= self._trap.expire_time
+            ):
+                self._expire(session)
+            else:
+                self.trigger()
+
+        elif self.stage == TrapStage.TRIGGERED:
+            self.stage = TrapStage.RESOLVE
+            self._elapsed = 0.0
+            self._duration = 0.5
+
+        elif (
+            self.stage == TrapStage.RESOLVE and self._elapsed >= self._duration
+        ):
+            if self._pending_encounter:
+                mon_slug, level = self._pending_encounter
+                session.client.event_engine.execute_action(
+                    "wild_encounter",
+                    [mon_slug, level, None, None, None, None, None],
+                    True,
+                )
+                session.client.event_engine.execute_action(
+                    "translated_dialog", [self._trap.success_dialog], True
+                )
+            else:
+                session.client.event_engine.execute_action(
+                    "translated_dialog", [self._trap.failure_dialog], True
+                )
+            self.stage = TrapStage.DONE
+            self._finished = True
+
+    def trigger(self) -> None:
+        if (
+            self._trap.trigger_chance
+            and random.random() <= self._trap.trigger_chance
+        ):
+            mon_slug = self._get_trap_monsters()[0]
+            low, high = self._trap.level_bounds
+            level = random.randint(low, high)
+            self._pending_encounter = (mon_slug, level)
+            self.stage = TrapStage.TRIGGERED
+        else:
+            self._pending_encounter = None
+
+    def cancel(self, session: Session) -> None:
+        self._expire(session)
+
+    def _expire(self, session: Session) -> None:
+        session.client.event_engine.execute_action(
+            "translated_dialog", ["trap_expired"], True
+        )
+        self.stage = TrapStage.DONE
+        self._finished = True
+
+    def _distance(self, pos1: tuple[int, int], pos2: tuple[int, int]) -> int:
+        return abs(pos1[0] - pos2[0]) + abs(pos1[1] - pos2[1])
+
+    def is_finished(self) -> bool:
+        return self._finished
+
+    def _get_trap_monsters(self) -> list[str]:
+        def matches(mon: MonsterModel) -> bool:
+            return (
+                (not self._trap.stages or mon.stage.value in self._trap.stages)
+                and (not self._trap.shapes or mon.shape in self._trap.shapes)
+                and (
+                    not self._trap.types
+                    or any(t in self._trap.types for t in mon.types)
+                )
+                and (
+                    not self._trap.tags
+                    or any(tag in self._trap.tags for tag in mon.tags)
+                )
+                and (
+                    not self._trap.weight_bounds
+                    or (
+                        self._trap.weight_bounds[0]
+                        <= mon.weight
+                        <= self._trap.weight_bounds[1]
+                    )
+                )
+            )
+
+        filtered = [mon for mon in lookup_cache.values() if matches(mon)]
+        if not filtered:
+            logger.error("No monsters matched trap filters")
+            return []
+
+        weights = [self._compute_monster_weight(mon) for mon in filtered]
+        return random.choices(
+            [mon.slug for mon in filtered], weights=weights, k=1
+        )
+
+    def _compute_monster_weight(self, mon: MonsterModel) -> float:
+        shape_weight = self._trap.shape_weights.get(mon.shape, 1.0)
+        stage_weight = self._trap.stage_weights.get(mon.stage.value, 1.0)
+        type_weight = max(
+            [self._trap.type_weights.get(t, 1.0) for t in mon.types],
+            default=1.0,
+        )
+        tag_weight = max(
+            [self._trap.tag_weights.get(tag, 1.0) for tag in mon.tags],
+            default=1.0,
+        )
+        return shape_weight * stage_weight * type_weight * tag_weight

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -224,6 +224,8 @@ class Item:
         result = self.effect_handler.process_item(
             session=session, source=self, target=target
         )
+        if session.client:
+            session.client.active_items.append(self)
         self.consume_if_needed(user, result)
         return result
 

--- a/tuxemon/states/transition_flash.py
+++ b/tuxemon/states/transition_flash.py
@@ -46,9 +46,10 @@ class FlashTransition(State):
         params = RumbleParams(target=-1, length=1.5)
         self.client.rumble.rumble(params)
         self.color = color
+        self.transition_surface = Surface(prepare.SCREEN_SIZE)
+        self.transition_surface.fill(self.color)
 
     def resume(self) -> None:
-        self.transition_surface = Surface(prepare.SCREEN_SIZE)
         self.transition_surface.fill(self.color)
 
     def update(self, time_delta: float) -> None:

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -221,6 +221,8 @@ class Status:
             session=session,
             source=self,
         )
+        if session.client:
+            session.client.active_statuses.append(self)
         return result
 
     def tick_turn(self) -> None:

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -174,6 +174,8 @@ class Technique:
             target=target,
         )
         self.next_use = self.recharge_length
+        if session.client:
+            session.client.active_techniques.append(self)
         return result
 
     def has_type(self, type_slug: str) -> bool:


### PR DESCRIPTION
Summary of changes:
- added three new lists to the base client to track currently active effects: `self.active_techniques: list[Technique] = []`, `self.active_items: list[Item] = []` and `self.active_statuses: list[Status] = []`
- extended `CoreEffect` with default lifecycle methods: `update(self, session: Session, dt: float)` now exists as a stub, allowing effects to implement staged behavior over time and `is_finished(self) -> bool` now exists as a stub, returning `True` by default, so effects can signal when they are complete
- updated `EffectProcessor` to support staged updates: added `update(session, dt)` which iterates over all managed effects and calls their `update` method and added `is_finished()` which checks all managed effects and returns `False` if any are still running
- applied the same staged update pattern to `FishingEffect`: fishing now progresses through phases (CAST, WAIT, BITE, ENCOUNTER, DONE), this makes it possible to insert animations or timed transitions between phases and as a result, fishing outcomes are no longer immediate; the player experiences the staged sequence before the final result
- applied the same staged update pattern to `DroneEffect` and `BivouacEffect`: both effects now progress through defined phases rather than resolving instantly, this makes it possible to add animations, delays, or dialog to enhance immersion and outcomes are no longer immediate; the player experiences the staged sequence before completion