### PR TITLE
Make combat menu smarter by disabling unusable options  

### DIFF
--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -130,6 +130,14 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         if self.enemy.combat.forfeit:
             visibility_map["menu_forfeit"] = True
 
+        items_filtered = ItemFilter(self.character.items)
+        items_filtered.set_filter_usable_in_state("MainCombatMenuState")
+        if not items_filtered.items:
+            visibility_map["menu_item"] = False
+
+        if self.character.party.party_size == 1:
+            visibility_map["menu_monster"] = False
+
         for key, method_name in menu_map.items():
             callback = getattr(self, method_name)
             visible = visibility_map.get(key, False)


### PR DESCRIPTION
PR tweaks the combat menu so players don’t get stuck clicking buttons that don’t make sense in the current battle. The Item option is now disabled if the player has no usable items, and the Monster option is disabled if there’s only one monster in the party (the one already fighting).  

The idea is to keep the menu context‑aware and avoid pointless popups or empty menus. It makes battles feel smoother and more intuitive, since the menu only shows actions that are actually available.  

<img width="600" height="348" alt="Screenshot_2025-11-14_16-15-10" src="https://github.com/user-attachments/assets/42e3999f-c749-4c36-85bd-e96b87c83483" />
