### PR TITLE
Event Timing and Priority Updates

### DIFF
--- a/tests/tuxemon/test_event_engine.py
+++ b/tests/tuxemon/test_event_engine.py
@@ -27,13 +27,9 @@ class TestEventEngine(unittest.TestCase):
     def test_reset(self):
         self.eng.running_events = {1: "event1", 2: "event2"}
         self.eng.current_map = "map1"
-        self.eng.timer = 10.0
-        self.eng.wait = 5.0
         self.eng.reset()
         self.assertIsNone(self.eng.current_map)
         self.assertEqual(self.eng.running_events, {})
-        self.assertEqual(self.eng.timer, 0.0)
-        self.assertEqual(self.eng.wait, 0.0)
 
     def test_start_event(self):
         event = EventObject(

--- a/tests/tuxemon/test_event_parser.py
+++ b/tests/tuxemon/test_event_parser.py
@@ -15,13 +15,11 @@ class TestEventParser(unittest.TestCase):
             "actions": ["set flag quest_completed"],
         }
         self.name = "test_event"
-        self.source_type = "event"
         self.box = BoundingBox(x=5, y=10, width=2, height=3)
 
     def test_create_event_object(self):
         event = self.parser.create_event_object(
             self.event_data,
-            self.source_type,
             self.name,
             self.box,
         )
@@ -56,17 +54,13 @@ class TestEventParser(unittest.TestCase):
         self.assertEqual(act.parameters, ["flag quest_completed"])
 
     def test_empty_event_data(self):
-        event = self.parser.create_event_object(
-            {}, self.source_type, self.name, self.box
-        )
+        event = self.parser.create_event_object({}, self.name, self.box)
         self.assertEqual(len(event.conds), 0)
         self.assertEqual(len(event.acts), 0)
 
     def test_behav_only(self):
         data = {"behav": ["run:east"]}
-        event = self.parser.create_event_object(
-            data, self.source_type, self.name, self.box
-        )
+        event = self.parser.create_event_object(data, self.name, self.box)
         self.assertEqual(len(event.conds), 1)
         self.assertEqual(len(event.acts), 1)
         self.assertEqual(event.conds[0].parameters, ["run:east"])
@@ -77,16 +71,13 @@ class TestEventParser(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.parser.create_event_object(
                 data,
-                self.source_type,
                 self.name,
                 self.box,
             )
 
     def test_multiple_behaviors(self):
         data = {"behav": ["jump:up", "slide:left"]}
-        event = self.parser.create_event_object(
-            data, self.source_type, self.name, self.box
-        )
+        event = self.parser.create_event_object(data, self.name, self.box)
         self.assertEqual(len(event.conds), 2)
         self.assertEqual(len(event.acts), 2)
         self.assertEqual(event.conds[0].name, "behav20")
@@ -94,9 +85,7 @@ class TestEventParser(unittest.TestCase):
 
     def test_complex_action(self):
         data = {"actions": ["set flag quest_completed:true"]}
-        event = self.parser.create_event_object(
-            data, self.source_type, self.name, self.box
-        )
+        event = self.parser.create_event_object(data, self.name, self.box)
         self.assertEqual(
             event.acts[0].parameters, ["flag quest_completed:true"]
         )
@@ -104,7 +93,6 @@ class TestEventParser(unittest.TestCase):
     def test_event_object_integrity(self):
         event = self.parser.create_event_object(
             self.event_data,
-            self.source_type,
             self.name,
             self.box,
         )
@@ -112,3 +100,43 @@ class TestEventParser(unittest.TestCase):
         self.assertEqual(event.name, "test_event")
         self.assertEqual(event.box.x, self.box.x)
         self.assertEqual(event.box.y, self.box.y)
+
+    def test_event_with_timeout_and_delay(self):
+        data = {"timeout": 5, "delay": 2}
+        event = self.parser.create_event_object(
+            data,
+            self.name,
+            self.box,
+            priority=0,
+            timeout=5.0,
+            delay=2.0,
+        )
+        self.assertEqual(event.timeout, 5.0)
+        self.assertEqual(event.delay, 2.0)
+
+    def test_event_defaults(self):
+        event = self.parser.create_event_object({}, self.name, self.box)
+        self.assertIsNone(event.timeout)
+        self.assertIsNone(event.delay)
+
+    def test_condition_with_not_operator(self):
+        data = {"conditions": ["not flag quest_started"]}
+        event = self.parser.create_event_object(data, self.name, self.box)
+        cond = event.conds[0]
+        self.assertEqual(cond.operator, "not")
+
+    def test_event_box_integrity(self):
+        event = self.parser.create_event_object(
+            self.event_data, self.name, self.box
+        )
+        self.assertEqual(event.box.width, 2)
+        self.assertEqual(event.box.height, 3)
+
+    def test_multiple_actions(self):
+        data = {
+            "actions": ["set flag quest_started", "clear flag quest_completed"]
+        }
+        event = self.parser.create_event_object(data, self.name, self.box)
+        self.assertEqual(len(event.acts), 2)
+        self.assertEqual(event.acts[0].type, "set")
+        self.assertEqual(event.acts[1].type, "clear")

--- a/tests/tuxemon/test_running_event.py
+++ b/tests/tuxemon/test_running_event.py
@@ -88,3 +88,88 @@ class TestRunningEvent(unittest.TestCase):
         event.context["score"] = 42
         event.context["score"] += 8
         self.assertEqual(event.context["score"], 50)
+
+    def test_tick_accumulates_elapsed_time(self):
+        map_event = Mock(acts=[1], timeout=None, delay=None)
+        event = RunningEvent(map_event)
+
+        self.assertEqual(event.elapsed_time, 0.0)
+        ready = event.tick(1.5)
+        self.assertTrue(ready)
+        self.assertAlmostEqual(event.elapsed_time, 1.5)
+
+        ready = event.tick(2.0)
+        self.assertTrue(ready)
+        self.assertAlmostEqual(event.elapsed_time, 3.5)
+
+    def test_tick_respects_delay(self):
+        map_event = Mock(acts=[1], timeout=None, delay=3.0)
+        event = RunningEvent(map_event)
+
+        self.assertFalse(event.tick(2.0))
+        self.assertEqual(event.elapsed_time, 2.0)
+
+        self.assertTrue(event.tick(2.0))
+        self.assertEqual(event.elapsed_time, 4.0)
+
+    def test_tick_respects_timeout(self):
+        map_event = Mock(acts=[1], timeout=5.0, delay=None)
+        event = RunningEvent(map_event)
+
+        self.assertTrue(event.tick(4.0))
+        self.assertFalse(event.is_cancelled())
+        self.assertEqual(event.elapsed_time, 4.0)
+
+        self.assertFalse(event.tick(2.0))
+        self.assertTrue(event.is_cancelled())
+
+    def test_tick_delay_and_timeout_combined(self):
+        map_event = Mock(acts=[1], timeout=8.0, delay=3.0)
+        event = RunningEvent(map_event)
+
+        self.assertFalse(event.tick(2.0))
+        self.assertEqual(event.elapsed_time, 2.0)
+
+        self.assertTrue(event.tick(2.0))
+        self.assertFalse(event.is_cancelled())
+
+        self.assertFalse(event.tick(5.0))
+        self.assertTrue(event.is_cancelled())
+
+    def test_tick_active_window(self):
+        map_event = Mock(acts=[1], delay=3.0, timeout=8.0)
+        event = RunningEvent(map_event)
+
+        self.assertFalse(event.tick(2.0))
+        self.assertFalse(event.is_cancelled())
+
+        self.assertTrue(event.tick(2.0))
+        self.assertFalse(event.is_cancelled())
+
+        self.assertTrue(event.tick(3.0))
+        self.assertFalse(event.is_cancelled())
+
+        self.assertFalse(event.tick(2.0))
+        self.assertTrue(event.is_cancelled())
+
+    def test_tick_active_window_with_context_flag(self):
+        map_event = Mock(acts=[1], delay=3.0, timeout=8.0)
+        event = RunningEvent(map_event)
+
+        self.assertFalse(event.tick(2.0))
+        self.assertFalse(event.is_cancelled())
+        self.assertNotIn("window_triggered", event.context)
+
+        ready = event.tick(2.0)
+        self.assertTrue(ready)
+        if ready and not event.context.get("window_triggered"):
+            event.context["window_triggered"] = True
+        self.assertTrue(event.context["window_triggered"])
+
+        ready = event.tick(2.0)
+        self.assertTrue(ready)
+        self.assertTrue(event.context["window_triggered"])
+
+        ready = event.tick(3.0)
+        self.assertFalse(ready)
+        self.assertTrue(event.is_cancelled())

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -234,18 +234,13 @@ class BoundingBox(BaseModel):
     width: int = Field(
         ...,
         description="The horizontal size of the bounding box. Must be a positive integer.",
+        gt=0,
     )
     height: int = Field(
         ...,
         description="The vertical size of the bounding box. Must be a positive integer.",
+        gt=0,
     )
-
-    @field_validator("width", "height")
-    @classmethod
-    def must_be_positive(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError("'width' and 'height' must be positive.")
-        return v
 
 
 class Operator(str, Enum):
@@ -300,7 +295,16 @@ class EventObject(BaseModel):
     )
     priority: int = Field(
         ...,
-        description="Order of evaluation relative to other EventObjects. Lower number (e.g., 0) is higher priority.",
+        description="Order of evaluation relative to other EventObjects. Higher number (e.g., 10) is higher priority.",
+        ge=0,
+    )
+    timeout: Optional[float] = Field(
+        None,
+        description="Maximum duration (in seconds) this event is allowed to run. None = no timeout.",
+    )
+    delay: Optional[float] = Field(
+        None,
+        description="Delay before the event starts processing (in seconds). None = no delay.",
     )
     box: BoundingBox = Field(
         ..., description="The spatial bounding box of the event."
@@ -313,16 +317,6 @@ class EventObject(BaseModel):
         default_factory=list,
         description="A sequence of actions/effects to execute when conditions are met.",
     )
-
-    @field_validator("priority")
-    @classmethod
-    def priority_must_be_non_negative(cls, v: int) -> int:
-        """Ensures the priority is 0 or a positive integer."""
-        if v < 0:
-            raise ValueError(
-                "priority must be a non-negative integer (0 or greater)"
-            )
-        return v
 
 
 class BaseComparison(BaseModel):

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -51,9 +51,6 @@ class EventEngine:
         self.running_events: dict[int, RunningEvent] = dict()
         self.name = "Event"
         self.current_map: Optional[AbstractMap] = None
-        self.timer = 0.0
-        self.wait = 0.0
-        self.button = None
         self._suspended: bool = False
 
         self.global_events: list[EventObject] = []
@@ -73,9 +70,7 @@ class EventEngine:
         """Clear out running events.  Use when changing maps."""
         self.running_events = dict()
         self.set_current_map(None)
-        self.timer = 0.0
-        self.wait = 0.0
-        self.button = None
+        self.triggered_global_events = set()
 
     def suspend(self) -> None:
         """
@@ -175,7 +170,7 @@ class EventEngine:
         """
         if self._suspended:
             return
-        # debug
+
         self.partial_events = []
         self.check_global_conditions()
         self.check_conditions()
@@ -190,6 +185,7 @@ class EventEngine:
         all_events = list(self.session.client.map_manager.inits) + list(
             self.session.client.map_manager.events
         )
+        all_events.sort(key=lambda event: event.priority, reverse=True)
         for event in all_events:
             self.process_map_event(event)
 
@@ -221,7 +217,11 @@ class EventEngine:
         return was_removed
 
     def check_global_conditions(self) -> None:
-        for event in self.global_events:
+        sorted_global_events = sorted(
+            self.global_events, key=lambda event: event.priority, reverse=True
+        )
+
+        for event in sorted_global_events:
             if event.id in self.triggered_global_events:
                 continue
             self._evaluate_and_queue_event(event, is_global=True)
@@ -273,6 +273,8 @@ class EventEngine:
         ]
 
         for event_id, running_event in running_events_to_process:
+            if not running_event.tick(dt):
+                continue  # either waiting for delay or cancelled by timeout
             # If the current map has changed, then `reset` has also been
             # called, which replaced self.running_events with an empty dict.
             # We need to stop processing the running_events, as they may not

--- a/tuxemon/event/eventparser.py
+++ b/tuxemon/event/eventparser.py
@@ -32,10 +32,11 @@ class EventParser:
     def create_event_object(
         self,
         event_data: dict[str, Any],
-        source_type: str,
         name: str,
         box: BoundingBox,
         priority: int = 0,
+        timeout: float | None = None,
+        delay: float | None = None,
     ) -> EventObject:
         """
         Creates an EventObject from a dictionary of event data.
@@ -124,6 +125,8 @@ class EventParser:
             name=name,
             box=box,
             priority=priority,
+            timeout=timeout,
+            delay=delay,
             conds=conditions,
             acts=actions,
         )

--- a/tuxemon/event/running.py
+++ b/tuxemon/event/running.py
@@ -51,15 +51,36 @@ class RunningEvent:
         "current_action",
         "state",
         "priority",
+        "elapsed_time",
     )
 
     def __init__(self, map_event: EventObject) -> None:
         self.map_event = map_event
         self.context: dict[str, Any] = dict()
-        self.action_index = 0
+        self.action_index: int = 0
         self.current_action: Optional[EventAction] = None
         self.state = EventState.WAITING
         self.priority = map_event.priority
+        self.elapsed_time: float = 0.0
+
+    def tick(self, dt: float) -> bool:
+        self.elapsed_time += dt
+
+        if (
+            self.map_event.delay is not None
+            and self.elapsed_time < self.map_event.delay
+        ):
+            return False
+
+        if (
+            self.map_event.timeout is not None
+            and self.elapsed_time > self.map_event.timeout
+        ):
+            logger.info(f"Event {self.map_event.id} timed out")
+            self.cancel()
+            return False
+
+        return True
 
     def get_next_action(self) -> Optional[ParameterizableRule]:
         """
@@ -84,7 +105,8 @@ class RunningEvent:
         return action
 
     def advance(self) -> None:
-        self.action_index += 1
+        if self.action_index < len(self.map_event.acts):
+            self.action_index += 1
 
     def cancel(self) -> None:
         self.state = EventState.CANCELLED

--- a/tuxemon/map/map_loader.py
+++ b/tuxemon/map/map_loader.py
@@ -326,14 +326,19 @@ class YAMLEventLoader:
         events_dict: dict[str, list[EventObject]] = {"event": [], "init": []}
 
         for name, event_data in yaml_data["events"].items():
-            event_type = str(event_data.get("type"))
+            _event_type = event_data.get("type")
+            event_type = str(_event_type) if _event_type is not None else None
             if event_type == source:
                 priority = int(event_data.get("priority", 0))
+                _timeout = event_data.get("timeout")
+                timeout = float(_timeout) if _timeout is not None else None
+                _delay = event_data.get("delay")
+                delay = float(_delay) if _delay is not None else None
                 x, y = event_data.get("x", 0), event_data.get("y", 0)
                 w, h = event_data.get("width", 1), event_data.get("height", 1)
                 box = BoundingBox(x=x, y=y, width=w, height=h)
                 event = event_parser.create_event_object(
-                    event_data, event_type, name, box, priority
+                    event_data, name, box, priority, timeout, delay
                 )
                 events_dict[event_type].append(event)
         return events_dict
@@ -643,6 +648,4 @@ class TMXMapLoader:
                 event_data["behav"].append(value)
 
         box = BoundingBox(x=x, y=y, width=w, height=h)
-        return event_parser.create_event_object(
-            event_data, obj.type or "event", obj.name, box
-        )
+        return event_parser.create_event_object(event_data, obj.name, box)


### PR DESCRIPTION
Changes `RunningEvent`
- added `elapsed_time` to track how long an event has been active
- updated `tick()` to enforce `delay` (wait before start) and `timeout` (cancel after limit)

Changes `EventObject`
- added `timeout` and `delay` fields.  
- TMX events from Tiled remain unchanged, but YAML events can now use these fields
- removed the field validator for a simple ge (priority)

Changes `Priority`
- priority handling has been clarified. Higher numbers now mean higher priority, making the system more intuitive. The evaluation order has been updated so that both global events and local events are sorted by priority in descending order before conditions are checked.

Various:
- `source_type` has been removed from `create_event_object` because unused