### PR TITLE
Add `prepare_for_teleport` to `WorldState` and decouple transition cleanup  

### DIFF
--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -72,6 +72,7 @@ class TransitionTeleportAction(EventAction):
         )
         teleport_queue.enqueue(request)
 
+        session.world.prepare_for_teleport()
         session.world.transition_manager.fade_and_teleport(
             _time,
             rgb,

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -83,6 +83,16 @@ class WorldState(State):
         for button, config in self.input_handler.get_handlers().items():
             self.input_router.register(button, config)
 
+    def prepare_for_teleport(self) -> None:
+        """
+        Stops all WorldState background activity and locks player controls
+        in preparation for a map change or teleport.
+        """
+        self.remove_animations_of(self)
+        self.stop_scheduled_callbacks()
+        self.client.movement_manager.stop_char(self.player)
+        self.client.movement_manager.lock_controls(self.player)
+
     def resume(self) -> None:
         """Called after returning focus to this state"""
         self.client.movement_manager.unlock_controls(self.player)

--- a/tuxemon/world/transition.py
+++ b/tuxemon/world/transition.py
@@ -89,10 +89,6 @@ class WorldTransition:
             self.fade_in(duration, color, character)
 
         self.movement.lock_controls(character)
-        self.world.remove_animations_of(self.world)
-        self.world.stop_scheduled_callbacks()
-        self.movement.stop_and_reset_char(character)
-
         self.fade_out(duration, color, character)
         task = self.world.task(teleport_function, interval=duration)
         task.chain(fade_in, duration + 0.5)


### PR DESCRIPTION
PR introduces a new method in `WorldState` to handle teleport preparation and removes unnecessary coupling between `WorldTransition` and `WorldState`.  

Key points:  
- added `prepare_for_teleport` method in `WorldState`  
- updated `WorldTransition.fade_and_teleport`  
- ensures `TransitionTeleportAction` now calls `prepare_for_teleport` before invoking `fade_and_teleport`  
- improves separation of concerns
- reduces coupling and makes teleport logic easier to maintain and extend