### PR TITLE
Extract Analysis Methods into `StatAnalyzer`

### DIFF
--- a/tests/tuxemon/test_stat_calculator.py
+++ b/tests/tuxemon/test_stat_calculator.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from tuxemon.monster_dir.stats import (
     BasicStats,
+    StatAnalyzer,
     StatCalculator,
     TemporaryStatBoosts,
     TrainingPoints,
@@ -41,7 +42,6 @@ class TestStatCalculator(unittest.TestCase):
 
         self.base_stats = BasicStats()
         self.training_points = TrainingPoints()
-
         self.level = 5
 
         self.calculator = StatCalculator(
@@ -105,7 +105,6 @@ class TestStatCalculator(unittest.TestCase):
 
     def test_calculate(self):
         final_stats = self.calculator.calculate()
-
         self.assertIsInstance(final_stats, BasicStats)
         self.assertGreater(final_stats.sum(), 0)
 
@@ -118,20 +117,71 @@ class TestStatCalculator(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.calculator.calculate_at_level(0)
 
-    def test_get_stat_growth_curve(self):
-        curve = self.calculator.get_stat_growth_curve(3)
-        self.assertEqual(len(curve), 3)
-        for level, stats in curve.items():
-            self.assertIsInstance(level, int)
-            self.assertIsInstance(stats, BasicStats)
-            self.assertGreater(stats.sum(), 0)
+    def test_training_point_scaling(self):
+        self.training_points.armour = 100
+        stats = self.calculator.calculate_raw_stats(level=50)
+        self.assertEqual(stats.armour, (2 * (50 + COEFF_STATS)) + 50 + 1)
 
-    def test_get_stat_growth_curve_invalid(self):
-        with self.assertRaises(ValueError):
-            self.calculator.get_stat_growth_curve(0)
+    def test_negative_modifier(self):
+        self.calculator.modifiers.hp = -10
+        stats = self.calculator.calculate_raw_stats(level=self.level)
+        self.assertLess(stats.hp, (5 * (self.level + COEFF_STATS)))
+
+    def test_high_level_scaling(self):
+        stats = self.calculator.calculate_raw_stats(level=1000)
+        self.assertGreater(stats.sum(), 0)
+
+
+class TestStatAnalyzer(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_shape = MagicMock(spec=ShapeHandler)
+        self.mock_shape.attributes = BasicStats(
+            armour=2, dodge=3, hp=5, melee=4, ranged=1, speed=2
+        )
+
+        self.mock_taste_cold = MagicMock(spec=Taste)
+        self.mock_taste_cold.slug = "cold"
+        self.mock_taste_cold.modifiers = [
+            MagicMock(values=["speed"], multiplier=1.2),
+            MagicMock(values=["hp"], multiplier=0.9),
+        ]
+
+        self.mock_taste_warm = MagicMock(spec=Taste)
+        self.mock_taste_warm.slug = "warm"
+        self.mock_taste_warm.modifiers = [
+            MagicMock(values=["melee"], multiplier=1.1),
+        ]
+
+        self.modifiers = TemporaryStatBoosts(
+            armour=1, dodge=0, hp=2, melee=0, ranged=0, speed=3
+        )
+
+        self.base_stats = BasicStats()
+        self.training_points = TrainingPoints()
+        self.level = 5
+
+        self.calculator = StatCalculator(
+            base_stats=self.base_stats,
+            level=self.level,
+            shape=self.mock_shape,
+            taste_cold="cold",
+            taste_warm="warm",
+            modifiers=self.modifiers,
+            training_points=self.training_points,
+        )
+
+        Taste.get_taste = MagicMock(
+            side_effect=lambda name: {
+                "cold": self.mock_taste_cold,
+                "warm": self.mock_taste_warm,
+            }[name]
+        )
+
+        self.analyzer = StatAnalyzer(self.calculator)
 
     def test_get_breakdown_structure(self):
-        breakdown = self.calculator.get_breakdown()
+        breakdown = self.analyzer.get_breakdown()
         self.assertEqual(set(breakdown.keys()), set(BasicStats.names()))
         for stat, details in breakdown.items():
             self.assertIn("base_value", details)
@@ -143,5 +193,51 @@ class TestStatCalculator(unittest.TestCase):
             self.assertIn("final_value", details)
 
     def test_evaluate_taste_efficiency(self):
-        score = self.calculator.evaluate_taste_efficiency()
+        score = self.analyzer.evaluate_taste_efficiency()
         self.assertIsInstance(score, float)
+
+    def test_get_stat_growth_curve(self):
+        curve = self.analyzer.get_stat_growth_curve(3)
+        self.assertEqual(len(curve), 3)
+        for level, stats in curve.items():
+            self.assertIsInstance(level, int)
+            self.assertIsInstance(stats, BasicStats)
+            self.assertGreater(stats.sum(), 0)
+
+    def test_get_stat_growth_curve_invalid(self):
+        with self.assertRaises(ValueError):
+            self.analyzer.get_stat_growth_curve(0)
+
+    def test_taste_efficiency_normalized_range(self):
+        score = self.analyzer.evaluate_taste_efficiency()
+        self.assertGreaterEqual(score, -1.0)
+        self.assertLessEqual(score, 1.0)
+
+    def test_growth_curve_monotonic(self):
+        curve = self.analyzer.get_stat_growth_curve(5)
+        hp_values = [curve[level].hp for level in range(1, 6)]
+        self.assertTrue(
+            all(
+                hp_values[i] <= hp_values[i + 1]
+                for i in range(len(hp_values) - 1)
+            )
+        )
+
+    def test_breakdown_matches_calculator(self):
+        breakdown = self.analyzer.get_breakdown()
+        final_stats = self.calculator.calculate()
+        for stat in BasicStats.names():
+            self.assertEqual(
+                breakdown[stat]["final_value"], getattr(final_stats, stat)
+            )
+
+    def test_taste_multiplier_stacking(self):
+        self.mock_taste_warm.modifiers = []
+        self.mock_taste_cold.modifiers = [
+            MagicMock(values=["hp"], multiplier=1.5),
+            MagicMock(values=["hp"], multiplier=2.0),
+        ]
+        breakdown = self.analyzer.get_breakdown()
+        self.assertAlmostEqual(
+            breakdown["hp"]["taste_multiplier"], 1.5 * 2.0, places=2
+        )

--- a/tuxemon/monster_dir/stats.py
+++ b/tuxemon/monster_dir/stats.py
@@ -163,19 +163,39 @@ class StatCalculator:
 
         return round(modified_stat)
 
+    def calculate_at_level(self, target_level: int) -> BasicStats:
+        """Returns final stats at a specific level without modifying internal state."""
+        if target_level <= 0:
+            raise ValueError("Target level must be a positive integer.")
+
+        raw_stats = self.calculate_raw_stats(level=target_level)
+        cold = Taste.get_taste(self.taste_cold)
+        warm = Taste.get_taste(self.taste_warm)
+        return self.apply_stat_updates(raw_stats, cold, warm)
+
+
+class StatAnalyzer:
+    """Provides detailed analysis, breakdown, and growth projections for monster stats."""
+
+    def __init__(self, calculator: StatCalculator):
+        self.calculator = calculator
+
     def get_breakdown(self) -> dict[str, dict[str, Any]]:
         """Returns a detailed breakdown of each stat's calculation."""
         breakdown = {}
-        multiplier = self.level + COEFF_STATS
-        level_scale = self.level / 100
-        cold = Taste.get_taste(self.taste_cold)
-        warm = Taste.get_taste(self.taste_warm)
+        multiplier = self.calculator.level + COEFF_STATS
+        level_scale = self.calculator.level / 100
+        cold = Taste.get_taste(self.calculator.taste_cold)
+        warm = Taste.get_taste(self.calculator.taste_warm)
 
         for stat_name in BasicStats.names():
-            base_value = getattr(self.shape.attributes, stat_name) * multiplier
-            raw_tp = getattr(self.training_points, stat_name)
+            base_value = (
+                getattr(self.calculator.shape.attributes, stat_name)
+                * multiplier
+            )
+            raw_tp = getattr(self.calculator.training_points, stat_name)
             scaled_tp = int(raw_tp * level_scale)
-            modifier_value = getattr(self.modifiers, stat_name, 0)
+            modifier_value = getattr(self.calculator.modifiers, stat_name, 0)
 
             pre_taste_total = base_value + scaled_tp + modifier_value
 
@@ -186,7 +206,7 @@ class StatCalculator:
                         if stat_name in modifier.values:
                             taste_multiplier *= modifier.multiplier
 
-            final_value = int(pre_taste_total * taste_multiplier)
+            final_value = round(pre_taste_total * taste_multiplier)
 
             breakdown[stat_name] = {
                 "base_value": int(base_value),
@@ -200,18 +220,29 @@ class StatCalculator:
         return breakdown
 
     def evaluate_taste_efficiency(self) -> float:
-        """Returns a synergy score based on how well tastes match shape attributes."""
+        """Returns a normalized synergy score (-1 to +1) based on taste effects."""
         breakdown = self.get_breakdown()
-        score = 0.0
+        score: float = 0.0
+        total_base: float = 0.0
 
         for stat_name, data in breakdown.items():
-            base_stat_value = getattr(self.shape.attributes, stat_name)
+            base_stat_value = getattr(
+                self.calculator.shape.attributes, stat_name
+            )
+            total_base += base_stat_value
+
             if data["taste_multiplier"] > 1.0:
                 score += base_stat_value * (data["taste_multiplier"] - 1.0)
             elif data["taste_multiplier"] < 1.0:
                 score -= base_stat_value * (1.0 - data["taste_multiplier"])
 
-        return score
+        # Normalize to [-1, +1] range
+        if total_base > 0:
+            normalized_score = score / total_base
+        else:
+            normalized_score = 0.0
+
+        return normalized_score
 
     def get_stat_growth_curve(self, max_level: int) -> dict[int, BasicStats]:
         """Returns a level-to-stats map showing progression up to max_level."""
@@ -220,19 +251,9 @@ class StatCalculator:
 
         growth_curve = {}
         for level in range(1, max_level + 1):
-            growth_curve[level] = self.calculate_at_level(level)
+            growth_curve[level] = self.calculator.calculate_at_level(level)
 
         return growth_curve
-
-    def calculate_at_level(self, target_level: int) -> BasicStats:
-        """Returns final stats at a specific level without modifying internal state."""
-        if target_level <= 0:
-            raise ValueError("Target level must be a positive integer.")
-
-        raw_stats = self.calculate_raw_stats(level=target_level)
-        cold = Taste.get_taste(self.taste_cold)
-        warm = Taste.get_taste(self.taste_warm)
-        return self.apply_stat_updates(raw_stats, cold, warm)
 
 
 def randomize_stats(min_val: int, max_val: int) -> BasicStats:


### PR DESCRIPTION
PR refactors the stats system by separating calculation logic from analysis logic. Moved `get_breakdown`, `evaluate_taste_efficiency`, and `get_stat_growth_curve` out of `StatCalculator` into a new class `StatAnalyzer`.