### PR TITLE
`PartyHandler`: `PartyStats` and Refactored Methods + Boxes: `BoxMetadata`

### DIFF
--- a/mods/routing_policies.yaml
+++ b/mods/routing_policies.yaml
@@ -1,21 +1,32 @@
-# Routing policies control how monsters are handled when added to a trainer's party.
+# Routing policies control how monsters and items are handled when added to a trainer's
+# party or storage.
 # Each policy is identified by a unique name (e.g., "default", "example_policy").
-# You can define multiple policies and assign them to NPCs or players via scripts or savegame data.
+# You can define multiple policies and assign them to NPCs or players via scripts or
+# savegame data.
 #
 # ─── Field Reference ─────────────────────────────────────────────────────────────
-# max_box_capacity: Optional override for the default box capacity (prepare.MAX_KENNEL). Example: 20 → box is full at 20 monsters.
+# max_box_capacity: Optional override for the default box capacity (prepare.MAX_KENNEL or prepare.MAX_LOCKER).
+#                  Example: 20 → box is full at 20 monsters/items.
 # force_to_box: If true, all monsters go directly to the box instead of the party.
-# kennel_override: Optional override for the default box name (KENNEL). Use null to disable.
-# overflow_kennel: Optional secondary box used if the primary kennel is full. If also full, kennel_name_rules may be used to create overflow boxes.
-# max_party_size: Maximum number of monsters allowed in the party. -1 means unlimited party size
+# kennel_override: Optional override for the default monster box name (KENNEL). Use null to disable.
+# locker_override: Optional override for the default item box name (LOCKER). Use null to disable.
+# overflow_kennel: Optional secondary monster box used if the primary kennel is full.
+#                  If also full, kennel_name_rules may be used to create overflow boxes.
+# overflow_locker: Optional secondary item box used if the primary locker is full.
+#                  If also full, locker_name_rules may be used to create overflow boxes.
+# max_party_size: Maximum number of monsters allowed in the party. -1 means unlimited party size.
 # allow_party_addition: If false, monsters are never allowed in the party.
-# auto_release_if_box_full: If true, monsters are released when the box is full.
+# auto_release_if_box_full: If true, monsters are released when the box is full and no overflow strategy applies.
+# auto_discard_if_box_full: If true, items are discarded when the box is full and no overflow strategy applies.
 # nickname_rules:
 #   prefix: Prefix added to nicknames. Example: "Elite-" → "Elite-Rockitten"
 #   suffix: Suffix added to nicknames. Example: "-X" → "Rockitten-X"
 # kennel_name_rules:
-#   prefix: Prefix added to box name suffix. Example: "_" → "KENNEL_1"
-#   suffix: Suffix added to box name suffix. Example: "-X" → "KENNEL_1-X"
+#   prefix: Prefix added to monster box name suffix. Example: "_" → "KENNEL_1"
+#   suffix: Suffix added to monster box name suffix. Example: "-X" → "KENNEL_1-X"
+# locker_name_rules:
+#   prefix: Prefix added to item box name suffix. Example: "_" → "LOCKER_1"
+#   suffix: Suffix added to item box name suffix. Example: "-X" → "LOCKER_1-X"
 # ────────────────────────────────────────────────────────────────────────────────
 
 default:

--- a/mods/tuxemon/maps/cotton_daycare.tmx
+++ b/mods/tuxemon/maps/cotton_daycare.tmx
@@ -86,7 +86,7 @@
    <properties>
     <property name="act10" value="translated_dialog cotton_breeder2a_1"/>
     <property name="act15" value="breeding female"/>
-    <property name="act16" value="create_kennel player,cotton_breeder"/>
+    <property name="act16" value="create_kennel player,cotton_breeder,true"/>
     <property name="act17" value="set_kennel_visible player,daycare,false"/>
     <property name="act18" value="store_monster breeding_mother,cotton_breeder"/>
     <property name="act20" value="translated_dialog cotton_breeder2a_2"/>

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -77,7 +77,7 @@ events:
     type: event
   Create Quarantine Kennel:
     actions:
-    - create_kennel player,quarantine
+    - create_kennel player,quarantine,true
     conditions:
     - not kennel player,quarantine,exist
     type: event

--- a/mods/tuxemon/maps/spyder_paper_daycare.yaml
+++ b/mods/tuxemon/maps/spyder_paper_daycare.yaml
@@ -51,7 +51,7 @@ events:
   Give Monster Yes:
     actions:
     - get_player_monster daycare_choice
-    - create_kennel player,daycare
+    - create_kennel player,daycare,true
     - set_kennel_visible player,daycare,false
     - store_monster daycare_choice,daycare
     - set_variable stored:stored

--- a/tests/tuxemon/test_boxes.py
+++ b/tests/tuxemon/test_boxes.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from tuxemon.boxes import MonsterBoxes
+from tuxemon.entity_dir.routing import RoutingPolicy
 from tuxemon.monster import Monster
 from tuxemon.states.pc_kennel import HIDDEN_LIST
 
@@ -138,10 +139,15 @@ class TestBoxes(unittest.TestCase):
         self.monster_boxes.create_box(self.box_id1, "monster")
         self.assertIn(self.box_id1, self.monster_boxes.monster_boxes)
 
-    def test_remove_box(self):
+    def test_remove_box_forced(self):
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
-        self.monster_boxes.remove_box(self.box_id1)
+        self.monster_boxes.remove_box(self.box_id1, force=True)
         self.assertNotIn(self.box_id1, self.monster_boxes.monster_boxes)
+
+    def test_remove_box_not_forced_raises(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        with self.assertRaises(ValueError):
+            self.monster_boxes.remove_box(self.box_id1, force=False)
 
     def test_swap_with_external_monster(self):
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
@@ -198,3 +204,108 @@ class TestBoxes(unittest.TestCase):
             len(self.monster_boxes.get_monsters(f"{self.box_id1}1")), 10
         )
         self.assertEqual(len(self.monster_boxes.get_monsters(self.box_id1)), 0)
+
+    def test_get_total_monster_count(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id2, self.monster2)
+        self.assertEqual(self.monster_boxes.get_total_monster_count(), 2)
+
+    def test_find_monster_by_slug_in_boxes_found(self):
+        self.monster1.slug = "test_slug"
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        result = self.monster_boxes.find_monster_by_slug_in_boxes("test_slug")
+        self.assertEqual(result, (self.box_id1, self.monster1))
+
+    def test_find_monster_by_slug_in_boxes_not_found(self):
+        self.monster1.slug = "test_slug"
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        result = self.monster_boxes.find_monster_by_slug_in_boxes("other_slug")
+        self.assertIsNone(result)
+
+    def test_remove_monsters(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.add_monster(self.box_id2, self.monster2)
+        self.monster_boxes.remove_monsters([self.monster1, self.monster2])
+        self.assertEqual(self.monster_boxes.get_total_monster_count(), 0)
+
+    def test_remove_box_force_false_empty(self):
+        self.monster_boxes.create_box(self.box_id1, "monster")
+        self.monster_boxes.remove_box(self.box_id1)
+        self.assertNotIn(self.box_id1, self.monster_boxes.monster_boxes)
+
+    def test_remove_box_force_false_non_empty_raises(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        with self.assertRaises(ValueError):
+            self.monster_boxes.remove_box(self.box_id1)
+
+    def test_remove_box_force_true_non_empty(self):
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.remove_box(self.box_id1, force=True)
+        self.assertNotIn(self.box_id1, self.monster_boxes.monster_boxes)
+
+    def test_remove_box_non_existent_raises(self):
+        with self.assertRaises(ValueError):
+            self.monster_boxes.remove_box("does_not_exist")
+
+    def test_attempt_add_monster_normal_case(self):
+        policy = RoutingPolicy(name="test", max_box_capacity=5)
+        self.monster_boxes.create_box(self.box_id1, "monster")
+        self.monster_boxes.attempt_add_monster(
+            self.monster1, policy, preferred_kennel=self.box_id1
+        )
+        self.assertIn(
+            self.monster1, self.monster_boxes.get_monsters(self.box_id1)
+        )
+
+    def test_attempt_add_monster_box_full_with_overflow(self):
+        policy = RoutingPolicy(
+            name="test", max_box_capacity=1, overflow_kennel=self.box_id2
+        )
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.create_box(self.box_id2, "monster")
+        self.monster_boxes.attempt_add_monster(
+            self.monster2, policy, preferred_kennel=self.box_id1
+        )
+        self.assertIn(
+            self.monster2, self.monster_boxes.get_monsters(self.box_id2)
+        )
+
+    def test_attempt_add_monster_box_full_auto_release(self):
+        policy = RoutingPolicy(
+            name="test", max_box_capacity=1, auto_release_if_box_full=True
+        )
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.monster_boxes.attempt_add_monster(
+            self.monster2, policy, preferred_kennel=self.box_id1
+        )
+        self.assertNotIn(self.monster2, self.monster_boxes.get_all_monsters())
+
+    def test_attempt_add_monster_box_full_with_kennel_name_rules(self):
+
+        policy = RoutingPolicy(
+            name="test",
+            max_box_capacity=1,
+            kennel_name_rules={"suffix": "extra"},
+        )
+
+        monster1 = Monster()
+        monster2 = Monster()
+        # Give monster2 a unique instance_id
+        monster2.instance_id = uuid4()
+
+        self.monster_boxes.add_monster(self.box_id1, monster1)
+        self.monster_boxes.attempt_add_monster(
+            monster2, policy, preferred_kennel=self.box_id1
+        )
+
+        created_box_id = f"{self.box_id1}1extra"
+        self.assertIn(created_box_id, self.monster_boxes.get_box_ids())
+        monsters_in_new_box = self.monster_boxes.get_monsters(created_box_id)
+
+        # Assert that a monster with the same instance_id is present
+        self.assertTrue(
+            any(
+                m.instance_id == monster2.instance_id
+                for m in monsters_in_new_box
+            )
+        )

--- a/tests/tuxemon/test_boxes.py
+++ b/tests/tuxemon/test_boxes.py
@@ -4,10 +4,9 @@ import unittest
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-from tuxemon.boxes import MonsterBoxes
+from tuxemon.boxes import BoxMetadata, MonsterBoxes
 from tuxemon.entity_dir.routing import RoutingPolicy
 from tuxemon.monster import Monster
-from tuxemon.states.pc_kennel import HIDDEN_LIST
 
 
 class TestBoxes(unittest.TestCase):
@@ -30,14 +29,16 @@ class TestBoxes(unittest.TestCase):
 
     def test_remove_monster(self):
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
-        self.monster_boxes.remove_monster(self.monster1)
+        self.monster_boxes.remove_from_box("monster", None, self.monster1)
         self.assertNotIn(
             self.monster1, self.monster_boxes.monster_boxes[self.box_id1]
         )
 
     def test_remove_monster_from(self):
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
-        self.monster_boxes.remove_monster_from(self.box_id1, self.monster1)
+        self.monster_boxes.remove_from_box(
+            "monster", self.box_id1, self.monster1
+        )
         self.assertNotIn(
             self.monster1, self.monster_boxes.monster_boxes[self.box_id1]
         )
@@ -65,7 +66,8 @@ class TestBoxes(unittest.TestCase):
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         self.monster_boxes.add_monster(self.box_id2, self.monster2)
         self.assertEqual(
-            self.monster_boxes.get_box_ids(), [self.box_id1, self.box_id2]
+            self.monster_boxes.get_box_ids("monster"),
+            [self.box_id1, self.box_id2],
         )
 
     def test_get_box_size(self):
@@ -91,29 +93,70 @@ class TestBoxes(unittest.TestCase):
         )
 
     def test_get_all_monsters_hidden(self):
-        HIDDEN_LIST.append(self.box_id1)
+        self.monster_boxes.create_box(
+            self.box_id1, BoxMetadata(max_capacity=10, is_hidden=True)
+        )
+        self.monster_boxes.create_box(
+            self.box_id2, BoxMetadata(max_capacity=10, is_hidden=False)
+        )
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         self.monster_boxes.add_monster(self.box_id2, self.monster2)
         self.assertEqual(
-            self.monster_boxes.get_all_monsters_hidden(), [self.monster1]
+            self.monster_boxes.get_all_monsters_hidden(),
+            [self.monster1],
         )
 
     def test_get_all_monsters_visible(self):
-        HIDDEN_LIST.append(self.box_id1)
+        self.monster_boxes.create_box(
+            self.box_id1, BoxMetadata(max_capacity=10, is_hidden=True)
+        )
+        self.monster_boxes.create_box(
+            self.box_id2, BoxMetadata(max_capacity=10, is_hidden=False)
+        )
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         self.monster_boxes.add_monster(self.box_id2, self.monster2)
         self.assertEqual(
-            self.monster_boxes.get_all_monsters_visible(), [self.monster2]
+            self.monster_boxes.get_all_monsters_visible(),
+            [self.monster2],
+        )
+
+    def test_set_box_hidden_toggle(self):
+        self.monster_boxes.create_box(
+            self.box_id1, BoxMetadata(max_capacity=10, is_hidden=False)
+        )
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        self.assertEqual(
+            self.monster_boxes.get_all_monsters_visible(),
+            [self.monster1],
+        )
+        self.monster_boxes.set_box_hidden(self.box_id1, "monster", True)
+        self.assertEqual(
+            self.monster_boxes.get_all_monsters_hidden(),
+            [self.monster1],
+        )
+        self.assertEqual(
+            self.monster_boxes.get_all_monsters_visible(),
+            [],
         )
 
     def test_is_box_full(self):
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         self.assertTrue(
-            self.monster_boxes.is_box_full(self.box_id1, max_capacity=1)
+            self.monster_boxes.is_box_full(
+                self.box_id1,
+                "monster",
+                RoutingPolicy("default", max_box_capacity=1),
+            )
         )
-        self.monster_boxes.remove_monster_from(self.box_id1, self.monster1)
+        self.monster_boxes.remove_from_box(
+            "monster", self.box_id1, self.monster1
+        )
         self.assertFalse(
-            self.monster_boxes.is_box_full(self.box_id1, max_capacity=1)
+            self.monster_boxes.is_box_full(
+                self.box_id1,
+                "monster",
+                RoutingPolicy("default", max_box_capacity=1),
+            )
         )
 
     def test_move_monster(self):
@@ -136,10 +179,11 @@ class TestBoxes(unittest.TestCase):
         )
 
     def test_create_box(self):
-        self.monster_boxes.create_box(self.box_id1, "monster")
+        self.monster_boxes.create_box(self.box_id1)
         self.assertIn(self.box_id1, self.monster_boxes.monster_boxes)
 
     def test_remove_box_forced(self):
+        self.monster_boxes.create_box(self.box_id1)
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         self.monster_boxes.remove_box(self.box_id1, force=True)
         self.assertNotIn(self.box_id1, self.monster_boxes.monster_boxes)
@@ -197,9 +241,17 @@ class TestBoxes(unittest.TestCase):
     def test_create_and_merge_box(self):
         for _ in range(10):
             self.monster_boxes.add_monster(self.box_id1, self.monster1)
-        self.assertTrue(self.monster_boxes.is_box_full(self.box_id1, 10))
+        self.assertTrue(
+            self.monster_boxes.is_box_full(
+                self.box_id1,
+                "monster",
+                RoutingPolicy("default", max_box_capacity=10),
+            )
+        )
         self.monster_boxes.create_and_merge_box(self.box_id1, {})
-        self.assertIn(f"{self.box_id1}1", self.monster_boxes.get_box_ids())
+        self.assertIn(
+            f"{self.box_id1}1", self.monster_boxes.get_box_ids("monster")
+        )
         self.assertEqual(
             len(self.monster_boxes.get_monsters(f"{self.box_id1}1")), 10
         )
@@ -229,16 +281,18 @@ class TestBoxes(unittest.TestCase):
         self.assertEqual(self.monster_boxes.get_total_monster_count(), 0)
 
     def test_remove_box_force_false_empty(self):
-        self.monster_boxes.create_box(self.box_id1, "monster")
+        self.monster_boxes.create_box(self.box_id1)
         self.monster_boxes.remove_box(self.box_id1)
         self.assertNotIn(self.box_id1, self.monster_boxes.monster_boxes)
 
     def test_remove_box_force_false_non_empty_raises(self):
+        self.monster_boxes.create_box(self.box_id1)
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         with self.assertRaises(ValueError):
             self.monster_boxes.remove_box(self.box_id1)
 
     def test_remove_box_force_true_non_empty(self):
+        self.monster_boxes.create_box(self.box_id1)
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
         self.monster_boxes.remove_box(self.box_id1, force=True)
         self.assertNotIn(self.box_id1, self.monster_boxes.monster_boxes)
@@ -249,10 +303,11 @@ class TestBoxes(unittest.TestCase):
 
     def test_attempt_add_monster_normal_case(self):
         policy = RoutingPolicy(name="test", max_box_capacity=5)
-        self.monster_boxes.create_box(self.box_id1, "monster")
-        self.monster_boxes.attempt_add_monster(
+        self.monster_boxes.create_box(self.box_id1)
+        result = self.monster_boxes.attempt_add_monster(
             self.monster1, policy, preferred_kennel=self.box_id1
         )
+        self.assertTrue(result)
         self.assertIn(
             self.monster1, self.monster_boxes.get_monsters(self.box_id1)
         )
@@ -262,10 +317,11 @@ class TestBoxes(unittest.TestCase):
             name="test", max_box_capacity=1, overflow_kennel=self.box_id2
         )
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
-        self.monster_boxes.create_box(self.box_id2, "monster")
-        self.monster_boxes.attempt_add_monster(
+        self.monster_boxes.create_box(self.box_id2)
+        result = self.monster_boxes.attempt_add_monster(
             self.monster2, policy, preferred_kennel=self.box_id1
         )
+        self.assertTrue(result)
         self.assertIn(
             self.monster2, self.monster_boxes.get_monsters(self.box_id2)
         )
@@ -275,9 +331,21 @@ class TestBoxes(unittest.TestCase):
             name="test", max_box_capacity=1, auto_release_if_box_full=True
         )
         self.monster_boxes.add_monster(self.box_id1, self.monster1)
-        self.monster_boxes.attempt_add_monster(
+        result = self.monster_boxes.attempt_add_monster(
             self.monster2, policy, preferred_kennel=self.box_id1
         )
+        self.assertFalse(result)
+        self.assertNotIn(self.monster2, self.monster_boxes.get_all_monsters())
+
+    def test_attempt_add_monster_overflow_missing_box(self):
+        policy = RoutingPolicy(
+            name="test", max_box_capacity=1, overflow_kennel="missing"
+        )
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        result = self.monster_boxes.attempt_add_monster(
+            self.monster2, policy, preferred_kennel=self.box_id1
+        )
+        self.assertFalse(result)
         self.assertNotIn(self.monster2, self.monster_boxes.get_all_monsters())
 
     def test_attempt_add_monster_box_full_with_kennel_name_rules(self):
@@ -290,7 +358,6 @@ class TestBoxes(unittest.TestCase):
 
         monster1 = Monster()
         monster2 = Monster()
-        # Give monster2 a unique instance_id
         monster2.instance_id = uuid4()
 
         self.monster_boxes.add_monster(self.box_id1, monster1)
@@ -299,13 +366,55 @@ class TestBoxes(unittest.TestCase):
         )
 
         created_box_id = f"{self.box_id1}1extra"
-        self.assertIn(created_box_id, self.monster_boxes.get_box_ids())
+        self.assertIn(
+            created_box_id, self.monster_boxes.get_box_ids("monster")
+        )
         monsters_in_new_box = self.monster_boxes.get_monsters(created_box_id)
 
-        # Assert that a monster with the same instance_id is present
         self.assertTrue(
             any(
                 m.instance_id == monster2.instance_id
                 for m in monsters_in_new_box
             )
+        )
+
+    def test_remove_box_cleans_metadata(self):
+        self.monster_boxes.create_box(self.box_id1)
+        self.monster_boxes.remove_box(self.box_id1)
+        self.assertNotIn(
+            self.box_id1,
+            self.monster_boxes.metadata_manager._get_dict("monster"),
+        )
+
+    def test_create_box_with_metadata(self):
+        meta = BoxMetadata(max_capacity=3, is_hidden=True)
+        self.monster_boxes.create_box(self.box_id1, meta)
+        capacity = self.monster_boxes.get_max_capacity(
+            self.box_id1, "monster", RoutingPolicy("default")
+        )
+        self.assertEqual(capacity, 3)
+        self.assertTrue(
+            self.monster_boxes.is_box_hidden(self.box_id1, "monster")
+        )
+
+    def test_set_box_hidden_and_is_box_hidden(self):
+        self.monster_boxes.create_box(
+            self.box_id1, BoxMetadata(max_capacity=5, is_hidden=False)
+        )
+        self.assertFalse(
+            self.monster_boxes.is_box_hidden(self.box_id1, "monster")
+        )
+        self.monster_boxes.set_box_hidden(self.box_id1, "monster", True)
+        self.assertTrue(
+            self.monster_boxes.is_box_hidden(self.box_id1, "monster")
+        )
+
+    def test_is_box_full_respects_metadata_capacity(self):
+        self.monster_boxes.create_box(
+            self.box_id1, BoxMetadata(max_capacity=1, is_hidden=False)
+        )
+        self.monster_boxes.add_monster(self.box_id1, self.monster1)
+        policy = RoutingPolicy("default", max_box_capacity=10)
+        self.assertTrue(
+            self.monster_boxes.is_box_full(self.box_id1, "monster", policy)
         )

--- a/tests/tuxemon/test_catch_release.py
+++ b/tests/tuxemon/test_catch_release.py
@@ -14,7 +14,7 @@ def mockNPC(self) -> None:
     self.is_player = True
     self._variables = GameVariablesManager()
     self.monster_boxes = MonsterBoxes()
-    self.monster_boxes.create_box(KENNEL, "monster")
+    self.monster_boxes.create_box(KENNEL)
     self.party = PartyHandler(self.monster_boxes, self)
     self.party._monsters = []
 

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from tuxemon.db import (
     Acquisition,
@@ -386,8 +386,9 @@ class TestCanEvolve(unittest.TestCase):
 
     def test_can_evolve_party_alignment_matches(self):
         with patch.object(
-            self.player.party, "get_alignment", return_value="fire"
-        ):
+            type(self.player.party), "alignment", new_callable=PropertyMock
+        ) as mock_alignment:
+            mock_alignment.return_value = "fire"
             evolution_item = MonsterEvolutionItemModel(
                 monster_slug="nut",
                 party_conditions=PartyConditionsModel(alignment="fire"),
@@ -400,8 +401,9 @@ class TestCanEvolve(unittest.TestCase):
 
     def test_can_evolve_party_alignment_mismatch(self):
         with patch.object(
-            self.player.party, "get_alignment", return_value="water"
-        ):
+            type(self.player.party), "alignment", new_callable=PropertyMock
+        ) as mock_alignment:
+            mock_alignment.return_value = "water"
             evolution_item = MonsterEvolutionItemModel(
                 monster_slug="nut",
                 party_conditions=PartyConditionsModel(alignment="fire"),

--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -41,6 +41,8 @@ class TestRewardSystem(unittest.TestCase):
         self.winner.owner = MagicMock(spec=NPC)
         self.winner.owner.is_player = True
         self.winner.owner.monsters = [self.winner]
+        self.winner.owner.party = MagicMock()
+        self.winner.owner.party.alive = [self.winner]
         self.winner.item_handler = MagicMock()
         self.winner.item_handler.held_item.return_value = MagicMock(
             slug="xp_transmitter"
@@ -102,8 +104,7 @@ class TestRewardSystem(unittest.TestCase):
         )
         self.assertEqual(experience[0], expected_experience)
 
-    @patch("tuxemon.combat.utils.alive_party")
-    def test_calculate_experience_with_transmitter(self, alive_party_mock):
+    def test_calculate_experience_with_transmitter(self):
         mock_monsters = [
             MagicMock(
                 spec=Monster,
@@ -127,7 +128,6 @@ class TestRewardSystem(unittest.TestCase):
                 stage="basic",
             ),
         ]
-        alive_party_mock.return_value = mock_monsters
 
         self.winner.item_handler = MagicMock()
         self.winner.item_handler.held_item = MagicMock(slug="xp_transmitter")
@@ -158,8 +158,7 @@ class TestRewardSystem(unittest.TestCase):
         )
         self.assertEqual(experience, expected_experience)
 
-    @patch("tuxemon.combat.utils.alive_party")
-    def test_award_rewards_distribution(self, alive_party_mock):
+    def test_award_rewards_distribution(self):
         mock_monsters = [
             MagicMock(
                 spec=Monster,
@@ -173,9 +172,10 @@ class TestRewardSystem(unittest.TestCase):
             )
             for _ in range(3)
         ]
-        alive_party_mock.return_value = mock_monsters
 
         self.winner.owner.monsters = mock_monsters
+        self.winner.owner.party = MagicMock()
+        self.winner.owner.party.alive = mock_monsters
 
         reward_system = RewardSystem(
             MagicMock(combat_type="trainer"), self.damage_tracker

--- a/tuxemon/boxes.py
+++ b/tuxemon/boxes.py
@@ -14,6 +14,7 @@ from tuxemon.states.pc_kennel import HIDDEN_LIST
 from tuxemon.states.pc_locker import HIDDEN_LIST_LOCKER
 
 if TYPE_CHECKING:
+    from tuxemon.entity_dir.routing import RoutingPolicy
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
     from tuxemon.npc import NPC
@@ -408,17 +409,52 @@ class MonsterBoxes(BoxCollection):
         """
         super().__init__()
 
-    def remove_box(self, box_id: str) -> None:
+    def get_total_monster_count(self) -> int:
+        """
+        Returns the total number of monsters stored across all boxes.
+        """
+        return sum(len(monsters) for monsters in self.monster_boxes.values())
+
+    def find_monster_by_slug_in_boxes(
+        self, monster_slug: str
+    ) -> Optional[tuple[str, Monster]]:
+        """
+        Finds a monster by its slug across all boxes.
+
+        Returns:
+            A tuple (box_id, Monster) or None.
+        """
+        for box_id, monsters in self.monster_boxes.items():
+            for monster in monsters:
+                if monster.slug == monster_slug:
+                    return (box_id, monster)
+        return None
+
+    def remove_monsters(self, monsters: list[Monster]) -> None:
+        """
+        Removes a list of monsters from their respective boxes.
+        """
+        for monster in monsters:
+            self.remove_monster(monster)
+
+    def remove_box(self, box_id: str, force: bool = False) -> None:
         """
         Removes a monster box with the given ID.
 
         Parameters:
             box_id: The ID of the box to remove.
+            force: If True, remove the box even if it is not empty.
         """
-        if box_id in self.monster_boxes:
-            del self.monster_boxes[box_id]
-        else:
-            raise ValueError(f"{box_id} doesn't exist.")
+        if box_id not in self.monster_boxes:
+            raise ValueError(f"Monster box '{box_id}' doesn't exist.")
+
+        if not force and self.monster_boxes[box_id]:
+            logger.error(
+                f"Cannot remove non-empty monster box '{box_id}'. Use force=True to override."
+            )
+            raise ValueError("Cannot remove a non-empty monster box.")
+
+        del self.monster_boxes[box_id]
 
     def get_box_ids(self) -> list[str]:
         """
@@ -488,7 +524,7 @@ class MonsterBoxes(BoxCollection):
 
     def create_and_merge_box(
         self, box_id: str, kennel_name_rules: dict[str, Any]
-    ) -> None:
+    ) -> str:
         """
         Creates a new monster box with a unique ID based on the given box_id
         and kennel_name_rules, then merges it with the original box.
@@ -511,6 +547,77 @@ class MonsterBoxes(BoxCollection):
 
         self.create_box(new_box_id, "monster")
         self.merge_boxes(box_id, new_box_id)
+        return new_box_id
+
+    def attempt_add_monster(
+        self,
+        monster: Monster,
+        policy: RoutingPolicy,
+        preferred_kennel: Optional[str] = None,
+    ) -> None:
+        """
+        Attempts to add a monster to a box according to the routing policy,
+        handling full boxes, overflow, and auto-release.
+
+        Parameters:
+            monster: The monster to store.
+            policy: The RoutingPolicy dictating storage rules.
+            preferred_kennel: An optional specific box ID to try first.
+        """
+        kennel = (
+            preferred_kennel
+            if preferred_kennel is not None
+            else policy.get_kennel()
+        )
+        max_box_capacity = policy.max_box_capacity or prepare.MAX_KENNEL
+
+        if self.is_box_full(kennel, max_box_capacity):
+            logger.warning(
+                f"Primary box '{kennel}' is full under policy '{policy.name}'."
+            )
+
+            overflow_kennel = policy.overflow_kennel
+            if overflow_kennel:
+                logger.info(
+                    f"Attempting to use overflow kennel '{overflow_kennel}'."
+                )
+                if not self.is_box_full(overflow_kennel):
+                    self.add_monster(overflow_kennel, monster)
+                    logger.info(
+                        f"Monster '{monster}' added to overflow kennel '{overflow_kennel}'."
+                    )
+                    return
+                else:
+                    logger.warning(
+                        f"Overflow kennel '{overflow_kennel}' is also full."
+                    )
+
+            if policy.kennel_name_rules:
+                logger.info(
+                    f"Creating overflow box using kennel_name_rules for base '{kennel}'."
+                )
+                new_box_id = self.create_and_merge_box(
+                    kennel, policy.kennel_name_rules
+                )
+                self.add_monster(new_box_id, monster)
+                return
+
+            # Final fallback: release if allowed
+            if policy.auto_release_if_box_full:
+                logger.info(
+                    f"Monster '{monster}' discarded due to full boxes and no overflow options."
+                )
+                return
+
+            # Otherwise, monster is lost or error
+            logger.error(
+                f"Monster '{monster}' could not be stored. All boxes full and no overflow strategy."
+            )
+            return
+
+        # Normal case: box is not full
+        self.add_monster(kennel, monster)
+        logger.info(f"Monster '{monster}' added to box '{kennel}'.")
 
     def swap_with_external_monster(
         self, box_id: str, monster_in_box: Monster, external_monster: Monster

--- a/tuxemon/boxes.py
+++ b/tuxemon/boxes.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID
 
 from tuxemon import prepare
 from tuxemon.item.item import decode_items, encode_items
 from tuxemon.monster import decode_monsters, encode_monsters
-from tuxemon.states.pc_kennel import HIDDEN_LIST
-from tuxemon.states.pc_locker import HIDDEN_LIST_LOCKER
 
 if TYPE_CHECKING:
     from tuxemon.entity_dir.routing import RoutingPolicy
@@ -23,6 +22,67 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class BoxMetadata:
+    max_capacity: int
+    is_hidden: bool = False
+
+
+class BoxMetadataManager:
+    def __init__(self) -> None:
+        self._metadata: dict[str, dict[str, BoxMetadata]] = {
+            "item": {},
+            "monster": {},
+        }
+
+    def _get_dict(self, box_type: str) -> dict[str, BoxMetadata]:
+        if box_type not in self._metadata:
+            raise ValueError("Invalid box_type")
+        return self._metadata[box_type]
+
+    def create(
+        self, box_id: str, box_type: str, metadata: BoxMetadata
+    ) -> None:
+        metadata_dict = self._get_dict(box_type)
+        if box_id in metadata_dict:
+            raise ValueError(
+                f"{box_type.capitalize()} box '{box_id}' already exists."
+            )
+        metadata_dict[box_id] = metadata
+
+    def get(self, box_id: str, box_type: str) -> Optional[BoxMetadata]:
+        return self._get_dict(box_type).get(box_id)
+
+    def delete(self, box_id: str, box_type: str) -> None:
+        metadata_dict = self._get_dict(box_type)
+        if box_id not in metadata_dict:
+            raise ValueError(
+                f"{box_type.capitalize()} box '{box_id}' not found."
+            )
+        del metadata_dict[box_id]
+
+    def is_hidden(self, box_id: str, box_type: str) -> bool:
+        metadata = self.get(box_id, box_type)
+        return metadata.is_hidden if metadata else False
+
+    def get_max_capacity(
+        self,
+        box_id: str,
+        box_type: str,
+        policy: RoutingPolicy,
+        default_capacity: int,
+    ) -> int:
+        metadata = self.get(box_id, box_type)
+        if metadata:
+            return max(0, metadata.max_capacity)
+        return policy.max_box_capacity or default_capacity
+
+    def set_metadata(
+        self, box_type: str, metadata: dict[str, BoxMetadata]
+    ) -> None:
+        self._metadata[box_type] = metadata
+
+
 class BoxCollection:
     def __init__(self) -> None:
         """
@@ -30,20 +90,7 @@ class BoxCollection:
         """
         self.item_boxes: dict[str, list[Item]] = {}
         self.monster_boxes: dict[str, list[Monster]] = {}
-
-    def create_box(self, box_id: str, box_type: str) -> None:
-        """
-        Creates a new box with the given ID and type.
-
-        Parameters:
-            box_id: The ID of the box to create.
-            box_type: The type of the box to create (either "item" or
-                "monster").
-        """
-        if box_type == "item":
-            self.item_boxes[box_id] = []
-        elif box_type == "monster":
-            self.monster_boxes[box_id] = []
+        self.metadata_manager = BoxMetadataManager()
 
     def add_item(self, box_id: str, item: Item) -> None:
         """
@@ -54,7 +101,7 @@ class BoxCollection:
             item: The item to add to the box.
         """
         if box_id not in self.item_boxes:
-            self.create_box(box_id, "item")
+            self.item_boxes[box_id] = []
         self.item_boxes[box_id].append(item)
 
     def add_monster(self, box_id: str, monster: Monster) -> None:
@@ -66,8 +113,19 @@ class BoxCollection:
             monster: The monster to add to the box.
         """
         if box_id not in self.monster_boxes:
-            self.create_box(box_id, "monster")
+            self.monster_boxes[box_id] = []
         self.monster_boxes[box_id].append(monster)
+
+    def set_box_hidden(self, box_id: str, box_type: str, hidden: bool) -> None:
+        """
+        Toggle the hidden state of a box via its metadata.
+        """
+        metadata = self.metadata_manager.get(box_id, box_type)
+        if metadata is None:
+            raise ValueError(
+                f"{box_type.capitalize()} box '{box_id}' has no metadata defined."
+            )
+        metadata.is_hidden = hidden
 
     def store_party_in_box(
         self,
@@ -87,7 +145,7 @@ class BoxCollection:
             True if the party was successfully stored, False otherwise.
         """
         if box_id not in self.monster_boxes:
-            self.create_box(box_id, "monster")
+            self.monster_boxes[box_id] = []
 
         current_size = len(self.monster_boxes[box_id])
         required_space = len(party)
@@ -105,51 +163,18 @@ class BoxCollection:
         party.clear()
         return True
 
-    def remove_item(self, item: Item) -> None:
-        """
-        Removes the given item from all boxes.
-
-        Parameters:
-            item: The item to remove from all boxes.
-        """
-        for box in self.item_boxes.values():
-            if item in box:
-                box.remove(item)
-                return
-
-    def remove_monster(self, monster: Monster) -> None:
-        """
-        Removes the given monster from all boxes.
-
-        Parameters:
-            monster: The monster to remove from all boxes.
-        """
-        for box in self.monster_boxes.values():
-            if monster in box:
-                box.remove(monster)
-                return
-
-    def remove_item_from(self, box_id: str, item: Item) -> None:
-        """
-        Removes the given item from the box with the given ID.
-
-        Parameters:
-            box_id: The ID of the box to remove the item from.
-            item: The item to remove from the box.
-        """
-        if box_id in self.item_boxes:
-            self.item_boxes[box_id].remove(item)
-
-    def remove_monster_from(self, box_id: str, monster: Monster) -> None:
-        """
-        Removes the given monster from the box with the given ID.
-
-        Parameters:
-            box_id: The ID of the box to remove the monster from.
-            monster: The monster to remove from the box.
-        """
-        if box_id in self.monster_boxes:
-            self.monster_boxes[box_id].remove(monster)
+    def remove_from_box(
+        self, box_type: str, box_id: Optional[str], obj: Any
+    ) -> None:
+        boxes = self.item_boxes if box_type == "item" else self.monster_boxes
+        if box_id:
+            if box_id in boxes and obj in boxes[box_id]:
+                boxes[box_id].remove(obj)
+        else:
+            for box in boxes.values():
+                if obj in box:
+                    box.remove(obj)
+                    return
 
     def get_items_by_iid(self, instance_id: UUID) -> Optional[Item]:
         """
@@ -215,6 +240,49 @@ class BoxCollection:
         """
         return self.monster_boxes.get(box_id, [])
 
+    def get_box_ids(self, box_type: str) -> list[str]:
+        """Retrieves a list of all box IDs for the given type."""
+        if box_type == "item":
+            return list(self.item_boxes.keys())
+        elif box_type == "monster":
+            return list(self.monster_boxes.keys())
+        else:
+            raise ValueError(f"{box_type} must be 'item' or 'monster'")
+
+    def get_max_capacity(
+        self, box_id: str, box_type: str, policy: RoutingPolicy
+    ) -> int:
+        """
+        Retrieve the effective maximum capacity for a box.
+        Prefer per-box metadata if available, otherwise fall back to policy or global defaults.
+        """
+        default = (
+            prepare.MAX_LOCKER if box_type == "item" else prepare.MAX_KENNEL
+        )
+        return self.metadata_manager.get_max_capacity(
+            box_id, box_type, policy, default
+        )
+
+    def is_box_full(
+        self, box_id: str, box_type: str, policy: RoutingPolicy
+    ) -> bool:
+        """
+        Checks if a box is full, using the capacity defined in its metadata or policy.
+        """
+        max_capacity = self.get_max_capacity(box_id, box_type, policy)
+        if box_type == "item":
+            return (
+                box_id in self.item_boxes
+                and len(self.item_boxes[box_id]) >= max_capacity
+            )
+        elif box_type == "monster":
+            return (
+                box_id in self.monster_boxes
+                and len(self.monster_boxes[box_id]) >= max_capacity
+            )
+        else:
+            raise ValueError(f"{box_type} must be 'item' or 'monster'")
+
     def get_box_size(self, box_id: str, box_type: str) -> int:
         """
         Retrieves the size of the box with the given ID and type.
@@ -274,61 +342,29 @@ class BoxCollection:
             monster for box in self.monster_boxes.values() for monster in box
         ]
 
-    def get_all_items_hidden(self) -> list[Item]:
-        """
-        Retrieves all hidden items in all boxes.
+    def is_box_hidden(self, box_id: str, box_type: str) -> bool:
+        return self.metadata_manager.is_hidden(box_id, box_type)
 
-        Returns:
-            A list of all hidden items in all boxes.
-        """
+    def get_all_by_visibility(self, box_type: str, hidden: bool) -> list[Any]:
+        boxes = self.item_boxes if box_type == "item" else self.monster_boxes
         return [
-            item
-            for key, box in self.item_boxes.items()
-            if key in HIDDEN_LIST_LOCKER
-            for item in box
-        ]
-
-    def get_all_monsters_hidden(self) -> list[Monster]:
-        """
-        Retrieves all hidden monsters in all boxes.
-
-        Returns:
-            A list of all hidden monsters in all boxes.
-        """
-        return [
-            monster
-            for key, box in self.monster_boxes.items()
-            if key in HIDDEN_LIST
-            for monster in box
-        ]
-
-    def get_all_items_visible(self) -> list[Item]:
-        """
-        Retrieves all visible items in all boxes.
-
-        Returns:
-            A list of all visible items in all boxes.
-        """
-        return [
-            item
-            for key, box in self.item_boxes.items()
-            if key not in HIDDEN_LIST_LOCKER
-            for item in box
+            obj
+            for box_id, box in boxes.items()
+            if self.is_box_hidden(box_id, box_type) == hidden
+            for obj in box
         ]
 
     def get_all_monsters_visible(self) -> list[Monster]:
-        """
-        Retrieves all visible monsters in all boxes.
+        return self.get_all_by_visibility("monster", False)
 
-        Returns:
-            A list of all visible monsters in all boxes.
-        """
-        return [
-            monster
-            for key, box in self.monster_boxes.items()
-            if key not in HIDDEN_LIST
-            for monster in box
-        ]
+    def get_all_monsters_hidden(self) -> list[Monster]:
+        return self.get_all_by_visibility("monster", True)
+
+    def get_all_items_visible(self) -> list[Item]:
+        return self.get_all_by_visibility("item", False)
+
+    def get_all_items_hidden(self) -> list[Item]:
+        return self.get_all_by_visibility("item", True)
 
     def move_item(
         self, source_box_id: str, target_box_id: str, item: Item
@@ -345,7 +381,7 @@ class BoxCollection:
             source_box_id in self.item_boxes
             and item in self.item_boxes[source_box_id]
         ):
-            self.remove_item_from(source_box_id, item)
+            self.remove_from_box("item", source_box_id, item)
             self.add_item(target_box_id, item)
 
     def move_monster(
@@ -363,67 +399,227 @@ class BoxCollection:
             source_box_id in self.monster_boxes
             and monster in self.monster_boxes[source_box_id]
         ):
-            self.remove_monster_from(source_box_id, monster)
+            self.remove_from_box("monster", source_box_id, monster)
             self.add_monster(target_box_id, monster)
         else:
             raise ValueError(
                 f"{source_box_id} doesn't exist or {monster.slug} isn't in the {source_box_id} box"
             )
 
+    def get_state_generic(
+        self,
+        boxes: dict[str, list[Any]],
+        metadata: dict[str, BoxMetadata],
+        encoder: Callable[[list[Any]], Sequence[Mapping[str, Any]]],
+        label: str,
+        metadata_label: str,
+    ) -> dict[str, Any]:
+        return {
+            label: {
+                box_id: encoder(contents) for box_id, contents in boxes.items()
+            },
+            metadata_label: {
+                box_id: asdict(meta) for box_id, meta in metadata.items()
+            },
+        }
+
+    def load_generic(
+        self,
+        save_data: NPCState,
+        label: str,
+        metadata_label: str,
+        decoder: Callable[[Sequence[Mapping[str, Any]]], list[Any]],
+        default_capacity: int,
+        owner: Optional[NPC] = None,
+    ) -> tuple[dict[str, list[Any]], dict[str, BoxMetadata]]:
+        boxes: dict[str, list[Any]] = {}
+        metadata: dict[str, BoxMetadata] = {}
+
+        loaded_metadata = getattr(save_data, metadata_label, {}) or {}
+        for box_id, metadata_dict in loaded_metadata.items():
+            metadata[box_id] = BoxMetadata(**metadata_dict)
+
+        box_data = getattr(save_data, label, {}) or {}
+        for box_id, encoded_contents in box_data.items():
+            contents = decoder(encoded_contents)
+            if box_id not in metadata:
+                metadata[box_id] = BoxMetadata(
+                    max_capacity=default_capacity, is_hidden=False
+                )
+            if owner:
+                for monster in contents:
+                    monster.set_owner(owner)
+            boxes[box_id] = contents
+
+        return boxes, metadata
+
 
 class ItemBoxes(BoxCollection):
     def __init__(self) -> None:
-        """
-        Initializes a new ItemBoxes instance.
-        """
         super().__init__()
 
-    def get_state(self) -> dict[str, Sequence[Mapping[str, Any]]]:
-        """
-        Saves the current state of the item boxes.
-        """
-        return {
-            box_id: encode_items(items)
-            for box_id, items in self.item_boxes.items()
-        }
+    def create_box(
+        self, box_id: str, box_metadata: Optional[BoxMetadata] = None
+    ) -> None:
+        """Create a new item box with optional metadata."""
+        if box_id in self.item_boxes:
+            raise ValueError(f"Item box '{box_id}' already exists.")
+        self.item_boxes[box_id] = []
+        metadata = box_metadata or BoxMetadata(
+            max_capacity=prepare.MAX_LOCKER, is_hidden=False
+        )
+        self.metadata_manager.create(box_id, "item", metadata)
+
+    def remove_box(self, box_id: str, force: bool = False) -> None:
+        """Remove an item box, optionally forcing removal if non‑empty."""
+        if box_id not in self.item_boxes:
+            raise ValueError(f"Item box '{box_id}' doesn't exist.")
+        if not force and self.item_boxes[box_id]:
+            logger.error(
+                f"Cannot remove non-empty item box '{box_id}'. Use force=True to override."
+            )
+            raise ValueError("Cannot remove a non-empty item box.")
+        del self.item_boxes[box_id]
+        self.metadata_manager.delete(box_id, "item")
+
+    def merge_boxes(self, source_box_id: str, target_box_id: str) -> None:
+        """Merge contents and metadata from one item box into another."""
+        if target_box_id not in self.item_boxes:
+            self.create_box(target_box_id)
+        if source_box_id in self.item_boxes:
+            self.item_boxes[target_box_id].extend(
+                self.item_boxes[source_box_id]
+            )
+            del self.item_boxes[source_box_id]
+
+            source_metadata = self.metadata_manager.get(source_box_id, "item")
+            if source_metadata:
+                target_metadata = self.metadata_manager.get(
+                    target_box_id, "item"
+                )
+                if target_metadata is None:
+                    self.metadata_manager.create(
+                        target_box_id, "item", source_metadata
+                    )
+                self.metadata_manager.delete(source_box_id, "item")
+
+    def attempt_add_item(
+        self,
+        item: Item,
+        policy: RoutingPolicy,
+        preferred_locker: Optional[str] = None,
+    ) -> bool:
+        """Attempt to add an item to a box following routing policy and overflow rules."""
+        locker = preferred_locker if preferred_locker else policy.get_locker()
+        if self.is_box_full(locker, "item", policy):
+            logger.warning(
+                f"Primary box '{locker}' is full under policy '{policy.name}'."
+            )
+            overflow_locker = policy.overflow_locker
+            if overflow_locker:
+                logger.info(
+                    f"Attempting to use overflow locker '{overflow_locker}'."
+                )
+                if overflow_locker not in self.item_boxes:
+                    logger.warning(
+                        f"Overflow locker '{overflow_locker}' does not exist."
+                    )
+                    return False
+                if not self.is_box_full(overflow_locker, "item", policy):
+                    self.add_item(overflow_locker, item)
+                    logger.info(
+                        f"Item '{item}' added to overflow locker '{overflow_locker}'."
+                    )
+                    return True
+                else:
+                    logger.warning(
+                        f"Overflow locker '{overflow_locker}' is also full."
+                    )
+            if policy.locker_name_rules:
+                logger.info(
+                    f"Creating overflow box using locker_name_rules for base '{locker}'."
+                )
+                new_box_id = self.create_and_merge_box(
+                    locker, policy.locker_name_rules
+                )
+                self.add_item(new_box_id, item)
+                return True
+            if policy.auto_discard_if_box_full:
+                logger.info(
+                    f"Item '{item}' discarded due to full boxes and no overflow options."
+                )
+                return False
+            logger.error(
+                f"Item '{item}' could not be stored. All boxes full and no overflow strategy."
+            )
+            return False
+        self.add_item(locker, item)
+        logger.info(f"Item '{item}' added to box '{locker}'.")
+        return True
+
+    def create_and_merge_box(
+        self, box_id: str, locker_name_rules: dict[str, Any]
+    ) -> str:
+        """Create a new item box using naming rules and merge contents from an existing box."""
+        prefix = str(locker_name_rules.get("prefix", ""))
+        suffix = str(locker_name_rules.get("suffix", ""))
+        i = 1
+        while True:
+            formatted_suffix = f"{prefix}{i}{suffix}"
+            new_box_id = f"{box_id}{formatted_suffix}"
+            if new_box_id not in self.get_box_ids("item"):
+                break
+            i += 1
+        self.create_box(new_box_id)
+        self.merge_boxes(box_id, new_box_id)
+        return new_box_id
+
+    def get_state(self) -> dict[str, Any]:
+        """Return a serializable state of all item boxes and metadata."""
+        return self.get_state_generic(
+            self.item_boxes,
+            self.metadata_manager._get_dict("item"),
+            encode_items,
+            "item_boxes",
+            "item_box_metadata",
+        )
 
     def load(self, save_data: NPCState) -> None:
-        """
-        Loads the item boxes from a saved state.
-        """
-        item_boxes = save_data.item_boxes or {}
-        self.item_boxes = {
-            box_id: decode_items(items) for box_id, items in item_boxes.items()
-        }
-
-        for box_id, items in self.item_boxes.items():
-            item_count = len(items)
-            if item_count == 0:
-                logger.debug(f"Warning: loaded box '{box_id}' is empty")
+        """Load item boxes and metadata from saved state."""
+        self.item_boxes, item_box_metadata = self.load_generic(
+            save_data,
+            label="item_boxes",
+            metadata_label="item_box_metadata",
+            decoder=decode_items,
+            default_capacity=prepare.MAX_LOCKER,
+        )
+        self.metadata_manager.set_metadata("item", item_box_metadata)
 
 
 class MonsterBoxes(BoxCollection):
     def __init__(self) -> None:
-        """
-        Initializes a new MonsterBoxes instance.
-        """
         super().__init__()
 
+    def create_box(
+        self, box_id: str, box_metadata: Optional[BoxMetadata] = None
+    ) -> None:
+        """Create a new monster box with optional metadata."""
+        if box_id in self.monster_boxes:
+            raise ValueError(f"Monster box '{box_id}' already exists.")
+        self.monster_boxes[box_id] = []
+        metadata = box_metadata or BoxMetadata(
+            max_capacity=prepare.MAX_KENNEL, is_hidden=False
+        )
+        self.metadata_manager.create(box_id, "monster", metadata)
+
     def get_total_monster_count(self) -> int:
-        """
-        Returns the total number of monsters stored across all boxes.
-        """
+        """Return the total number of monsters across all boxes."""
         return sum(len(monsters) for monsters in self.monster_boxes.values())
 
     def find_monster_by_slug_in_boxes(
         self, monster_slug: str
     ) -> Optional[tuple[str, Monster]]:
-        """
-        Finds a monster by its slug across all boxes.
-
-        Returns:
-            A tuple (box_id, Monster) or None.
-        """
+        """Find a monster by slug and return its box ID and instance."""
         for box_id, monsters in self.monster_boxes.items():
             for monster in monsters:
                 if monster.slug == monster_slug:
@@ -431,52 +627,24 @@ class MonsterBoxes(BoxCollection):
         return None
 
     def remove_monsters(self, monsters: list[Monster]) -> None:
-        """
-        Removes a list of monsters from their respective boxes.
-        """
+        """Remove a list of monsters from any boxes they occupy."""
         for monster in monsters:
-            self.remove_monster(monster)
+            self.remove_from_box("monster", None, monster)
 
     def remove_box(self, box_id: str, force: bool = False) -> None:
-        """
-        Removes a monster box with the given ID.
-
-        Parameters:
-            box_id: The ID of the box to remove.
-            force: If True, remove the box even if it is not empty.
-        """
+        """Remove a monster box, optionally forcing removal if non-empty."""
         if box_id not in self.monster_boxes:
             raise ValueError(f"Monster box '{box_id}' doesn't exist.")
-
         if not force and self.monster_boxes[box_id]:
             logger.error(
                 f"Cannot remove non-empty monster box '{box_id}'. Use force=True to override."
             )
             raise ValueError("Cannot remove a non-empty monster box.")
-
         del self.monster_boxes[box_id]
-
-    def get_box_ids(self) -> list[str]:
-        """
-        Retrieves a list of all monster box IDs.
-
-        Returns:
-            A list of all monster box IDs.
-        """
-        return list(self.monster_boxes.keys())
+        self.metadata_manager.delete(box_id, "monster")
 
     def get_box_name(self, instance_id: UUID) -> Optional[str]:
-        """
-        Retrieves the name of the monster box that contains the monster
-        with the given instance ID.
-
-        Parameters:
-            instance_id: The instance ID of the monster to find the box for.
-
-        Returns:
-            The name of the monster box that contains the monster, or None
-            if not found.
-        """
+        """Return the box ID containing the monster with the given instance ID."""
         return next(
             (
                 box
@@ -487,65 +655,43 @@ class MonsterBoxes(BoxCollection):
             None,
         )
 
-    def is_box_full(
-        self, box_id: str, max_capacity: int = prepare.MAX_KENNEL
-    ) -> bool:
-        """
-        Checks if a monster box is full.
-
-        Parameters:
-            box_id: The ID of the box to check.
-            max_capacity: The maximum capacity of the box (default is
-                prepare.MAX_KENNEL).
-
-        Returns:
-            True if the box is full, False otherwise.
-        """
-        return (
-            box_id in self.monster_boxes
-            and len(self.monster_boxes[box_id]) >= max_capacity
-        )
-
     def merge_boxes(self, source_box_id: str, target_box_id: str) -> None:
-        """
-        Merges two monster boxes.
-
-        Parameters:
-            source_box_id: The ID of the box to merge from.
-            target_box_id: The ID of the box to merge to.
-        """
+        """Merge contents and metadata from one box into another."""
         if target_box_id not in self.monster_boxes:
-            self.create_box(target_box_id, "monster")
+            self.create_box(target_box_id)
         if source_box_id in self.monster_boxes:
             self.monster_boxes[target_box_id].extend(
                 self.monster_boxes[source_box_id]
             )
             del self.monster_boxes[source_box_id]
 
+            source_metadata = self.metadata_manager.get(
+                source_box_id, "monster"
+            )
+            if source_metadata:
+                target_metadata = self.metadata_manager.get(
+                    target_box_id, "monster"
+                )
+                if target_metadata is None:
+                    self.metadata_manager.create(
+                        target_box_id, "monster", source_metadata
+                    )
+                self.metadata_manager.delete(source_box_id, "monster")
+
     def create_and_merge_box(
         self, box_id: str, kennel_name_rules: dict[str, Any]
     ) -> str:
-        """
-        Creates a new monster box with a unique ID based on the given box_id
-        and kennel_name_rules, then merges it with the original box.
-
-        Parameters:
-            box_id: The base ID of the box to merge into.
-            kennel_name_rules: Dict with 'prefix' and 'suffix' to format the
-                numeric suffix.
-                Example: {'prefix': '_', 'suffix': '-X'} → 'KENNEL_1-X'
-        """
+        """Create a new box using naming rules and merge contents from an existing box."""
         prefix = str(kennel_name_rules.get("prefix", ""))
         suffix = str(kennel_name_rules.get("suffix", ""))
         i = 1
         while True:
             formatted_suffix = f"{prefix}{i}{suffix}"
             new_box_id = f"{box_id}{formatted_suffix}"
-            if new_box_id not in self.get_box_ids():
+            if new_box_id not in self.get_box_ids("monster"):
                 break
             i += 1
-
-        self.create_box(new_box_id, "monster")
+        self.create_box(new_box_id)
         self.merge_boxes(box_id, new_box_id)
         return new_box_id
 
@@ -554,44 +700,33 @@ class MonsterBoxes(BoxCollection):
         monster: Monster,
         policy: RoutingPolicy,
         preferred_kennel: Optional[str] = None,
-    ) -> None:
-        """
-        Attempts to add a monster to a box according to the routing policy,
-        handling full boxes, overflow, and auto-release.
-
-        Parameters:
-            monster: The monster to store.
-            policy: The RoutingPolicy dictating storage rules.
-            preferred_kennel: An optional specific box ID to try first.
-        """
-        kennel = (
-            preferred_kennel
-            if preferred_kennel is not None
-            else policy.get_kennel()
-        )
-        max_box_capacity = policy.max_box_capacity or prepare.MAX_KENNEL
-
-        if self.is_box_full(kennel, max_box_capacity):
+    ) -> bool:
+        """Attempt to add a monster to a box following routing policy and overflow rules."""
+        kennel = preferred_kennel if preferred_kennel else policy.get_kennel()
+        if self.is_box_full(kennel, "monster", policy):
             logger.warning(
                 f"Primary box '{kennel}' is full under policy '{policy.name}'."
             )
-
             overflow_kennel = policy.overflow_kennel
             if overflow_kennel:
                 logger.info(
                     f"Attempting to use overflow kennel '{overflow_kennel}'."
                 )
-                if not self.is_box_full(overflow_kennel):
+                if overflow_kennel not in self.monster_boxes:
+                    logger.warning(
+                        f"Overflow kennel '{overflow_kennel}' does not exist."
+                    )
+                    return False
+                if not self.is_box_full(overflow_kennel, "monster", policy):
                     self.add_monster(overflow_kennel, monster)
                     logger.info(
                         f"Monster '{monster}' added to overflow kennel '{overflow_kennel}'."
                     )
-                    return
+                    return True
                 else:
                     logger.warning(
                         f"Overflow kennel '{overflow_kennel}' is also full."
                     )
-
             if policy.kennel_name_rules:
                 logger.info(
                     f"Creating overflow box using kennel_name_rules for base '{kennel}'."
@@ -600,59 +735,37 @@ class MonsterBoxes(BoxCollection):
                     kennel, policy.kennel_name_rules
                 )
                 self.add_monster(new_box_id, monster)
-                return
-
-            # Final fallback: release if allowed
+                return True
             if policy.auto_release_if_box_full:
                 logger.info(
                     f"Monster '{monster}' discarded due to full boxes and no overflow options."
                 )
-                return
-
-            # Otherwise, monster is lost or error
+                return False
             logger.error(
                 f"Monster '{monster}' could not be stored. All boxes full and no overflow strategy."
             )
-            return
-
-        # Normal case: box is not full
+            return False
         self.add_monster(kennel, monster)
         logger.info(f"Monster '{monster}' added to box '{kennel}'.")
+        return True
 
     def swap_with_external_monster(
         self, box_id: str, monster_in_box: Monster, external_monster: Monster
     ) -> Monster:
-        """
-        Swaps a monster in a box with an external monster.
-
-        Parameters:
-            box_id: The ID of the box to swap the monster in.
-            monster_in_box: The monster in the box to swap.
-            external_monster: The external monster to swap with.
-
-        Returns:
-            The monster that was swapped out of the box.
-        """
-        if box_id in self.monster_boxes:
-            self.remove_monster_from(box_id, monster_in_box)
-            self.add_monster(box_id, external_monster)
-            return monster_in_box
-        else:
-            raise ValueError("Monster not found in box.")
+        """Swap a monster in a box with an external monster."""
+        if box_id not in self.monster_boxes:
+            raise ValueError(f"Box '{box_id}' not found.")
+        box_contents = self.monster_boxes[box_id]
+        if monster_in_box not in box_contents:
+            raise ValueError(f"Monster not found in box '{box_id}'.")
+        self.remove_from_box("monster", box_id, monster_in_box)
+        self.add_monster(box_id, external_monster)
+        return monster_in_box
 
     def swap_with_external_monster_by_iid(
         self, instance_id: UUID, external_monster: Monster
     ) -> Monster:
-        """
-        Swaps a monster in a box with an external monster by instance ID.
-
-        Parameters:
-            instance_id: The instance ID of the monster to swap.
-            external_monster: The external monster to swap with.
-
-        Returns:
-            The monster that was swapped out of the box.
-        """
+        """Swap a monster by instance ID with an external monster."""
         monster = self.get_monsters_by_iid(instance_id)
         box_id = self.get_box_name(instance_id)
         if monster is not None and box_id is not None:
@@ -662,34 +775,24 @@ class MonsterBoxes(BoxCollection):
         else:
             raise ValueError("Monster not found in box.")
 
-    def get_state(self) -> dict[str, Sequence[Mapping[str, Any]]]:
-        """
-        Saves the current state of the monster boxes.
-        """
-        return {
-            box_id: encode_monsters(monsters)
-            for box_id, monsters in self.monster_boxes.items()
-        }
+    def get_state(self) -> dict[str, Any]:
+        """Return a serializable state of all monster boxes and metadata."""
+        return self.get_state_generic(
+            self.monster_boxes,
+            self.metadata_manager._get_dict("monster"),
+            encode_monsters,
+            "monster_boxes",
+            "monster_box_metadata",
+        )
 
     def load(self, char: NPC, save_data: NPCState) -> None:
-        """
-        Loads the monster boxes from a saved state.
-        """
-        self.monster_boxes = {}
-
-        monster_boxes = save_data.monster_boxes or {}
-        for box_id, encoded_monsters in monster_boxes.items():
-            monsters = decode_monsters(encoded_monsters)
-            monster_count = len(monsters)
-            logger.debug(
-                f"Loaded box '{box_id}' with {monster_count} monsters."
-            )
-            if monster_count == 0:
-                logger.debug(
-                    f"Warning: loaded monster box '{box_id}' is empty"
-                )
-            for monster in monsters:
-                monster.set_owner(char)
-            self.monster_boxes[box_id] = monsters
-
-        logger.debug(f"Loaded {len(self.monster_boxes)} monster boxes.")
+        """Load monster boxes and metadata from saved state, assigning ownership to a character."""
+        self.monster_boxes, monster_box_metadata = self.load_generic(
+            save_data,
+            label="monster_boxes",
+            metadata_label="monster_box_metadata",
+            decoder=decode_monsters,
+            default_capacity=prepare.MAX_KENNEL,
+            owner=char,
+        )
+        self.metadata_manager.set_metadata("monster", monster_box_metadata)

--- a/tuxemon/combat/reward_system.py
+++ b/tuxemon/combat/reward_system.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from tuxemon.combat.utils import alive_party
 from tuxemon.formula import config_monster
 from tuxemon.locale import T
 from tuxemon.monster_dir.stats import BasicStats
@@ -97,7 +96,7 @@ class RewardSystem:
             winner = next(iter(winners))
 
             if winner.owner is not None:
-                all_monsters = set(alive_party(winner.owner))
+                all_monsters = set(winner.owner.party.alive)
             else:
                 all_monsters = set()
 
@@ -275,7 +274,7 @@ def calculate_experience(
         if winner.owner is None:
             return 0, 0
 
-        all_monsters = set(alive_party(winner.owner))
+        all_monsters = set(winner.owner.party.alive)
         non_participants = all_monsters - participants
 
         participant_exp = (

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -11,7 +11,7 @@ from tuxemon.combat.action_queue import ActionQueue, EnqueuedAction
 from tuxemon.combat.combat_context import CombatType
 from tuxemon.combat.damage_tracker import DamageTracker
 from tuxemon.combat.field_monsters import FieldMonsters
-from tuxemon.combat.utils import alive_party, battlefield, defeated
+from tuxemon.combat.utils import battlefield
 from tuxemon.db import EffectPhase, TargetType
 from tuxemon.event import get_event_bus
 from tuxemon.locale import T
@@ -86,7 +86,7 @@ class CombatSession:
     def active_players(self) -> Iterable[NPC]:
         """All trainers still active in the battle."""
         for player in self.players:
-            if not defeated(player):
+            if not player.party.is_fainted:
                 yield player
 
     @property
@@ -129,12 +129,12 @@ class CombatSession:
     @property
     def defeated_players(self) -> Sequence[NPC]:
         """All trainers who have lost (party fully fainted)."""
-        return [p for p in self.players if defeated(p)]
+        return [p for p in self.players if p.party.is_fainted]
 
     @property
     def remaining_players(self) -> Sequence[NPC]:
         """Alias for non-defeated players. WIP: subject to future team logic."""
-        return [p for p in self.players if not defeated(p)]
+        return [p for p in self.players if not p.party.is_fainted]
 
     def get_bench(self, player: NPC) -> Sequence[Monster]:
         """Returns non-fainted, off-field monsters for the given player."""
@@ -390,7 +390,7 @@ class CombatSession:
         Calculates the maximum number of positions for a player based on
         their party size and battle mode.
         """
-        if len(alive_party(player)) == 1:
+        if len(player.party.alive) == 1:
             return 1
         return 2 if self.is_double else 1
 

--- a/tuxemon/combat/utils.py
+++ b/tuxemon/combat/utils.py
@@ -43,15 +43,15 @@ def check_battle_legal(character: NPC) -> bool:
         logger.error(f"Cannot start battle, {character.name} has no monsters!")
         return False
 
-    if fainted_party(character.monsters):
+    if character.party.is_fainted:
         logger.error(
             f"Cannot start battle, {character.name}'s monsters are all DEAD."
         )
         return False
 
-    if party_no_tech(character.monsters):
+    if character.party.no_tech:
         logger.error(
-            f"Cannot start battle, {party_no_tech(character.monsters)} has/have no techniques."
+            f"Cannot start battle, {character.party.no_tech} has/have no techniques."
         )
         return False
 
@@ -73,13 +73,6 @@ def has_effect(technique: Technique, effect_name: str) -> bool:
     Checks to see if the technique has a specific effect (eg ram -> damage).
     """
     return any(t for t in technique.effects if t.name == effect_name)
-
-
-def party_no_tech(party: list[Monster]) -> list[str]:
-    """
-    Return list of monsters without techniques.
-    """
-    return [p.name for p in party if not p.moves.has_moves()]
 
 
 def has_effect_param(
@@ -105,25 +98,6 @@ def has_effect_param(
         ele.name == effect_name and getattr(ele, attribute, None) == name
         for ele in tech.effects
     )
-
-
-def alive_party(character: NPC) -> list[Monster]:
-    """
-    Returns a list with all the monsters alive in the character's party.
-    """
-    return [m for m in character.monsters if not m.is_fainted]
-
-
-def fainted_party(party: Sequence[Monster]) -> bool:
-    """Whether the party is fainted or not."""
-    return all(monster.is_fainted for monster in party)
-
-
-def defeated(character: NPC) -> bool:
-    """
-    Whether all the character's party is fainted.
-    """
-    return fainted_party(character.monsters)
 
 
 def battlefield(session: Session, monster: Monster) -> None:

--- a/tuxemon/entity_dir/bag.py
+++ b/tuxemon/entity_dir/bag.py
@@ -59,7 +59,7 @@ class BagHandler:
             logger.debug(
                 f"Item box '{locker}' does not exist. Creating new item box."
             )
-            self._item_boxes.create_box(locker, "item")
+            self._item_boxes.create_box(locker)
 
         existing = self.find_item(item.slug)
         if existing:

--- a/tuxemon/entity_dir/party.py
+++ b/tuxemon/entity_dir/party.py
@@ -136,9 +136,9 @@ class PartyHandler:
 
     def send_monster_to_box(
         self, monster: Monster, kennel: Optional[str] = None
-    ) -> None:
+    ) -> bool:
         policy = self.routing_policy
-        self._monster_boxes.attempt_add_monster(monster, policy, kennel)
+        return self._monster_boxes.attempt_add_monster(monster, policy, kennel)
 
     def insert_monster_to_party(
         self, monster: Monster, slot: Optional[int] = None
@@ -370,9 +370,7 @@ class PartyHandler:
             return False
 
         self.remove_monster(monster)
-        self.send_monster_to_box(monster, kennel)
-        logger.info(f"Monster '{monster}' transferred from party to box.")
-        return True
+        return self.send_monster_to_box(monster, kennel)
 
     def transfer_monster_to_party(
         self, monster: Monster, slot: Optional[int] = None

--- a/tuxemon/entity_dir/party.py
+++ b/tuxemon/entity_dir/party.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID
 
 from tuxemon import prepare
 from tuxemon.boxes import MonsterBoxes
+from tuxemon.entity_dir.party_stats import PartyStats
 from tuxemon.entity_dir.routing import RoutingPolicy, RoutingPolicyRegistry
 from tuxemon.monster import Monster, decode_monsters, encode_monsters
 
@@ -75,25 +75,37 @@ class PartyHandler:
 
     @property
     def level_lowest(self) -> Optional[int]:
-        """Returns the lowest level among monsters in the party, or None if empty."""
-        if not self._monsters:
-            return None
-        return min(mon.level for mon in self._monsters)
+        return PartyStats.calculate_level_lowest(self._monsters)
 
     @property
     def level_highest(self) -> Optional[int]:
-        """Returns the highest level among monsters in the party, or None if empty."""
-        if not self._monsters:
-            return None
-        return max(mon.level for mon in self._monsters)
+        return PartyStats.calculate_level_highest(self._monsters)
 
     @property
     def level_average(self) -> Optional[int]:
-        """Returns the average level of monsters in the party, or None if empty."""
-        if not self._monsters:
-            return None
-        total = sum(mon.level for mon in self._monsters)
-        return round(total / len(self._monsters))
+        return PartyStats.calculate_level_average(self._monsters)
+
+    @property
+    def alignment(self) -> Optional[str]:
+        return PartyStats.get_alignment(self._monsters)
+
+    @property
+    def no_tech(self) -> list[str]:
+        return PartyStats.no_tech(self._monsters)
+
+    @property
+    def is_fainted(self) -> bool:
+        return PartyStats.is_fainted(self._monsters)
+
+    @property
+    def alive(self) -> list[Monster]:
+        return PartyStats.alive(self._monsters)
+
+    def has_type(self, element_slug: str) -> bool:
+        return PartyStats.has_type(self._monsters, element_slug)
+
+    def has_tech(self, tech_slug: str) -> bool:
+        return PartyStats.has_tech(self._monsters, tech_slug)
 
     def apply_nickname_rules(self, monster: Monster) -> None:
         policy = self.routing_policy
@@ -126,56 +138,7 @@ class PartyHandler:
         self, monster: Monster, kennel: Optional[str] = None
     ) -> None:
         policy = self.routing_policy
-        kennel = kennel if kennel is not None else policy.get_kennel()
-        max_box_capacity = policy.max_box_capacity or prepare.MAX_KENNEL
-
-        if self._monster_boxes.is_box_full(kennel, max_box_capacity):
-            logger.warning(
-                f"Primary box '{kennel}' is full under policy '{policy.name}'."
-            )
-
-            overflow_kennel = policy.overflow_kennel
-            if overflow_kennel:
-                logger.info(
-                    f"Attempting to use overflow kennel '{overflow_kennel}'."
-                )
-                if not self._monster_boxes.is_box_full(overflow_kennel):
-                    self._monster_boxes.add_monster(overflow_kennel, monster)
-                    logger.info(
-                        f"Monster '{monster}' added to overflow kennel '{overflow_kennel}'."
-                    )
-                    return
-                else:
-                    logger.warning(
-                        f"Overflow kennel '{overflow_kennel}' is also full."
-                    )
-
-            if policy.kennel_name_rules:
-                logger.info(
-                    f"Creating overflow box using kennel_name_rules for base '{kennel}'."
-                )
-                self._monster_boxes.create_and_merge_box(
-                    kennel, policy.kennel_name_rules
-                )
-                self._monster_boxes.add_monster(kennel, monster)
-                return
-
-            # Final fallback: release if allowed
-            if policy.auto_release_if_box_full:
-                logger.info(
-                    f"Monster '{monster}' discarded due to full boxes and no overflow options."
-                )
-                return
-
-            # Otherwise, monster is lost or error
-            logger.error(
-                f"Monster '{monster}' could not be stored. All boxes full and no overflow strategy."
-            )
-            return
-
-        # Normal case
-        self._monster_boxes.add_monster(kennel, monster)
-        logger.info(f"Monster '{monster}' added to box '{kennel}'.")
+        self._monster_boxes.attempt_add_monster(monster, policy, kennel)
 
     def insert_monster_to_party(
         self, monster: Monster, slot: Optional[int] = None
@@ -235,10 +198,9 @@ class PartyHandler:
         Returns:
             Monster found, or None.
         """
-        for monster in self._monsters:
-            if monster.slug == monster_slug:
-                return monster
-        return None
+        return next(
+            (m for m in self._monsters if m.slug == monster_slug), None
+        )
 
     def find_monster_by_id(self, instance_id: UUID) -> Optional[Monster]:
         """
@@ -334,18 +296,6 @@ class PartyHandler:
         """
         return monster in self._monsters
 
-    def has_tech(self, tech_slug: str) -> bool:
-        """
-        Returns True if any monster in the party has the given technique.
-
-        Parameters:
-            tech_slug: The slug name of the technique.
-        """
-        for monster in self._monsters:
-            if monster.moves.has_move(tech_slug):
-                return True
-        return False
-
     def replace_monster(
         self, old_monster: Monster, new_monster: Monster
     ) -> bool:
@@ -366,12 +316,6 @@ class PartyHandler:
             return True
         return False
 
-    def has_type(self, element_slug: str) -> bool:
-        """
-        Returns True if any monster in the party has the given type.
-        """
-        return any(mon.has_type(element_slug) for mon in self._monsters)
-
     def clear_party(self) -> None:
         """
         Removes all monsters from the party and clears their ownership.
@@ -380,27 +324,6 @@ class PartyHandler:
             for monster in self._monsters:
                 monster.owner = None
         self._monsters.clear()
-
-    def get_alignment(self) -> Optional[str]:
-        """
-        Returns the dominant elemental type in the party,
-        based on the most frequently occurring type among monsters.
-        If no types are found, returns None.
-        """
-        type_counter: Counter[str] = Counter()
-
-        for monster in self._monsters:
-            try:
-                type_slugs = monster.types.get_type_slugs()
-                type_counter.update(type_slugs)
-            except Exception:
-                continue  # Skip if the monster has no types
-
-        if not type_counter:
-            return None
-
-        dominant_type, _ = type_counter.most_common(1)[0]
-        return dominant_type
 
     def replace_party(
         self,
@@ -414,15 +337,10 @@ class PartyHandler:
         """
         self.clear_party()
 
-        if override_policy_name:
-            policy = RoutingPolicyRegistry.get(override_policy_name)
-        else:
-            policy = self.routing_policy
-
-        party_limit = (
-            policy.max_party_size
-            if policy.max_party_size is not None
-            else self._party_limit
+        policy = (
+            RoutingPolicyRegistry.get(override_policy_name)
+            if override_policy_name
+            else self.routing_policy
         )
 
         if policy.max_party_size == -1:
@@ -435,7 +353,8 @@ class PartyHandler:
 
         for monster in party_monsters:
             monster.set_owner(self._owner)
-            self._monsters.append(monster)
+
+        self._monsters.extend(party_monsters)
 
         if add_overflow_to_box and overflow:
             kennel_for_overflow = policy.get_kennel()

--- a/tuxemon/entity_dir/party_stats.py
+++ b/tuxemon/entity_dir/party_stats.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+
+logger = logging.getLogger(__name__)
+
+
+class PartyStats:
+    """Provides statistical calculations for a list of Monster objects."""
+
+    @staticmethod
+    def alive(monsters: list[Monster]) -> list[Monster]:
+        return [m for m in monsters if not m.is_fainted]
+
+    @staticmethod
+    def is_fainted(monsters: list[Monster]) -> bool:
+        return all(m.is_fainted for m in monsters)
+
+    @staticmethod
+    def no_tech(monsters: list[Monster]) -> list[str]:
+        return [m.name for m in monsters if not m.moves.has_moves()]
+
+    @staticmethod
+    def calculate_level_lowest(monsters: list[Monster]) -> Optional[int]:
+        """Returns the lowest level, or None if the list is empty."""
+        if not monsters:
+            return None
+        return min(mon.level for mon in monsters)
+
+    @staticmethod
+    def calculate_level_highest(monsters: list[Monster]) -> Optional[int]:
+        """Returns the highest level, or None if the list is empty."""
+        if not monsters:
+            return None
+        return max(mon.level for mon in monsters)
+
+    @staticmethod
+    def calculate_level_average(monsters: list[Monster]) -> Optional[int]:
+        """Returns the average level, or None if the list is empty."""
+        if not monsters:
+            return None
+        total = sum(mon.level for mon in monsters)
+        return round(total / len(monsters))
+
+    @staticmethod
+    def get_alignment(monsters: list[Monster]) -> Optional[str]:
+        """
+        Returns the dominant elemental type in the list,
+        based on the most frequently occurring type.
+        """
+        type_counter: Counter[str] = Counter()
+
+        for monster in monsters:
+            try:
+                type_slugs = monster.types.get_type_slugs()
+                type_counter.update(type_slugs)
+            except Exception:
+                continue
+
+        if not type_counter:
+            return None
+
+        dominant_type, _ = type_counter.most_common(1)[0]
+        return dominant_type
+
+    @staticmethod
+    def has_type(monsters: list[Monster], element_slug: str) -> bool:
+        """Returns True if any monster has the given type."""
+        return any(mon.has_type(element_slug) for mon in monsters)
+
+    @staticmethod
+    def has_tech(monsters: list[Monster], tech_slug: str) -> bool:
+        """Returns True if any monster has the given technique."""
+        for monster in monsters:
+            if monster.moves.has_move(tech_slug):
+                return True
+        return False

--- a/tuxemon/entity_dir/routing.py
+++ b/tuxemon/entity_dir/routing.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import yaml
 
 from tuxemon.constants.paths import mods_folder
-from tuxemon.prepare import KENNEL
+from tuxemon.prepare import KENNEL, LOCKER
 
 if TYPE_CHECKING:
     from tuxemon.save_state import NPCState
@@ -47,13 +47,17 @@ class RoutingPolicy:
     name: str
     force_to_box: bool = False
     kennel_override: Optional[str] = None
+    locker_override: Optional[str] = None
     max_party_size: Optional[int] = None
     allow_party_addition: bool = True
     auto_release_if_box_full: bool = False
+    auto_discard_if_box_full: bool = False
     overflow_kennel: Optional[str] = None
+    overflow_locker: Optional[str] = None
     max_box_capacity: Optional[int] = None
     nickname_rules: dict[str, Any] = field(default_factory=dict)
     kennel_name_rules: dict[str, Any] = field(default_factory=dict)
+    locker_name_rules: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_registry(cls, name: str) -> RoutingPolicy:
@@ -62,15 +66,21 @@ class RoutingPolicy:
             name=name,
             force_to_box=bool(raw.get("force_to_box", False)),
             kennel_override=raw.get("kennel_override"),
+            locker_override=raw.get("locker_override"),
             max_party_size=raw.get("max_party_size"),
             allow_party_addition=bool(raw.get("allow_party_addition", True)),
             auto_release_if_box_full=bool(
                 raw.get("auto_release_if_box_full", False)
             ),
+            auto_discard_if_box_full=bool(
+                raw.get("auto_discard_if_box_full", False)
+            ),
             overflow_kennel=raw.get("overflow_kennel"),
+            overflow_locker=raw.get("overflow_locker"),
             max_box_capacity=raw.get("max_box_capacity"),
             nickname_rules=raw.get("nickname_rules", {}),
             kennel_name_rules=raw.get("kennel_name_rules", {}),
+            locker_name_rules=raw.get("locker_name_rules", {}),
         )
 
     def should_force_to_box(self) -> bool:
@@ -78,6 +88,9 @@ class RoutingPolicy:
 
     def get_kennel(self) -> str:
         return self.kennel_override or KENNEL
+
+    def get_locker(self) -> str:
+        return self.locker_override or LOCKER
 
     def to_dict(self) -> str:
         return self.name

--- a/tuxemon/event/actions/create_kennel.py
+++ b/tuxemon/event/actions/create_kennel.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import final
+from typing import Optional, final
 
+from tuxemon.boxes import BoxMetadata
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from tuxemon.prepare import MAX_KENNEL
 from tuxemon.session import Session
+from tuxemon.tools import parse_flag
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +20,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CreateKennelAction(EventAction):
     """
-    Creates a new kennel.
+    Creates a new kennel with optional metadata.
 
     It's advisable to create a msgid in the en_US PO file.
 
@@ -27,16 +30,26 @@ class CreateKennelAction(EventAction):
     Script usage:
         .. code-block::
 
-            create_kennel <character>,<kennel>
+            # Create a visible kennel with default capacity
+            create_kennel player,my_kennel
+
+            # Create a hidden kennel with capacity 20
+            create_kennel player,my_kennel,true,20
 
     Script parameters:
         character: Either "player" or npc slug name (e.g. "npc_maple").
         kennel: Name of the kennel.
+        hidden: Optional flag ("true"/"false", "1"/"0", "yes"/"no") for
+            visibility.
+        max_capacity: Optional integer for maximum capacity (defaults to
+            prepare.MAX_KENNEL).
     """
 
     name = "create_kennel"
     npc_slug: str
     kennel: str
+    hidden: Optional[str] = None
+    max_capacity: Optional[int] = None
 
     def start(self, session: Session) -> None:
         character = get_npc(session, self.npc_slug)
@@ -45,4 +58,16 @@ class CreateKennelAction(EventAction):
             return
 
         if not character.monster_boxes.has_box(self.kennel, "monster"):
-            character.monster_boxes.create_box(self.kennel, "monster")
+            capacity = (
+                self.max_capacity
+                if self.max_capacity is not None
+                else MAX_KENNEL
+            )
+            is_hidden = parse_flag(self.hidden)
+
+            metadata = BoxMetadata(max_capacity=capacity, is_hidden=is_hidden)
+            character.monster_boxes.create_box(self.kennel, metadata)
+            logger.info(
+                f"Created kennel '{self.kennel}' for {self.npc_slug} "
+                f"(capacity={capacity}, hidden={is_hidden})"
+            )

--- a/tuxemon/event/actions/quarantine.py
+++ b/tuxemon/event/actions/quarantine.py
@@ -7,8 +7,10 @@ import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, final
 
+from tuxemon.boxes import BoxMetadata
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
+from tuxemon.prepare import MAX_KENNEL
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
@@ -48,7 +50,9 @@ class QuarantineAction(EventAction):
         boxes = character.monster_boxes
 
         if not boxes.has_box(self.name, "monster"):
-            boxes.create_box(self.name, "monster")
+            boxes.create_box(
+                self.name, BoxMetadata(max_capacity=MAX_KENNEL, is_hidden=True)
+            )
 
         to_quarantine = [
             mon
@@ -95,7 +99,7 @@ class QuarantineAction(EventAction):
             monster.plague.inoculate(self.plague_slug)
 
             if party.transfer_monster_to_party(monster):
-                boxes.remove_monster_from(self.name, monster)
+                boxes.remove_from_box("monster", self.name, monster)
                 logger.info(f"{monster} has been inoculated and released")
             else:
                 logger.warning(f"Failed to release {monster} to party")

--- a/tuxemon/event/actions/set_kennel_visible.py
+++ b/tuxemon/event/actions/set_kennel_visible.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Optional, final
 from tuxemon.event import get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.prepare import KENNEL
-from tuxemon.states.pc_kennel import HIDDEN_LIST
 from tuxemon.tools import parse_flag
 
 if TYPE_CHECKING:
@@ -62,7 +61,13 @@ class SetKennelVisibleAction(EventAction):
         if not character.monster_boxes.has_box(kennel, "monster"):
             return
 
-        if is_visible:
-            HIDDEN_LIST.remove(kennel)
-        else:
-            HIDDEN_LIST.append(kennel) if kennel not in HIDDEN_LIST else None
+        try:
+            character.monster_boxes.set_box_hidden(
+                kennel, "monster", not is_visible
+            )
+            logger.info(
+                f"Set kennel '{kennel}' visibility for {self.npc_slug}: "
+                f"{'visible' if is_visible else 'hidden'}"
+            )
+        except ValueError as e:
+            logger.error(str(e))

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -58,8 +58,7 @@ class StoreMonsterAction(EventAction):
             logger.error(f"No box found with name {box}")
             return
 
-        success = character.party.transfer_monster_to_box(monster, box)
-        if success:
+        if character.party.transfer_monster_to_box(monster, box):
             logger.info(f"{monster.name} stored in '{box}' box!")
         else:
             logger.error(

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -53,7 +53,7 @@ class WithdrawMonsterAction(EventAction):
             logger.error("Monster not found")
             return
 
-        player.monster_boxes.remove_monster(monster)
+        player.monster_boxes.remove_from_box("monster", None, monster)
 
         character = get_npc(session, self.character)
         if character is None:
@@ -65,7 +65,11 @@ class WithdrawMonsterAction(EventAction):
                 f"{character.name} withdrew {monster.name} into party!"
             )
         else:
-            character.party.send_monster_to_box(monster)
-            logger.info(
-                f"{character.name}'s party was full. {monster.name} sent to box instead."
-            )
+            if character.party.send_monster_to_box(monster):
+                logger.info(
+                    f"{character.name}'s party was full. {monster.name} sent to box instead."
+                )
+            else:
+                logger.error(
+                    f"Failed to withdraw monster '{monster.name}' from box"
+                )

--- a/tuxemon/event/conditions/kennel.py
+++ b/tuxemon/event/conditions/kennel.py
@@ -9,7 +9,6 @@ from tuxemon.db import SpatialCondition
 from tuxemon.event import get_npc
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
-from tuxemon.states.pc_kennel import HIDDEN_LIST
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ OPTIONS: list[str] = ["visible", "hidden", "exist"]
 @dataclass
 class KennelCondition(EventCondition):
     """
-    Check if a kennel is hidden or visible.
+    Check if a kennel is hidden, visible, or exists.
 
     Script usage:
         .. code-block::
@@ -32,11 +31,6 @@ class KennelCondition(EventCondition):
         kennel: The name of the kennel to check.
         option: The expected visibility of the kennel ("hidden" or
             "visible") or existence of it ("exist").
-
-    Note: This condition checks if the kennel is in the HIDDEN_LIST. If the
-        kennel is in the list, it is considered hidden; otherwise, it is
-        considered visible.
-
     """
 
     name = "kennel"
@@ -48,10 +42,17 @@ class KennelCondition(EventCondition):
         if character is None:
             logger.error(f"{_character} not found")
             return False
+
         if option == "visible":
-            return kennel_name not in HIDDEN_LIST
+            return character.monster_boxes.has_box(
+                kennel_name, "monster"
+            ) and not character.monster_boxes.is_box_hidden(
+                kennel_name, "monster"
+            )
         elif option == "hidden":
-            return kennel_name in HIDDEN_LIST
+            return character.monster_boxes.has_box(
+                kennel_name, "monster"
+            ) and character.monster_boxes.is_box_hidden(kennel_name, "monster")
         elif option == "exist":
             return character.monster_boxes.has_box(kennel_name, "monster")
         else:

--- a/tuxemon/monster_dir/evolution.py
+++ b/tuxemon/monster_dir/evolution.py
@@ -250,7 +250,7 @@ def check_party_conditions(
 
     # Check party alignment
     if conditions_model.alignment is not None:
-        alignment = party_handler.get_alignment()
+        alignment = party_handler.alignment
         conditions.append(alignment == conditions_model.alignment)
 
     # Check required monster slugs

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -148,6 +148,8 @@ class NPC(Entity[NPCState]):
         Returns:
             Dictionary containing all the information about the npc.
         """
+        monster_boxes_state = self.monster_boxes.get_state()
+        item_boxes_state = self.item_boxes.get_state()
 
         state: dict[str, Any] = {
             "current_map": session.client.get_map_name(),
@@ -164,8 +166,12 @@ class NPC(Entity[NPCState]):
             "player_slug": self.slug,
             "player_name": self.name,
             "player_steps": self.steps,
-            "monster_boxes": self.monster_boxes.get_state(),
-            "item_boxes": self.item_boxes.get_state(),
+            "monster_boxes": monster_boxes_state["monster_boxes"],
+            "monster_box_metadata": monster_boxes_state[
+                "monster_box_metadata"
+            ],
+            "item_boxes": item_boxes_state["item_boxes"],
+            "item_box_metadata": item_boxes_state["item_box_metadata"],
             "tile_pos": self.tile_pos,
             "teleport_faint": self.teleport_faint.to_dict(),
             "tracker": encode_tracking(self.tracker),

--- a/tuxemon/save_state.py
+++ b/tuxemon/save_state.py
@@ -43,6 +43,8 @@ class NPCState(BaseModel):
     item_boxes: dict[str, list[Mapping[str, Any]]] = Field(
         default_factory=dict
     )
+    monster_box_metadata: dict[str, Any] = Field(default_factory=dict)
+    item_box_metadata: dict[str, Any] = Field(default_factory=dict)
     tile_pos: Optional[tuple[int, int]] = Field(default=None)
     teleport_faint: dict[str, Any] = Field(default_factory=dict)
     tracker: dict[str, Any] = Field(default_factory=dict)

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -25,7 +25,6 @@ from pygame.surface import Surface
 from pygame.transform import rotozoom, scale
 
 from tuxemon import graphics
-from tuxemon.combat.utils import fainted_party
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.surfanim import SurfaceAnimation
@@ -33,6 +32,7 @@ from tuxemon.tools import scale as tuxemon_scale
 
 if TYPE_CHECKING:
     from tuxemon.db import BattleIconsModel
+    from tuxemon.entity_dir.party import PartyHandler
     from tuxemon.menu.interface import MenuItem
     from tuxemon.monster import Monster
 
@@ -363,7 +363,7 @@ class HordeSprite(Sprite):
 
     def __init__(
         self,
-        opponent_party: list[Monster],
+        opponent_party: PartyHandler,
         tray_rect: Rect,
         shadow_text_func: Callable[[str], Surface],
         scale_func: Callable[[int], int],
@@ -377,10 +377,9 @@ class HordeSprite(Sprite):
 
     def update_count_display(self) -> bool:
         """Updates the sprite to show the current horde count as text only."""
-        horde = [m for m in self.opponent_party if not m.is_fainted]
-        if not horde:
+        if self.is_defeated():
             return False
-        horde_size = len(horde)
+        horde_size = len(self.opponent_party.alive)
         horde_text = f"x{horde_size}"
         text_surface = self.shadow_text(horde_text)
         x_pad = self.scale(2)
@@ -395,7 +394,7 @@ class HordeSprite(Sprite):
 
     def is_defeated(self) -> bool:
         """Checks if the entire horde is defeated."""
-        return fainted_party(self.opponent_party)
+        return self.opponent_party.is_fainted
 
     def animate_in(self, animate_func: Callable[..., object]) -> None:
         """Animates the horde icon sliding into its final position."""

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -17,7 +17,7 @@ from pygame.surface import Surface
 from pygame.transform import flip as pg_flip
 
 from tuxemon import graphics, prepare
-from tuxemon.combat.utils import alive_party, build_hud_text
+from tuxemon.combat.utils import build_hud_text
 from tuxemon.formula import config_combat
 from tuxemon.menu.menu import Menu
 from tuxemon.sprite import CaptureDeviceSprite, HordeSprite, Sprite
@@ -514,7 +514,7 @@ class CombatAnimations(Menu[None], ABC):
             tray, _, _ = self.animate_party_hud_left(home)
 
             self.horde_sprite = HordeSprite(
-                opponent_party=player.monsters,
+                opponent_party=player.party,
                 tray_rect=home,
                 shadow_text_func=self.shadow_text,
                 scale_func=scale,
@@ -921,7 +921,7 @@ class CombatAnimations(Menu[None], ABC):
         if delete:
             self._delete_monster_huds(monsters)
 
-        alive_members = alive_party(character)
+        alive_members = character.party.alive
         if len(monsters) > 1 and len(monsters) <= len(alive_members):
             self._update_multiple_huds(monsters, animate)
         else:

--- a/tuxemon/states/party.py
+++ b/tuxemon/states/party.py
@@ -69,7 +69,7 @@ class PartyState(PygameMenuState):
         level_lowest = self.char.party.level_lowest
         level_highest = self.char.party.level_highest
         level_average = self.char.party.level_average
-        party_alignment = self.char.party.get_alignment()
+        party_alignment = self.char.party.alignment
         # highest
         highest = T.translate("menu_party_level_highest")
         lab2: Any = menu.add.label(

--- a/tuxemon/states/pc.py
+++ b/tuxemon/states/pc.py
@@ -91,7 +91,7 @@ class PCMenuBuilder:
                 "ItemStorageState", character=char
             )
 
-        if char.item_boxes.get_all_items_visible():
+        if char.item_boxes.get_all_monsters_visible():
             menu.append(("menu_item_storage", item_storage_callback))
 
         if len(char.items) > 1:
@@ -128,9 +128,9 @@ class PCState(PygameMenuState):
 
         # it creates the kennel and locker (new players)
         if not char.monster_boxes.has_box(kennel, "monster"):
-            char.monster_boxes.create_box(kennel, "monster")
+            char.monster_boxes.create_box(kennel)
         if not char.item_boxes.has_box(locker, "item"):
-            char.item_boxes.create_box(locker, "item")
+            char.item_boxes.create_box(locker)
 
         if menu_builder is None:
             self.menu_builder = PCMenuBuilder(self.client, char)

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
 MenuGameObj = Callable[[], object]
 
 
-HIDDEN = "hidden_kennel"
-HIDDEN_LIST = [HIDDEN]
 MAX_BOX = prepare.MAX_KENNEL
 
 
@@ -56,7 +54,7 @@ class MonsterActionHandler:
 
     def pick(self, monster: Monster) -> None:
         self._clear_states("ChoiceState", "MonsterTakeState")
-        self.monster_boxes.remove_monster(monster)
+        self.monster_boxes.remove_from_box("monster", None, monster)
         self.char.party.insert_monster_to_party(
             monster, len(self.char.monsters)
         )
@@ -108,7 +106,9 @@ class MonsterActionHandler:
     def output(self, monster: Optional[Monster]) -> None:
         self._clear_states("ChoiceState", "MonsterTakeState")
         if monster is not None:
-            self.monster_boxes.remove_monster_from(self.box_name, monster)
+            self.monster_boxes.remove_from_box(
+                "monster", self.box_name, monster
+            )
             open_dialog(
                 self.client,
                 [T.format("tuxemon_released", {"name": monster.name})],
@@ -214,8 +214,8 @@ class MonsterTakeState(PygameMenuState):
 
             box_ids = [
                 key
-                for key, value in self.monster_boxes.monster_boxes.items()
-                if len(value) < MAX_BOX and key not in HIDDEN_LIST
+                for key in self.monster_boxes.monster_boxes
+                if not self.monster_boxes.is_box_hidden(key, "monster")
             ]
             kennels = [
                 key
@@ -430,7 +430,8 @@ class MonsterStorageState(MonsterBoxState):
         menu_items_map = []
         monster_boxes = self.char.monster_boxes
         for box_name, monsters in monster_boxes.monster_boxes.items():
-            if box_name not in HIDDEN_LIST:
+            metadata = monster_boxes.metadata_manager.get(box_name, "monster")
+            if metadata is None or not metadata.is_hidden:
                 if not monsters:
                     menu_callback = partial(
                         open_dialog,
@@ -456,7 +457,8 @@ class MonsterDropOffState(MonsterBoxState):
         menu_items_map = []
         monster_boxes = self.char.monster_boxes
         for box_name, monsters in monster_boxes.monster_boxes.items():
-            if box_name not in HIDDEN_LIST:
+            metadata = monster_boxes.metadata_manager.get(box_name, "monster")
+            if metadata is None or not metadata.is_hidden:
                 if len(monsters) < MAX_BOX:
                     menu_callback = self.change_state(
                         "MonsterDropOff",

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -38,10 +38,6 @@ if TYPE_CHECKING:
 MenuGameObj = Callable[[], object]
 
 
-HIDDEN_LOCKER = "hidden_locker"
-HIDDEN_LIST_LOCKER = [HIDDEN_LOCKER]
-
-
 class ItemActionHandler:
     def __init__(
         self,
@@ -63,7 +59,7 @@ class ItemActionHandler:
         retrieve = self.char.bag.find_item(item.slug)
 
         if diff <= 0:
-            self.item_boxes.remove_item(item)
+            self.item_boxes.remove_from_box("item", None, item)
         else:
             item.set_quantity(diff)
 
@@ -96,7 +92,7 @@ class ItemActionHandler:
 
         diff = item.quantity - quantity
         if diff <= 0:
-            self.item_boxes.remove_item_from(self.box_name, item)
+            self.item_boxes.remove_from_box("item", self.box_name, item)
         else:
             item.set_quantity(diff)
 
@@ -144,7 +140,7 @@ class ItemTakeState(PygameMenuState):
             box_ids = [
                 key
                 for key in self.item_boxes.item_boxes
-                if key not in HIDDEN_LIST_LOCKER
+                if not self.item_boxes.is_box_hidden(key, "item")
             ]
             lockers = [key for key in box_ids if key != self.box_name]
 
@@ -356,7 +352,8 @@ class ItemStorageState(ItemBoxState):
         item_boxes = self.char.item_boxes
         menu_items_map = []
         for box_name, items in item_boxes.item_boxes.items():
-            if box_name not in HIDDEN_LIST_LOCKER:
+            metadata = item_boxes.metadata_manager.get(box_name, "item")
+            if metadata is None or not metadata.is_hidden:
                 if not items:
                     menu_callback = partial(
                         open_dialog,
@@ -382,7 +379,8 @@ class ItemDropOffState(ItemBoxState):
         item_boxes = self.char.item_boxes
         menu_items_map = []
         for box_name, items in item_boxes.item_boxes.items():
-            if box_name not in HIDDEN_LIST_LOCKER:
+            metadata = item_boxes.metadata_manager.get(box_name, "item")
+            if metadata is None or not metadata.is_hidden:
                 menu_callback = self.change_state(
                     "ItemDropOff", box_name=box_name, character=self.char
                 )


### PR DESCRIPTION
Key changes:
- added `PartyStats` to track party size, composition and overflow handling
- refactored `replace_party`: simplified policy selection logic, used `extend` for adding monsters to party
- introduced `attempt_add_monster` in `MonsterBoxes`: handles preferred kennel, capacity checks, overflow kennel usage, supports dynamic box creation via `kennel_name_rules` and provides auto‑release fallback when all boxes are full. Clearer separation of responsibilities:  `PartyHandler` manages active party, `MonsterBoxes` manages storage, overflow, and release policies

Bug fix:
- Issue: in the `kennel_name_rules` overflow path, `attempt_add_monster` created a new box but then added the monster back into the original (now emptied) box, this caused tests to fail and monsters to appear in the wrong place 
- Solution: updated `create_and_merge_box` to return the new box ID, and modified `attempt_add_monster` to add the monster into the newly created box instead of the old one, this ensures monsters are correctly routed to overflow boxes and their identity (`instance_id`) is preserved

Metadata and savegame changes:
- introduced `BoxMetadata` as a structured record for each box, storing `max_capacity` and `is_hidden` flags  
- savegame format updated: metadata is now persisted separately under `monster_box_metadata` and `item_box_metadata` keys, ensuring visibility state and capacity rules are preserved across sessions  
- hidden state (`is_hidden`) now drives visibility instead of the old global `HIDDEN_LIST`, allowing per‑box control and persistence  
- `max_capacity` is saved per box, enabling flexible kennel/locker sizes rather than relying only on global defaults (`MAX_KENNEL`, `MAX_LOCKER`)  
- this design opens the door for expanding `BoxMetadata` in the future (e.g. custom names, themes, ownership flags, timestamps), without breaking save compatibility 