### PR TITLE
Fix double battle menu sequencing in combat state

### DIFF
--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -563,7 +563,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             if len(self.opponents) > 1:
                 self.client.remove_state_by_name("CombatTargetMenuState")
             self.client.remove_state_by_name("Menu")
-            self.client.remove_state_by_name("MainCombatMenuState")
+            self.client.pop_state(self)
 
         choose_technique()
 

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -440,7 +440,7 @@ class CombatState(CombatAnimations):
 
         # Start the menu flow for human players
         if self._decision_queue:
-            self.show_monster_action_menu(self._decision_queue.pop(0))
+            self.update_phase()
 
     def remove_monster_from_play(self, monster: Monster) -> None:
         """

--- a/tuxemon/states/start.py
+++ b/tuxemon/states/start.py
@@ -66,14 +66,15 @@ class StartState(PygameMenuState):
             )
 
         def change_state(
-            state: Union[State, str],
-            **change_state_kwargs: Any,
-        ) -> Callable[[], State]:
-            return partial(
-                self.client.push_state,
-                state,
-                **change_state_kwargs,
-            )
+            state: Union[State, str], **kwargs: Any
+        ) -> Callable[[], None]:
+            def _change() -> None:
+                self.unsubscribe(
+                    "afk.threshold_reached", self._on_afk_threshold
+                )
+                self.client.push_state(state, **kwargs)
+
+            return _change
 
         def exit_game() -> None:
             self.client.quit()


### PR DESCRIPTION
This change resolves a long‑standing issue where, in double battles, only one monster’s action menu would appear and the second monster could not select a move. The problem was caused by two behaviors in the combat state logic:

- the decision queue was being consumed too early, which meant only the first monster ever reached the menu flow
- menu states were being removed too aggressively, which disrupted the stack and prevented the second monster’s menu from appearing

Additionally, the StartState was still subscribed to AFK events when pushing into battle states. This caused unintended AFK triggers mid‑battle. To fix this, `change_state` now explicitly unsubscribes from the `afk.threshold_reached` event before pushing a new state.

The update ensures that the decision queue is handed off to the phase driver without prematurely popping entries, that only the active menu state is closed when a monster finishes its action, and that AFK subscriptions are cleaned up before entering combat. With these adjustments, both monsters in a double battle now receive their action menus in sequence, the state stack remains consistent throughout the turn, and AFK events no longer interfere with battles.