### PR TITLE
Introduction of the Music Model and Overrides + Fix low volume combat

### DIFF
--- a/mods/tuxemon/db/environment/37707.json
+++ b/mods/tuxemon/db/environment/37707.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "37707"

--- a/mods/tuxemon/db/environment/arid.json
+++ b/mods/tuxemon/db/environment/arid.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "arid"

--- a/mods/tuxemon/db/environment/beach.json
+++ b/mods/tuxemon/db/environment/beach.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "beach"

--- a/mods/tuxemon/db/environment/bridge.json
+++ b/mods/tuxemon/db/environment/bridge.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "bridge"

--- a/mods/tuxemon/db/environment/canyon.json
+++ b/mods/tuxemon/db/environment/canyon.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "canyon"

--- a/mods/tuxemon/db/environment/cave.json
+++ b/mods/tuxemon/db/environment/cave.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "cave"

--- a/mods/tuxemon/db/environment/cavern.json
+++ b/mods/tuxemon/db/environment/cavern.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "cavern"

--- a/mods/tuxemon/db/environment/cliff.json
+++ b/mods/tuxemon/db/environment/cliff.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "cliff"

--- a/mods/tuxemon/db/environment/clouds.json
+++ b/mods/tuxemon/db/environment/clouds.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "clouds"

--- a/mods/tuxemon/db/environment/desert.json
+++ b/mods/tuxemon/db/environment/desert.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "desert"

--- a/mods/tuxemon/db/environment/forest.json
+++ b/mods/tuxemon/db/environment/forest.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "forest"

--- a/mods/tuxemon/db/environment/grass.json
+++ b/mods/tuxemon/db/environment/grass.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "grass"

--- a/mods/tuxemon/db/environment/interior.json
+++ b/mods/tuxemon/db/environment/interior.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "interior"

--- a/mods/tuxemon/db/environment/night_arid.json
+++ b/mods/tuxemon/db/environment/night_arid.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_arid"

--- a/mods/tuxemon/db/environment/night_beach.json
+++ b/mods/tuxemon/db/environment/night_beach.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_beach"

--- a/mods/tuxemon/db/environment/night_bridge.json
+++ b/mods/tuxemon/db/environment/night_bridge.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_bridge"

--- a/mods/tuxemon/db/environment/night_canyon.json
+++ b/mods/tuxemon/db/environment/night_canyon.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_canyon"

--- a/mods/tuxemon/db/environment/night_cliff.json
+++ b/mods/tuxemon/db/environment/night_cliff.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_cliff"

--- a/mods/tuxemon/db/environment/night_desert.json
+++ b/mods/tuxemon/db/environment/night_desert.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_desert"

--- a/mods/tuxemon/db/environment/night_forest.json
+++ b/mods/tuxemon/db/environment/night_forest.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_forest"

--- a/mods/tuxemon/db/environment/night_grass.json
+++ b/mods/tuxemon/db/environment/night_grass.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_grass"

--- a/mods/tuxemon/db/environment/night_ocean.json
+++ b/mods/tuxemon/db/environment/night_ocean.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_ocean"

--- a/mods/tuxemon/db/environment/night_park.json
+++ b/mods/tuxemon/db/environment/night_park.json
@@ -23,15 +23,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_park"

--- a/mods/tuxemon/db/environment/night_plain.json
+++ b/mods/tuxemon/db/environment/night_plain.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_plain"

--- a/mods/tuxemon/db/environment/night_sand.json
+++ b/mods/tuxemon/db/environment/night_sand.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_sand"

--- a/mods/tuxemon/db/environment/night_sea.json
+++ b/mods/tuxemon/db/environment/night_sea.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_sea"

--- a/mods/tuxemon/db/environment/night_snow.json
+++ b/mods/tuxemon/db/environment/night_snow.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_snow"

--- a/mods/tuxemon/db/environment/night_snowplain.json
+++ b/mods/tuxemon/db/environment/night_snowplain.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_snowplain"

--- a/mods/tuxemon/db/environment/night_valley.json
+++ b/mods/tuxemon/db/environment/night_valley.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "night_valley"

--- a/mods/tuxemon/db/environment/ocean.json
+++ b/mods/tuxemon/db/environment/ocean.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "ocean"

--- a/mods/tuxemon/db/environment/park.json
+++ b/mods/tuxemon/db/environment/park.json
@@ -23,15 +23,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "park"

--- a/mods/tuxemon/db/environment/plain.json
+++ b/mods/tuxemon/db/environment/plain.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "plain"

--- a/mods/tuxemon/db/environment/sand.json
+++ b/mods/tuxemon/db/environment/sand.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "sand"

--- a/mods/tuxemon/db/environment/sea.json
+++ b/mods/tuxemon/db/environment/sea.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "sea"

--- a/mods/tuxemon/db/environment/snow.json
+++ b/mods/tuxemon/db/environment/snow.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "snow"

--- a/mods/tuxemon/db/environment/snowplain.json
+++ b/mods/tuxemon/db/environment/snowplain.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "snowplain"

--- a/mods/tuxemon/db/environment/stadium.json
+++ b/mods/tuxemon/db/environment/stadium.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "stadium"

--- a/mods/tuxemon/db/environment/sunset.json
+++ b/mods/tuxemon/db/environment/sunset.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "sunset"

--- a/mods/tuxemon/db/environment/underwater.json
+++ b/mods/tuxemon/db/environment/underwater.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "underwater"

--- a/mods/tuxemon/db/environment/valley.json
+++ b/mods/tuxemon/db/environment/valley.json
@@ -19,15 +19,15 @@
   "battle_music": {
     "battle": {
       "music": "music_battle_loop",
-      "volume": 0.5
+      "volume": 1.0
     },
     "victory_music": {
       "music": "music_win_battle_boss",
-      "volume": 0.5
+      "volume": 1.0
     },
     "defeat_music": {
       "music": "music_gameover",
-      "volume": 0.5
+      "volume": 1.0
     }
   },
   "slug": "valley"

--- a/mods/tuxemon/db/npc/37707_female.json
+++ b/mods/tuxemon/db/npc/37707_female.json
@@ -2,6 +2,7 @@
   "slug": "37707_female",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "37707_female",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/37707_female_missing.json
+++ b/mods/tuxemon/db/npc/37707_female_missing.json
@@ -2,6 +2,7 @@
   "slug": "37707_female_missing",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "37707_female_missing",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/37707_male.json
+++ b/mods/tuxemon/db/npc/37707_male.json
@@ -2,6 +2,7 @@
   "slug": "37707_male",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "37707_male",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/37707_male_missing.json
+++ b/mods/tuxemon/db/npc/37707_male_missing.json
@@ -2,6 +2,7 @@
   "slug": "37707_male_missing",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "37707_male_missing",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/aeble.json
+++ b/mods/tuxemon/db/npc/aeble.json
@@ -2,6 +2,7 @@
   "slug": "aeble",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "ceo",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/allie.json
+++ b/mods/tuxemon/db/npc/allie.json
@@ -2,6 +2,7 @@
   "slug": "allie",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "omnichannelallie",
     "combat_front": "goth_rose",

--- a/mods/tuxemon/db/npc/azure_npcs.json
+++ b/mods/tuxemon/db/npc/azure_npcs.json
@@ -3,6 +3,7 @@
     "slug": "unknownwitch",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "witch",
       "combat_front": "witch",
@@ -13,6 +14,7 @@
     "slug": "azure_enforcer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -23,6 +25,7 @@
     "slug": "azure_enforcer2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -33,6 +36,7 @@
     "slug": "azure_knight",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knight",

--- a/mods/tuxemon/db/npc/bob.json
+++ b/mods/tuxemon/db/npc/bob.json
@@ -2,6 +2,7 @@
   "slug": "bob",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/christie.json
+++ b/mods/tuxemon/db/npc/christie.json
@@ -2,6 +2,7 @@
   "slug": "christie",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "christie",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/conworker1.json
+++ b/mods/tuxemon/db/npc/conworker1.json
@@ -2,6 +2,7 @@
   "slug": "conworker1",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/conworker2.json
+++ b/mods/tuxemon/db/npc/conworker2.json
@@ -2,6 +2,7 @@
   "slug": "conworker2",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/conworker3.json
+++ b/mods/tuxemon/db/npc/conworker3.json
@@ -2,6 +2,7 @@
   "slug": "conworker3",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/cotton_breeder.json
+++ b/mods/tuxemon/db/npc/cotton_breeder.json
@@ -2,6 +2,7 @@
   "slug": "cotton_breeder",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "bob",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/cotton_misa_bro.json
+++ b/mods/tuxemon/db/npc/cotton_misa_bro.json
@@ -2,6 +2,7 @@
   "slug": "cotton_misa_bro",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "childactor_fiery",
     "combat_front": "yellowbelt",

--- a/mods/tuxemon/db/npc/cotton_misa_gramps.json
+++ b/mods/tuxemon/db/npc/cotton_misa_gramps.json
@@ -2,6 +2,7 @@
   "slug": "cotton_misa_gramps",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "granny",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/eclipse_bank_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_bank_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_blonde",
       "combat_front": "magician",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_lapi",
       "combat_front": "professor",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude_black",
       "combat_front": "rocker",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "winger",
@@ -174,6 +183,7 @@
     "slug": "eclipse_bank_bob",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -184,6 +194,7 @@
     "slug": "eclipse_bank_jeff",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "baller",
@@ -194,6 +205,7 @@
     "slug": "eclipse_zircon",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/eclipse_crystal_town_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_crystal_town_npcs.json
@@ -3,6 +3,7 @@
     "slug": "eclipse_crystal_magician_fiery",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -13,6 +14,7 @@
     "slug": "eclipse_crystal_homemaker",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -23,6 +25,7 @@
     "slug": "eclipse_crystal_barmaid",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -33,6 +36,7 @@
     "slug": "eclipse_crystal_granny",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -43,6 +47,7 @@
     "slug": "eclipse_crystal_maniac_green",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -53,6 +58,7 @@
     "slug": "eclipse_crystal_monk_orange",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -63,6 +69,7 @@
     "slug": "eclipse_crystal_tennisplayer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -73,6 +80,7 @@
     "slug": "eclipse_crystal_shopkeeper",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant_black",
       "combat_front": "shopassistant",
@@ -83,6 +91,7 @@
     "slug": "eclipse_cathedral_jada",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -93,6 +102,7 @@
     "slug": "eclipse_cathedral_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -103,6 +113,7 @@
     "slug": "eclipse_cathedral_enforcer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",

--- a/mods/tuxemon/db/npc/eclipse_lion_mountain_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_lion_mountain_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -183,6 +192,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -193,6 +203,7 @@
     "slug": "eclipse_lionmountain_scientist",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -203,6 +214,7 @@
     "slug": "eclipse_lionmountain_enforcer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_agent",
@@ -213,6 +225,7 @@
     "slug": "eclipse_lionmountain_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -223,6 +236,7 @@
     "slug": "eclipse_lionmountain_snarlon",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "landrace",
       "combat_front": "sludgehog",

--- a/mods/tuxemon/db/npc/eclipse_park_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_park_npcs.json
@@ -3,6 +3,7 @@
     "slug": "eclipse_park_reception",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -13,6 +14,7 @@
     "slug": "eclipse_park_florist",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -23,6 +25,7 @@
     "slug": "eclipse_park_guardian",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -33,6 +36,7 @@
     "slug": "eclipse_park_soldier",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -43,6 +47,7 @@
     "slug": "eclipse_park_scientist",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -53,6 +58,7 @@
     "slug": "eclipse_park_professor",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -63,6 +69,7 @@
     "slug": "eclipse_park_tennisplayer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/eclipse_route7_npcs.json
+++ b/mods/tuxemon/db/npc/eclipse_route7_npcs.json
@@ -3,6 +3,7 @@
     "slug": "eclipse_route7_arnold",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -13,6 +14,7 @@
     "slug": "eclipse_route7_sylvester",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -23,6 +25,7 @@
     "slug": "eclipse_route7_fritz",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -42,6 +45,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -61,6 +65,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_blonde",
       "combat_front": "magician",
@@ -80,6 +85,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -99,6 +105,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "baller",
@@ -118,6 +125,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_lapi",
       "combat_front": "professor",
@@ -137,6 +145,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude_black",
       "combat_front": "rocker",
@@ -156,6 +165,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "winger",
@@ -175,6 +185,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -194,6 +205,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "postboy_green",
       "combat_front": "cooldude",
@@ -213,6 +225,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "coach",
@@ -223,6 +236,7 @@
     "slug": "eclipse_route7_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/grace.json
+++ b/mods/tuxemon/db/npc/grace.json
@@ -2,6 +2,7 @@
   "slug": "grace",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "heroine",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/happy_guy.json
+++ b/mods/tuxemon/db/npc/happy_guy.json
@@ -2,6 +2,7 @@
   "slug": "happy_guy",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "ceo",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/knight1.json
+++ b/mods/tuxemon/db/npc/knight1.json
@@ -2,6 +2,7 @@
   "slug": "knight1",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/knight2.json
+++ b/mods/tuxemon/db/npc/knight2.json
@@ -2,6 +2,7 @@
   "slug": "knight2",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/knight3.json
+++ b/mods/tuxemon/db/npc/knight3.json
@@ -2,6 +2,7 @@
   "slug": "knight3",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/knight4.json
+++ b/mods/tuxemon/db/npc/knight4.json
@@ -2,6 +2,7 @@
   "slug": "knight4",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/kyle.json
+++ b/mods/tuxemon/db/npc/kyle.json
@@ -2,6 +2,7 @@
   "slug": "kyle",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "cooldude",
     "combat_front": "cooldude",

--- a/mods/tuxemon/db/npc/liela.json
+++ b/mods/tuxemon/db/npc/liela.json
@@ -2,6 +2,7 @@
   "slug": "liela",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "heroine",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/maple.json
+++ b/mods/tuxemon/db/npc/maple.json
@@ -2,6 +2,7 @@
   "slug": "maple_girl",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "fashionista_fiery",
     "combat_front": "fashionista",

--- a/mods/tuxemon/db/npc/marissa.json
+++ b/mods/tuxemon/db/npc/marissa.json
@@ -2,6 +2,7 @@
   "slug": "marissa",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "girl1",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/misa.json
+++ b/mods/tuxemon/db/npc/misa.json
@@ -2,6 +2,7 @@
   "slug": "misa",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "fashionista",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/npc_mom.json
+++ b/mods/tuxemon/db/npc/npc_mom.json
@@ -2,6 +2,7 @@
   "slug": "npc_mom",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "girl1",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/npc_test.json
+++ b/mods/tuxemon/db/npc/npc_test.json
@@ -2,6 +2,7 @@
   "slug": "npc_test",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "adventurer",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/npc_wife.json
+++ b/mods/tuxemon/db/npc/npc_wife.json
@@ -2,6 +2,7 @@
   "slug": "npc_wife",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "girl1",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/nurse1.json
+++ b/mods/tuxemon/db/npc/nurse1.json
@@ -2,6 +2,7 @@
   "slug": "nurse1",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "nurse",
     "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/nurse2.json
+++ b/mods/tuxemon/db/npc/nurse2.json
@@ -2,6 +2,7 @@
   "slug": "nurse2",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "nurse",
     "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/omnigrunt.json
+++ b/mods/tuxemon/db/npc/omnigrunt.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt10.json
+++ b/mods/tuxemon/db/npc/omnigrunt10.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt10",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt2.json
+++ b/mods/tuxemon/db/npc/omnigrunt2.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt2",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt3.json
+++ b/mods/tuxemon/db/npc/omnigrunt3.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt3",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt4.json
+++ b/mods/tuxemon/db/npc/omnigrunt4.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt4",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt5.json
+++ b/mods/tuxemon/db/npc/omnigrunt5.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt5",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt6.json
+++ b/mods/tuxemon/db/npc/omnigrunt6.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt6",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt7.json
+++ b/mods/tuxemon/db/npc/omnigrunt7.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt7",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt8.json
+++ b/mods/tuxemon/db/npc/omnigrunt8.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt8",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt9.json
+++ b/mods/tuxemon/db/npc/omnigrunt9.json
@@ -2,6 +2,7 @@
   "slug": "omnigrunt9",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/omnigrunt_zeke.json
+++ b/mods/tuxemon/db/npc/omnigrunt_zeke.json
@@ -2,6 +2,7 @@
   "slug": "zeke",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "knight",
     "combat_front": "knight",

--- a/mods/tuxemon/db/npc/penguin.json
+++ b/mods/tuxemon/db/npc/penguin.json
@@ -2,6 +2,7 @@
   "slug": "penguin",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "penguin",
     "combat_front": "penguin",

--- a/mods/tuxemon/db/npc/postboy.json
+++ b/mods/tuxemon/db/npc/postboy.json
@@ -2,6 +2,7 @@
   "slug": "postboy",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "postboy",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/professor.json
+++ b/mods/tuxemon/db/npc/professor.json
@@ -2,6 +2,7 @@
   "slug": "professor",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "professor",
     "combat_front": "professor",

--- a/mods/tuxemon/db/npc/red.json
+++ b/mods/tuxemon/db/npc/red.json
@@ -2,6 +2,7 @@
   "slug": "npc_red",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "adventurer",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/rock.json
+++ b/mods/tuxemon/db/npc/rock.json
@@ -2,6 +2,7 @@
   "slug": "rock",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "boulder",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/shady_guy.json
+++ b/mods/tuxemon/db/npc/shady_guy.json
@@ -2,6 +2,7 @@
   "slug": "shady_guy",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "ninja",
     "combat_front": "ninja",

--- a/mods/tuxemon/db/npc/speck.json
+++ b/mods/tuxemon/db/npc/speck.json
@@ -2,6 +2,7 @@
   "slug": "speck",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "beachcomber",
     "combat_front": "beachgoer",

--- a/mods/tuxemon/db/npc/spyder_boulder.json
+++ b/mods/tuxemon/db/npc/spyder_boulder.json
@@ -2,6 +2,7 @@
   "slug": "spyder_boulder",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "boulder",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_candy_town_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_candy_henrik",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_rookie",
@@ -13,6 +14,7 @@
     "slug": "spyder_candy_eliane",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -23,6 +25,7 @@
     "slug": "spyder_candycafe_nora",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -33,6 +36,7 @@
     "slug": "spyder_candyhouse2_indiana",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -43,6 +47,7 @@
     "slug": "spyder_candyhouse2_barney",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",
@@ -53,6 +58,7 @@
     "slug": "spyder_candyhouse3_joanie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "catgirl",
       "combat_front": "catgirl",
@@ -63,6 +69,7 @@
     "slug": "spyder_candyhouse1_tillie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -73,6 +80,7 @@
     "slug": "spyder_candyhouse1_sawyer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "adventurer",
@@ -83,6 +91,7 @@
     "slug": "spyder_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -93,6 +102,7 @@
     "slug": "spyder_candyinn_cott",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -103,6 +113,7 @@
     "slug": "spyder_candyinn_lyle",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "pirate",
@@ -113,6 +124,7 @@
     "slug": "spyder_candyinn_bob",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_rose",
       "combat_front": "adventurer",
@@ -123,6 +135,7 @@
     "slug": "spyder_candyinn_prof",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_lapi",
       "combat_front": "professor",
@@ -133,6 +146,7 @@
     "slug": "spyder_candyinn_jess",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "adventurer",
@@ -143,6 +157,7 @@
     "slug": "spyder_candyinn_james",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -153,6 +168,7 @@
     "slug": "spyder_candyport_monk",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -163,6 +179,7 @@
     "slug": "spyder_candyinn_monk",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",

--- a/mods/tuxemon/db/npc/spyder_citypark_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_citypark_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "catgirl_green",
       "combat_front": "catgirl",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -41,6 +43,7 @@
     "slug": "spyder_citypark_florist",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -60,6 +63,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_black",
       "combat_front": "florist",
@@ -70,6 +74,7 @@
     "slug": "spyder_citypark_magdalene",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -80,6 +85,7 @@
     "slug": "spyder_citypark_prue",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -90,6 +96,7 @@
     "slug": "spyder_citypark_mack",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -100,6 +107,7 @@
     "slug": "spyder_citypark_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -110,6 +118,7 @@
     "slug": "spyder_citypark_cd1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -120,6 +129,7 @@
     "slug": "spyder_citypark_cd2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -130,6 +140,7 @@
     "slug": "spyder_citypark_restoration",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -140,6 +151,7 @@
     "slug": "spyder_citypark_potion1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -150,6 +162,7 @@
     "slug": "spyder_citypark_potion2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -160,6 +173,7 @@
     "slug": "spyder_citypark_house_maniac",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_cotton_town_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_cottontown_barmaid",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid",
       "combat_front": "barmaid",
@@ -13,6 +14,7 @@
     "slug": "spyder_cottontown_monk",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk",
       "combat_front": "monk",
@@ -23,6 +25,7 @@
     "slug": "spyder_cottontown_hacker",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician",
       "combat_front": "magician",
@@ -33,6 +36,7 @@
     "slug": "spyder_cottonhouse1_rodger",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -43,6 +47,7 @@
     "slug": "spyder_cottonhouse1_lila",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker_blonde",
       "combat_front": "adventurer",
@@ -53,6 +58,7 @@
     "slug": "spyder_cottoncafe_juliana",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker_black",
       "combat_front": "adventurer",
@@ -72,6 +78,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -82,6 +89,7 @@
     "slug": "spyder_cottoncafe_wilford",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "shopassistant",
@@ -92,6 +100,7 @@
     "slug": "spyder_cottoncafe_hillary",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -102,6 +111,7 @@
     "slug": "spyder_cottoncafe_lotus",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny_lapi",
       "combat_front": "adventurer",
@@ -112,6 +122,7 @@
     "slug": "spyder_cottonartshop_phoenix",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "adventurer",
@@ -122,6 +133,7 @@
     "slug": "spyder_cottonartshop_philis",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny_green",
       "combat_front": "adventurer",
@@ -132,6 +144,7 @@
     "slug": "spyder_cottonhouse2_sidney",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "catgirl_fiery",
       "combat_front": "catgirl",
@@ -142,6 +155,7 @@
     "slug": "spyder_cottonartshop_luvinia",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist",
       "combat_front": "florist",
@@ -152,6 +166,7 @@
     "slug": "spyder_cottonhouse2_neva",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -162,6 +177,7 @@
     "slug": "spyder_cottonhouse2_davis",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper_blonde",
       "combat_front": "adventurer",
@@ -172,6 +188,7 @@
     "slug": "spyder_cottonartshop_carter",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper_brown",
       "combat_front": "adventurer",
@@ -182,6 +199,7 @@
     "slug": "spyder_cottoncenter_ada",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -192,6 +210,7 @@
     "slug": "spyder_shopkeeper",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -202,6 +221,7 @@
     "slug": "spyder_cottontunnel_box1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -212,6 +232,7 @@
     "slug": "spyder_cottontunnel_box2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -222,6 +243,7 @@
     "slug": "spyder_cottontunnel_box3",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -232,6 +254,7 @@
     "slug": "spyder_cottontunnel_box4",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -242,6 +265,7 @@
     "slug": "spyder_cottontunnel_box5",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -252,6 +276,7 @@
     "slug": "spyder_cottontunnel_box6",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -262,6 +287,7 @@
     "slug": "spyder_cottontunnel_professor",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_fiery",
       "combat_front": "professor",
@@ -272,6 +298,7 @@
     "slug": "spyder_cottontunnel_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant_black",
       "combat_front": "shopassistant",
@@ -291,6 +318,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -310,6 +338,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "childactor_fiery",
       "combat_front": "tennisplayer_fiery",

--- a/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_datacenter_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -98,6 +103,7 @@
     "slug": "spyder_box_goldpass",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -108,6 +114,7 @@
     "slug": "spyder_datacenter_s1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -118,6 +125,7 @@
     "slug": "spyder_datacenter_s2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -128,6 +136,7 @@
     "slug": "spyder_datacenter_s3",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -138,6 +147,7 @@
     "slug": "spyder_datacenter_s4",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -148,6 +158,7 @@
     "slug": "spyder_datacenter_s5",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -158,6 +169,7 @@
     "slug": "spyder_datacenter_s6",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",
@@ -168,6 +180,7 @@
     "slug": "spyder_datacenter_s7",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "screen_small",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_dojo_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dojo_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -22,6 +23,7 @@
     "slug": "spyder_dojo_fu",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny_yellow",
       "combat_front": "adventurer",
@@ -32,6 +34,7 @@
     "slug": "spyder_dojo_fu_student1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "childactor_black",
       "combat_front": "childactor",
@@ -42,6 +45,7 @@
     "slug": "spyder_dojo_fu_student2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "childactor_blonde",
       "combat_front": "childactor",
@@ -61,6 +65,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -80,6 +85,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -99,6 +105,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_orange",
       "combat_front": "monk",
@@ -118,6 +125,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -137,6 +145,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",
@@ -156,6 +165,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -175,6 +185,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_green",
       "combat_front": "monk",
@@ -185,6 +196,7 @@
     "slug": "spyder_dojo_thri",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "riddler",
@@ -204,6 +216,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_black",
       "combat_front": "monk",
@@ -214,6 +227,7 @@
     "slug": "spyder_dojo_tu",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ninja_red",
       "combat_front": "ninja",
@@ -224,6 +238,7 @@
     "slug": "spyder_dojo_wan",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ninja_blue",
       "combat_front": "ninja",
@@ -234,6 +249,7 @@
     "slug": "spyder_dojo_xiang",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny_green",
       "combat_front": "adventurer",
@@ -253,6 +269,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -263,6 +280,7 @@
     "slug": "spyder_dojo_yin",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -273,6 +291,7 @@
     "slug": "spyder_dojo_zhao",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -283,6 +302,7 @@
     "slug": "spyder_dojo_zhu",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_rose",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dragonscave_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_dragonscave_angrybrute",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -22,6 +23,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -41,6 +43,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_blue",
       "combat_front": "dragonrider",
@@ -51,6 +54,7 @@
     "slug": "spyder_dragonscave_concernedbrute",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -70,6 +74,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider",
       "combat_front": "dragonrider",
@@ -89,6 +94,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_fiery",
       "combat_front": "dragonrider",
@@ -99,6 +105,7 @@
     "slug": "spyder_dragonscave_lazybrute",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -118,6 +125,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_black",
       "combat_front": "dragonrider",
@@ -137,6 +145,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -156,6 +165,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss_fiery",
       "combat_front": "spyder_boss",
@@ -175,6 +185,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -194,6 +205,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_green",
       "combat_front": "dragonrider",
@@ -204,6 +216,7 @@
     "slug": "spyder_drokoro",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "drokoro",
       "combat_front": "noclass",
@@ -214,6 +227,7 @@
     "slug": "spyder_dragonscave_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_dryadsgrove_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "waternymph",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "metalnymph",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firenymph",
       "combat_front": "firenymph",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "earthnymph",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "woodnymph",
       "combat_front": "woodnymph",
@@ -98,6 +103,7 @@
     "slug": "spyder_volcoli",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "volcoli",
       "combat_front": "noclass",
@@ -108,6 +114,7 @@
     "slug": "spyder_dryadsgrove_boy",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "childactor_black",
       "combat_front": "yellowbelt",
@@ -118,6 +125,7 @@
     "slug": "spyder_dryadsgrove_dad",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_gray",
       "combat_front": "yellowbelt",

--- a/mods/tuxemon/db/npc/spyder_flower_city_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_flower_city_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_flower_cady",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "snugglepot",
       "combat_front": "yellowbelt",
@@ -13,6 +14,7 @@
     "slug": "spyder_flower_fez",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "yellowbelt",
@@ -23,6 +25,7 @@
     "slug": "spyder_flower_mieke",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "catgirl_blue",
       "combat_front": "catgirl",
@@ -33,6 +36,7 @@
     "slug": "spyder_flower_sandy",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "childactor",
       "combat_front": "yellowbelt",
@@ -43,6 +47,7 @@
     "slug": "spyder_flower_teach",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -53,6 +58,7 @@
     "slug": "spyder_flower_monk",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_blue",
       "combat_front": "monk",
@@ -63,6 +69,7 @@
     "slug": "spyder_flowerhouse1_willie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -73,6 +80,7 @@
     "slug": "spyder_flowerhouse2_pip",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -83,6 +91,7 @@
     "slug": "spyder_flowerhouse1_jonette",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -93,6 +102,7 @@
     "slug": "spyder_flower_lissa",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist",
       "combat_front": "florist",
@@ -103,6 +113,7 @@
     "slug": "spyder_flowerhouse2_bruce",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -113,6 +124,7 @@
     "slug": "spyder_flowerpetshop_denzel",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper_blonde",
       "combat_front": "adventurer",
@@ -123,6 +135,7 @@
     "slug": "spyder_flowerpetshop_titus",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant_grey",
       "combat_front": "shopassistant",
@@ -133,6 +146,7 @@
     "slug": "spyder_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_greenwash_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "aviator",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -174,6 +183,7 @@
     "slug": "spyder_greenwash_guard",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -193,6 +203,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "postboy_red",
       "combat_front": "cooldude",
@@ -212,6 +223,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -231,6 +243,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -250,6 +263,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -269,6 +283,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -288,6 +303,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -307,6 +323,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -326,6 +343,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -336,6 +354,7 @@
     "slug": "spyder_greenwash_norton",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -346,6 +365,7 @@
     "slug": "spyder_greenwash_selby",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/spyder_hospital_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_hospital_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss_blonde",
       "combat_front": "spyder_boss",
@@ -22,6 +23,7 @@
     "slug": "spyder_hospital1_pem",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -41,6 +43,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss_fiery",
       "combat_front": "spyder_boss",
@@ -60,6 +63,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss_green",
       "combat_front": "spyder_boss",
@@ -79,6 +83,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -98,6 +103,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -117,6 +123,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss_lapi",
       "combat_front": "spyder_boss",
@@ -136,6 +143,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -146,6 +154,7 @@
     "slug": "spyder_hospital1_rea",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss",
       "combat_front": "spyder_boss",
@@ -165,6 +174,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -184,6 +194,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -203,6 +214,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -213,6 +225,7 @@
     "slug": "spyder_hospital1_smith",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -223,6 +236,7 @@
     "slug": "spyder_hospital1_lesley",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -233,6 +247,7 @@
     "slug": "spyder_hospital1_trafford",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -243,6 +258,7 @@
     "slug": "spyder_hospital1_marylyn",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -253,6 +269,7 @@
     "slug": "spyder_hospital1_melanie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",
@@ -263,6 +280,7 @@
     "slug": "spyder_hospital1_audie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_leather_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_leather_town_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_leathergym_chadine",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "barmaid",
@@ -13,6 +14,7 @@
     "slug": "spyder_leathergym_chadfort",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -23,6 +25,7 @@
     "slug": "spyder_leathergym_chad",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -33,6 +36,7 @@
     "slug": "spyder_leathergym_bradfort",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "postboy_green",
       "combat_front": "adventurer",
@@ -43,6 +47,7 @@
     "slug": "spyder_leathergym_brad",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -53,6 +58,7 @@
     "slug": "spyder_leathergym_gigachad",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_brown",
       "combat_front": "magician",
@@ -63,6 +69,7 @@
     "slug": "spyder_leathergym_virgin",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "adventurer",
@@ -73,6 +80,7 @@
     "slug": "spyder_leather_eula",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid",
       "combat_front": "barmaid",
@@ -83,6 +91,7 @@
     "slug": "spyder_leatherhouse2_memphis",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -93,6 +102,7 @@
     "slug": "spyder_leathermuseum_davie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -103,6 +113,7 @@
     "slug": "spyder_leathershaft1_cole",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -113,6 +124,7 @@
     "slug": "spyder_leathershaft1_rutherford",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -123,6 +135,7 @@
     "slug": "spyder_leathershaft1_beryll",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -133,6 +146,7 @@
     "slug": "spyder_leathershaft1_surat",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -143,6 +157,7 @@
     "slug": "spyder_leathershaft1_roxby",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner",
       "combat_front": "miner",
@@ -153,6 +168,7 @@
     "slug": "spyder_leathershaft2_colin",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
@@ -163,6 +179,7 @@
     "slug": "spyder_leatherhouse1_roger",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "adventurer",
@@ -173,6 +190,7 @@
     "slug": "spyder_leathermuseum_kasey",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "postboy_red",
       "combat_front": "adventurer",
@@ -183,6 +201,7 @@
     "slug": "spyder_leathermuseum_historian",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_brown",
       "combat_front": "professor",
@@ -193,6 +212,7 @@
     "slug": "spyder_leathermuseum_security",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -203,6 +223,7 @@
     "slug": "spyder_leathermuseum_visitor",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -213,6 +234,7 @@
     "slug": "spyder_leatherhouse1_gail",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",
@@ -223,6 +245,7 @@
     "slug": "spyder_leatherhouse2_elias",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "snugglepot",
       "combat_front": "snugglepot",
@@ -233,6 +256,7 @@
     "slug": "spyder_leatherhouse2_gabe",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -243,6 +267,7 @@
     "slug": "spyder_leather_filbur",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -253,6 +278,7 @@
     "slug": "spyder_leathermuseum_giles",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_rose",
       "combat_front": "adventurer",
@@ -263,6 +289,7 @@
     "slug": "spyder_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_log.json
+++ b/mods/tuxemon/db/npc/spyder_log.json
@@ -2,6 +2,7 @@
   "slug": "spyder_log",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "log",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_mansion_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_mansion_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_red",
       "combat_front": "rogue",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "mage",
@@ -79,6 +83,7 @@
     "slug": "spyder_top_penelope",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -89,6 +94,7 @@
     "slug": "spyder_top_maura",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "barmaid",
@@ -99,6 +105,7 @@
     "slug": "spyder_top_lenny",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician",
       "combat_front": "magician",
@@ -109,6 +116,7 @@
     "slug": "spyder_mansion_drinkingbuddya",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_green",
       "combat_front": "rogue",
@@ -119,6 +127,7 @@
     "slug": "spyder_mansion_wayne",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_black",
       "combat_front": "magician",
@@ -138,6 +147,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "pirate",
@@ -157,6 +167,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_red",
       "combat_front": "barmaid",
@@ -176,6 +187,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_brown",
       "combat_front": "magician",
@@ -186,6 +198,7 @@
     "slug": "spyder_mansion_drinkingbuddyb",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "warrior",
       "combat_front": "enforcer_rookie",
@@ -196,6 +209,7 @@
     "slug": "spyder_mansion_lainey",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid",
       "combat_front": "barmaid",
@@ -206,6 +220,7 @@
     "slug": "spyder_mansion_rolo",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",
@@ -216,6 +231,7 @@
     "slug": "spyder_mansion_tamara",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -226,6 +242,7 @@
     "slug": "spyder_mansion_reed",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_fiery",
       "combat_front": "magician",
@@ -236,6 +253,7 @@
     "slug": "spyder_mansion_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -255,6 +273,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "postboy",
       "combat_front": "rocker",
@@ -274,6 +293,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "disciple",
       "combat_front": "healer",
@@ -293,6 +313,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "barmaid_blonde",
       "combat_front": "dancer",
@@ -303,6 +324,7 @@
     "slug": "spyder_basement_josephine",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "disciple",
       "combat_front": "healer",
@@ -322,6 +344,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer_lapi",
       "combat_front": "tennisplayer",
@@ -332,6 +355,7 @@
     "slug": "spyder_basement_josh",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "baller",
@@ -342,6 +366,7 @@
     "slug": "spyder_basement_garret",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_green",
       "combat_front": "rogue",
@@ -352,6 +377,7 @@
     "slug": "spyder_basement_flick",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",

--- a/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_nimrod_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist_brown",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "robot",
       "combat_front": "xeon",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knightlord",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "aviator",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -183,6 +192,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "robot",
       "combat_front": "chrome_robo",
@@ -202,6 +212,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -221,6 +232,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_boss",
@@ -240,6 +252,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -259,6 +272,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist_black",
@@ -269,6 +283,7 @@
     "slug": "spyder_nimrod_dirk",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -279,6 +294,7 @@
     "slug": "spyder_nimrod_jake",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -289,6 +305,7 @@
     "slug": "spyder_nimrod_jervis",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -299,6 +316,7 @@
     "slug": "spyder_nimrod_elara",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",

--- a/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_omnichannel_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_omnichannel_beaverbrook",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -22,6 +23,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue",
       "combat_front": "rogue",
@@ -41,6 +43,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "warrior",
       "combat_front": "warrior",
@@ -60,6 +63,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_black",
       "combat_front": "yellowbelt",
@@ -79,6 +83,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -89,6 +94,7 @@
     "slug": "spyder_omnichannel_worm",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "37707_female",
       "combat_front": "ceo",
@@ -99,6 +105,7 @@
     "slug": "spyder_omnichannel_enforcer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -109,6 +116,7 @@
     "slug": "spyder_omnichannel_thedukeofdeadair",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_red",
       "combat_front": "rogue",
@@ -128,6 +136,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss",
       "combat_front": "spyder_boss",
@@ -147,6 +156,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -166,6 +176,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -185,6 +196,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -204,6 +216,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_copper",
       "combat_front": "rogue",
@@ -214,6 +227,7 @@
     "slug": "spyder_omnichannel_talbot",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -224,6 +238,7 @@
     "slug": "spyder_omnichannel_gore",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -234,6 +249,7 @@
     "slug": "spyder_omnichannel_danita",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -244,6 +260,7 @@
     "slug": "spyder_omnichannel_ethan",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_paintings.json
+++ b/mods/tuxemon/db/npc/spyder_paintings.json
@@ -3,6 +3,7 @@
     "slug": "p_one",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "p_one",
       "combat_front": "noclass",
@@ -13,6 +14,7 @@
     "slug": "p_two",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "p_two",
       "combat_front": "noclass",
@@ -23,6 +25,7 @@
     "slug": "p_three",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "p_three",
       "combat_front": "noclass",
@@ -33,6 +36,7 @@
     "slug": "p_four",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "p_four",
       "combat_front": "noclass",
@@ -43,6 +47,7 @@
     "slug": "p_five",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "p_five",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_paper_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_paper_town_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_grannypiper",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny_yellow",
       "combat_front": "adventurer",
@@ -13,6 +14,7 @@
     "slug": "spyder_conileaffrolicking",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "conileaf",
       "combat_front": "adventurer",
@@ -23,6 +25,7 @@
     "slug": "spyder_rockittenfrolicking",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rockitten",
       "combat_front": "adventurer",
@@ -33,6 +36,7 @@
     "slug": "spyder_papermart_harith",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "adventurer",
@@ -43,6 +47,7 @@
     "slug": "spyder_papermart_miles",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "tennisplayer",
@@ -53,6 +58,7 @@
     "slug": "spyder_papermart_shirley",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -63,6 +69,7 @@
     "slug": "spyder_papermart_rafael",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer_lapi",
       "combat_front": "tennisplayer",
@@ -73,6 +80,7 @@
     "slug": "spyder_papertown_mom",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker",
       "combat_front": "adventurer",
@@ -83,6 +91,7 @@
     "slug": "spyder_papertown_silver",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist",
       "combat_front": "florist",
@@ -93,6 +102,7 @@
     "slug": "spyder_papermanor_princeton",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_yellow",
       "combat_front": "adventurer",
@@ -103,6 +113,7 @@
     "slug": "spyder_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_route1_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route1_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_route1_bjorn",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/spyder_route2_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route2_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer_green",
       "combat_front": "tennisplayer",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer_fiery",
       "combat_front": "tennisplayer",

--- a/mods/tuxemon/db/npc/spyder_route3_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route3_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "overseer",
       "combat_front": "overseer",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "knight",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "fisher",
       "combat_front": "fisher",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_green",
       "combat_front": "miner",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -183,6 +192,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "tennisplayer",
@@ -193,6 +203,7 @@
     "slug": "spyder_route3_ryland",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -203,6 +214,7 @@
     "slug": "spyder_route3_miner1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_blue",
       "combat_front": "miner",
@@ -213,6 +225,7 @@
     "slug": "spyder_route3_miner2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_red",
       "combat_front": "miner",
@@ -223,6 +236,7 @@
     "slug": "spyder_route3_miner3",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",

--- a/mods/tuxemon/db/npc/spyder_route4_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route4_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tennisplayer",
       "combat_front": "yellowbelt",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_blue",
       "combat_front": "yellowbelt",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "alchemist",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -117,6 +123,7 @@
     "slug": "spyder_route4_super",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -127,6 +134,7 @@
     "slug": "spyder_route4_boost",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -137,6 +145,7 @@
     "slug": "spyder_route4_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_route5_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route5_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "catgirl_blonde",
       "combat_front": "catgirl",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "soldier",
       "combat_front": "soldier",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -117,6 +123,7 @@
     "slug": "spyder_route5_lexia",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny_lapi",
       "combat_front": "adventurer",
@@ -127,6 +134,7 @@
     "slug": "spyder_route5_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_route6_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_route6_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_brown",
       "combat_front": "florist",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician_grey",
       "combat_front": "magician",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "miner_yellow",
       "combat_front": "miner",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_blue",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/spyder_routea_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routea_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "beachgoer",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "boss_orange",
       "combat_front": "rocker",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_blue",
       "combat_front": "florist",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "boss_red",
       "combat_front": "rocker",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "catgirl_violet",
       "combat_front": "catgirl",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "monk_red",
       "combat_front": "monk",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "goth",
       "combat_front": "goth",
@@ -174,6 +183,7 @@
     "slug": "spyder_routea_jarod",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -184,6 +194,7 @@
     "slug": "spyder_routea_john",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_green",
       "combat_front": "adventurer",
@@ -194,6 +205,7 @@
     "slug": "spyder_routea_super",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -204,6 +216,7 @@
     "slug": "spyder_routea_cureall",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -214,6 +227,7 @@
     "slug": "spyder_routea_tea",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -224,6 +238,7 @@
     "slug": "spyder_routea_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_routeb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routeb_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_agent",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_agent",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_rookie",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_yellow",
       "combat_front": "enforcer_boss",

--- a/mods/tuxemon/db/npc/spyder_routee_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_routee_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_red",
       "combat_front": "enforcer_agent",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight_green",
       "combat_front": "enforcer_rookie",

--- a/mods/tuxemon/db/npc/spyder_scoop_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_scoop_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_blonde",
       "combat_front": "nurse",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderrookie",
       "combat_front": "spyder_rookie",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -136,6 +143,7 @@
     "slug": "spyder_scoop_arachne",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "spyderboss_blonde",
       "combat_front": "spyder_boss",
@@ -155,6 +163,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_black",
       "combat_front": "professor",
@@ -165,6 +174,7 @@
     "slug": "spyder_scoop_cochinia",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "cochini",
@@ -175,6 +185,7 @@
     "slug": "spyder_scoop_cochinib",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "cochini",
@@ -185,6 +196,7 @@
     "slug": "spyder_scoop_cochinic",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "cochini",
@@ -204,6 +216,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude_fiery",
       "combat_front": "cooldude",
@@ -214,6 +227,7 @@
     "slug": "spyder_scoop_landrace",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "landrace",
       "combat_front": "sludgehog",
@@ -233,6 +247,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -243,6 +258,7 @@
     "slug": "spyder_scoop_lapinoua",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "lapinou",
@@ -253,6 +269,7 @@
     "slug": "spyder_scoop_lapinoub",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "lapinou",
@@ -263,6 +280,7 @@
     "slug": "spyder_scoop_lapinouc",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "varmint",
       "combat_front": "lapinou",
@@ -273,6 +291,7 @@
     "slug": "spyder_scoop_nash",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -283,6 +302,7 @@
     "slug": "spyder_scoop_reese",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_brown",
       "combat_front": "scientist",

--- a/mods/tuxemon/db/npc/spyder_screen.json
+++ b/mods/tuxemon/db/npc/spyder_screen.json
@@ -2,6 +2,7 @@
   "slug": "spyder_screen",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "screen",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_searoutec_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_searoutec_alpha",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_red",
       "combat_front": "swimmer",
@@ -22,6 +23,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_orange",
       "combat_front": "swimmer",
@@ -41,6 +43,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "dragonrider_blue",
       "combat_front": "dragonrider",
@@ -60,6 +63,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_green",
       "combat_front": "swimmer",
@@ -79,6 +83,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -98,6 +103,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "fisher",
       "combat_front": "fisher",
@@ -117,6 +123,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "fisher_fiery",
       "combat_front": "fisher",
@@ -136,6 +143,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer",
       "combat_front": "swimmer",
@@ -155,6 +163,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_blue",
       "combat_front": "swimmer",
@@ -174,6 +183,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_copper",
       "combat_front": "yellowbelt",
@@ -193,6 +203,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_blue",
       "combat_front": "swimmer",
@@ -212,6 +223,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_blue",
       "combat_front": "yellowbelt",
@@ -231,6 +243,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_red",
       "combat_front": "swimmer",
@@ -241,6 +254,7 @@
     "slug": "spyder_searoutec_beta",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "swimmer_orange",
       "combat_front": "swimmer",

--- a/mods/tuxemon/db/npc/spyder_sign.json
+++ b/mods/tuxemon/db/npc/spyder_sign.json
@@ -3,6 +3,7 @@
     "slug": "spyder_sign",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "sign",
       "combat_front": "noclass",
@@ -13,6 +14,7 @@
     "slug": "spyder_sign_flower1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "sign",
       "combat_front": "noclass",
@@ -23,6 +25,7 @@
     "slug": "spyder_sign_flower2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "sign",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_statues.json
+++ b/mods/tuxemon/db/npc/spyder_statues.json
@@ -3,6 +3,7 @@
     "slug": "spyder_statue_blue",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "statue_blue",
       "combat_front": "noclass",
@@ -13,6 +14,7 @@
     "slug": "spyder_statue_red",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "statue_red",
       "combat_front": "noclass",
@@ -23,6 +25,7 @@
     "slug": "spyder_statue_orange",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "statue_orange",
       "combat_front": "noclass",
@@ -33,6 +36,7 @@
     "slug": "spyder_statue_grey",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "statue_grey",
       "combat_front": "noclass",
@@ -43,6 +47,7 @@
     "slug": "spyder_statue_green",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "statue_green",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_timber_town_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_timber_town_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_timberhouse_zed",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "firefighter",
       "combat_front": "firefighter",
@@ -13,6 +14,7 @@
     "slug": "spyder_timbercafe_grady",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "magician",
       "combat_front": "magician",
@@ -23,6 +25,7 @@
     "slug": "spyder_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "adventurer",
@@ -33,6 +36,7 @@
     "slug": "spyder_outsidewalled_rogue",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "rogue_green",
       "combat_front": "rogue",
@@ -43,6 +47,7 @@
     "slug": "spyder_outsidewalled_midas",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",

--- a/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_tunnelb_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_brown",
       "combat_front": "florist",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_fiery",
       "combat_front": "scientist",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_gray",
       "combat_front": "yellowbelt",
@@ -117,6 +123,7 @@
     "slug": "spyder_tunnelb_rhincus",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -127,6 +134,7 @@
     "slug": "spyder_tunnelb_shammer",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "box",
       "combat_front": "noclass",
@@ -137,6 +145,7 @@
     "slug": "spyder_tunnelb_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/spyder_tuxeballs.json
+++ b/mods/tuxemon/db/npc/spyder_tuxeballs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_tuxeball_green",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tuxeball_green",
       "combat_front": "noclass",
@@ -13,6 +14,7 @@
     "slug": "spyder_tuxeball_red",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tuxeball_red",
       "combat_front": "noclass",
@@ -23,6 +25,7 @@
     "slug": "spyder_tuxeball_violet",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tuxeball_violet",
       "combat_front": "noclass",
@@ -33,6 +36,7 @@
     "slug": "spyder_tuxeball_yellow",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tuxeball_yellow",
       "combat_front": "noclass",
@@ -43,6 +47,7 @@
     "slug": "spyder_tuxeball",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "tuxeball",
       "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/spyder_unique_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_unique_npcs.json
@@ -3,6 +3,7 @@
     "slug": "spyder_dante",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "adventurer",
@@ -13,6 +14,7 @@
     "slug": "spyder_shady",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude_blue",
       "combat_front": "cooldude",
@@ -23,6 +25,7 @@
     "slug": "spyder_captain",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "riverboatcaptain",
       "combat_front": "enforcer_rookie",
@@ -33,6 +36,7 @@
     "slug": "spyder_billie",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "fashionista",
       "combat_front": "fashionista",
@@ -43,6 +47,7 @@
     "slug": "spyder_cathedral_nurse",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -53,6 +58,7 @@
     "slug": "spyder_shopkeeper",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper",
       "combat_front": "shopassistant",
@@ -63,6 +69,7 @@
     "slug": "spyder_shopassistant",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant",
       "combat_front": "shopassistant",

--- a/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_walled_garden_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -183,6 +192,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -202,6 +212,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "cooldude",
       "combat_front": "cooldude",
@@ -221,6 +232,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "ceo",
       "combat_front": "ceo",
@@ -240,6 +252,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "picnicker",
       "combat_front": "picnicker",

--- a/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
+++ b/mods/tuxemon/db/npc/spyder_wayfarer_npcs.json
@@ -12,6 +12,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist_black",
       "combat_front": "scientist",
@@ -31,6 +32,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_rookie",
@@ -50,6 +52,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse",
       "combat_front": "nurse",
@@ -69,6 +72,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_blue",
       "combat_front": "nurse",
@@ -88,6 +92,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "beachcomber_fiery",
       "combat_front": "yellowbelt",
@@ -107,6 +112,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_red",
       "combat_front": "nurse",
@@ -126,6 +132,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_lapi",
       "combat_front": "nurse",
@@ -145,6 +152,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "scientist",
       "combat_front": "scientist",
@@ -164,6 +172,7 @@
       }
     },
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "knight",
       "combat_front": "enforcer_agent",
@@ -174,6 +183,7 @@
     "slug": "spyder_wayfarer2_gae",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "adventurer",
@@ -184,6 +194,7 @@
     "slug": "spyder_wayfarer1_addy",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "nurse_green",
       "combat_front": "nurse",
@@ -194,6 +205,7 @@
     "slug": "spyder_wayfarer1_wes",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac_violet",
       "combat_front": "adventurer",
@@ -204,6 +216,7 @@
     "slug": "spyder_wayfarer2_kim",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
@@ -214,6 +227,7 @@
     "slug": "spyder_wayfarer1_norm",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopkeeper_brown",
       "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/taba_acolyte_1.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_1.json
@@ -2,6 +2,7 @@
   "slug": "acolyte",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_2.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_2.json
@@ -2,6 +2,7 @@
   "slug": "garth",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_3.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_3.json
@@ -2,6 +2,7 @@
   "slug": "acolyte3",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_4.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_4.json
@@ -2,6 +2,7 @@
   "slug": "loch",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_acolyte_cam.json
+++ b/mods/tuxemon/db/npc/taba_acolyte_cam.json
@@ -2,6 +2,7 @@
   "slug": "cam",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "disciple",
     "combat_front": "disciple",

--- a/mods/tuxemon/db/npc/taba_greeter.json
+++ b/mods/tuxemon/db/npc/taba_greeter.json
@@ -2,6 +2,7 @@
   "slug": "taba_greeter",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "shopassistant",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/taba_houses.json
+++ b/mods/tuxemon/db/npc/taba_houses.json
@@ -3,6 +3,7 @@
     "slug": "taba_house1_husband",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "maniac",
       "combat_front": "adventurer",
@@ -13,6 +14,7 @@
     "slug": "taba_house1_wife",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "granny",
       "combat_front": "heroine",
@@ -23,6 +25,7 @@
     "slug": "taba_house2_owner",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -33,6 +36,7 @@
     "slug": "taba_house2_reader1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "heroine_brown",
       "combat_front": "heroine",
@@ -43,6 +47,7 @@
     "slug": "taba_house2_reader2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "heroine_red",
       "combat_front": "heroine",
@@ -53,6 +58,7 @@
     "slug": "taba_house3_owner",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker_black",
       "combat_front": "heroine",
@@ -63,6 +69,7 @@
     "slug": "taba_house3_client1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_rose",
       "combat_front": "florist",
@@ -73,6 +80,7 @@
     "slug": "taba_house3_client2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "homemaker_fiery",
       "combat_front": "heroine",
@@ -83,6 +91,7 @@
     "slug": "taba_house4_client1",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor_green",
       "combat_front": "professor",
@@ -93,6 +102,7 @@
     "slug": "taba_house4_waiter",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant_grey",
       "combat_front": "adventurer",
@@ -103,6 +113,7 @@
     "slug": "taba_house4_client2",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "shopassistant_red",
       "combat_front": "adventurer",
@@ -113,6 +124,7 @@
     "slug": "taba_house4_owner",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "florist_fiery",
       "combat_front": "florist",

--- a/mods/tuxemon/db/npc/tabanurse.json
+++ b/mods/tuxemon/db/npc/tabanurse.json
@@ -2,6 +2,7 @@
   "slug": "tabanurse",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "nurse",
     "combat_front": "nurse",

--- a/mods/tuxemon/db/npc/tallon.json
+++ b/mods/tuxemon/db/npc/tallon.json
@@ -2,6 +2,7 @@
   "slug": "tallon",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "ninja",
     "combat_front": "ninja",

--- a/mods/tuxemon/db/npc/test_npcs.json
+++ b/mods/tuxemon/db/npc/test_npcs.json
@@ -3,6 +3,7 @@
     "slug": "test_npc001",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -13,6 +14,7 @@
     "slug": "test_npc002",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -23,6 +25,7 @@
     "slug": "test_npc003",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -33,6 +36,7 @@
     "slug": "test_npc004",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -43,6 +47,7 @@
     "slug": "test_npc005",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -53,6 +58,7 @@
     "slug": "test_npc006",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -63,6 +69,7 @@
     "slug": "test_npc007",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -73,6 +80,7 @@
     "slug": "test_npc008",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -83,6 +91,7 @@
     "slug": "test_npc009",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -93,6 +102,7 @@
     "slug": "test_npc010",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -103,6 +113,7 @@
     "slug": "test_npc011",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -113,6 +124,7 @@
     "slug": "test_npc012",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -123,6 +135,7 @@
     "slug": "test_npc013",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -133,6 +146,7 @@
     "slug": "test_npc014",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -143,6 +157,7 @@
     "slug": "test_npc015",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -153,6 +168,7 @@
     "slug": "test_npc016",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -163,6 +179,7 @@
     "slug": "test_npc017",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -173,6 +190,7 @@
     "slug": "test_npc018",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -183,6 +201,7 @@
     "slug": "test_npc019",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -193,6 +212,7 @@
     "slug": "test_npc020",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -203,6 +223,7 @@
     "slug": "test_npc021",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -213,6 +234,7 @@
     "slug": "test_npc022",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -223,6 +245,7 @@
     "slug": "test_npc023",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -233,6 +256,7 @@
     "slug": "test_npc024",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -243,6 +267,7 @@
     "slug": "test_npc025",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -253,6 +278,7 @@
     "slug": "test_npc026",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -263,6 +289,7 @@
     "slug": "test_npc027",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -273,6 +300,7 @@
     "slug": "test_npc028",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -283,6 +311,7 @@
     "slug": "test_npc029",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -293,6 +322,7 @@
     "slug": "test_npc030",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -303,6 +333,7 @@
     "slug": "test_npc031",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -313,6 +344,7 @@
     "slug": "test_npc032",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -323,6 +355,7 @@
     "slug": "test_npc033",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -333,6 +366,7 @@
     "slug": "test_npc034",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -343,6 +377,7 @@
     "slug": "test_npc035",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -353,6 +388,7 @@
     "slug": "test_npc036",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -363,6 +399,7 @@
     "slug": "test_npc037",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -373,6 +410,7 @@
     "slug": "test_npc038",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -383,6 +421,7 @@
     "slug": "test_npc039",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -393,6 +432,7 @@
     "slug": "test_npc040",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -403,6 +443,7 @@
     "slug": "test_npc041",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -413,6 +454,7 @@
     "slug": "test_npc042",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -423,6 +465,7 @@
     "slug": "test_npc043",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -433,6 +476,7 @@
     "slug": "test_npc044",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -443,6 +487,7 @@
     "slug": "test_npc045",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -453,6 +498,7 @@
     "slug": "test_npc046",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -463,6 +509,7 @@
     "slug": "test_npc047",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -473,6 +520,7 @@
     "slug": "test_npc048",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -483,6 +531,7 @@
     "slug": "test_npc049",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -493,6 +542,7 @@
     "slug": "test_npc050",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -503,6 +553,7 @@
     "slug": "test_npc051",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -513,6 +564,7 @@
     "slug": "test_npc052",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -523,6 +575,7 @@
     "slug": "test_npc053",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -533,6 +586,7 @@
     "slug": "test_npc054",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -543,6 +597,7 @@
     "slug": "test_npc055",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -553,6 +608,7 @@
     "slug": "test_npc056",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -563,6 +619,7 @@
     "slug": "test_npc057",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -573,6 +630,7 @@
     "slug": "test_npc058",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -583,6 +641,7 @@
     "slug": "test_npc059",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -593,6 +652,7 @@
     "slug": "test_npc060",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -603,6 +663,7 @@
     "slug": "test_npc061",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -613,6 +674,7 @@
     "slug": "test_npc062",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -623,6 +685,7 @@
     "slug": "test_npc063",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -633,6 +696,7 @@
     "slug": "test_npc064",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -643,6 +707,7 @@
     "slug": "test_npc065",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -653,6 +718,7 @@
     "slug": "test_npc066",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -663,6 +729,7 @@
     "slug": "test_npc067",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -673,6 +740,7 @@
     "slug": "test_npc068",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -683,6 +751,7 @@
     "slug": "test_npc069",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -693,6 +762,7 @@
     "slug": "test_npc070",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -703,6 +773,7 @@
     "slug": "test_npc071",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -713,6 +784,7 @@
     "slug": "test_npc072",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -723,6 +795,7 @@
     "slug": "test_npc073",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -733,6 +806,7 @@
     "slug": "test_npc074",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -743,6 +817,7 @@
     "slug": "test_npc075",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -753,6 +828,7 @@
     "slug": "test_npc076",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -763,6 +839,7 @@
     "slug": "test_npc077",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -773,6 +850,7 @@
     "slug": "test_npc078",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -783,6 +861,7 @@
     "slug": "test_npc079",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -793,6 +872,7 @@
     "slug": "test_npc080",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -803,6 +883,7 @@
     "slug": "test_npc081",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -813,6 +894,7 @@
     "slug": "test_npc082",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -823,6 +905,7 @@
     "slug": "test_npc083",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -833,6 +916,7 @@
     "slug": "test_npc084",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -843,6 +927,7 @@
     "slug": "test_npc085",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -853,6 +938,7 @@
     "slug": "test_npc086",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -863,6 +949,7 @@
     "slug": "test_npc087",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -873,6 +960,7 @@
     "slug": "test_npc088",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -883,6 +971,7 @@
     "slug": "test_npc089",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -893,6 +982,7 @@
     "slug": "test_npc090",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -903,6 +993,7 @@
     "slug": "test_npc091",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -913,6 +1004,7 @@
     "slug": "test_npc092",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -923,6 +1015,7 @@
     "slug": "test_npc093",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -933,6 +1026,7 @@
     "slug": "test_npc094",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -943,6 +1037,7 @@
     "slug": "test_npc095",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -953,6 +1048,7 @@
     "slug": "test_npc096",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -963,6 +1059,7 @@
     "slug": "test_npc097",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -973,6 +1070,7 @@
     "slug": "test_npc098",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -983,6 +1081,7 @@
     "slug": "test_npc099",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -993,6 +1092,7 @@
     "slug": "test_npc100",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1003,6 +1103,7 @@
     "slug": "test_npc101",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1013,6 +1114,7 @@
     "slug": "test_npc102",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1023,6 +1125,7 @@
     "slug": "test_npc103",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1033,6 +1136,7 @@
     "slug": "test_npc104",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1043,6 +1147,7 @@
     "slug": "test_npc105",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1053,6 +1158,7 @@
     "slug": "test_npc106",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1063,6 +1169,7 @@
     "slug": "test_npc107",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1073,6 +1180,7 @@
     "slug": "test_npc108",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1083,6 +1191,7 @@
     "slug": "test_npc109",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1093,6 +1202,7 @@
     "slug": "test_npc110",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1103,6 +1213,7 @@
     "slug": "test_npc111",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1113,6 +1224,7 @@
     "slug": "test_npc112",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1123,6 +1235,7 @@
     "slug": "test_npc113",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1133,6 +1246,7 @@
     "slug": "test_npc114",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1143,6 +1257,7 @@
     "slug": "test_npc115",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1153,6 +1268,7 @@
     "slug": "test_npc116",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1163,6 +1279,7 @@
     "slug": "test_npc117",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1173,6 +1290,7 @@
     "slug": "test_npc118",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1183,6 +1301,7 @@
     "slug": "test_npc119",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1193,6 +1312,7 @@
     "slug": "test_npc120",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1203,6 +1323,7 @@
     "slug": "test_npc121",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1213,6 +1334,7 @@
     "slug": "test_npc122",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1223,6 +1345,7 @@
     "slug": "test_npc123",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1233,6 +1356,7 @@
     "slug": "test_npc124",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1243,6 +1367,7 @@
     "slug": "test_npc125",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1253,6 +1378,7 @@
     "slug": "test_npc126",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1263,6 +1389,7 @@
     "slug": "test_npc127",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1273,6 +1400,7 @@
     "slug": "test_npc128",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1283,6 +1411,7 @@
     "slug": "test_npc129",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1293,6 +1422,7 @@
     "slug": "test_npc130",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1303,6 +1433,7 @@
     "slug": "test_npc131",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1313,6 +1444,7 @@
     "slug": "test_npc132",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1323,6 +1455,7 @@
     "slug": "test_npc133",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1333,6 +1466,7 @@
     "slug": "test_npc134",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1343,6 +1477,7 @@
     "slug": "test_npc135",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1353,6 +1488,7 @@
     "slug": "test_npc136",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1363,6 +1499,7 @@
     "slug": "test_npc137",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1373,6 +1510,7 @@
     "slug": "test_npc138",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1383,6 +1521,7 @@
     "slug": "test_npc139",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1393,6 +1532,7 @@
     "slug": "test_npc140",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1403,6 +1543,7 @@
     "slug": "test_npc141",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1413,6 +1554,7 @@
     "slug": "test_npc142",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1423,6 +1565,7 @@
     "slug": "test_npc143",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1433,6 +1576,7 @@
     "slug": "test_npc144",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1443,6 +1587,7 @@
     "slug": "test_npc145",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1453,6 +1598,7 @@
     "slug": "test_npc146",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1463,6 +1609,7 @@
     "slug": "test_npc147",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1473,6 +1620,7 @@
     "slug": "test_npc148",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1483,6 +1631,7 @@
     "slug": "test_npc149",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1493,6 +1642,7 @@
     "slug": "test_npc150",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1503,6 +1653,7 @@
     "slug": "test_npc151",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1513,6 +1664,7 @@
     "slug": "test_npc152",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1523,6 +1675,7 @@
     "slug": "test_npc153",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1533,6 +1686,7 @@
     "slug": "test_npc154",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1543,6 +1697,7 @@
     "slug": "test_npc155",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1553,6 +1708,7 @@
     "slug": "test_npc156",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1563,6 +1719,7 @@
     "slug": "test_npc157",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1573,6 +1730,7 @@
     "slug": "test_npc158",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1583,6 +1741,7 @@
     "slug": "test_npc159",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1593,6 +1752,7 @@
     "slug": "test_npc160",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1603,6 +1763,7 @@
     "slug": "test_npc161",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1613,6 +1774,7 @@
     "slug": "test_npc162",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1623,6 +1785,7 @@
     "slug": "test_npc163",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1633,6 +1796,7 @@
     "slug": "test_npc164",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1643,6 +1807,7 @@
     "slug": "test_npc165",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1653,6 +1818,7 @@
     "slug": "test_npc166",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1663,6 +1829,7 @@
     "slug": "test_npc167",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1673,6 +1840,7 @@
     "slug": "test_npc168",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1683,6 +1851,7 @@
     "slug": "test_npc169",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1693,6 +1862,7 @@
     "slug": "test_npc170",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1703,6 +1873,7 @@
     "slug": "test_npc171",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1713,6 +1884,7 @@
     "slug": "test_npc172",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1723,6 +1895,7 @@
     "slug": "test_npc173",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1733,6 +1906,7 @@
     "slug": "test_npc174",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1743,6 +1917,7 @@
     "slug": "test_npc175",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1753,6 +1928,7 @@
     "slug": "test_npc176",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1763,6 +1939,7 @@
     "slug": "test_npc177",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1773,6 +1950,7 @@
     "slug": "test_npc178",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1783,6 +1961,7 @@
     "slug": "test_npc179",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1793,6 +1972,7 @@
     "slug": "test_npc180",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1803,6 +1983,7 @@
     "slug": "test_npc181",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1813,6 +1994,7 @@
     "slug": "test_npc182",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1823,6 +2005,7 @@
     "slug": "test_npc183",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1833,6 +2016,7 @@
     "slug": "test_npc184",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1843,6 +2027,7 @@
     "slug": "test_npc185",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1853,6 +2038,7 @@
     "slug": "test_npc186",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1863,6 +2049,7 @@
     "slug": "test_npc187",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1873,6 +2060,7 @@
     "slug": "test_npc188",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1883,6 +2071,7 @@
     "slug": "test_npc189",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1893,6 +2082,7 @@
     "slug": "test_npc190",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1903,6 +2093,7 @@
     "slug": "test_npc191",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1913,6 +2104,7 @@
     "slug": "test_npc192",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1923,6 +2115,7 @@
     "slug": "test_npc193",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1933,6 +2126,7 @@
     "slug": "test_npc194",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1943,6 +2137,7 @@
     "slug": "test_npc195",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1953,6 +2148,7 @@
     "slug": "test_npc196",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1963,6 +2159,7 @@
     "slug": "test_npc197",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1973,6 +2170,7 @@
     "slug": "test_npc198",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1983,6 +2181,7 @@
     "slug": "test_npc199",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -1993,6 +2192,7 @@
     "slug": "test_npc200",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2003,6 +2203,7 @@
     "slug": "test_npc201",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2013,6 +2214,7 @@
     "slug": "test_npc202",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2023,6 +2225,7 @@
     "slug": "test_npc203",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2033,6 +2236,7 @@
     "slug": "test_npc204",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2043,6 +2247,7 @@
     "slug": "test_npc205",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2053,6 +2258,7 @@
     "slug": "test_npc206",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2063,6 +2269,7 @@
     "slug": "test_npc207",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2073,6 +2280,7 @@
     "slug": "test_npc208",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2083,6 +2291,7 @@
     "slug": "test_npc209",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2093,6 +2302,7 @@
     "slug": "test_npc210",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2103,6 +2313,7 @@
     "slug": "test_npc211",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2113,6 +2324,7 @@
     "slug": "test_npc212",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2123,6 +2335,7 @@
     "slug": "test_npc213",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2133,6 +2346,7 @@
     "slug": "test_npc214",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2143,6 +2357,7 @@
     "slug": "test_npc215",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2153,6 +2368,7 @@
     "slug": "test_npc216",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2163,6 +2379,7 @@
     "slug": "test_npc217",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2173,6 +2390,7 @@
     "slug": "test_npc218",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2183,6 +2401,7 @@
     "slug": "test_npc219",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2193,6 +2412,7 @@
     "slug": "test_npc220",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2203,6 +2423,7 @@
     "slug": "test_npc221",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2213,6 +2434,7 @@
     "slug": "test_npc222",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2223,6 +2445,7 @@
     "slug": "test_npc223",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2233,6 +2456,7 @@
     "slug": "test_npc224",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2243,6 +2467,7 @@
     "slug": "test_npc225",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2253,6 +2478,7 @@
     "slug": "test_npc226",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2263,6 +2489,7 @@
     "slug": "test_npc227",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2273,6 +2500,7 @@
     "slug": "test_npc228",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2283,6 +2511,7 @@
     "slug": "test_npc229",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2293,6 +2522,7 @@
     "slug": "test_npc230",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2303,6 +2533,7 @@
     "slug": "test_npc231",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2313,6 +2544,7 @@
     "slug": "test_npc232",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2323,6 +2555,7 @@
     "slug": "test_npc233",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2333,6 +2566,7 @@
     "slug": "test_npc234",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2343,6 +2577,7 @@
     "slug": "test_npc235",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2353,6 +2588,7 @@
     "slug": "test_npc236",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2363,6 +2599,7 @@
     "slug": "test_npc237",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2373,6 +2610,7 @@
     "slug": "test_npc238",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2383,6 +2621,7 @@
     "slug": "test_npc239",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2393,6 +2632,7 @@
     "slug": "test_npc240",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2403,6 +2643,7 @@
     "slug": "test_npc241",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2413,6 +2654,7 @@
     "slug": "test_npc242",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2423,6 +2665,7 @@
     "slug": "test_npc243",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2433,6 +2676,7 @@
     "slug": "test_npc244",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2443,6 +2687,7 @@
     "slug": "test_npc245",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2453,6 +2698,7 @@
     "slug": "test_npc246",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2463,6 +2709,7 @@
     "slug": "test_npc247",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2473,6 +2720,7 @@
     "slug": "test_npc248",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2483,6 +2731,7 @@
     "slug": "test_npc249",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2493,6 +2742,7 @@
     "slug": "test_npc250",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2503,6 +2753,7 @@
     "slug": "test_npc251",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2513,6 +2764,7 @@
     "slug": "test_npc252",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2523,6 +2775,7 @@
     "slug": "test_npc253",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2533,6 +2786,7 @@
     "slug": "test_npc254",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2543,6 +2797,7 @@
     "slug": "test_npc255",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2553,6 +2808,7 @@
     "slug": "test_npc256",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2563,6 +2819,7 @@
     "slug": "test_npc257",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2573,6 +2830,7 @@
     "slug": "test_npc258",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2583,6 +2841,7 @@
     "slug": "test_npc259",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2593,6 +2852,7 @@
     "slug": "test_npc260",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2603,6 +2863,7 @@
     "slug": "test_npc261",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2613,6 +2874,7 @@
     "slug": "test_npc262",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2623,6 +2885,7 @@
     "slug": "test_npc263",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2633,6 +2896,7 @@
     "slug": "test_npc264",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2643,6 +2907,7 @@
     "slug": "test_npc265",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2653,6 +2918,7 @@
     "slug": "test_npc266",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2663,6 +2929,7 @@
     "slug": "test_npc267",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2673,6 +2940,7 @@
     "slug": "test_npc268",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2683,6 +2951,7 @@
     "slug": "test_npc269",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2693,6 +2962,7 @@
     "slug": "test_npc270",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2703,6 +2973,7 @@
     "slug": "test_npc271",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2713,6 +2984,7 @@
     "slug": "test_npc272",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2723,6 +2995,7 @@
     "slug": "test_npc273",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2733,6 +3006,7 @@
     "slug": "test_npc274",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2743,6 +3017,7 @@
     "slug": "test_npc275",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2753,6 +3028,7 @@
     "slug": "test_npc276",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2763,6 +3039,7 @@
     "slug": "test_npc277",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2773,6 +3050,7 @@
     "slug": "test_npc278",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2783,6 +3061,7 @@
     "slug": "test_npc279",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2793,6 +3072,7 @@
     "slug": "test_npc280",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2803,6 +3083,7 @@
     "slug": "test_npc281",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2813,6 +3094,7 @@
     "slug": "test_npc282",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2823,6 +3105,7 @@
     "slug": "test_npc283",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2833,6 +3116,7 @@
     "slug": "test_npc284",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2843,6 +3127,7 @@
     "slug": "test_npc285",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2853,6 +3138,7 @@
     "slug": "test_npc286",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2863,6 +3149,7 @@
     "slug": "test_npc287",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2873,6 +3160,7 @@
     "slug": "test_npc288",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2883,6 +3171,7 @@
     "slug": "test_npc289",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2893,6 +3182,7 @@
     "slug": "test_npc290",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2903,6 +3193,7 @@
     "slug": "test_npc291",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2913,6 +3204,7 @@
     "slug": "test_npc292",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2923,6 +3215,7 @@
     "slug": "test_npc293",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2933,6 +3226,7 @@
     "slug": "test_npc294",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2943,6 +3237,7 @@
     "slug": "test_npc295",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2953,6 +3248,7 @@
     "slug": "test_npc296",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2963,6 +3259,7 @@
     "slug": "test_npc297",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2973,6 +3270,7 @@
     "slug": "test_npc298",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2983,6 +3281,7 @@
     "slug": "test_npc299",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -2993,6 +3292,7 @@
     "slug": "test_npc300",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3003,6 +3303,7 @@
     "slug": "test_npc301",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3013,6 +3314,7 @@
     "slug": "test_npc302",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3023,6 +3325,7 @@
     "slug": "test_npc303",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3033,6 +3336,7 @@
     "slug": "test_npc304",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3043,6 +3347,7 @@
     "slug": "test_npc305",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3053,6 +3358,7 @@
     "slug": "test_npc306",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3063,6 +3369,7 @@
     "slug": "test_npc307",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3073,6 +3380,7 @@
     "slug": "test_npc308",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3083,6 +3391,7 @@
     "slug": "test_npc309",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3093,6 +3402,7 @@
     "slug": "test_npc310",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3103,6 +3413,7 @@
     "slug": "test_npc311",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3113,6 +3424,7 @@
     "slug": "test_npc312",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3123,6 +3435,7 @@
     "slug": "test_npc313",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3133,6 +3446,7 @@
     "slug": "test_npc314",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3143,6 +3457,7 @@
     "slug": "test_npc315",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3153,6 +3468,7 @@
     "slug": "test_npc316",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3163,6 +3479,7 @@
     "slug": "test_npc317",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3173,6 +3490,7 @@
     "slug": "test_npc318",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3183,6 +3501,7 @@
     "slug": "test_npc319",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3193,6 +3512,7 @@
     "slug": "test_npc320",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3203,6 +3523,7 @@
     "slug": "test_npc321",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3213,6 +3534,7 @@
     "slug": "test_npc322",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3223,6 +3545,7 @@
     "slug": "test_npc323",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3233,6 +3556,7 @@
     "slug": "test_npc324",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3243,6 +3567,7 @@
     "slug": "test_npc325",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3253,6 +3578,7 @@
     "slug": "test_npc326",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3263,6 +3589,7 @@
     "slug": "test_npc327",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3273,6 +3600,7 @@
     "slug": "test_npc328",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3283,6 +3611,7 @@
     "slug": "test_npc329",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3293,6 +3622,7 @@
     "slug": "test_npc330",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3303,6 +3633,7 @@
     "slug": "test_npc331",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3313,6 +3644,7 @@
     "slug": "test_npc332",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3323,6 +3655,7 @@
     "slug": "test_npc333",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3333,6 +3666,7 @@
     "slug": "test_npc334",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3343,6 +3677,7 @@
     "slug": "test_npc335",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3353,6 +3688,7 @@
     "slug": "test_npc336",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3363,6 +3699,7 @@
     "slug": "test_npc337",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3373,6 +3710,7 @@
     "slug": "test_npc338",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3383,6 +3721,7 @@
     "slug": "test_npc339",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3393,6 +3732,7 @@
     "slug": "test_npc340",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3403,6 +3743,7 @@
     "slug": "test_npc341",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3413,6 +3754,7 @@
     "slug": "test_npc342",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3423,6 +3765,7 @@
     "slug": "test_npc343",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3433,6 +3776,7 @@
     "slug": "test_npc344",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3443,6 +3787,7 @@
     "slug": "test_npc345",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3453,6 +3798,7 @@
     "slug": "test_npc346",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3463,6 +3809,7 @@
     "slug": "test_npc347",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3473,6 +3820,7 @@
     "slug": "test_npc348",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3483,6 +3831,7 @@
     "slug": "test_npc349",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3493,6 +3842,7 @@
     "slug": "test_npc350",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3503,6 +3853,7 @@
     "slug": "test_npc351",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3513,6 +3864,7 @@
     "slug": "test_npc352",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3523,6 +3875,7 @@
     "slug": "test_npc353",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3533,6 +3886,7 @@
     "slug": "test_npc354",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3543,6 +3897,7 @@
     "slug": "test_npc355",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3553,6 +3908,7 @@
     "slug": "test_npc356",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3563,6 +3919,7 @@
     "slug": "test_npc357",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3573,6 +3930,7 @@
     "slug": "test_npc358",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3583,6 +3941,7 @@
     "slug": "test_npc359",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3593,6 +3952,7 @@
     "slug": "test_npc360",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3603,6 +3963,7 @@
     "slug": "test_npc361",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3613,6 +3974,7 @@
     "slug": "test_npc362",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3623,6 +3985,7 @@
     "slug": "test_npc363",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3633,6 +3996,7 @@
     "slug": "test_npc364",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3643,6 +4007,7 @@
     "slug": "test_npc365",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3653,6 +4018,7 @@
     "slug": "test_npc366",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3663,6 +4029,7 @@
     "slug": "test_npc367",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3673,6 +4040,7 @@
     "slug": "test_npc368",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3683,6 +4051,7 @@
     "slug": "test_npc369",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3693,6 +4062,7 @@
     "slug": "test_npc370",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3703,6 +4073,7 @@
     "slug": "test_npc371",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3713,6 +4084,7 @@
     "slug": "test_npc372",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3723,6 +4095,7 @@
     "slug": "test_npc373",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3733,6 +4106,7 @@
     "slug": "test_npc374",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3743,6 +4117,7 @@
     "slug": "test_npc375",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3753,6 +4128,7 @@
     "slug": "test_npc376",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3763,6 +4139,7 @@
     "slug": "test_npc377",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3773,6 +4150,7 @@
     "slug": "test_npc378",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3783,6 +4161,7 @@
     "slug": "test_npc379",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3793,6 +4172,7 @@
     "slug": "test_npc380",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3803,6 +4183,7 @@
     "slug": "test_npc381",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3813,6 +4194,7 @@
     "slug": "test_npc382",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3823,6 +4205,7 @@
     "slug": "test_npc383",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3833,6 +4216,7 @@
     "slug": "test_npc384",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3843,6 +4227,7 @@
     "slug": "test_npc385",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3853,6 +4238,7 @@
     "slug": "test_npc386",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3863,6 +4249,7 @@
     "slug": "test_npc387",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3873,6 +4260,7 @@
     "slug": "test_npc388",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3883,6 +4271,7 @@
     "slug": "test_npc389",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3893,6 +4282,7 @@
     "slug": "test_npc390",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3903,6 +4293,7 @@
     "slug": "test_npc391",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3913,6 +4304,7 @@
     "slug": "test_npc392",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3923,6 +4315,7 @@
     "slug": "test_npc393",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3933,6 +4326,7 @@
     "slug": "test_npc394",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3943,6 +4337,7 @@
     "slug": "test_npc395",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3953,6 +4348,7 @@
     "slug": "test_npc396",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3963,6 +4359,7 @@
     "slug": "test_npc397",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3973,6 +4370,7 @@
     "slug": "test_npc398",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3983,6 +4381,7 @@
     "slug": "test_npc399",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -3993,6 +4392,7 @@
     "slug": "test_npc400",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4003,6 +4403,7 @@
     "slug": "test_npc401",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4013,6 +4414,7 @@
     "slug": "test_npc402",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4023,6 +4425,7 @@
     "slug": "test_npc403",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4033,6 +4436,7 @@
     "slug": "test_npc404",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4043,6 +4447,7 @@
     "slug": "test_npc405",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4053,6 +4458,7 @@
     "slug": "test_npc406",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4063,6 +4469,7 @@
     "slug": "test_npc407",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4073,6 +4480,7 @@
     "slug": "test_npc408",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4083,6 +4491,7 @@
     "slug": "test_npc409",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4093,6 +4502,7 @@
     "slug": "test_npc410",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4103,6 +4513,7 @@
     "slug": "test_npc411",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4113,6 +4524,7 @@
     "slug": "test_npc412",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4123,6 +4535,7 @@
     "slug": "test_npc413",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4133,6 +4546,7 @@
     "slug": "test_npc414",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4143,6 +4557,7 @@
     "slug": "test_npc415",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4153,6 +4568,7 @@
     "slug": "test_npc416",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4163,6 +4579,7 @@
     "slug": "test_npc417",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4173,6 +4590,7 @@
     "slug": "test_npc418",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4183,6 +4601,7 @@
     "slug": "test_npc419",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4193,6 +4612,7 @@
     "slug": "test_npc420",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4203,6 +4623,7 @@
     "slug": "test_npc421",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4213,6 +4634,7 @@
     "slug": "test_npc422",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4223,6 +4645,7 @@
     "slug": "test_npc423",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4233,6 +4656,7 @@
     "slug": "test_npc424",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4243,6 +4667,7 @@
     "slug": "test_npc425",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4253,6 +4678,7 @@
     "slug": "test_npc426",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4263,6 +4689,7 @@
     "slug": "test_npc427",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4273,6 +4700,7 @@
     "slug": "test_npc428",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4283,6 +4711,7 @@
     "slug": "test_npc429",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4293,6 +4722,7 @@
     "slug": "test_npc430",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4303,6 +4733,7 @@
     "slug": "test_npc431",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4313,6 +4744,7 @@
     "slug": "test_npc432",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4323,6 +4755,7 @@
     "slug": "test_npc433",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4333,6 +4766,7 @@
     "slug": "test_npc434",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4343,6 +4777,7 @@
     "slug": "test_npc435",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4353,6 +4788,7 @@
     "slug": "test_npc436",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4363,6 +4799,7 @@
     "slug": "test_npc437",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4373,6 +4810,7 @@
     "slug": "test_npc438",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4383,6 +4821,7 @@
     "slug": "test_npc439",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4393,6 +4832,7 @@
     "slug": "test_npc440",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4403,6 +4843,7 @@
     "slug": "test_npc441",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4413,6 +4854,7 @@
     "slug": "test_npc442",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4423,6 +4865,7 @@
     "slug": "test_npc443",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4433,6 +4876,7 @@
     "slug": "test_npc444",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4443,6 +4887,7 @@
     "slug": "test_npc445",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4453,6 +4898,7 @@
     "slug": "test_npc446",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4463,6 +4909,7 @@
     "slug": "test_npc447",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4473,6 +4920,7 @@
     "slug": "test_npc448",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4483,6 +4931,7 @@
     "slug": "test_npc449",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4493,6 +4942,7 @@
     "slug": "test_npc450",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4503,6 +4953,7 @@
     "slug": "test_npc451",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4513,6 +4964,7 @@
     "slug": "test_npc452",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4523,6 +4975,7 @@
     "slug": "test_npc453",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4533,6 +4986,7 @@
     "slug": "test_npc454",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4543,6 +4997,7 @@
     "slug": "test_npc455",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4553,6 +5008,7 @@
     "slug": "test_npc456",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4563,6 +5019,7 @@
     "slug": "test_npc457",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4573,6 +5030,7 @@
     "slug": "test_npc458",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4583,6 +5041,7 @@
     "slug": "test_npc459",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4593,6 +5052,7 @@
     "slug": "test_npc460",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4603,6 +5063,7 @@
     "slug": "test_npc461",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4613,6 +5074,7 @@
     "slug": "test_npc462",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4623,6 +5085,7 @@
     "slug": "test_npc463",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4633,6 +5096,7 @@
     "slug": "test_npc464",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4643,6 +5107,7 @@
     "slug": "test_npc465",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4653,6 +5118,7 @@
     "slug": "test_npc466",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4663,6 +5129,7 @@
     "slug": "test_npc467",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4673,6 +5140,7 @@
     "slug": "test_npc468",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4683,6 +5151,7 @@
     "slug": "test_npc469",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4693,6 +5162,7 @@
     "slug": "test_npc470",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4703,6 +5173,7 @@
     "slug": "test_npc471",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4713,6 +5184,7 @@
     "slug": "test_npc472",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4723,6 +5195,7 @@
     "slug": "test_npc473",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4733,6 +5206,7 @@
     "slug": "test_npc474",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4743,6 +5217,7 @@
     "slug": "test_npc475",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4753,6 +5228,7 @@
     "slug": "test_npc476",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4763,6 +5239,7 @@
     "slug": "test_npc477",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4773,6 +5250,7 @@
     "slug": "test_npc478",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4783,6 +5261,7 @@
     "slug": "test_npc479",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4793,6 +5272,7 @@
     "slug": "test_npc480",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4803,6 +5283,7 @@
     "slug": "test_npc481",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4813,6 +5294,7 @@
     "slug": "test_npc482",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4823,6 +5305,7 @@
     "slug": "test_npc483",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4833,6 +5316,7 @@
     "slug": "test_npc484",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4843,6 +5327,7 @@
     "slug": "test_npc485",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4853,6 +5338,7 @@
     "slug": "test_npc486",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4863,6 +5349,7 @@
     "slug": "test_npc487",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4873,6 +5360,7 @@
     "slug": "test_npc488",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4883,6 +5371,7 @@
     "slug": "test_npc489",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4893,6 +5382,7 @@
     "slug": "test_npc490",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4903,6 +5393,7 @@
     "slug": "test_npc491",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4913,6 +5404,7 @@
     "slug": "test_npc492",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4923,6 +5415,7 @@
     "slug": "test_npc493",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4933,6 +5426,7 @@
     "slug": "test_npc494",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4943,6 +5437,7 @@
     "slug": "test_npc495",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4953,6 +5448,7 @@
     "slug": "test_npc496",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4963,6 +5459,7 @@
     "slug": "test_npc497",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4973,6 +5470,7 @@
     "slug": "test_npc498",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4983,6 +5481,7 @@
     "slug": "test_npc499",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",
@@ -4993,6 +5492,7 @@
     "slug": "test_npc500",
     "speech": {"profile": {"default": {}}},
     "combat": {},
+    "audio": {},
     "template": {
       "sprite_name": "professor",
       "combat_front": "professor",

--- a/mods/tuxemon/db/npc/timmy.json
+++ b/mods/tuxemon/db/npc/timmy.json
@@ -3,6 +3,7 @@
   "gender": "male",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "childactor",
     "combat_front": "heroine",

--- a/mods/tuxemon/db/npc/tuxeball.json
+++ b/mods/tuxemon/db/npc/tuxeball.json
@@ -2,6 +2,7 @@
   "slug": "tuxeball",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "tuxeball",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_green.json
+++ b/mods/tuxemon/db/npc/tuxeball_green.json
@@ -2,6 +2,7 @@
   "slug": "tuxeball_green",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "tuxeball_green",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_red.json
+++ b/mods/tuxemon/db/npc/tuxeball_red.json
@@ -2,6 +2,7 @@
   "slug": "tuxeball_red",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "tuxeball_red",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_violet.json
+++ b/mods/tuxemon/db/npc/tuxeball_violet.json
@@ -2,6 +2,7 @@
   "slug": "tuxeball_violet",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "tuxeball_violet",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxeball_yellow.json
+++ b/mods/tuxemon/db/npc/tuxeball_yellow.json
@@ -2,6 +2,7 @@
   "slug": "tuxeball_yellow",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "tuxeball_yellow",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/tuxemart.json
+++ b/mods/tuxemon/db/npc/tuxemart.json
@@ -2,6 +2,7 @@
   "slug": "tuxemart_keeper",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "shopassistant",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/wild_encounter.json
+++ b/mods/tuxemon/db/npc/wild_encounter.json
@@ -2,6 +2,7 @@
   "slug": "wild_encounter",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "invisible",
     "combat_front": "noclass",

--- a/mods/tuxemon/db/npc/xerogrund1.json
+++ b/mods/tuxemon/db/npc/xerogrund1.json
@@ -2,6 +2,7 @@
   "slug": "xerogrund1",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrund2.json
+++ b/mods/tuxemon/db/npc/xerogrund2.json
@@ -2,6 +2,7 @@
   "slug": "xerogrund2",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt1.json
+++ b/mods/tuxemon/db/npc/xerogrunt1.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt1",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt10.json
+++ b/mods/tuxemon/db/npc/xerogrunt10.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt10",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt2.json
+++ b/mods/tuxemon/db/npc/xerogrunt2.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt2",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt3.json
+++ b/mods/tuxemon/db/npc/xerogrunt3.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt3",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt4.json
+++ b/mods/tuxemon/db/npc/xerogrunt4.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt4",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt5.json
+++ b/mods/tuxemon/db/npc/xerogrunt5.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt5",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt6.json
+++ b/mods/tuxemon/db/npc/xerogrunt6.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt6",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt7.json
+++ b/mods/tuxemon/db/npc/xerogrunt7.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt7",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt8.json
+++ b/mods/tuxemon/db/npc/xerogrunt8.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt8",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/mods/tuxemon/db/npc/xerogrunt9.json
+++ b/mods/tuxemon/db/npc/xerogrunt9.json
@@ -2,6 +2,7 @@
   "slug": "xerogrunt9",
   "speech": {"profile": {"default": {}}},
   "combat": {},
+  "audio": {},
   "template": {
     "sprite_name": "xerogrunt",
     "combat_front": "adventurer",

--- a/tuxemon/combat/utils.py
+++ b/tuxemon/combat/utils.py
@@ -138,7 +138,7 @@ def battlefield(session: Session, monster: Monster) -> None:
 
 
 def get_battle_outcome_music(
-    session: Session, music: BattleMusicModel, monster: Monster
+    session: Session, default_music: BattleMusicModel, monster: Monster
 ) -> Optional[tuple[str, float]]:
     """
     Return the appropriate music track based on outcome and participants.
@@ -151,21 +151,30 @@ def get_battle_outcome_music(
     if not any(True for _ in session.client.combat_session.human_players):
         return None
 
+    # Use override if present, else fall back to default
+    active_music = monster.owner.get_active_battle_music(default_music)
+
     # If the defeated was a player → defeat music
     if (
         monster.owner.is_player
-        and music.defeat_music
-        and music.defeat_music.music
+        and active_music.defeat_music
+        and active_music.defeat_music.music
     ):
-        return (music.defeat_music.music, music.defeat_music.volume)
+        return (
+            active_music.defeat_music.music,
+            active_music.defeat_music.volume,
+        )
 
     # If the defeated was not a player → victory music
     if (
         not monster.owner.is_player
-        and music.victory_music
-        and music.victory_music.music
+        and active_music.victory_music
+        and active_music.victory_music.music
     ):
-        return (music.victory_music.music, music.victory_music.volume)
+        return (
+            active_music.victory_music.music,
+            active_music.victory_music.volume,
+        )
 
     return None
 

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1740,6 +1740,13 @@ class NpcCombatModel(BaseModel):
     )
 
 
+class NpcAudioModel(BaseModel):
+    battle_music: Optional[BattleMusicModel] = Field(
+        None,
+        description="Battle music configuration for the NPC; defaults to empty if not set",
+    )
+
+
 class NpcModel(BaseModel, BaseLookupModel):
     table_name: ClassVar[str] = "npc"
     slug: str = Field(..., description="Slug of the name of the NPC")
@@ -1751,7 +1758,14 @@ class NpcModel(BaseModel, BaseLookupModel):
     items: Sequence[BagItemModel] = Field(
         [], description="List of items in the NPCs bag"
     )
-    speech: NpcSpeech
+    speech: NpcSpeech = Field(
+        ...,
+        description="Dialogue configuration for the NPC, including default lines and location-based overrides",
+    )
+    audio: NpcAudioModel = Field(
+        ...,
+        description="Audio configuration for the NPC, including music themes, sound effects, and ambient sounds",
+    )
 
     @classmethod
     def lookup(cls, slug: str, db: ModData) -> NpcModel:

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -66,6 +66,7 @@ class CreateNpcAction(EventAction):
         npc_details = load_party(slug)
         npc.template = npc_details.template
         npc.combat = npc_details.combat
+        npc.audio = npc_details.audio
         game_variables = session.player.game_variables.get_state()
         if npc_details.monsters:
             load_party_monsters(npc, npc_details, game_variables)

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -121,11 +121,10 @@ class RandomBattleAction(EventAction):
             battle_mode=BattleMode.SINGLE,
         )
         session.client.push_state("CombatState", context=context)
-        sound = env.battle_music.battle
+        active_music = npc.get_active_battle_music(env.battle_music)
+        sound = active_music.battle
         if sound.music:
-            session.client.event_engine.execute_action(
-                "play_music", [sound.music, sound.volume], True
-            )
+            session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -127,9 +127,7 @@ class RandomEncounterAction(EventAction):
 
         sound = environment.battle_music.battle
         if sound.music:
-            session.client.event_engine.execute_action(
-                "play_music", [sound.music, sound.volume], True
-            )
+            session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/event/actions/random_horde.py
+++ b/tuxemon/event/actions/random_horde.py
@@ -140,9 +140,7 @@ class RandomHordeAction(EventAction):
 
         sound = environment.battle_music.battle
         if sound.music:
-            session.client.event_engine.execute_action(
-                "play_music", [sound.music, sound.volume], True
-            )
+            session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -87,12 +87,11 @@ class StartBattleAction(EventAction):
         )
         session.client.push_state("CombatState", context=context)
 
-        sound = env.battle_music.battle
+        active_music = character1.get_active_battle_music(env.battle_music)
+        sound = active_music.battle
         if sound.music:
             filename = sound.music if not self.music else self.music
-            session.client.event_engine.execute_action(
-                "play_music", [filename], True
-            )
+            session.client.current_music.play(filename, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/event/actions/start_double_battle.py
+++ b/tuxemon/event/actions/start_double_battle.py
@@ -95,12 +95,11 @@ class StartDoubleBattleAction(EventAction):
         )
         session.client.push_state("CombatState", context=context)
         # music
-        sound = env.battle_music.battle
+        active_music = character1.get_active_battle_music(env.battle_music)
+        sound = active_music.battle
         if sound.music:
             filename = sound.music if not self.music else self.music
-            session.client.event_engine.execute_action(
-                "play_music", [filename], True
-            )
+            session.client.current_music.play(filename, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -114,9 +114,7 @@ class WildEncounterAction(EventAction):
 
         sound = environment.battle_music.battle
         if sound.music:
-            session.client.event_engine.execute_action(
-                "play_music", [sound.music, sound.volume], True
-            )
+            session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -38,6 +38,7 @@ from tuxemon.tuxepedia import Tuxepedia, decode_tuxepedia, encode_tuxepedia
 from tuxemon.ui.cipher_processor import decode_cipher, encode_cipher
 
 if TYPE_CHECKING:
+    from tuxemon.db import BattleMusicModel
     from tuxemon.economy.applier import ShopInventory
     from tuxemon.economy.economy import Economy
     from tuxemon.item.item import Item
@@ -72,6 +73,7 @@ class NPC(Entity[NPCState]):
         npc_data = NpcModel.lookup(npc_slug, db)
         self.template = npc_data.template
         self.combat = npc_data.combat
+        self.audio = npc_data.audio
 
         # This is the NPC's name to be used in dialog
         self.name = T.translate(self.slug)
@@ -216,6 +218,13 @@ class NPC(Entity[NPCState]):
                 "combat_front", ""
             )
             self.sprite_controller.load_sprites(self.template)
+
+    def get_active_battle_music(
+        self, default_music: BattleMusicModel
+    ) -> BattleMusicModel:
+        if self.audio and self.audio.battle_music:
+            return self.audio.battle_music
+        return default_music
 
     def pathfind(self, destination: tuple[int, int]) -> None:
         self.path_controller.start_path(destination)

--- a/tuxemon/states/transition_fade.py
+++ b/tuxemon/states/transition_fade.py
@@ -86,8 +86,8 @@ class FadeOutTransition(FadeTransitionBase):
 
     def shutdown(self) -> None:
         if self.client.current_music.previous_song:
-            self.client.event_engine.execute_action(
-                "play_music", [self.client.current_music.previous_song], True
+            self.client.current_music.play(
+                self.client.current_music.previous_song
             )
             self.client.current_music.previous_song = None
         self.client.pop_state(self.caller)


### PR DESCRIPTION
PR builds on and extends the foundation established in #3270, adding more flexibility to how battle music is handled in the game.

Key points:
- a music model was introduced to manage three categories of tracks: combat, victory, and defeat
- an override method was added so that NPC or player‑specific audio can replace the default environment music when available
- this design allows each NPC or player to define their own unique soundtrack