### PR TITLE
Fix combat menu crash with raw Monster objects; add item target filter

### DIFF
--- a/tests/tuxemon/test_tools.py
+++ b/tests/tuxemon/test_tools.py
@@ -261,6 +261,24 @@ class TestCastValue(unittest.TestCase):
     def test_empty_string_optional(self):
         self.assertIsNone(cast_value(((Optional[int], "param"), "")))
 
+    def test_empty_string_casts_to_none_for_optional(self):
+        self.assertIsNone(cast_value(((Optional[str], "param"), "")))
+        self.assertIsNone(cast_value(((Optional[int], "param"), "")))
+        self.assertIsNone(cast_value(((Union[int, None], "param"), "")))
+        self.assertEqual(cast_value(((str, "param"), "")), "")
+
+    def test_empty_string_in_collections(self):
+        self.assertEqual(
+            cast_value(((Optional[list[str]], "param"), ",1.0")), [None, "1.0"]
+        )
+        self.assertEqual(
+            cast_value(((Optional[tuple[str]], "param"), "a,,b")),
+            ("a", None, "b"),
+        )
+        self.assertEqual(
+            cast_value(((list[str], "param"), "x,,y")), ["x", "", "y"]
+        )
+
 
 class TestCompare(unittest.TestCase):
     def test_less_than(self):

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -187,6 +187,7 @@ class BaseClient(ABC):
         """Handles necessary cleanup before shutting down."""
         self.map_loader.clear_cache()
         self.current_music.stop()
+        self.event_bus.reset_all_events()
         local_session.reset()
         local_session.reset_time()
         logger.info("Performing cleanup before exiting...")

--- a/tuxemon/item/filter.py
+++ b/tuxemon/item/filter.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from tuxemon.db import State
 from tuxemon.item.item import Item
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -96,3 +100,29 @@ class ItemFilter:
         """Set filter that excludes items matching the condition."""
         self.clear_filters()
         self.add_filter(not_filter(filter_func))
+
+    def set_filter_combat_targets(
+        self,
+        session: Session,
+        monsters: list[Monster],
+        opponents: list[Monster],
+    ) -> None:
+        """
+        Show items usable in MainCombatMenuState that are visible,
+        and that have at least one valid target (monster or opponent).
+        """
+
+        def usable(item: Item) -> bool:
+            return any(
+                item.validate_monster(session, m) for m in monsters
+            ) or (
+                item.behaviors.throwable
+                and any(item.validate_monster(session, o) for o in opponents)
+            )
+
+        self.clear_filters()
+        self.add_filter(
+            lambda item: State["MainCombatMenuState"] in item.usable_in
+        )
+        self.add_filter(lambda item: item.behaviors.visible)
+        self.add_filter(usable)

--- a/tuxemon/platform/combo_detector.py
+++ b/tuxemon/platform/combo_detector.py
@@ -203,7 +203,11 @@ class ComboDetector:
     def _check_release_completion(
         self, event: PlayerInput, hold_time: float, now: float
     ) -> list[_ActiveCombo]:
-        if int(event.value) != 0 or hold_time <= 0:
+        try:
+            val = int(event.value)
+        except (ValueError, TypeError):
+            return []
+        if val != 0 or hold_time <= 0:
             return []
         return [
             ac

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -131,7 +131,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
             visibility_map["menu_forfeit"] = True
 
         items_filtered = ItemFilter(self.character.items)
-        items_filtered.set_filter_usable_in_state("MainCombatMenuState")
+        items_filtered.set_filter_combat_targets(
+            self.session, self.character.monsters, self.opponents
+        )
         if not items_filtered.items:
             visibility_map["menu_item"] = False
 
@@ -234,7 +236,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         def choose_item() -> None:
             # open menu to choose item
             items_filtered = ItemFilter(self.character.items)
-            items_filtered.set_filter_usable_in_state("MainCombatMenuState")
+            items_filtered.set_filter_combat_targets(
+                self.session, self.character.monsters, self.opponents
+            )
             menu = self.client.push_state(
                 ItemMenuState(self.character, self.name, items_filtered)
             )

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -315,12 +315,13 @@ class CombatState(CombatAnimations):
             self.client.remove_state_by_name("MonsterMenuState")
 
         def validate(menu_item: MenuItem[Monster]) -> bool:
-            monster = menu_item.game_object
-            if monster.is_fainted:
-                return False
-            if monster in self.client.combat_session.active_monsters:
-                return False
-            return True
+            if isinstance(menu_item, Monster):
+                if menu_item.is_fainted:
+                    return False
+                if menu_item in self.client.combat_session.active_monsters:
+                    return False
+                return True
+            return False
 
         state = self.client.push_state(MonsterMenuState(player.monsters))
         state.task(
@@ -899,7 +900,8 @@ class CombatState(CombatAnimations):
         self.award_experience_and_money(monster)
         # Remove monster from damage map
         self.client.combat_session.damage_tracker.remove_monster(monster)
-        play_outcome_music(self.session, self.music, monster)
+        if len(self.client.combat_session.remaining_players) <= 1:
+            play_outcome_music(self.session, self.music, monster)
 
     def clean_combat(self) -> None:
         """Clean combat."""

--- a/tuxemon/states/park_menu.py
+++ b/tuxemon/states/park_menu.py
@@ -148,7 +148,9 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
 
         def choose_item() -> None:
             items_filtered = ItemFilter(self.player.items)
-            items_filtered.set_filter_usable_in_state("MainCombatMenuState")
+            items_filtered.set_filter_combat_targets(
+                self.session, self.player.monsters, self.opponents
+            )
             menu = self.client.push_state(
                 ItemMenuState(self.player, self.name, items_filtered)
             )

--- a/tuxemon/states/pc.py
+++ b/tuxemon/states/pc.py
@@ -91,7 +91,7 @@ class PCMenuBuilder:
                 "ItemStorageState", character=char
             )
 
-        if char.item_boxes.get_all_monsters_visible():
+        if char.item_boxes.get_all_items_visible():
             menu.append(("menu_item_storage", item_storage_callback))
 
         if len(char.items) > 1:

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -373,18 +373,22 @@ def cast_value(
 
     # Handle empty string
     if isinstance(value, str) and not value.strip():
-        if str in constructors_to_try:
-            return ""
         if is_optional:
             return None
+        if str in constructors_to_try:
+            return ""
         raise ValueError(f"Parameter '{param_name}' cannot be empty string.")
 
     # First pass: direct isinstance
     for constructor in constructors_to_try:
         if get_origin(constructor) is Literal:
             continue
-        if isinstance(value, constructor):
-            return value
+        origin = get_origin(constructor) or constructor
+        try:
+            if isinstance(value, origin):
+                return value
+        except TypeError:
+            continue
 
     # Special handling for numerics
     if any(c in constructors_to_try for c in (int, float, Decimal, Fraction)):
@@ -472,8 +476,13 @@ def cast_value(
         if origin in (list, set, tuple):
             try:
                 if isinstance(value, str):
-                    # split on commas, strip whitespace
-                    items = [v.strip() for v in value.split(",") if v.strip()]
+                    parts = value.split(",")
+                    if is_optional:
+                        items = [
+                            p.strip() if p.strip() else None for p in parts
+                        ]
+                    else:
+                        items = [p.strip() for p in parts]
                     return origin(items)
                 return origin(value)
             except Exception:


### PR DESCRIPTION
Added:
- combat‑target filter to ItemFilter: items shown in the combat menu are now restricted to those usable in `MainCombatMenuState` and with at least one valid monster or opponent target

Updated:
- `get_all_monsters_visible` in `PCMenuBuilder` (wrong, it was item)

Fixed:
- optional parameter handling: empty string now correctly treated as `None` instead of `""`
- combat ending sound triggering prematurely before the battle actually ends
- crash in combat menu validation by correctly handling raw `Monster` objects instead of expecting a `MenuItem` (*)

(*) `validate()` previously assumed it would always receive a `MenuItem` and tried to access `.game_object`. In double battles the menu sometimes passed a raw `Monster` instead, causing an `AttributeError`. The function was updated to check `isinstance(menu_item, Monster)` and validate directly on the monster’s state (`is_fainted`, already active, etc.), returning `False` otherwise. This prevents crashes when the menu hands a `Monster` instead of a `MenuItem`

the crash solved:
```
Traceback:
Traceback (most recent call last):
  File "/home/giorgio/Tuxemon/run_tuxemon.py", line 63, in launch_game
    main.main(config=config, load_slot=args.slot)
  File "/home/giorgio/Tuxemon/tuxemon/main.py", line 52, in main
    client.main()
  File "/home/giorgio/Tuxemon/tuxemon/client.py", line 125, in main
    update(clock_tick)
  File "/home/giorgio/Tuxemon/tuxemon/client.py", line 160, in update
    self.update_states(time_delta)
  File "/home/giorgio/Tuxemon/tuxemon/base_client.py", line 202, in update_states
    self.state_manager.update(time_delta)
  File "/home/giorgio/Tuxemon/tuxemon/state/manager.py", line 104, in update
    self._check_resume(state)
  File "/home/giorgio/Tuxemon/tuxemon/state/manager.py", line 123, in _check_resume
    state.resume()
  File "/home/giorgio/Tuxemon/tuxemon/menu/menu.py", line 743, in resume
    self.reload_items()
  File "/home/giorgio/Tuxemon/tuxemon/menu/menu.py", line 472, in reload_items
    item.enabled = self.is_valid_entry(item.game_object)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/states/combat_state.py", line 318, in validate
    monster = menu_item.game_object
              ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'game_object'
```
and
```
  File "<string>", line 4, in __init__
  File "/home/giorgio/Tuxemon/tuxemon/core/core_effect.py", line 48, in __post_init__
    cast_dataclass_parameters(self)
  File "/home/giorgio/Tuxemon/tuxemon/tools.py", line 565, in cast_dataclass_parameters
    new_value = cast_value(((constructors, field_name), old_value))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giorgio/Tuxemon/tuxemon/tools.py", line 350, in cast_value
    if not isinstance(type_constructors, Sequence) or isinstance(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen abc>", line 119, in __instancecheck__
  File "<frozen abc>", line 123, in __subclasscheck__
RecursionError: maximum recursion depth exceeded
```
