### PR TITLE
Refactor Monster Menu: Extract Renderer, Add Sorting, Switch NPC to Party

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4358,6 +4358,9 @@ msgstr "Body Type"
 msgid "monster_menu_release"
 msgstr "Release"
 
+msgid "menu_sort"
+msgstr "Sort"
+
 msgid "shop_heal_to"
 msgstr "Heal to {hp} HP"
 
@@ -4375,6 +4378,18 @@ msgstr "Buy"
 
 msgid "sell"
 msgstr "Sell"
+
+msgid "sort_by_level"
+msgstr "Sort by Level"
+
+msgid "sort_by_hp"
+msgstr "Sort by HP"
+
+msgid "sort_by_name"
+msgstr "Sort by Name"
+
+msgid "sort_by_id"
+msgstr "Sort by ID"
 
 # Release notifications
 msgid "cant_release"

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections import OrderedDict
+from collections.abc import Callable, Generator
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
@@ -27,8 +28,8 @@ from tuxemon.ui.text import TextArea, draw_text
 
 if TYPE_CHECKING:
     from tuxemon.client import LocalPygameClient
+    from tuxemon.entity_dir.party import PartyHandler
     from tuxemon.monster import Monster
-    from tuxemon.npc import NPC
 
 
 class MonsterMenuState(Menu[Optional[Monster]]):
@@ -57,7 +58,7 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
         self.text_area.rect = Rect(tools.scale_sequence((20, 80, 80, 100)))
         self.sprites.add(self.text_area, layer=100)
-        self.held_item_display = HeldItemDisplay(self)
+        self.monster_stats_display = MonsterStatsDisplay(self)
         self.monster_sprite_displays: list[MonsterSpriteDisplay] = []
         self.monster_sprite_display = MonsterSpriteDisplay(self)
         self.monster_portrait_display = MonsterPortraitDisplay(self)
@@ -65,10 +66,9 @@ class MonsterMenuState(Menu[Optional[Monster]]):
         # Set up the border images used for the monster slots
         self.hp_bar = HpBar()
         self.exp_bar = ExpBar()
-        self.monster_info_renderer = MonsterInfoRenderer(
+        self.slot_renderer = MonsterSlotRenderer(
             self.font, self.hp_bar, self.font_color
         )
-        self.monster_slot_border = MonsterSlotBorder()
 
         # Load monster visuals
         for monster in self.monsters:
@@ -113,20 +113,6 @@ class MonsterMenuState(Menu[Optional[Monster]]):
     ) -> None:
         pass
 
-    def render_monster_slot(
-        self,
-        surface: Surface,
-        rect: Rect,
-        monster: Optional[Monster],
-        in_focus: bool,
-    ) -> Surface:
-        filled = monster is not None
-        border = self.monster_slot_border.get_border(in_focus, filled)
-        border.draw(surface)
-        if monster is not None:
-            self.draw_monster_info(surface, monster, rect)
-        return surface
-
     def is_valid_entry(self, monster: Optional[Monster]) -> bool:
         """
         Used to determine if a given monster should be selectable.
@@ -142,46 +128,35 @@ class MonsterMenuState(Menu[Optional[Monster]]):
     def refresh_menu_items(self) -> None:
         """Used to render slots after their 'focus' flags change."""
         self.monster_sprite_displays = []
-
         for index, item in enumerate(self.menu_items):
-            monster: Optional[Monster]
-            try:
-                monster = self.monsters[index]
-            except IndexError:
-                monster = None
-            item.game_object = monster
+            self.assign_monster_to_item(index, item)
 
-            item.enabled = (monster is not None) and self.is_valid_entry(
-                item.game_object
-            )
-            item.image.fill(prepare.TRANSPARENT_COLOR)
-            item.in_focus = (index == self.selected_index) and item.enabled
-            self.render_monster_slot(
-                item.image,
-                item.image.get_rect(),
-                item.game_object,
-                item.in_focus,
-            )
-            if monster:
-                monster_sprite_display = MonsterSpriteDisplay(self)
-                monster_sprite_display.update(monster, item.rect)
-                self.monster_sprite_displays.append(monster_sprite_display)
-
-    def draw_monster_info(
-        self,
-        surface: Surface,
-        monster: Monster,
-        rect: Rect,
+    def assign_monster_to_item(
+        self, index: int, item: MenuItem[Optional[Monster]]
     ) -> None:
-        self.monster_info_renderer.draw(surface, monster, rect)
+        monster = self.monsters[index] if index < len(self.monsters) else None
+        item.game_object = monster
+        item.enabled = (monster is not None) and self.is_valid_entry(monster)
+        item.image.fill(prepare.TRANSPARENT_COLOR)
+        item.in_focus = (index == self.selected_index) and item.enabled
+        self.slot_renderer.render_slot(
+            item.image, item.image.get_rect(), monster, item.in_focus
+        )
+
+        if monster:
+            sprite_display = MonsterSpriteDisplay(self)
+            sprite_display.update(monster, item.rect)
+            self.monster_sprite_displays.append(sprite_display)
 
     def on_menu_selection_change(self) -> None:
+        monster: Optional[Monster] = None
         try:
             monster = self.monsters[self.selected_index]
             self.monster_portrait_display.update(monster)
         except IndexError:
             self.monster_portrait_display.update(None)
-        self.held_item_display.update(monster)
+
+        self.monster_stats_display.update(monster)
         self.refresh_menu_items()
 
     def remove_monster_sprite_display(self, monster: Monster) -> None:
@@ -196,18 +171,18 @@ class MonsterMenuState(Menu[Optional[Monster]]):
 class MonsterMenuHandler:
     """Handles interactions within the monster menu."""
 
-    def __init__(self, client: LocalPygameClient, character: NPC) -> None:
+    def __init__(self, client: LocalPygameClient, party: PartyHandler) -> None:
         """Initialize with client and character."""
         self.name = "WorldMenuState"
         self.client = client
-        self.char = character
+        self.party = party
         self.context: dict[str, Any] = {}
 
     def monster_menu_hook(self, monster_menu: MonsterMenuState) -> None:
         """Handles monster reordering."""
         monster = self.context.get("monster")
         if monster:
-            monster_list = self.char.monsters
+            monster_list = self.party.monsters
             original = monster_menu.get_selected_item()
             if original and original.game_object:
                 original_monster = original.game_object
@@ -221,7 +196,7 @@ class MonsterMenuHandler:
     def select_monster(self, monster: Monster) -> None:
         """Selects a monster for movement."""
         self.context["monster"] = monster
-        self.context["old_index"] = self.char.monsters.index(monster)
+        self.context["old_index"] = self.party.monsters.index(monster)
         self.client.remove_state_by_name("ChoiceState")
 
     def monster_stats(self, monster: Monster) -> None:
@@ -265,7 +240,7 @@ class MonsterMenuHandler:
 
     def positive_answer(self, monster: Monster) -> None:
         """Handles monster release."""
-        success = self.char.party.release_monster(monster)
+        success = self.party.release_monster(monster)
         if success:
             self.client.remove_state_by_name("ChoiceState")
             self.client.remove_state_by_name("DialogState")
@@ -274,7 +249,7 @@ class MonsterMenuHandler:
             open_dialog(self.client, [msg])
             self.monster_menu.remove_monster_sprite_display(monster)
 
-            num_monsters = len(self.char.monsters)
+            num_monsters = len(self.party.monsters)
             if self.monster_menu.selected_index >= num_monsters:
                 self.monster_menu.change_selection(max(0, num_monsters - 1))
 
@@ -321,7 +296,7 @@ class MonsterMenuHandler:
                     )
                 )
 
-            if mon.owner and mon.owner.party.party_size > 1:
+            if self.party.party_size > 1:
                 options.append(
                     ChoiceOption(
                         key="move",
@@ -329,8 +304,14 @@ class MonsterMenuHandler:
                         action=partial(self.select_monster, mon),
                     )
                 )
+                options.append(
+                    ChoiceOption(
+                        key="sort",
+                        display_text=T.translate("menu_sort").upper(),
+                        action=lambda: self.open_sort_submenu(monster_menu),
+                    )
+                )
 
-            if mon.owner and mon.owner.party.party_size > 1:
                 options.append(
                     ChoiceOption(
                         key="release",
@@ -355,16 +336,63 @@ class MonsterMenuHandler:
         else:
             self.open_monster_submenu(monster_menu)
 
+    def sort_monsters(
+        self,
+        monster_menu: MonsterMenuState,
+        key: Callable[[Monster], Any],
+        reverse: bool = False,
+    ) -> None:
+        """Sorts the monsters in the party by a given key."""
+        self.party.monsters.sort(key=key, reverse=reverse)
+        monster_menu.monsters = self.party.monsters
+        monster_menu.refresh_menu_items()
+        monster_menu.on_menu_selection_change()
+
     def open_monster_menu(self) -> None:
         """Pushes the monster menu state."""
         self.monster_menu = self.client.push_state(
-            MonsterMenuState(self.char.monsters)
+            MonsterMenuState(self.party.monsters)
         )
         self.monster_menu.on_menu_selection = lambda item: self.handle_selection(item, self.monster_menu)  # type: ignore[assignment]
         self.monster_menu.on_menu_selection_change = partial(self.monster_menu_hook, self.monster_menu)  # type: ignore[method-assign]
 
+    def open_sort_submenu(self, monster_menu: MonsterMenuState) -> None:
+        """Opens a submenu with sorting options."""
+        sort_options = [
+            ChoiceOption(
+                key="level",
+                display_text=T.translate("sort_by_level").upper(),
+                action=lambda: self.sort_monsters(
+                    monster_menu, key=lambda m: m.level
+                ),
+            ),
+            ChoiceOption(
+                key="hp",
+                display_text=T.translate("sort_by_hp").upper(),
+                action=lambda: self.sort_monsters(
+                    monster_menu, key=lambda m: m.hp_ratio, reverse=True
+                ),
+            ),
+            ChoiceOption(
+                key="name",
+                display_text=T.translate("sort_by_name").upper(),
+                action=lambda: self.sort_monsters(
+                    monster_menu, key=lambda m: m.name.lower()
+                ),
+            ),
+            ChoiceOption(
+                key="id",
+                display_text=T.translate("sort_by_id").upper(),
+                action=lambda: self.sort_monsters(
+                    monster_menu, key=lambda m: m.txmn_id
+                ),
+            ),
+        ]
+        menu = MenuOptions(sort_options)
+        open_choice_dialog(self.client, menu, escape_key_exits=True)
 
-class HeldItemDisplay:
+
+class MonsterStatsDisplay:
     def __init__(self, menu_state: MonsterMenuState) -> None:
         self.menu_state = menu_state
         self.sprite = TextArea(
@@ -373,29 +401,34 @@ class HeldItemDisplay:
         self.menu_state.sprites.add(self.sprite)
 
     def update(self, monster: Optional[Monster]) -> None:
-        text = ""
-        if monster:
-            stats = [
+        if not monster:
+            self.sprite.image = self.menu_state.shadow_text("")
+            return
+
+        stats = OrderedDict(
+            [
                 (
                     T.translate("short_hp"),
                     f"{monster.current_hp}/{monster.hp}",
                 ),
-                (T.translate("armour"), monster.armour),
-                (T.translate("dodge"), monster.dodge),
-                (T.translate("melee"), monster.melee),
-                (T.translate("ranged"), monster.ranged),
-                (T.translate("speed"), monster.speed),
+                (T.translate("armour"), str(monster.armour)),
+                (T.translate("dodge"), str(monster.dodge)),
+                (T.translate("melee"), str(monster.melee)),
+                (T.translate("ranged"), str(monster.ranged)),
+                (T.translate("speed"), str(monster.speed)),
+                (
+                    T.translate("menu_item"),
+                    T.translate("yes" if monster.held_item else "no"),
+                ),
             ]
-            if monster.held_item:
-                stats.append((T.translate("menu_item"), T.translate("yes")))
-            else:
-                stats.append((T.translate("menu_item"), T.translate("no")))
+        )
 
-            max_len = max(len(stat[0]) for stat in stats)
-            for stat in stats:
-                text += f"{stat[0]:<{max_len}}: {stat[1]}\n"
-        image = self.menu_state.shadow_text(text)
-        self.sprite.image = image
+        max_len = max(len(label) for label in stats.keys())
+        text = "\n".join(
+            f"{label:<{max_len}}: {value}" for label, value in stats.items()
+        )
+
+        self.sprite.image = self.menu_state.shadow_text(text)
         width, height = prepare.SCREEN_SIZE
         self.sprite.rect.topleft = (width // 10, height // 2 + 50)
 
@@ -413,15 +446,18 @@ class MonsterSpriteDisplay:
                 self.sprite = monster.get_sprite("menu", 0.25, 2.5)
                 self.menu_state.sprites.add(self.sprite)
             if self.sprite is not None:
-                self.sprite.rect.x = prepare.SCREEN_SIZE[0] - (
-                    self.sprite.rect.width
-                    + int(prepare.SCREEN_SIZE[0] * 0.005)
-                )
-                self.sprite.rect.y = rect.y + (self.sprite.rect.height)
+                width = prepare.SCREEN_SIZE[0]
+                margin = int(width * 0.005)
+                self.sprite.rect.x = width - (self.sprite.rect.width + margin)
+                self.sprite.rect.y = rect.y + tools.scale(10)
         else:
-            if self.sprite is not None:
-                self.menu_state.sprites.remove(self.sprite)
-                self.sprite = None
+            self.remove_sprite()
+
+    def remove_sprite(self) -> None:
+        if self.sprite is not None:
+            self.menu_state.sprites.remove(self.sprite)
+            self.sprite = None
+        self.monster = None
 
 
 class MonsterPortraitDisplay:
@@ -493,12 +529,11 @@ class MonsterInfoRenderer:
     def draw_name_and_level(
         self, surface: Surface, monster: Monster, rect: Rect
     ) -> None:
-        if monster.gender == "male":
-            icon = "♂"
-        elif monster.gender == "female":
-            icon = "♀"
-        else:
-            icon = ""
+        gender_icons = {
+            "male": "♂",
+            "female": "♀",
+        }
+        icon = gender_icons.get(monster.gender, "")
         upper_label = f"{monster.name}{icon}"
         text_rect = rect.inflate(-tools.scale(6), -tools.scale(6))
         draw_text(surface, upper_label, text_rect, font=self.font)
@@ -548,3 +583,27 @@ class MonsterSlotBorder:
             return self.borders["filled"]
         else:
             return self.borders["empty"]
+
+
+class MonsterSlotRenderer:
+    """Handles rendering of monster slots and info."""
+
+    def __init__(self, font: Font, hp_bar: HpBar, font_color: ColorLike):
+        self.monster_info_renderer = MonsterInfoRenderer(
+            font, hp_bar, font_color
+        )
+        self.monster_slot_border = MonsterSlotBorder()
+
+    def render_slot(
+        self,
+        surface: Surface,
+        rect: Rect,
+        monster: Optional[Monster],
+        in_focus: bool,
+    ) -> Surface:
+        filled = monster is not None
+        border = self.monster_slot_border.get_border(in_focus, filled)
+        border.draw(surface)
+        if monster is not None:
+            self.monster_info_renderer.draw(surface, monster, rect)
+        return surface

--- a/tuxemon/states/world_menus.py
+++ b/tuxemon/states/world_menus.py
@@ -68,7 +68,7 @@ class WorldMenuState(PygameMenuState):
         self.menu_manager = menu_manager
         self.menu_manager.set_menu_renderer(self)
         self.update_menu_from_manager()
-        self.handler = MonsterMenuHandler(self.client, self.char)
+        self.handler = MonsterMenuHandler(self.client, self.char.party)
 
     def update_menu_from_manager(self) -> None:
         """Refreshes the menu display using items provided by the manager."""


### PR DESCRIPTION
PR introduces several structural improvements to the monster menu system.

Changes
- Extracted the `MonsterSlotRenderer` class from `MonsterMenuState` to separate rendering logic from state management
- Added sorting functionality to `MonsterMenuHandler`, allowing monsters to be ordered by level, HP, or name
- Refactored `MonsterMenuHandler` to work directly with `Party` instead of `NPC`, simplifying access to monsters and party operations
- Renamed `held_item_display` in `monster_stats_display`


https://github.com/user-attachments/assets/c5e0dd34-b97d-4bd7-b553-e439c190882c

