### PR TITLE
Fix: `TextArea` Animation Robustness and Edge Case Handling + `AlertManager`

### DIFF
--- a/tests/tuxemon/test_alert_manager.py
+++ b/tests/tuxemon/test_alert_manager.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import time
 import unittest
 
 import pygame
@@ -146,3 +147,278 @@ class TestAlertManager(unittest.TestCase):
         self.assertEqual(self.text_area.text, "")
         self.manager.dump_remaining_text(self.text_area)
         self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_alert_without_callback_advances_queue(self):
+        self.manager.alert("First message", self.text_area)
+        self.manager.alert("Second message", self.text_area)
+        self.assertEqual(self.text_area.text, "First message")
+        self.assertTrue(self.manager.is_busy())
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertTrue(self.manager.is_busy())
+        self.assertEqual(self.text_area.text, "Second message")
+
+    def test_advance_without_split_state(self):
+        self.manager.alert("Single message", self.text_area, split_lines=False)
+        self.manager.dump_remaining_text(self.text_area)
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertFalse(self.manager.is_busy())
+        self.assertEqual(self.text_area.text, "Single message")
+
+    def test_empty_split_lines_alert(self):
+        self.manager.alert("", self.text_area, split_lines=True)
+        self.assertEqual(self.text_area.text, "")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_mixed_split_and_single_alerts(self):
+        split_msg = "Line1\nLine2"
+        single_msg = "Final single line"
+        self.manager.alert(split_msg, self.text_area, split_lines=True)
+        self.manager.alert(single_msg, self.text_area, split_lines=False)
+        self.assertEqual(self.text_area.text, "Line1")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line2")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertEqual(self.text_area.text, single_msg)
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_callback_ordering(self):
+        order = []
+
+        def cb1():
+            order.append("first_callback")
+
+        def cb2():
+            order.append("second_callback")
+
+        self.manager.alert("First message", self.text_area, callback=cb1)
+        self.manager.alert("Second message", self.text_area, callback=cb2)
+        self.assertEqual(self.text_area.text, "First message")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertIn("first_callback", order)
+        self.assertEqual(self.text_area.text, "Second message")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertEqual(order, ["first_callback", "second_callback"])
+        self.assertFalse(self.manager.is_busy())
+
+    def test_update_with_no_active_area(self):
+        self.manager._active_area = None
+
+        try:
+            self.manager.update(0.1)
+        except Exception as e:
+            self.fail(f"update() raised an exception unexpectedly: {e}")
+
+        self.assertFalse(self.manager.is_busy())
+        self.assertIsNone(self.manager._current_text_area())
+
+    def test_multiple_alerts_mixed_speeds_and_callbacks(self):
+        order = []
+
+        def cb1():
+            order.append("callback1")
+
+        def cb2():
+            order.append("callback2")
+
+        def cb3():
+            order.append("callback3")
+
+        msg_split = "LineA\nLineB"
+        self.manager.alert(
+            "Instant alert",
+            self.text_area,
+            dialog_speed="instant",
+            callback=cb1,
+        )
+        self.manager.alert(
+            "Normal alert",
+            self.text_area,
+            dialog_speed=CONFIG.dialog_speed,
+            callback=cb2,
+        )
+        self.manager.alert(
+            msg_split, self.text_area, split_lines=True, callback=cb3
+        )
+        self.assertEqual(self.text_area.text, "Instant alert")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertIn("callback1", order)
+        self.assertEqual(self.text_area.text, "Normal alert")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertIn("callback2", order)
+        self.assertEqual(self.text_area.text, "LineA")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "LineB")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertIn("callback3", order)
+        self.assertEqual(order, ["callback1", "callback2", "callback3"])
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_callback_exception_does_not_block_queue(self):
+        order = []
+
+        def good_cb1():
+            order.append("good1")
+
+        def bad_cb():
+            raise RuntimeError("intentional failure")
+
+        def good_cb2():
+            order.append("good2")
+
+        self.manager.alert("First alert", self.text_area, callback=good_cb1)
+        self.manager.alert("Bad alert", self.text_area, callback=bad_cb)
+        self.manager.alert("Final alert", self.text_area, callback=good_cb2)
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertIn("good1", order)
+        self.assertEqual(self.text_area.text, "Bad alert")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertEqual(self.text_area.text, "Final alert")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertIn("good2", order)
+        self.assertEqual(order, ["good1", "good2"])
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_current_message_during_alert_lifecycle(self):
+        self.assertIsNone(self.manager.current_message())
+        msg = "Line1\nLine2\nLine3"
+        self.manager.alert(msg, self.text_area, split_lines=True)
+        self.assertEqual(self.text_area.text, "Line1")
+        self.assertEqual(self.manager.current_message(), "Line2")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line2")
+        self.assertEqual(self.manager.current_message(), "Line3")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line3")
+        self.assertIsNone(self.manager.current_message())
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_dump_remaining_text_with_no_active_alert(self):
+        self.assertFalse(self.manager.is_busy())
+        self.assertIsNone(self.manager.current_message())
+
+        try:
+            self.manager.dump_remaining_text(self.text_area)
+        except Exception as e:
+            self.fail(
+                f"dump_remaining_text() raised an exception unexpectedly: {e}"
+            )
+
+        self.assertFalse(self.manager.is_busy())
+        self.assertEqual(self.text_area.text, "")
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_multiple_split_alerts_back_to_back(self):
+        msg1 = "Line1a\nLine1b\nLine1c"
+        msg2 = "Line2a\nLine2b"
+        msg3 = "Line3a\nLine3b\nLine3c\nLine3d"
+        self.manager.alert(msg1, self.text_area, split_lines=True)
+        self.manager.alert(msg2, self.text_area, split_lines=True)
+        self.manager.alert(msg3, self.text_area, split_lines=True)
+        self.assertEqual(self.text_area.text, "Line1a")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line1b")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line1c")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertEqual(self.text_area.text, "Line2a")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line2b")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertEqual(self.text_area.text, "Line3a")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line3b")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line3c")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line3d")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_update_with_large_dt_consumes_line_only(self):
+        msg = "Hello World"
+        self.manager.alert(msg, self.text_area)
+        self.manager.character_delay = 0.01
+        self.manager.update(10.0)
+        self.assertEqual(self.text_area.text, msg)
+        self.assertFalse(self.text_area.drawing_text)
+
+    def test_split_and_instant_alerts_mixed(self):
+        self.manager.alert("Line1\nLine2", self.text_area, split_lines=True)
+        self.manager.alert(
+            "Instant line", self.text_area, dialog_speed="instant"
+        )
+        self.assertEqual(self.text_area.text, "Line1")
+        self.manager.advance_dialog_line(CONFIG.dialog_speed, self.text_area)
+        self.assertEqual(self.text_area.text, "Line2")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertEqual(self.text_area.text, "Instant line")
+        self.manager.dump_remaining_text(self.text_area)
+        self.assertFalse(self.manager.is_busy())
+
+    def test_event_bus_publish_payload(self):
+        published = []
+
+        def fake_publish(event, payload):
+            published.append((event, payload))
+
+        self.manager.event_bus.publish = fake_publish
+        self.manager.alert("Test message", self.text_area)
+        self.assertEqual(published[0][0], "DIALOG_STARTED")
+        self.assertEqual(published[0][1]["message"], "Test message")
+
+    def test_performance_with_many_alerts(self):
+        for i in range(500):
+            self.manager.alert(f"Message {i}", self.text_area)
+
+        processed = 0
+        while self.manager.is_busy():
+            self.manager.dump_remaining_text(self.text_area)
+            processed += 1
+
+        self.assertEqual(processed, 500)
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+
+    def test_concurrent_alert_queueing(self):
+        self.manager.alert("Initial message", self.text_area)
+
+        for i in range(50):
+            self.manager.alert(f"Concurrent message {i}", self.text_area)
+
+        processed = 0
+        while self.manager.is_busy():
+            self.manager.dump_remaining_text(self.text_area)
+            processed += 1
+
+        self.assertEqual(processed, 51)
+        self.assertFalse(self.manager.is_busy())
+
+    def test_performance_with_many_alerts_and_timing(self):
+        for i in range(500):
+            self.manager.alert(f"Message {i}", self.text_area)
+
+        start = time.perf_counter()
+
+        processed = 0
+        while self.manager.is_busy():
+            self.manager.dump_remaining_text(self.text_area)
+            processed += 1
+
+        end = time.perf_counter()
+        elapsed = end - start
+
+        self.assertEqual(processed, 500)
+        self.assertFalse(self.manager.is_busy())
+        self.assertTrue(self.manager.is_dialog_complete(self.text_area))
+        self.assertLess(
+            elapsed, 1.0, f"Processing took too long: {elapsed:.3f}s"
+        )

--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import unittest
+
+import pygame
+
+from tuxemon.ui.draw import (
+    TextOverflow,
+    iter_render_text,
+)
+from tuxemon.ui.text import TextArea
+from tuxemon.ui.text_alignment import HorizontalAlignment, VerticalAlignment
+from tuxemon.ui.text_renderer import TextRenderer
+
+
+class DummyChar:
+    def __init__(self, ch="X"):
+        self.surface = pygame.Surface((1, 1))
+        self.rect = self.surface.get_rect()
+
+
+def dummy_iter_render_text(**kwargs):
+    for _ in kwargs["text"]:
+        yield DummyChar()
+
+
+class TestTextArea(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pygame.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
+    def setUp(self):
+        font = pygame.font.Font(None, 16)
+        self.text_area = TextArea(font=font, font_color=(255, 255, 255))
+        self.text_area._iter = None
+
+    def test_initial_state(self):
+        self.assertEqual(self.text_area.text, "")
+        self.assertFalse(self.text_area.drawing_text)
+
+    def test_text_setter_triggers_animation(self):
+        self.text_area._start_text_animation = lambda: setattr(
+            self.text_area, "drawing_text", True
+        )
+        self.text_area.text = "Hello"
+        self.assertEqual(self.text_area.text, "Hello")
+        self.assertTrue(self.text_area.drawing_text)
+
+    def test_len_returns_length(self):
+        self.text_area.text = "abc"
+        self.assertEqual(len(self.text_area), 3)
+
+    def test_iter_and_next(self):
+        self.text_area._iter = iter([DummyChar(), DummyChar()])
+        self.text_area.animated = True
+        self.text_area.drawing_text = True
+        next(self.text_area)
+        self.assertTrue(self.text_area.drawing_text)
+        with self.assertRaises(StopIteration):
+            while True:
+                next(self.text_area)
+        self.assertFalse(self.text_area.drawing_text)
+
+    def test_non_animated_text_sets_image_directly(self):
+        self.text_area.animated = False
+        self.text_area.text = "Direct"
+        self.assertIsNotNone(self.text_area.image)
+
+    def test_set_background_color(self):
+        self.text_area.rect = pygame.Rect(0, 0, 10, 10)
+        self.text_area.set_background(background_color=(255, 0, 0))
+        self.assertEqual(
+            self.text_area.image.get_at((0, 0)), pygame.Color(255, 0, 0, 255)
+        )
+
+    def test_set_background_image(self):
+        surf = pygame.Surface((10, 10))
+        surf.fill((0, 255, 0))
+        self.text_area.rect = pygame.Rect(0, 0, 10, 10)
+        self.text_area.set_background(background_image=surf)
+        self.assertEqual(
+            self.text_area.image.get_at((0, 0)), pygame.Color(0, 255, 0, 255)
+        )
+
+    def test_overflow_behavior_setter(self):
+        self.text_area.set_overflow_behavior(TextOverflow.WRAP)
+        self.assertEqual(self.text_area.overflow_behavior, TextOverflow.WRAP)
+
+    def test_start_text_animation_resets_surface(self):
+        self.text_area.rect = pygame.Rect(0, 0, 10, 10)
+        global iter_render_text
+        old_iter = iter_render_text
+        iter_render_text = dummy_iter_render_text
+        try:
+            self.text_area.text = "abc"
+            self.assertTrue(self.text_area.drawing_text)
+            self.assertIsNotNone(self.text_area._iter)
+        finally:
+            iter_render_text = old_iter
+
+    def test_next_raises_stopiteration_when_not_animated(self):
+        self.text_area.animated = False
+        with self.assertRaises(StopIteration):
+            next(self.text_area)
+
+    def test_text_setter_same_value_does_not_restart_animation(self):
+        self.text_area.text = "abc"
+        self.text_area.drawing_text = False
+        self.text_area.text = "abc"
+        self.assertFalse(self.text_area.drawing_text)
+
+
+class TestTextAreaStress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pygame.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
+    def setUp(self):
+        font = pygame.font.Font(None, 16)
+        self.text_area = TextArea(font=font, font_color=(255, 255, 255))
+        self.text_area.rect = pygame.Rect(0, 0, 100, 20)
+
+    def test_fast_click_before_update(self):
+        self.text_area.text = "FastClick"
+        self.text_area.drawing_text = True
+        for _ in self.text_area:
+            pass
+        self.assertFalse(self.text_area.drawing_text)
+        self.assertEqual(self.text_area.text, "FastClick")
+
+    def test_update_progressive_render(self):
+        self.text_area.text = "Hello"
+        self.text_area.drawing_text = True
+        try:
+            while True:
+                next(self.text_area)
+        except StopIteration:
+            pass
+        self.assertFalse(self.text_area.drawing_text)
+
+    def test_empty_string(self):
+        self.text_area.text = ""
+        self.assertFalse(self.text_area.drawing_text)
+        self.assertEqual(self.text_area.text, "")
+
+    def test_repeated_text_changes(self):
+        for msg in ["One", "Two", "Three"]:
+            self.text_area.text = msg
+            for _ in self.text_area:
+                pass
+            self.assertEqual(self.text_area.text, msg)
+            self.assertFalse(self.text_area.drawing_text)
+
+    def test_surface_size_zero(self):
+        ta = TextArea(
+            font=pygame.font.Font(None, 16), font_color=(255, 255, 255)
+        )
+        ta.rect = pygame.Rect(0, 0, 0, 0)
+        ta.text = "ZeroRect"
+        self.assertTrue(ta.drawing_text or ta.text == "ZeroRect")
+
+    def test_drawing_text_stays_true_until_stopiteration(self):
+        self.text_area.text = "Hello"
+        self.assertTrue(self.text_area.drawing_text)
+
+        count = 0
+        try:
+            while True:
+                next(self.text_area)
+                count += 1
+                self.assertTrue(self.text_area.drawing_text)
+        except StopIteration:
+            pass
+
+        self.assertEqual(count, len(self.text_area.text))
+        self.assertFalse(self.text_area.drawing_text)
+
+    def test_non_animated_text_is_fully_rendered_immediately(self):
+        self.text_area.animated = False
+        self.text_area.text = "Static Text"
+        self.assertEqual(self.text_area.text, "Static Text")
+        self.assertFalse(self.text_area.drawing_text)
+
+    def test_len_after_setting_empty_text(self):
+        self.text_area.text = "A B C"
+        self.assertEqual(len(self.text_area), 5)
+        self.text_area.text = ""
+        self.assertEqual(len(self.text_area), 0)
+
+    def test_next_on_completed_text_raises_stopiteration(self):
+        self.text_area.animated = True
+        self.text_area.drawing_text = False
+
+        with self.assertRaises(StopIteration):
+            next(self.text_area)
+
+    def test_empty_string_animation_state(self):
+        self.text_area.animated = True
+        self.text_area.text = "Testing"
+        self.assertTrue(self.text_area.drawing_text)
+
+        self.text_area.text = ""
+        self.assertFalse(self.text_area.drawing_text)
+        self.assertEqual(self.text_area.text, "")

--- a/tuxemon/menu/alert.py
+++ b/tuxemon/menu/alert.py
@@ -19,19 +19,37 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class SplitAlertState:
+    """Manages the state for an alert that is split into multiple lines."""
+
+    dialog_lines: list[str]
+    dialog_index: int = 0
+    dialog_speed: str = CONFIG.dialog_speed
+
+    def current_line(self) -> Optional[str]:
+        """Returns the current line to be displayed."""
+        if 0 <= self.dialog_index < len(self.dialog_lines):
+            return self.dialog_lines[self.dialog_index]
+        return None
+
+    def advance(self) -> None:
+        """Move to the next line index."""
+        self.dialog_index += 1
+
+
+@dataclass
 class AlertEntry:
     message: str
     text_area: TextArea
     callback: Optional[Callable[[], None]]
     dialog_speed: str
     split_lines: bool
+    split_state: Optional[SplitAlertState] = None
 
 
 class AlertManager:
     def __init__(self, event_bus: EventBus) -> None:
         self.event_bus = event_bus
-        self._dialog_lines: list[str] = []
-        self._dialog_index: int = 0
         self._final_callback: Optional[Callable[[], None]] = None
         self._time_accum: float = 0.0
         self.character_delay = resolve_character_delay(CONFIG.dialog_speed)
@@ -39,6 +57,7 @@ class AlertManager:
         self._alert_queue: deque[AlertEntry] = deque()
         self._is_busy: bool = False
         self._active_area: Optional[TextArea] = None
+        self._active_split_state: Optional[SplitAlertState] = None
 
     def update(self, dt: float) -> None:
         area = self._active_area
@@ -75,6 +94,7 @@ class AlertManager:
                     pass
             except Exception as e:
                 logger.warning(f"Unexpected error while dumping text: {e}")
+
             self._on_line_complete()
 
     def alert(
@@ -86,8 +106,23 @@ class AlertManager:
         split_lines: bool = False,
     ) -> None:
         """Queue a new alert message for display in a TextArea."""
+        split_state: Optional[SplitAlertState] = None
+        if split_lines:
+            lines = message.splitlines()
+            if lines:
+                split_state = SplitAlertState(
+                    dialog_lines=lines, dialog_speed=dialog_speed
+                )
+
         self._alert_queue.append(
-            AlertEntry(message, text_area, callback, dialog_speed, split_lines)
+            AlertEntry(
+                message,
+                text_area,
+                callback,
+                dialog_speed,
+                split_lines,
+                split_state,
+            )
         )
         if not self._is_busy:
             self._process_next_alert()
@@ -98,6 +133,9 @@ class AlertManager:
             self._is_busy = True
             next_alert = self._alert_queue.popleft()
             self._active_area = next_alert.text_area
+            self._active_split_state = (
+                next_alert.split_state
+            )  # Set the active state
 
             def alert_complete_callback() -> None:
                 try:
@@ -105,32 +143,41 @@ class AlertManager:
                         next_alert.callback()
                 except Exception as e:
                     logger.error(f"Error in alert callback: {e}")
-                finally:
-                    self._finish_alert()
 
             self._final_callback = alert_complete_callback
 
             if next_alert.split_lines:
-                self._dialog_lines = next_alert.message.splitlines()
-                self._dialog_index = 0
+                # If there is no split state (empty message), finish immediately
+                if not self._active_split_state:
+                    self._on_alert_complete()
+                    return
+
+                first_line = self._active_split_state.current_line()
+                if first_line is None:
+                    # No lines to show, finish immediately
+                    self._on_alert_complete()
+                    return
+
                 self.event_bus.publish(
                     "DIALOG_STARTED",
                     payload={
                         "state": "DialogState",
-                        "message": self._dialog_lines[0],
-                        "split_lines": next_alert.split_lines,
+                        "message": first_line,
+                        "split_lines": True,
                     },
                 )
-                self.advance_dialog_line(
-                    next_alert.dialog_speed, next_alert.text_area
+
+                self._animate_next_line(
+                    self._active_split_state, next_alert.text_area
                 )
+                self._active_split_state.advance()
             else:
                 self.event_bus.publish(
                     "DIALOG_STARTED",
                     payload={
                         "state": "DialogState",
                         "message": next_alert.message,
-                        "split_lines": next_alert.split_lines,
+                        "split_lines": False,
                     },
                 )
                 self.animate_text(
@@ -141,30 +188,55 @@ class AlertManager:
         else:
             self._is_busy = False
             self._active_area = None
+            self._active_split_state = None
+
+    def _animate_next_line(
+        self, split_state: SplitAlertState, text_area: TextArea
+    ) -> None:
+        """Helper to animate the current line from the split state."""
+        line = split_state.current_line()
+        if line is not None:
+            self.animate_text(text_area, line, split_state.dialog_speed)
+        else:
+            self._on_alert_complete()
 
     def advance_dialog_line(
         self, dialog_speed: str, text_area: TextArea
     ) -> None:
         """Advance to the next line of a split-line alert."""
-        if self._dialog_index < len(self._dialog_lines):
-            line = self._dialog_lines[self._dialog_index]
-            self._dialog_index += 1
-            self.animate_text(text_area, line, dialog_speed)
+        if self._active_split_state:
+
+            line = self._active_split_state.current_line()
+
+            if line is not None:
+                self.animate_text(text_area, line, dialog_speed)
+                self._active_split_state.advance()
+            else:
+                # All lines done
+                self._active_split_state = None
+                self._on_alert_complete()
         else:
-            # All lines done
-            self._dialog_lines = []
-            self._dialog_index = 0
+            # Not a split alert, or state is complete
             self._on_alert_complete()
 
     def _on_line_complete(self) -> None:
         """Handle completion of a line, advancing or finishing the alert."""
-        # If more lines remain, advance automatically
-        if self._dialog_index < len(self._dialog_lines):
-            current_area = self._current_text_area()
-            if current_area:
-                self.advance_dialog_line(CONFIG.dialog_speed, current_area)
-        # Otherwise, finish the alert (close)
-        else:
+        # Check if we are in a multi-line alert and if there are more lines
+        if self._active_split_state:
+            next_line = self._active_split_state.current_line()
+
+            if next_line is not None:
+                # More lines remain — wait for DialogState to advance or
+                # auto‑advance if delay is 0
+                logger.debug(
+                    "Waiting for DialogState to advance to the next line."
+                )
+
+        # If no split state, or the split state is finished, finalize the alert.
+        if (
+            self._active_split_state is None
+            or self._active_split_state.current_line() is None
+        ):
             self._on_alert_complete()
 
     def _on_alert_complete(self) -> None:
@@ -173,13 +245,17 @@ class AlertManager:
             try:
                 self._final_callback()
             except Exception as e:
-                logger.error(f"Error in final callback: {e}")
+                logger.error(f"Error in alert callback: {e}")
             finally:
                 self._final_callback = None
+
+        # Always finish the alert, even if no callback
+        self._finish_alert()
 
     def _finish_alert(self) -> None:
         """Mark the current alert as finished and process the next one."""
         self._is_busy = False
+        self._active_split_state = None
         self._process_next_alert()
 
     def dump_remaining_text(self, text_area: TextArea) -> None:
@@ -210,8 +286,6 @@ class AlertManager:
 
     def current_message(self) -> Optional[str]:
         """Return the current message line being displayed, if any."""
-        if self._dialog_lines and 0 <= self._dialog_index < len(
-            self._dialog_lines
-        ):
-            return self._dialog_lines[self._dialog_index]
+        if self._active_split_state:
+            return self._active_split_state.current_line()
         return None

--- a/tuxemon/states/dialog_state.py
+++ b/tuxemon/states/dialog_state.py
@@ -119,8 +119,14 @@ class DialogState(PopUpMenu[None]):
                 logger.debug("Fast-forwarding current dialog line")
                 self.dialog.dump_remaining_text(self.dialog_box)
             else:
-                logger.debug("Dialog line complete, advancing to next")
-                self.next_text()
+                if self.dialog.is_busy():
+                    logger.debug(
+                        "Ignoring rapid click during AlertManager transition."
+                    )
+                    return None
+                if self.text_queue or self.auto_close:
+                    self.next_text()
+                    logger.debug("Dialog line complete, advancing to next")
         return None
 
     def update(self, dt: float) -> None:
@@ -154,6 +160,10 @@ class DialogState(PopUpMenu[None]):
 
         if self.text_queue:
             text = self.text_queue.pop(0)
+
+            if not text:
+                return self.next_text()
+
             self.dialog.alert(text, self.dialog_box)
             self._reset_timer()
             return text

--- a/tuxemon/ui/text.py
+++ b/tuxemon/ui/text.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Optional, Union
 
 from pygame import SRCALPHA
@@ -14,6 +15,7 @@ from tuxemon import prepare
 from tuxemon.graphics import ColorLike
 from tuxemon.sprite import Sprite
 from tuxemon.ui.draw import (
+    RenderedChar,
     TextOverflow,
     break_text_into_lines,
     calculate_alignment_offset,
@@ -105,6 +107,7 @@ class TextArea(Sprite):
         self._rendered_text = None
         self._text_rect = None
         self._text = ""
+        self._iter: Optional[Iterator[RenderedChar]] = None
 
     def __iter__(self) -> TextArea:
         return self
@@ -118,8 +121,15 @@ class TextArea(Sprite):
 
     @text.setter
     def text(self, value: str) -> None:
-        if value != self._text:
-            self._text = value
+        if value == self._text:
+            return
+
+        self._text = value
+
+        if not self._text:
+            self.drawing_text = False
+            self.image = Surface(self.rect.size, SRCALPHA)
+            return
 
         if self.animated:
             self._start_text_animation()
@@ -128,6 +138,9 @@ class TextArea(Sprite):
 
     def __next__(self) -> None:
         if self.animated:
+            if self._iter is None:
+                self.drawing_text = False
+                raise StopIteration
             try:
                 rendered_char = next(self._iter)
                 self.image.blit(rendered_char.surface, rendered_char.rect)


### PR DESCRIPTION
The changes focus on enforcing the integrity of the iterator protocol (`__iter__`/`__next__`) and cleaning up state management within the `text.setter`.

Iterator tweaks
- We now make sure the iterator is properly set up before you try to use it
- That means no more random crashes when `__next__` gets called too soon

Smarter `__next__`
- If you call `__next__` before any text is loaded, it just shrugs and says "nothing to do" instead of blowing up
- If the text animation is already finished and you call `__next__` again, it calmly says "we’re done here"

Cleaner `text.setter`
- First thing it does is check: “Is this the same text as last time?” If yes, it skips restarting the animation
- If the new text is empty, it wipes the display right away and stops drawing, so you don’t get leftover bits hanging around

AlertManager
- Introduced a new `SplitAlertState` class to encapsulate multi‑line dialog state (`dialog_lines`, `dialog_index`, `dialog_speed`).
- Removed internal fields `_dialog_lines` and `_dialog_index` from `AlertManager`; state is now managed through `SplitAlertState`.
- Extended `AlertEntry` with a `split_state` field so each alert carries its own multi‑line state.
- Updated methods (`_process_next_alert`, `advance_dialog_line`, `_on_line_complete`, `current_message`) to use `SplitAlertState` instead of raw list/index tracking.
- Added `_animate_next_line` helper to simplify animating the current line from a split alert.
- Improved separation of concerns: `AlertManager` now orchestrates alerts, while `SplitAlertState` owns the details of line progression.
- Behavior for multi‑line alerts is clearer: AlertManager waits for external input (via `DialogState`) to advance lines, instead of auto‑advancing internally.