### PR TITLE
Remove outdated `K_RETURN` binding, standardize on `INTERACT`

### DIFF
--- a/mods/tuxemon/maps/37707_tower.tmx
+++ b/mods/tuxemon/maps/37707_tower.tmx
@@ -69,7 +69,7 @@
     <property name="act10" value="translated_dialog 37707_computer"/>
     <property name="act20" value="set_variable 37707_tower:activated"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not variable_set 37707_tower:activated"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/37707_town.tmx
+++ b/mods/tuxemon/maps/37707_town.tmx
@@ -144,7 +144,7 @@
     <property name="act10" value="translated_dialog 37707_town01"/>
     <property name="act20" value="add_monster fruitera,10"/>
     <property name="cond10" value="is char_at player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="186" name="Villager Male" type="event" x="528" y="128" width="16" height="16">
@@ -169,21 +169,21 @@
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_welcome"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="189" name="Sign Tower" type="event" x="480" y="160" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_tower"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="191" name="Sign Foreign" type="event" x="432" y="256" width="48" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_foreign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="192" name="Sign Hidden" type="event" x="624" y="64" width="16" height="16">
@@ -191,7 +191,7 @@
     <property name="act10" value="translated_dialog 37707_sign_hidden"/>
     <property name="act20" value="set_variable 37707_sign:read"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="193" name="Villager Female Talk 1" type="event" x="192" y="256" width="16" height="16">
@@ -250,77 +250,77 @@
    <properties>
     <property name="act10" value="translated_dialog 37707_house"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="202" name="Mail" type="event" x="112" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="203" name="Mail" type="event" x="208" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="204" name="Mail" type="event" x="320" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="205" name="Mail" type="event" x="528" y="304" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="206" name="Mail" type="event" x="560" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="207" name="House" type="event" x="240" y="240" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_house"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="208" name="House" type="event" x="176" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_house"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="209" name="House" type="event" x="288" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_house"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="210" name="House" type="event" x="608" y="112" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_house"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="211" name="Flower" type="event" x="384" y="176" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_flower"/>
     <property name="cond10" value="is char_at player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/37707_town_missing.tmx
+++ b/mods/tuxemon/maps/37707_town_missing.tmx
@@ -361,28 +361,28 @@
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_missing_welcome"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="188" name="Sign Tower" type="event" x="480" y="160" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_missing_tower"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="189" name="Sign Foreign" type="event" x="432" y="256" width="48" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_missing_foreign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="190" name="Sign Hidden Unread" type="event" x="624" y="64" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_missing_hidden_unread"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not variable_set 37707_sign:read"/>
    </properties>
   </object>
@@ -390,7 +390,7 @@
    <properties>
     <property name="act10" value="translated_dialog 37707_sign_missing_hidden_read"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="is variable_set 37707_sign:read"/>
    </properties>
   </object>
@@ -398,84 +398,84 @@
    <properties>
     <property name="act10" value="translated_dialog 37707_house_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="194" name="Mail" type="event" x="112" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="195" name="House" type="event" x="240" y="304" width="80" height="48">
    <properties>
     <property name="act10" value="translated_dialog 37707_house_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="196" name="House" type="event" x="96" y="208" width="80" height="48">
    <properties>
     <property name="act10" value="translated_dialog 37707_house_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="197" name="House" type="event" x="208" y="208" width="80" height="48">
    <properties>
     <property name="act10" value="translated_dialog 37707_house_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="198" name="House" type="event" x="544" y="240" width="96" height="48">
    <properties>
     <property name="act10" value="translated_dialog 37707_house_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="199" name="House" type="event" x="560" y="80" width="80" height="48">
    <properties>
     <property name="act10" value="translated_dialog 37707_house_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="200" name="Mail" type="event" x="208" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="201" name="Mail" type="event" x="320" y="336" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="202" name="Mail" type="event" x="528" y="304" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="203" name="Mail" type="event" x="560" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_mail_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="204" name="Tower" type="event" x="384" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog 37707_tower_missing"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="211" name="Flower" type="event" x="384" y="176" width="16" height="16">
@@ -483,7 +483,7 @@
     <property name="act10" value="translated_dialog 37707_flower_missing"/>
     <property name="act20" value="set_monster_health"/>
     <property name="cond10" value="is char_at player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/azure_town.tmx
+++ b/mods/tuxemon/maps/azure_town.tmx
@@ -232,7 +232,7 @@
    <properties>
     <property name="act10" value="translated_dialog flower_lady"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>
@@ -255,7 +255,7 @@
    <properties>
     <property name="act10" value="translated_dialog town_hall"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="6" name="Enter Town Hall" type="event" x="656" y="352" width="16" height="16">

--- a/mods/tuxemon/maps/bedroom_test.tmx
+++ b/mods/tuxemon/maps/bedroom_test.tmx
@@ -57,28 +57,28 @@
    <properties>
     <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="16" name="Lord Lampy" type="event" x="16" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog test_lamp"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="17" name="Lord or Filth" type="event" x="32" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog test_trash"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="18" name="tree" type="event" x="128" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog test_tree"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/buddha_mountain.tmx
+++ b/mods/tuxemon/maps/buddha_mountain.tmx
@@ -44,7 +44,7 @@
     <property name="act10" value="translated_dialog buddha_welcome"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="3" name="Play Music" type="event" x="0" y="1584" width="16" height="16">

--- a/mods/tuxemon/maps/candy_town.tmx
+++ b/mods/tuxemon/maps/candy_town.tmx
@@ -177,7 +177,7 @@
     <property name="act10" value="translated_dialog candy_town"/>
     <property name="act20" value="translated_dialog candy_town_description"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="213" name="Teleport to Route6" type="event" x="80" y="624" width="16" height="16">

--- a/mods/tuxemon/maps/city1_mart_junkyard.tmx
+++ b/mods/tuxemon/maps/city1_mart_junkyard.tmx
@@ -57,7 +57,7 @@
     <property name="act30" value="translated_dialog mart_junkyard01"/>
     <property name="act40" value="set_variable got_first_tuxemon:true"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not variable_set got_first_tuxemon:true"/>
     <property name="cond40" value="is variable_set maple_bedroom1:true"/>
    </properties>
@@ -69,7 +69,7 @@
     <property name="act30" value="translated_dialog mart_junkyard02"/>
     <property name="act40" value="set_variable got_first_tuxemon:true"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not variable_set got_first_tuxemon:true"/>
     <property name="cond40" value="is variable_set maple_bedroom1:true"/>
    </properties>

--- a/mods/tuxemon/maps/citypark.tmx
+++ b/mods/tuxemon/maps/citypark.tmx
@@ -323,21 +323,21 @@
    <properties>
     <property name="act10" value="translated_dialog xero_citypark_achievement"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="102" name="Sign: Leather Town" type="event" x="608" y="160" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog citypark"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="111" name="ripjimmy" type="event" x="32" y="384" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog ripjimmy"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="112" name="make npcs" type="event" x="48" y="0" width="16" height="16">
@@ -358,7 +358,7 @@
     <property name="act50" value="translated_dialog_choice mistaken:thats_me,cityparkchoice"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,right"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
     <property name="cond40" value="is variable_set firstgo:no"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/cotton_cathedral.tmx
+++ b/mods/tuxemon/maps/cotton_cathedral.tmx
@@ -66,7 +66,7 @@
     <property name="act10" value="translated_dialog tabanurse_dialog_cotton"/>
     <property name="act20" value="translated_dialog_choice yes:no,chooses"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not variable_set chooses:yes"/>
    </properties>
   </object>
@@ -88,7 +88,7 @@
    <properties>
     <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_misa_house.tmx
+++ b/mods/tuxemon/maps/cotton_misa_house.tmx
@@ -58,7 +58,7 @@
    <properties>
     <property name="act1" value="translated_dialog cotton_misa_fireplace"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="53" name="Talk Granny Male" type="event" x="0" y="16" width="16" height="16">
@@ -82,7 +82,7 @@
    <properties>
     <property name="act1" value="translated_dialog cotton_misa_tv"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="61" name="Go Upstairs" type="event" x="64" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/cotton_scoop.tmx
+++ b/mods/tuxemon/maps/cotton_scoop.tmx
@@ -67,14 +67,14 @@
    <properties>
     <property name="act10" value="open_shop tuxemart_keeper,both_item"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="19" name="capture devices" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog cash_register"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/cotton_town.tmx
+++ b/mods/tuxemon/maps/cotton_town.tmx
@@ -147,7 +147,7 @@
     <property name="act50" value="translated_dialog kmere"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
     <property name="cond40" value="not char_exists aeble"/>
     <property name="cond50" value="not variable_set donewithyou:yes"/>
    </properties>
@@ -250,21 +250,21 @@
    <properties>
     <property name="act10" value="translated_dialog Cotton_Town_Sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="247" name="Sign: Omnichannel HQ" type="event" x="272" y="144" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog xero_omnichannel_sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="248" name="Sign: Cathedral Centre" type="event" x="352" y="416" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog Cathedral_Center"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="249" name="Teleport to Cafe" type="event" x="160" y="256" width="16" height="16">
@@ -326,49 +326,49 @@
    <properties>
     <property name="act10" value="translated_dialog empty_pot"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="263" name="purple flowers1" type="event" x="128" y="320" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog purple_flowers"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="264" name="purple flowers2" type="event" x="160" y="320" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog purple_flowers"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="265" name="purple flowers3" type="event" x="256" y="320" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog purple_flowers"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="266" name="purple flowers4" type="event" x="288" y="320" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog purple_flowers"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="267" name="purple flowers5" type="event" x="384" y="320" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog purple_flowers"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="269" name="orange flowers" type="event" x="208" y="256" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog orange_flowers"/>
     <property name="cond20" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="270" name="talk to liela" type="event" x="592" y="272" width="16" height="16">
@@ -384,28 +384,28 @@
    <properties>
     <property name="act10" value="translated_dialog famous_statue"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="272" name="statue2" type="event" x="512" y="464" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog famous_statue2"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="273" name="fountain" type="event" x="464" y="368" width="48" height="48">
    <properties>
     <property name="act10" value="translated_dialog cotton_town_fountain"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="274" name="tree" type="event" x="144" y="128" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog tree"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="276" name="personhere" type="event" x="16" y="448" width="16" height="16">
@@ -436,7 +436,7 @@
    <properties>
     <property name="act1" value="translated_dialog Cotton_Mart"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="283" name="Teleport to Misa House" type="event" x="368" y="256" width="16" height="16">
@@ -451,7 +451,7 @@
    <properties>
     <property name="act10" value="translated_dialog purple_flowers"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="288" name="reenter_daycare" type="event" x="96" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/eclipse_crystal_bank2.yaml
+++ b/mods/tuxemon/maps/eclipse_crystal_bank2.yaml
@@ -66,7 +66,7 @@ events:
     - set_variable eclipse_rubbish:yes
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     width: 2
     x: 1

--- a/mods/tuxemon/maps/eclipse_crystal_town.yaml
+++ b/mods/tuxemon/maps/eclipse_crystal_town.yaml
@@ -69,7 +69,7 @@ events:
     - translated_dialog here_to_east
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 37
     y: 7
@@ -136,7 +136,7 @@ events:
     - translated_dialog eclipse_crystal_alert_skating
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 26
     y: 9
@@ -145,7 +145,7 @@ events:
     - translated_dialog welcome_location_town
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 32
     y: 17

--- a/mods/tuxemon/maps/eclipse_crystal_town_cafe.yaml
+++ b/mods/tuxemon/maps/eclipse_crystal_town_cafe.yaml
@@ -93,7 +93,7 @@ events:
     conditions:
     - is char_at player
     - is char_facing player,up
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     x: 2
     y: 6
     type: event

--- a/mods/tuxemon/maps/eclipse_crystal_town_house.yaml
+++ b/mods/tuxemon/maps/eclipse_crystal_town_house.yaml
@@ -48,7 +48,7 @@ events:
     - translated_dialog eclipse_crystal_tvwatch
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2

--- a/mods/tuxemon/maps/eclipse_lion_mountain_low.yaml
+++ b/mods/tuxemon/maps/eclipse_lion_mountain_low.yaml
@@ -182,7 +182,7 @@ events:
     - translated_dialog welcome_location_route
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     x: 12
     y: 8
     type: event

--- a/mods/tuxemon/maps/eclipse_obsidian_town.yaml
+++ b/mods/tuxemon/maps/eclipse_obsidian_town.yaml
@@ -58,7 +58,7 @@ events:
     - translated_dialog welcome_location_town
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 9
     y: 12

--- a/mods/tuxemon/maps/eclipse_park.yaml
+++ b/mods/tuxemon/maps/eclipse_park.yaml
@@ -259,7 +259,7 @@ events:
     - translated_dialog welcome_location_route
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 5
     y: 35

--- a/mods/tuxemon/maps/eclipse_park_cabin.yaml
+++ b/mods/tuxemon/maps/eclipse_park_cabin.yaml
@@ -59,7 +59,7 @@ events:
     - unlock_controls
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 1
     y: 2

--- a/mods/tuxemon/maps/eclipse_park_entrance.yaml
+++ b/mods/tuxemon/maps/eclipse_park_entrance.yaml
@@ -98,7 +98,7 @@ events:
     - translated_dialog eclipse_park_assistant
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 7
     y: 5

--- a/mods/tuxemon/maps/eclipse_park_south.yaml
+++ b/mods/tuxemon/maps/eclipse_park_south.yaml
@@ -174,7 +174,7 @@ events:
     - translated_dialog welcome_location_route
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 55
     y: 5

--- a/mods/tuxemon/maps/eclipse_route7.yaml
+++ b/mods/tuxemon/maps/eclipse_route7.yaml
@@ -380,7 +380,7 @@ events:
     - translated_dialog here_to_east
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     x: 33
     y: 1
     type: event

--- a/mods/tuxemon/maps/flower_city.tmx
+++ b/mods/tuxemon/maps/flower_city.tmx
@@ -173,7 +173,7 @@
    <properties>
     <property name="act1" value="translated_dialog Cotton_Mart"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="208" name="Sign: Flower City" type="event" x="32" y="48" width="16" height="16">
@@ -181,14 +181,14 @@
     <property name="act10" value="translated_dialog cotton_town"/>
     <property name="act20" value="translated_dialog cotton_town_description"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="209" name="Sign: Flower East" type="event" x="608" y="208" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog route5"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="220" name="Teleport to Leather Town" type="event" x="224" y="624" width="16" height="16">

--- a/mods/tuxemon/maps/healing_center.tmx
+++ b/mods/tuxemon/maps/healing_center.tmx
@@ -57,7 +57,7 @@
    <properties>
     <property name="act10" value="translated_dialog tabanurse_dialog_welcome"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not party_size player,greater_than,0"/>
    </properties>
   </object>
@@ -66,7 +66,7 @@
     <property name="act10" value="translated_dialog tabanurse_dialog_taba"/>
     <property name="act20" value="translated_dialog_choice yes:no,chooses"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
     <property name="cond30" value="not variable_set chooses:yes"/>
     <property name="cond40" value="is party_size player,greater_than,0"/>
    </properties>
@@ -134,7 +134,7 @@
    <properties>
     <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="38" name="create nurse" type="event" x="80" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/leather_scoop.tmx
+++ b/mods/tuxemon/maps/leather_scoop.tmx
@@ -63,14 +63,14 @@
    <properties>
     <property name="act10" value="open_shop tuxemart_keeper,both_item"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="21" name="capture devices" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog cash_register"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/leather_town.tmx
+++ b/mods/tuxemon/maps/leather_town.tmx
@@ -175,14 +175,14 @@
    <properties>
     <property name="act10" value="translated_dialog route3"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="91" name="Sign: Route 3" type="event" x="480" y="384" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog leather_town_open_air"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="93" name="Teleport to City Park" type="event" x="0" y="480" width="16" height="16">
@@ -198,28 +198,28 @@
     <property name="act1" value="translated_dialog leather_town"/>
     <property name="act2" value="translated_dialog leather_town_description"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="96" name="Sign: Leather Scoop" type="event" x="432" y="144" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog Cotton_Mart"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="98" name="Sign: Shaft 1" type="event" x="288" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog xero_shaft1_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="99" name="Sign: Shaft 2" type="event" x="400" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog xero_shaft2_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="100" name="Teleport to Shaft1" type="event" x="240" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/maple_bedroom.tmx
+++ b/mods/tuxemon/maps/maple_bedroom.tmx
@@ -52,14 +52,14 @@
    <properties>
     <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="34" name="Read Sign" type="event" x="128" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog maple_bedroom_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="36" name="Stop" type="event" x="96" y="64" width="16" height="32">

--- a/mods/tuxemon/maps/maple_house.tmx
+++ b/mods/tuxemon/maps/maple_house.tmx
@@ -71,7 +71,7 @@
     <property name="act20" value="translated_dialog nodrink"/>
     <property name="act30" value="char_face npc_wife,down"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="40" name="create knight" type="event" x="176" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/player_house_bedroom.yaml
+++ b/mods/tuxemon/maps/player_house_bedroom.yaml
@@ -73,7 +73,7 @@ events:
     - set_monster_status
     - set_teleport_faint player,player_house_bedroom.tmx,3,4
     conditions:
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is char_facing_tile player
     height: 2
     type: event
@@ -85,7 +85,7 @@ events:
     - access_pc player
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 3
     y: 2

--- a/mods/tuxemon/maps/player_house_downstairs.tmx
+++ b/mods/tuxemon/maps/player_house_downstairs.tmx
@@ -51,7 +51,7 @@
     <property name="cond10" value="is party_size player,greater_than,0"/>
     <property name="cond20" value="is char_at player"/>
     <property name="cond30" value="is char_facing player,up"/>
-    <property name="cond40" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="is button_pressed INTERACT"/>
     <property name="cond50" value="not variable_set scene:yes"/>
    </properties>
   </object>
@@ -59,7 +59,7 @@
    <properties>
     <property name="act10" value="translated_dialog xero_taba_poster"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="26" name="Go Upstairs" type="event" x="0" y="16" width="16" height="16">
@@ -126,7 +126,7 @@
     <property name="act9" value="set_variable aeble_talk:2"/>
     <property name="cond1" value="is variable_set aeble_talk:1"/>
     <property name="cond2" value="is char_at player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is char_facing player,up"/>
    </properties>
   </object>
@@ -158,7 +158,7 @@
    <properties>
     <property name="act1" value="translated_dialog waterwater"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="38" name="create mom3" type="event" x="0" y="64" width="16" height="16">
@@ -189,7 +189,7 @@
     <property name="act3" value="set_variable announce_trials:2"/>
     <property name="cond1" value="is char_facing player,up"/>
     <property name="cond2" value="is char_at player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is variable_set announce_trials:1"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/professor_lab.tmx
+++ b/mods/tuxemon/maps/professor_lab.tmx
@@ -65,7 +65,7 @@
     <property name="act6" value="translated_dialog_choice yes:no,rockittenchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
     <property name="cond2" value="is char_facing_tile player"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
     <property name="cond5" value="is variable_set gettuxemon:now"/>
    </properties>
   </object>
@@ -78,7 +78,7 @@
     <property name="act6" value="translated_dialog_choice yes:no,cardilingchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
     <property name="cond2" value="is char_facing_tile player"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
     <property name="cond5" value="is variable_set gettuxemon:now"/>
    </properties>
   </object>
@@ -91,7 +91,7 @@
     <property name="act6" value="translated_dialog_choice yes:no,tweesherchoice"/>
     <property name="cond1" value="not variable_set havetuxemon:yes"/>
     <property name="cond2" value="is char_facing_tile player"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
     <property name="cond5" value="is variable_set gettuxemon:now"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/route1.tmx
+++ b/mods/tuxemon/maps/route1.tmx
@@ -100,7 +100,7 @@
     <property name="act10" value="translated_dialog xero_hideout1"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="85" name="Teleport to route1a" type="event" x="512" y="64" width="16" height="16">
@@ -132,7 +132,7 @@
     <property name="act1" value="translated_dialog tabatownbattlearea"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="97" name="block the door" type="event" x="224" y="112" width="16" height="16">
@@ -171,7 +171,7 @@
     <property name="act10" value="translated_dialog rockywhy"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="111" name="angry populace" type="event" x="432" y="320" width="16" height="16">
@@ -382,7 +382,7 @@
     <property name="act30" value="set_variable whoartthou:done"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is variable_set whoartthou:tuxemon"/>
    </properties>
   </object>
@@ -391,7 +391,7 @@
     <property name="act10" value="translated_dialog taketheleft2"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is variable_set whoartthou:tuxemon"/>
    </properties>
   </object>
@@ -622,7 +622,7 @@
     <property name="act10" value="translated_dialog imherenow"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="138" name="talktojon2" type="event" x="528" y="416" width="16" height="16">
@@ -632,7 +632,7 @@
     <property name="act12" value="char_face omnigrunt4,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="139" name="talktojon3" type="event" x="544" y="400" width="16" height="16">
@@ -642,7 +642,7 @@
     <property name="act12" value="char_face omnigrunt4,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is variable_set misaisgone:true"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/route2.tmx
+++ b/mods/tuxemon/maps/route2.tmx
@@ -90,28 +90,28 @@
     <property name="act1" value="translated_dialog route2"/>
     <property name="act2" value="translated_dialog route2_description"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="83" name="Sign: City Park" type="event" x="144" y="32" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog citypark"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="84" name="Sign: Column 1" type="event" x="176" y="112" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog column1"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="85" name="Sign: Column 2" type="event" x="240" y="80" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog column2"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="87" name="create npc" type="event" x="48" y="0" width="16" height="16">
@@ -135,7 +135,7 @@
     <property name="act90" value="translated_dialog_choice sure_i_do:not_really,route2choice"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,left"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
     <property name="cond40" value="is variable_set skadoosh:yes"/>
     <property name="cond50" value="not variable_set leavemealone:yes"/>
     <property name="cond60" value="not variable_set sadsong:yes"/>
@@ -430,7 +430,7 @@
     <property name="act50" value="unlock_controls"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,left"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
     <property name="cond40" value="is variable_set leavemealone:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/rubberduck_cave_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_cave_01.tmx
@@ -219,7 +219,7 @@
     <property name="act10" value="translated_dialog rubberduck_cave_01"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,right"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="174" name="Item hint" type="event" x="448" y="832" width="16" height="16">
@@ -227,7 +227,7 @@
     <property name="act10" value="translated_dialog rubberduck_cave_01"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,down"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="175" name="If I could Swim" type="event" x="592" y="880" width="64" height="16">
@@ -235,7 +235,7 @@
     <property name="act10" value="translated_dialog rubberduck_cave_02"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,down"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="176" name="If I could Swim" type="event" x="544" y="864" width="48" height="16">
@@ -243,14 +243,14 @@
     <property name="act10" value="translated_dialog rubberduck_cave_02"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,down"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="177" name="Ladder" type="event" x="160" y="752" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog rubberduck_cave_03"/>
     <property name="cond10" value="is char_at player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/rubberduck_city_01.tmx
+++ b/mods/tuxemon/maps/rubberduck_city_01.tmx
@@ -213,7 +213,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_01"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="135" name="empty house" type="event" x="720" y="352" width="16" height="16">
@@ -221,7 +221,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_02"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="136" name="empty house" type="event" x="800" y="496" width="16" height="16">
@@ -229,7 +229,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_01"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="137" name="empty house" type="event" x="624" y="496" width="16" height="16">
@@ -237,7 +237,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_04"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="138" name="empty house" type="event" x="432" y="624" width="16" height="16">
@@ -245,7 +245,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_03"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="139" name="empty house" type="event" x="208" y="624" width="16" height="16">
@@ -253,7 +253,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_02"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="140" name="empty house" type="event" x="384" y="784" width="32" height="16">
@@ -261,7 +261,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_05"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="141" name="empty house" type="event" x="432" y="768" width="16" height="16">
@@ -269,7 +269,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_05"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="142" name="empty house" type="event" x="448" y="784" width="16" height="16">
@@ -277,7 +277,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_05"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="143" name="empty house" type="event" x="416" y="752" width="16" height="16">
@@ -285,7 +285,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_05"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="144" name="empty house" type="event" x="432" y="464" width="16" height="16">
@@ -293,7 +293,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_06"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="145" name="empty house" type="event" x="864" y="688" width="16" height="16">
@@ -301,7 +301,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_07"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="146" name="empty house" type="event" x="240" y="416" width="16" height="16">
@@ -309,7 +309,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_02"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="150" name="cave route" type="event" x="480" y="272" width="16" height="16">
@@ -317,7 +317,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_08"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="151" name="where_to_go" type="event" x="992" y="704" width="16" height="32">
@@ -338,7 +338,7 @@
     <property name="act10" value="translated_dialog rubberduck_city_10"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/sphalian_center.tmx
+++ b/mods/tuxemon/maps/sphalian_center.tmx
@@ -50,7 +50,7 @@
     <property name="act40" value="set_teleport_faint player,sphalian_center.tmx,6,10"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="17" name="Go outside" type="event" x="96" y="160" width="16" height="16">
@@ -79,7 +79,7 @@
    <properties>
     <property name="act1" value="access_pc player"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="27" name="create npcs" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/sphalian_town.tmx
+++ b/mods/tuxemon/maps/sphalian_town.tmx
@@ -81,7 +81,7 @@
     <property name="act10" value="translated_dialog old_sphalian_town01"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="36" name="go to route1a right" type="event" x="208" y="384" width="16" height="16">

--- a/mods/tuxemon/maps/sphalian_town_house.tmx
+++ b/mods/tuxemon/maps/sphalian_town_house.tmx
@@ -63,14 +63,14 @@
     <property name="act10" value="translated_dialog old_sphalian_house01"/>
     <property name="cond10" value="is party_size player,greater_than,0"/>
     <property name="cond20" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="25" name="Read Sign" type="event" x="32" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog old_sphalian_house02"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="27" name="Go Outside" type="event" x="80" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/spyder.yaml
+++ b/mods/tuxemon/maps/spyder.yaml
@@ -72,7 +72,7 @@ events:
     conditions:
     - is has_item player,surfboard
     - is char_facing_tile player,surfable
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not char_in player,surfable
     type: event
   Create Quarantine Kennel:

--- a/mods/tuxemon/maps/spyder_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_bedroom.yaml
@@ -40,7 +40,7 @@ events:
     - set_monster_status
     - set_teleport_faint player,spyder_bedroom.tmx,6,5
     conditions:
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is char_facing_tile player
     height: 2
     type: event
@@ -79,7 +79,7 @@ events:
     - access_pc player
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set kernelquest:yes
     type: event
     x: 3
@@ -89,7 +89,7 @@ events:
     - translated_dialog spyder_pc_alert
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is variable_set kernelquest:yes
     type: event
     x: 3

--- a/mods/tuxemon/maps/spyder_candy_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_candy_cafe.yaml
@@ -109,7 +109,7 @@ events:
     - translated_dialog_choice yes:no,chooses
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 1
     y: 5
@@ -143,7 +143,7 @@ events:
     - access_pc player
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set kernelquest:yes
     type: event
     x: 10
@@ -153,7 +153,7 @@ events:
     - translated_dialog spyder_pc_alert
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is variable_set kernelquest:yes
     type: event
     x: 10

--- a/mods/tuxemon/maps/spyder_candy_center.yaml
+++ b/mods/tuxemon/maps/spyder_candy_center.yaml
@@ -26,7 +26,7 @@ events:
     - translated_dialog_choice 1floor:2floor:no,choice_floor
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2
@@ -37,7 +37,7 @@ events:
     - translated_dialog_choice 1floor:2floor:no,choice_floor
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2

--- a/mods/tuxemon/maps/spyder_candy_hospital1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital1.tmx
@@ -58,28 +58,28 @@
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:2floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="42" name="Elevator2a" type="event" x="176" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:2floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="43" name="Elevator1b" type="event" x="128" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:2floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="44" name="Elevator2b" type="event" x="192" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:2floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="62" name="Choice Floor Ground" type="event" x="128" y="192" width="16" height="16">
@@ -355,14 +355,14 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_hospital_pc_message_rivalry1"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="106" name="PC Researcher 2" type="event" x="256" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_hospital_pc_message_rivalry2"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_hospital2.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital2.tmx
@@ -58,28 +58,28 @@
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:1floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="42" name="Elevator2a" type="event" x="176" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:1floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="43" name="Elevator1b" type="event" x="128" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:1floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="44" name="Elevator2b" type="event" x="192" y="224" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog_choice 0floor:1floor:no,choice_floor"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="62" name="Choice Floor Ground" type="event" x="128" y="192" width="16" height="16">
@@ -298,7 +298,7 @@
     <property name="act4" value="translated_dialog spyder_hospital_pc_message6"/>
     <property name="act5" value="translated_dialog spyder_hospital_pc_message9"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="116" name="PC Dr Lee 2" type="event" x="128" y="16" width="16" height="16">
@@ -308,7 +308,7 @@
     <property name="act3" value="translated_dialog spyder_hospital_pc_message7"/>
     <property name="act4" value="translated_dialog spyder_hospital_pc_message8"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_hospital3.tmx
+++ b/mods/tuxemon/maps/spyder_candy_hospital3.tmx
@@ -141,7 +141,7 @@
     <property name="act61" value="translated_dialog spyder_hospital_billie2"/>
     <property name="act62" value="char_plague spyderbite,inoculated"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set hospitalcure:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_candy_house1.tmx
+++ b/mods/tuxemon/maps/spyder_candy_house1.tmx
@@ -52,7 +52,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_flower_artist_clipping"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="68" name="Create Maniac" type="event" x="48" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_candy_inn1.yaml
+++ b/mods/tuxemon/maps/spyder_candy_inn1.yaml
@@ -52,7 +52,7 @@ events:
     - translated_dialog spyder_candyinn_cott1
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 11
     y: 7

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -70,7 +70,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
@@ -79,7 +79,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="36" name="Create Tech Shop" type="event" x="16" y="64" width="16" height="16">
@@ -96,7 +96,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_candy_town.tmx
+++ b/mods/tuxemon/maps/spyder_candy_town.tmx
@@ -284,7 +284,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="228" name="Teleport to Candy House 2" type="event" x="32" y="384" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cathedral.yaml
+++ b/mods/tuxemon/maps/spyder_cathedral.yaml
@@ -101,7 +101,7 @@ events:
     - translated_dialog spyder_pay_cathedral
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 1
     y: 2
@@ -126,7 +126,7 @@ events:
     - translated_dialog_choice yes:no,billcathedral
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set chooses:yes
     type: event
     x: 5
@@ -145,7 +145,7 @@ events:
     - access_pc player
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set kernelquest:yes
     type: event
     x: 10
@@ -155,7 +155,7 @@ events:
     - translated_dialog spyder_pc_alert
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is variable_set kernelquest:yes
     type: event
     x: 10

--- a/mods/tuxemon/maps/spyder_citypark.tmx
+++ b/mods/tuxemon/maps/spyder_citypark.tmx
@@ -162,14 +162,14 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_citypark_achievement"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="43" name="Sign: Leather Town" type="event" x="16" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog here_to_west"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="44" name="Create Maniac" type="event" x="128" y="576" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_artshop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_artshop.tmx
@@ -179,7 +179,7 @@
     <property name="act3" value="translated_dialog player_wallet"/>
     <property name="act4" value="translated_dialog_choice yes:no,barmaid_starry"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not has_item player,p_starry_night"/>
     <property name="cond4" value="is money_is player,greater_or_equal,1000"/>
    </properties>
@@ -191,7 +191,7 @@
     <property name="act3" value="translated_dialog player_wallet"/>
     <property name="act4" value="translated_dialog_choice yes:no,barmaid_trepidation"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not has_item player,p_trepidation"/>
     <property name="cond4" value="is money_is player,greater_or_equal,1000"/>
    </properties>
@@ -203,7 +203,7 @@
     <property name="act3" value="translated_dialog player_wallet"/>
     <property name="act4" value="translated_dialog_choice yes:no,barmaid_monsters"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not has_item player,p_monsters_eyes"/>
     <property name="cond4" value="is money_is player,greater_or_equal,1000"/>
    </properties>
@@ -276,7 +276,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_cottonart_barmaid_painting_sold_billie"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="45" name="Billie Visit" type="event" x="48" y="64" width="16" height="48">

--- a/mods/tuxemon/maps/spyder_cotton_cafe.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_cafe.tmx
@@ -77,7 +77,7 @@
     <property name="cond2" value="not variable_set chooses:yes"/>
     <property name="cond3" value="is variable_set introdcottoncafe2:yes"/>
     <property name="cond4" value="is char_facing_tile player"/>
-    <property name="cond5" value="is button_pressed K_RETURN"/>
+    <property name="cond5" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="20" name="First Visit to Cotton Cafe" type="event" x="160" y="48" width="16" height="16">
@@ -174,7 +174,7 @@
     <property name="cond3" value="not variable_set introdcottoncafe2:yes"/>
     <property name="cond4" value="is char_at player"/>
     <property name="cond5" value="is char_facing player,up"/>
-    <property name="cond6" value="is button_pressed K_RETURN"/>
+    <property name="cond6" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="29" name="Cayden Talk" type="event" x="32" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_cotton_house1.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_house1.tmx
@@ -74,7 +74,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_cottonhouse1_tvwatch"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -128,7 +128,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="31" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
@@ -137,7 +137,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopkeeper,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="36" name="Create Tech Shop" type="event" x="16" y="64" width="16" height="16">
@@ -154,7 +154,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_town.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_town.tmx
@@ -126,7 +126,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="531" name="Talk hackerintro" type="event" x="400" y="592" width="48" height="16">
@@ -156,7 +156,7 @@
   <object id="533" name="Sign: Cathedral Centre" type="event" x="272" y="416" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog Cathedral_Center"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is char_facing_tile player"/>
    </properties>
   </object>
@@ -172,7 +172,7 @@
    <properties>
     <property name="act1" value="translated_dialog cotton_town_fountain"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="538" name="Teleport to Dryad's Grove" type="event" x="0" y="112" width="16" height="16">
@@ -195,7 +195,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="542" name="Create Monk" type="event" x="80" y="112" width="16" height="16">
@@ -310,7 +310,7 @@
    <properties>
     <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="562" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -489,14 +489,14 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="595" name="Door locked" type="event" x="560" y="416" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="596" name="Talk to confused" type="event" x="112" y="544" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_datacenter.tmx
+++ b/mods/tuxemon/maps/spyder_datacenter.tmx
@@ -70,7 +70,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_pc_alert"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="42" name="Route Music" type="event" x="0" y="0" width="16" height="16">
@@ -99,14 +99,14 @@
     <property name="act2" value="wild_encounter kernel,50,3"/>
     <property name="act3" value="set_variable kernelquest:done"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="62" name="PC3" type="event" x="240" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_pc_alert"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="71" name="PC4" type="event" x="64" y="128" width="16" height="16">
@@ -114,7 +114,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc04"/>
     <property name="act2" value="translated_dialog_choice snokari:woodoor:furnursus,lightest"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set lightest:snokari"/>
    </properties>
   </object>
@@ -123,7 +123,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc06"/>
     <property name="act2" value="translated_dialog_choice shybulb:ruption:narcileaf,binary77"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set binary77:shybulb"/>
    </properties>
   </object>
@@ -132,7 +132,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc08"/>
     <property name="act2" value="translated_dialog_choice ignibus:squink:possessun,smallest"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set smallest:ignibus"/>
    </properties>
   </object>
@@ -141,7 +141,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc07"/>
     <property name="act2" value="translated_dialog_choice pythock:snarlon:pigabyte,tallest"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set tallest:snarlon"/>
    </properties>
   </object>
@@ -150,7 +150,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc09"/>
     <property name="act2" value="translated_dialog_choice apeoro:jemuar:mauai,heaviest"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set heaviest:jemuar"/>
    </properties>
   </object>
@@ -159,7 +159,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc10"/>
     <property name="act2" value="translated_dialog_choice baobaraffe:statursus:exclawvate,binary193"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set binary193:baobaraffe"/>
    </properties>
   </object>
@@ -168,7 +168,7 @@
     <property name="act1" value="translated_dialog spyder_data_pc05"/>
     <property name="act2" value="translated_dialog_choice shammer:drokoro:rhincus,binary144"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set binary144:shammer"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_dojo1.yaml
+++ b/mods/tuxemon/maps/spyder_dojo1.yaml
@@ -5,7 +5,7 @@ events:
     - translated_dialog spyder_dojo_fu2
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2
@@ -17,7 +17,7 @@ events:
     - translated_dialog spyder_dojo_yin2
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2
@@ -29,7 +29,7 @@ events:
     - translated_dialog spyder_dojo_zhu2
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2
@@ -41,7 +41,7 @@ events:
     - translated_dialog spyder_dojo_xiang2
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2

--- a/mods/tuxemon/maps/spyder_downstairs.tmx
+++ b/mods/tuxemon/maps/spyder_downstairs.tmx
@@ -50,7 +50,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_home"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="39" name="Watch TV" type="event" x="16" y="80" width="16" height="16">
@@ -58,7 +58,7 @@
     <property name="act1" value="translated_dialog spyder_papertown_tvwatch"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond3" value="is char_facing player,up"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="41" name="Create Homemaker" type="event" x="64" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_dragonscave.tmx
+++ b/mods/tuxemon/maps/spyder_dragonscave.tmx
@@ -214,7 +214,7 @@
     <property name="act3" value="set_variable dragonscavedrokoro:yes"/>
     <property name="act4" value="remove_npc spyder_drokoro"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set dragonscavedrokoro:yes"/>
    </properties>
   </object>
@@ -225,7 +225,7 @@
     <property name="act3" value="set_variable dragonscavedrokoro:yes"/>
     <property name="act4" value="remove_npc spyder_drokoro"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set dragonscavedrokoro:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_dryadsgrove.tmx
+++ b/mods/tuxemon/maps/spyder_dryadsgrove.tmx
@@ -588,7 +588,7 @@
     <property name="act3" value="set_variable dryadsgrovevolcoli:yes"/>
     <property name="act4" value="remove_npc spyder_volcoli"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set dryadsgrovevolcoli:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_flower_city.tmx
+++ b/mods/tuxemon/maps/spyder_flower_city.tmx
@@ -195,14 +195,14 @@
    <properties>
     <property name="act1" value="translated_dialog welcome_location_city"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="412" name="Sign: Route 5" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog here_to_west"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="413" name="Teleport to Pet Shop" type="event" x="160" y="432" width="16" height="16">
@@ -217,7 +217,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_flower_dojo_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="423" name="Teleport to Flower House 2" type="event" x="368" y="272" width="16" height="16">
@@ -480,7 +480,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="471" name="Teleport to Routed 1" type="event" x="400" y="624" width="16" height="16">
@@ -571,7 +571,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="501" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -598,7 +598,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_flower_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not battle_outcome_count player,won,spyder_nimrod_tru,1"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_flower_house1.yaml
+++ b/mods/tuxemon/maps/spyder_flower_house1.yaml
@@ -24,7 +24,7 @@ events:
     - translated_dialog spyder_flowerhouse1_tv
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2

--- a/mods/tuxemon/maps/spyder_flower_petshop.yaml
+++ b/mods/tuxemon/maps/spyder_flower_petshop.yaml
@@ -27,7 +27,7 @@ events:
     - open_shop spyder_flowerpetshop_titus,buy_monster
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 7
     y: 5
@@ -39,7 +39,7 @@ events:
     - open_shop spyder_flowerpetshop_titus,buy_monster
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 8
     y: 4

--- a/mods/tuxemon/maps/spyder_flower_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_flower_scoop.yaml
@@ -65,7 +65,7 @@ events:
     - open_shop spyder_shopassistant,both_item
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 2
     y: 6
@@ -76,7 +76,7 @@ events:
     - open_shop spyder_shopassistant,both_item
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 1
     y: 7

--- a/mods/tuxemon/maps/spyder_greenwash_level2.tmx
+++ b/mods/tuxemon/maps/spyder_greenwash_level2.tmx
@@ -370,7 +370,7 @@
     <property name="act1" value="translated_dialog spyder_pc_recorded_conversation"/>
     <property name="act2" value="translated_dialog_choice no:yes,unveildefossilator"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="133" name="Flashback Dempsey" type="event" x="208" y="16" width="16" height="16">
@@ -378,7 +378,7 @@
     <property name="act1" value="translated_dialog spyder_pc_recorded_conversation"/>
     <property name="act2" value="translated_dialog_choice no:yes,dempsey_flashback"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="134" name="Trigger Fossilator" type="event" x="160" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_greenwash_level3.yaml
+++ b/mods/tuxemon/maps/spyder_greenwash_level3.yaml
@@ -105,7 +105,7 @@ events:
     - translated_dialog spyder_greenwash_note1
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 8
     y: 3
@@ -114,7 +114,7 @@ events:
     - translated_dialog spyder_greenwash_pc_message3
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 7
     y: 3
@@ -123,7 +123,7 @@ events:
     - translated_dialog spyder_greenwash_pc_message2
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 9
     y: 3
@@ -132,7 +132,7 @@ events:
     - translated_dialog spyder_greenwash_pc_message1
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 10
     y: 10

--- a/mods/tuxemon/maps/spyder_leather_gym.yaml
+++ b/mods/tuxemon/maps/spyder_leather_gym.yaml
@@ -6,7 +6,7 @@ events:
     - translated_dialog spyder_leathergym_board
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 6
     y: 2
@@ -37,7 +37,7 @@ events:
     - translated_dialog spyder_leathergym_chadine1
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 5
     y: 8

--- a/mods/tuxemon/maps/spyder_leather_house1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house1.tmx
@@ -66,7 +66,7 @@
    <properties>
     <property name="act1" value="tune_radio player,94.7"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="28" name="Create Tennis Player" type="event" x="144" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_house2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_house2.tmx
@@ -47,7 +47,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_leatherhouse2_tv"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="64" name="Create Scientist" type="event" x="96" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_museum.yaml
+++ b/mods/tuxemon/maps/spyder_leather_museum.yaml
@@ -153,7 +153,7 @@ events:
     - translated_dialog spyder_agate_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 6
     y: 7
@@ -162,7 +162,7 @@ events:
     - translated_dialog spyder_diamond_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 13
     y: 7
@@ -171,7 +171,7 @@ events:
     - translated_dialog spyder_emerald_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 9
     y: 7
@@ -180,7 +180,7 @@ events:
     - translated_dialog spyder_nimrod_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 16
     y: 3
@@ -189,7 +189,7 @@ events:
     - translated_dialog spyder_nimrod2_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 19
     y: 3
@@ -198,7 +198,7 @@ events:
     - translated_dialog spyder_nimrod3_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 22
     y: 3
@@ -207,7 +207,7 @@ events:
     - translated_dialog spyder_nimrod4_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 25
     y: 3
@@ -216,7 +216,7 @@ events:
     - translated_dialog spyder_nimrod5_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 28
     y: 3
@@ -225,7 +225,7 @@ events:
     - translated_dialog spyder_opal_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 7
     y: 7
@@ -234,7 +234,7 @@ events:
     - translated_dialog spyder_quartz_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 12
     y: 7
@@ -243,7 +243,7 @@ events:
     - translated_dialog spyder_ruby_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 10
     y: 7
@@ -252,7 +252,7 @@ events:
     - translated_dialog spyder_shaft_plaque
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 7
     y: 5

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -64,7 +64,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="20" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
@@ -73,7 +73,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="21" name="Create Shopkeeper" type="event" x="16" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_shaft1.tmx
+++ b/mods/tuxemon/maps/spyder_leather_shaft1.tmx
@@ -43,7 +43,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_leathershaft1_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="18" name="Create NPCs" type="event" x="160" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_shaft2.tmx
+++ b/mods/tuxemon/maps/spyder_leather_shaft2.tmx
@@ -55,28 +55,28 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_leathershaft2_pc"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="69" name="Papers" type="event" x="32" y="96" width="32" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leathershaft2_papers"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="70" name="Dude" type="event" x="112" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leathershaft2_dude"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="71" name="Achievement" type="event" x="64" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leathershaft2_achievement"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="72" name="Create NPCs" type="event" x="16" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_leather_town.tmx
+++ b/mods/tuxemon/maps/spyder_leather_town.tmx
@@ -164,14 +164,14 @@
    <properties>
     <property name="act1" value="translated_dialog here_to_north"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="186" name="Sign: Open Air" type="event" x="144" y="384" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leathercafe_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="268" name="Teleport to Leather Museum" type="event" x="400" y="224" width="16" height="16">
@@ -186,21 +186,21 @@
    <properties>
     <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="270" name="Sign: Shaft 1" type="event" x="224" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_shaft1_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="271" name="Sign: Leather CBD" type="event" x="288" y="176" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leathercbd_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="272" name="Make Scout" type="event" x="304" y="224" width="16" height="16">
@@ -245,14 +245,14 @@
     <property name="cond2" value="not variable_set chooses:yes"/>
     <property name="cond4" value="is char_at player"/>
     <property name="cond5" value="is char_facing player,up"/>
-    <property name="cond6" value="is button_pressed K_RETURN"/>
+    <property name="cond6" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="279" name="Sign: Shaft 2" type="event" x="336" y="48" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_shaft2_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="282" name="Teleport to Leather House 1" type="event" x="304" y="544" width="16" height="16">
@@ -383,7 +383,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="307" name="Teleport to Shaft2" type="event" x="384" y="48" width="16" height="16">
@@ -446,49 +446,49 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="323" name="Door locked" type="event" x="384" y="432" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="324" name="Door locked" type="event" x="208" y="544" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="326" name="Notes1" type="event" x="480" y="224" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leather_note1"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="327" name="Notes2" type="event" x="480" y="208" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leather_note2"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="328" name="Notes3" type="event" x="480" y="192" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leather_note3"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="329" name="Notes4" type="event" x="480" y="176" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_leather_note4"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="334" name="Create Sarah" type="event" x="160" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_mansion.tmx
+++ b/mods/tuxemon/maps/spyder_mansion.tmx
@@ -285,7 +285,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_mansion_painting"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="66" name="Talk Picnicker" type="event" x="80" y="176" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_bottom.tmx
@@ -332,7 +332,7 @@
     <property name="act1" value="translated_dialog spyder_nimrod_pc_message1"/>
     <property name="act2" value="translated_dialog spyder_nimrod_pc_message2"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="71" name="Notes" type="event" x="32" y="256" width="16" height="16">
@@ -340,7 +340,7 @@
     <property name="act1" value="translated_dialog spyder_nimrod_note1"/>
     <property name="act2" value="translated_dialog spyder_nimrod_note2"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_nimrod_room.yaml
+++ b/mods/tuxemon/maps/spyder_nimrod_room.yaml
@@ -106,7 +106,7 @@ events:
     - translated_dialog spyder_nimrod_papers1
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 6
     y: 3
@@ -115,7 +115,7 @@ events:
     - translated_dialog spyder_nimrod_papers2
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 3
     y: 3

--- a/mods/tuxemon/maps/spyder_nimrod_top.tmx
+++ b/mods/tuxemon/maps/spyder_nimrod_top.tmx
@@ -256,7 +256,7 @@
     <property name="act1" value="translated_dialog spyder_nimrod_pc_message3"/>
     <property name="act2" value="translated_dialog spyder_nimrod_pc_message4"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_omnichannel1.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel1.tmx
@@ -213,7 +213,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel1_screen"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set omnichannel1wall:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_omnichannel2.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel2.tmx
@@ -211,7 +211,7 @@
     <property name="act1" value="translated_dialog spyder_omnichannel2_pc"/>
     <property name="act2" value="set_variable omnichannel1wall:yes"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="42" name="Threats" type="event" x="0" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_omnichannel4.tmx
+++ b/mods/tuxemon/maps/spyder_omnichannel4.tmx
@@ -99,7 +99,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel_note"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="40" name="Threats" type="event" x="0" y="32" width="16" height="16">
@@ -113,7 +113,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel4_elevator_nopass"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not has_item player,spyder_pass"/>
    </properties>
   </object>
@@ -121,7 +121,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel4_elevator_nopass"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not has_item player,spyder_pass"/>
    </properties>
   </object>
@@ -129,7 +129,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel4_elevator_pass"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is has_item player,spyder_pass"/>
    </properties>
   </object>
@@ -137,7 +137,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_omnichannel4_elevator_pass"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is has_item player,spyder_pass"/>
    </properties>
   </object>
@@ -146,7 +146,7 @@
     <property name="act1" value="translated_dialog spyder_omnichannel_intro"/>
     <property name="act2" value="translated_dialog_choice yes:no,cut_scenes2"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set cut_scenes2:yes"/>
    </properties>
   </object>
@@ -166,7 +166,7 @@
     <property name="act1" value="translated_dialog spyder_omnichannel_intro"/>
     <property name="act2" value="translated_dialog_choice yes:no,cut_scenes1"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set cut_scenes1:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_paper_daycare.yaml
+++ b/mods/tuxemon/maps/spyder_paper_daycare.yaml
@@ -76,7 +76,7 @@ events:
     - translated_dialog spyder_papertown_grannypiper8
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is variable_set seentimber:yes
     type: event
     x: 8
@@ -86,7 +86,7 @@ events:
     - translated_dialog spyder_papertown_grannypiper10
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set seentimber:yes
     type: event
     x: 8

--- a/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_bedroom.yaml
@@ -4,7 +4,7 @@ events:
     - translated_dialog spyder_rivalbedroom_bed
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 2
     type: event
     width: 2
@@ -15,7 +15,7 @@ events:
     - translated_dialog spyder_rivalbedroom_bookshelf
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2
@@ -36,7 +36,7 @@ events:
     - tune_radio player,94.7
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 0
     y: 5
@@ -51,7 +51,7 @@ events:
     - access_pc player
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 2
     y: 3
@@ -60,7 +60,7 @@ events:
     - translated_dialog spyder_rivalbedroom_weights
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 1
     y: 6

--- a/mods/tuxemon/maps/spyder_paper_rival_downstairs.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_downstairs.yaml
@@ -14,7 +14,7 @@ events:
     - translated_dialog_choice no:yes,billie_grandma
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set billie_grandma
     type: event
     x: 8
@@ -62,7 +62,7 @@ events:
     - translated_dialog spyder_rivaldownstairs_package
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is variable_set billie_grandma
     type: event
     x: 8
@@ -81,7 +81,7 @@ events:
     - set_variable flashback:on
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     height: 1
     type: event
     width: 2

--- a/mods/tuxemon/maps/spyder_paper_rival_office.yaml
+++ b/mods/tuxemon/maps/spyder_paper_rival_office.yaml
@@ -14,7 +14,7 @@ events:
     - translated_dialog spyder_rivaloffice_haiku
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 2
     y: 4

--- a/mods/tuxemon/maps/spyder_paper_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_paper_scoop.yaml
@@ -39,7 +39,7 @@ events:
     - open_journal dollfin
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 8
     y: 8
@@ -48,7 +48,7 @@ events:
     - open_journal memnomnom
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 9
     y: 8
@@ -57,7 +57,7 @@ events:
     - open_journal budaye
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 10
     y: 8
@@ -66,7 +66,7 @@ events:
     - open_journal grintot
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 11
     y: 8
@@ -75,7 +75,7 @@ events:
     - open_journal ignibus
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 12
     y: 8
@@ -258,7 +258,7 @@ events:
     - translated_dialog potions_in_shop
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     width: 5
     x: 8

--- a/mods/tuxemon/maps/spyder_paper_town.tmx
+++ b/mods/tuxemon/maps/spyder_paper_town.tmx
@@ -73,7 +73,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="136" name="Teleport to Protagonist House" type="event" x="160" y="96" width="16" height="16">
@@ -87,7 +87,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_home"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="134" name="Sign Repairs" type="event" x="64" y="240" width="16" height="16">
@@ -101,7 +101,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_underrepairs"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set captainreturns:yes"/>
    </properties>
   </object>
@@ -109,7 +109,7 @@
    <properties>
     <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="141" name="Sign for Daycare, Before Opening" type="event" x="256" y="64" width="16" height="16">
@@ -117,7 +117,7 @@
     <property name="act1" value="translated_dialog spyder_papertown_daycare1"/>
     <property name="cond1" value="not variable_set seentimber:yes"/>
     <property name="cond2" value="is char_facing_tile player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="142" name="Teleport to Route 1" type="event" x="224" y="0" width="16" height="16">
@@ -174,7 +174,7 @@
     <property name="act1" value="translated_dialog spyder_papertown_daycare2"/>
     <property name="cond1" value="is variable_set seentimber:yes"/>
     <property name="cond2" value="is char_facing_tile player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="158" name="Create Conileaf" type="event" x="384" y="32" width="16" height="16">
@@ -353,7 +353,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_sunnyside"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="200" name="Create Captain" type="event" x="64" y="256" width="16" height="16">
@@ -486,7 +486,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_papertown_rival"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="240" name="My First Mon - Not Met" type="event" x="368" y="208" width="144" height="16">
@@ -522,7 +522,7 @@
     <property name="act25" value="translated_dialog spyder_papertown_rockitten"/>
     <property name="act30" value="translated_dialog_choice yes:no,rockittenchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
@@ -533,7 +533,7 @@
     <property name="act25" value="translated_dialog spyder_papertown_lambert"/>
     <property name="act30" value="translated_dialog_choice yes:no,lambertchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
@@ -544,7 +544,7 @@
     <property name="act25" value="translated_dialog spyder_papertown_nut"/>
     <property name="act30" value="translated_dialog_choice yes:no,nutchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
@@ -555,7 +555,7 @@
     <property name="act25" value="translated_dialog spyder_papertown_tweesher"/>
     <property name="act30" value="translated_dialog_choice yes:no,tweesherchosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>
@@ -566,7 +566,7 @@
     <property name="act25" value="translated_dialog spyder_papertown_agnite"/>
     <property name="act30" value="translated_dialog_choice yes:no,agnitechosen"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is party_size player,less_than,1"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_route1.tmx
+++ b/mods/tuxemon/maps/spyder_route1.tmx
@@ -124,7 +124,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_route1_routesign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="172" name="Teleport to Cotton Town" type="event" x="352" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route2.tmx
+++ b/mods/tuxemon/maps/spyder_route2.tmx
@@ -92,21 +92,21 @@
    <properties>
     <property name="act1" value="translated_dialog here_to_north"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="84" name="Sign: Column 1" type="event" x="176" y="112" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_column1_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="85" name="Sign: Column 2" type="event" x="240" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_column2_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="97" name="random battle" type="event" x="160" y="192" width="16" height="48">
@@ -362,7 +362,7 @@
    <properties>
     <property name="act1" value="translated_dialog welcome_location_route"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="158" name="Create Roddick" type="event" x="192" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_route3.tmx
+++ b/mods/tuxemon/maps/spyder_route3.tmx
@@ -522,7 +522,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarerinn_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="674" name="Create Boulder" type="event" x="512" y="112" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_routeb.tmx
+++ b/mods/tuxemon/maps/spyder_routeb.tmx
@@ -75,7 +75,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_datacenter_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="70" name="Create Electra" type="event" x="256" y="560" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_scoop3.tmx
+++ b/mods/tuxemon/maps/spyder_scoop3.tmx
@@ -166,7 +166,7 @@
     <property name="act1" value="translated_dialog spyder_scoop_cctv"/>
     <property name="act2" value="translated_dialog_choice yes:no,cctv_scoop"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set cctv_scoop:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/spyder_test_map.tmx
+++ b/mods/tuxemon/maps/spyder_test_map.tmx
@@ -53,7 +53,7 @@
     <property name="act1" value="translated_dialog aardornforyou"/>
     <property name="act2" value="add_monster aardorn,4"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="562" name="Play Music" type="event" x="112" y="0" width="16" height="16">
@@ -133,7 +133,7 @@
     <property name="act1" value="translated_dialog resetcleo"/>
     <property name="act2" value="set_variable testcleo:no"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="609" name="Create Shopkeeper" type="event" x="48" y="256" width="16" height="16">
@@ -150,7 +150,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="611" name="Open Shop" type="event" x="48" y="272" width="16" height="16">
@@ -159,7 +159,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="612" name="Create Tech Shop" type="event" x="48" y="224" width="16" height="16">
@@ -176,7 +176,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="614" name="Create Barmaid - hidden away" type="event" x="64" y="336" width="16" height="16">
@@ -194,7 +194,7 @@
     <property name="cond2" value="not variable_set chooses:yes"/>
     <property name="cond3" value="is variable_set introdcottoncafe2:yes"/>
     <property name="cond4" value="is char_facing_tile player"/>
-    <property name="cond5" value="is button_pressed K_RETURN"/>
+    <property name="cond5" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="616" name="Talk Barmaid (1st)" type="event" x="64" y="368" width="16" height="16">
@@ -207,7 +207,7 @@
     <property name="cond3" value="not variable_set introdcottoncafe2:yes"/>
     <property name="cond4" value="is char_at player"/>
     <property name="cond5" value="is char_facing player,up"/>
-    <property name="cond6" value="is button_pressed K_RETURN"/>
+    <property name="cond6" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="617" name="Create Barmaid - accessible" type="event" x="80" y="336" width="16" height="16">
@@ -230,7 +230,7 @@
     <property name="act1" value="translated_dialog addlevel"/>
     <property name="act2" value="set_monster_level"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="620" name="Create Box1" type="event" x="320" y="224" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_timber_cafe.yaml
+++ b/mods/tuxemon/maps/spyder_timber_cafe.yaml
@@ -90,7 +90,7 @@ events:
     - translated_dialog_choice yes:no,chooses
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     type: event
     x: 1
     y: 5
@@ -130,7 +130,7 @@ events:
     - access_pc player
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - not variable_set kernelquest:yes
     type: event
     x: 10
@@ -140,7 +140,7 @@ events:
     - translated_dialog spyder_pc_alert
     conditions:
     - is char_facing_tile player
-    - is button_pressed K_RETURN
+    - is button_pressed INTERACT
     - is variable_set kernelquest:yes
     type: event
     x: 10

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -70,7 +70,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="30" name="Open Shop" type="event" x="16" y="112" width="16" height="16">
@@ -79,7 +79,7 @@
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_town.tmx
+++ b/mods/tuxemon/maps/spyder_timber_town.tmx
@@ -261,14 +261,14 @@
    <properties>
     <property name="act1" value="translated_dialog welcome_location_town"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="354" name="Sign: Scoop" type="event" x="480" y="368" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog spyder_scoop_sign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="357" name="Environment Day" type="event" x="16" y="0" width="16" height="16">
@@ -297,7 +297,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_multi_martsign"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="364" name="Teleport to Flower City 1" type="event" x="624" y="192" width="16" height="16">
@@ -454,7 +454,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_door_locked"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="389" name="Play Music" type="event" x="0" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn1.tmx
@@ -131,7 +131,7 @@
     <property name="act1" value="translated_dialog spyder_wayfarer_shopkeeper"/>
     <property name="act2" value="translated_dialog_choice yes:no,chooses"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="not variable_set chooses:yes"/>
    </properties>
   </object>
@@ -417,7 +417,7 @@
     <property name="act1" value="translated_dialog spyder_enforcershq_trigger"/>
     <property name="act2" value="translated_dialog_choice no:yes,enforcers_response"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="90" name="Trigger Flashback" type="event" x="160" y="80" width="16" height="16">

--- a/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
+++ b/mods/tuxemon/maps/spyder_wayfarer_inn2.tmx
@@ -153,7 +153,7 @@
    <properties>
     <property name="act1" value="translated_dialog spyder_wayfarerinn_tv1"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="48" name="Environment" type="event" x="16" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/taba_ba_br_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_1.tmx
@@ -76,7 +76,7 @@
     <property name="act3" value="set_variable choose:chose"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="not variable_set choose:chose"/>
     <property name="cond5" value="not variable_set movealong:now"/>
    </properties>

--- a/mods/tuxemon/maps/taba_ba_br_2.tmx
+++ b/mods/tuxemon/maps/taba_ba_br_2.tmx
@@ -155,7 +155,7 @@
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
     <property name="cond3" value="is variable_set lossbattle:yes"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
     <property name="cond5" value="is variable_set acolyte2battledone:yes"/>
    </properties>
   </object>

--- a/mods/tuxemon/maps/taba_ba_foyer.tmx
+++ b/mods/tuxemon/maps/taba_ba_foyer.tmx
@@ -61,7 +61,7 @@
     <property name="act7" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="10" name="talk to timmy2" type="event" x="32" y="48" width="16" height="16">
@@ -74,7 +74,7 @@
     <property name="act7" value="unlock_controls"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="11" name="enter the battle area" type="event" x="32" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/taba_ba_main.tmx
+++ b/mods/tuxemon/maps/taba_ba_main.tmx
@@ -423,7 +423,7 @@
     <property name="cond1" value="is variable_set moveit2:now"/>
     <property name="cond2" value="is char_at player"/>
     <property name="cond3" value="is char_facing player,down"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
     <property name="cond5" value="not variable_set opentwo:yes"/>
    </properties>
   </object>
@@ -433,7 +433,7 @@
     <property name="cond1" value="is variable_set moveit3:now"/>
     <property name="cond2" value="is char_at player"/>
     <property name="cond3" value="is char_facing player,down"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
     <property name="cond5" value="not variable_set openthree:yes"/>
    </properties>
   </object>
@@ -443,7 +443,7 @@
     <property name="cond1" value="not variable_set allthree:done"/>
     <property name="cond2" value="is char_at player"/>
     <property name="cond3" value="is char_facing player,down"/>
-    <property name="cond4" value="is button_pressed K_RETURN"/>
+    <property name="cond4" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="37" name="locked" type="event" x="272" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/taba_ba_passageway_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_passageway_1.tmx
@@ -135,7 +135,7 @@
     <property name="act8" value="char_face omnigrunt2,left"/>
     <property name="cond1" value="is char_facing player,left"/>
     <property name="cond2" value="is char_at player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="33" name="heal me top" type="event" x="256" y="64" width="16" height="16">
@@ -149,7 +149,7 @@
     <property name="act7" value="translated_dialog healsdone"/>
     <property name="act8" value="char_face omnigrunt2,left"/>
     <property name="cond1" value="is char_facing player,down"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
     <property name="cond3" value="is char_at player"/>
    </properties>
   </object>
@@ -165,7 +165,7 @@
     <property name="act8" value="char_face omnigrunt2,left"/>
     <property name="cond1" value="is char_facing player,up"/>
     <property name="cond2" value="is char_at player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_ba_passageway_2.tmx
+++ b/mods/tuxemon/maps/taba_ba_passageway_2.tmx
@@ -102,7 +102,7 @@
     <property name="act8" value="char_face omnigrunt2,left"/>
     <property name="cond1" value="is char_facing player,right"/>
     <property name="cond2" value="is char_at player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="18" name="heal me down" type="event" x="128" y="80" width="16" height="16">
@@ -117,7 +117,7 @@
     <property name="act8" value="char_face omnigrunt2,left"/>
     <property name="cond1" value="is char_facing player,up"/>
     <property name="cond2" value="is char_at player"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="19" name="to battle room" type="event" x="224" y="304" width="16" height="16">

--- a/mods/tuxemon/maps/taba_ba_passageway_3.tmx
+++ b/mods/tuxemon/maps/taba_ba_passageway_3.tmx
@@ -126,7 +126,7 @@
     <property name="act8" value="translated_dialog healertabapassageway3-2"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="29" name="heal me pls-right" type="event" x="32" y="192" width="16" height="16">
@@ -140,7 +140,7 @@
     <property name="act8" value="translated_dialog healertabapassageway3-2"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="30" name="to battle room" type="event" x="304" y="256" width="16" height="16">

--- a/mods/tuxemon/maps/taba_ba_passageway_4.tmx
+++ b/mods/tuxemon/maps/taba_ba_passageway_4.tmx
@@ -67,7 +67,7 @@
     <property name="act9" value="char_face omnigrunt5,left"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,down"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="17" name="heal tuxemon left" type="event" x="80" y="144" width="16" height="16">
@@ -83,7 +83,7 @@
     <property name="act9" value="char_face omnigrunt5,left"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="18" name="heal tuxemon down" type="event" x="96" y="160" width="16" height="16">
@@ -99,7 +99,7 @@
     <property name="act9" value="char_face omnigrunt5,left"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="19" name="teleport to main" type="event" x="48" y="0" width="16" height="16">

--- a/mods/tuxemon/maps/taba_ba_stairwell_1.tmx
+++ b/mods/tuxemon/maps/taba_ba_stairwell_1.tmx
@@ -72,7 +72,7 @@
     <property name="act9" value="char_face omnigrunt2,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="12" name="heal me stairwell 1" type="event" x="144" y="48" width="16" height="16">
@@ -87,7 +87,7 @@
     <property name="act9" value="char_face omnigrunt2,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_house1.tmx
+++ b/mods/tuxemon/maps/taba_house1.tmx
@@ -69,7 +69,7 @@
    <properties>
     <property name="act1" value="translated_dialog taba_house1_calendar"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="42" name="Husband Talk" type="event" x="32" y="16" width="16" height="16">
@@ -88,14 +88,14 @@
    <properties>
     <property name="act1" value="translated_dialog taba_house1_reading"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="45" name="Watching" type="event" x="16" y="32" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house1_watching"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/taba_house2.tmx
+++ b/mods/tuxemon/maps/taba_house2.tmx
@@ -68,42 +68,42 @@
     <property name="act2" value="translated_dialog taba_house2_owner1"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="46" name="Reading1" type="event" x="0" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house2_reading1"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="47" name="Reading2" type="event" x="16" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house2_reading2"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="48" name="Reading3" type="event" x="32" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house2_reading3"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="49" name="Reading4" type="event" x="48" y="64" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house2_reading4"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="50" name="Books" type="event" x="0" y="32" width="64" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house2_books"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="51" name="Create Reader1" type="event" x="64" y="64" width="16" height="16">

--- a/mods/tuxemon/maps/taba_house2_upstairs.tmx
+++ b/mods/tuxemon/maps/taba_house2_upstairs.tmx
@@ -58,7 +58,7 @@
     <property name="act2" value="translated_dialog taba_house2_owner1"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="60" name="Create Reader1" type="event" x="64" y="48" width="16" height="16">

--- a/mods/tuxemon/maps/taba_house3.tmx
+++ b/mods/tuxemon/maps/taba_house3.tmx
@@ -69,7 +69,7 @@
     <property name="act2" value="translated_dialog taba_house3_owner1"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="52" name="Create Client1" type="event" x="0" y="96" width="16" height="16">

--- a/mods/tuxemon/maps/taba_house4.tmx
+++ b/mods/tuxemon/maps/taba_house4.tmx
@@ -67,7 +67,7 @@
     <property name="act2" value="translated_dialog taba_house4_owner1"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,right"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="47" name="Talk2" type="event" x="144" y="96" width="16" height="16">
@@ -76,14 +76,14 @@
     <property name="act2" value="translated_dialog taba_house4_owner1"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="49" name="Dish" type="event" x="16" y="80" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog taba_house4_dish1"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="51" name="Waiter" type="event" x="64" y="32" width="16" height="16">

--- a/mods/tuxemon/maps/taba_town.tmx
+++ b/mods/tuxemon/maps/taba_town.tmx
@@ -191,14 +191,14 @@
    <properties>
     <property name="act10" value="translated_dialog taba_town_homeplace"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="79" name="Professor's House Sign" type="event" x="560" y="688" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_town_sign_profhouse"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="80" name="Teleport to Route 1" type="event" x="128" y="176" width="16" height="16">
@@ -225,7 +225,7 @@
    <properties>
     <property name="act10" value="translated_dialog taba_town_sign_proflab"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="98" name="Teleport to healing center" type="event" x="640" y="48" width="16" height="16">
@@ -246,28 +246,28 @@
    <properties>
     <property name="act10" value="translated_dialog taba_town_sign_tuxemart"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="110" name="Tuxecenter Sign" type="event" x="688" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_town_sign_tuxecenter"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="112" name="Startup Town Sign" type="event" x="624" y="640" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_town_sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="115" name="Route 0 Sign" type="event" x="576" y="544" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_town_route20"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="123" name="Check for Healing Center Teleport" type="event" x="208" y="0" width="16" height="16">
@@ -292,7 +292,7 @@
     <property name="act10" value="translated_dialog nopenotyet"/>
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,up"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="154" name="bring the cavalry" type="event" x="672" y="752" width="16" height="16">
@@ -530,7 +530,7 @@
     <property name="act10" value="translated_dialog frowntime"/>
     <property name="cond10" value="is variable_set goodbyeoldknight:finallydone"/>
     <property name="cond20" value="is char_facing_tile player"/>
-    <property name="cond30" value="is button_pressed K_RETURN"/>
+    <property name="cond30" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="129" name="nuuujohnisgone" type="event" x="752" y="704" width="16" height="16">
@@ -598,7 +598,7 @@
     <property name="act3" value="char_face xerogrund1,down"/>
     <property name="cond1" value="is char_at player"/>
     <property name="cond2" value="is char_facing player,left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is variable_set curfewz:yes"/>
    </properties>
   </object>
@@ -653,7 +653,7 @@
     <property name="act98" value="translated_dialog hmmm7"/>
     <property name="cond1" value="not variable_set announcetwo:done"/>
     <property name="cond2" value="is char_facing player,left"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is char_at player"/>
    </properties>
   </object>
@@ -725,7 +725,7 @@
     <property name="act6" value="unlock_controls"/>
     <property name="cond1" value="is variable_set go_get_tuxemon:yes"/>
     <property name="cond2" value="is char_facing player,up"/>
-    <property name="cond3" value="is button_pressed K_RETURN"/>
+    <property name="cond3" value="is button_pressed INTERACT"/>
     <property name="cond4" value="is char_at player"/>
    </properties>
   </object>
@@ -773,7 +773,7 @@
     <property name="cond10" value="is char_at player"/>
     <property name="cond20" value="is char_facing player,right"/>
     <property name="cond30" value="not variable_set secret_ball:found"/>
-    <property name="cond40" value="is button_pressed K_RETURN"/>
+    <property name="cond40" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="151" name="removerocky" type="event" x="800" y="592" width="16" height="16">
@@ -833,28 +833,28 @@
    <properties>
     <property name="act10" value="translated_dialog taba_house2_sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="176" name="sign house1" type="event" x="720" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_house1_sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="177" name="sign house3" type="event" x="560" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_house3_sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="178" name="sign house4" type="event" x="432" y="48" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog taba_house4_sign"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="179" name="Environment Day" type="event" x="0" y="16" width="16" height="16">

--- a/mods/tuxemon/maps/timber_town.tmx
+++ b/mods/tuxemon/maps/timber_town.tmx
@@ -150,14 +150,14 @@
     <property name="act1" value="translated_dialog flower_city"/>
     <property name="act2" value="translated_dialog flower_city_description"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="185" name="Sign: Timber North" type="event" x="528" y="16" width="16" height="16">
    <properties>
     <property name="act1" value="translated_dialog tunnel"/>
     <property name="cond1" value="is char_facing_tile player"/>
-    <property name="cond2" value="is button_pressed K_RETURN"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="199" name="Teleport to Flower City" type="event" x="544" y="624" width="16" height="16">

--- a/mods/tuxemon/maps/tuxe_mart_taba.tmx
+++ b/mods/tuxemon/maps/tuxe_mart_taba.tmx
@@ -60,7 +60,7 @@
    <properties>
     <property name="act10" value="open_shop tuxemart_keeper,both_item"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="56" name="employee" type="event" x="16" y="80" width="16" height="16">
@@ -81,21 +81,21 @@
    <properties>
     <property name="act10" value="translated_dialog potions_in_shop"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="64" name="capture devices" type="event" x="128" y="128" width="80" height="16">
    <properties>
     <property name="act10" value="translated_dialog capture_devices_in_shop"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="65" name="capture devices" type="event" x="32" y="96" width="16" height="16">
    <properties>
     <property name="act10" value="translated_dialog cash_register"/>
     <property name="cond10" value="is char_facing_tile player"/>
-    <property name="cond20" value="is button_pressed K_RETURN"/>
+    <property name="cond20" value="is button_pressed INTERACT"/>
    </properties>
   </object>
   <object id="66" name="professor pls" type="event" x="144" y="160" width="16" height="16">

--- a/tuxemon/event/conditions/behavior.py
+++ b/tuxemon/event/conditions/behavior.py
@@ -41,7 +41,7 @@ class BehaviorCondition(EventCondition):
                 session,
                 SpatialCondition(
                     type="button_pressed",
-                    parameters=["K_RETURN"],
+                    parameters=["INTERACT"],
                     box=condition.box,
                     operator=Operator.IS,
                     name="cond20",

--- a/tuxemon/event/conditions/button_pressed.py
+++ b/tuxemon/event/conditions/button_pressed.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 from tuxemon.db import SpatialCondition
 from tuxemon.event.eventcondition import EventCondition
-from tuxemon.platform.const import intentions
 from tuxemon.platform.const.intentions import constants
 from tuxemon.session import Session
 
@@ -16,16 +15,13 @@ class ButtonPressedCondition(EventCondition):
     """
     Check to see if a particular key was pressed.
 
-    Currently only "K_RETURN" is supported.
-
     Script usage:
         .. code-block::
 
             is button_pressed <button>
 
     Script parameters:
-        button: A button/intention key (E.g. "K_RETURN").
-
+        button: A button/intention key (E.g. "INTERACT").
     """
 
     name = "button_pressed"
@@ -33,15 +29,10 @@ class ButtonPressedCondition(EventCondition):
     def test(self, session: Session, condition: SpatialCondition) -> bool:
         button = str(condition.parameters[0])
 
-        # TODO: workaround for old maps.  eventually need to decide on a scheme
-        # and fix existing scripts
-        if button == "K_RETURN":
-            button_id = intentions.INTERACT
-        else:
-            try:
-                button_id = constants[button]
-            except KeyError:
-                raise ValueError(f"Cannot support key type: {button}")
+        try:
+            button_id = constants[button]
+        except KeyError:
+            raise ValueError(f"Cannot support key type: {button}")
 
         # Loop through each event
         for event in session.client.key_events:

--- a/tuxemon/event/conditions/to_use_tile.py
+++ b/tuxemon/event/conditions/to_use_tile.py
@@ -35,7 +35,7 @@ class ToUseTileCondition(EventCondition):
             SpatialCondition(
                 type="button_pressed",
                 parameters=[
-                    "K_RETURN",
+                    "INTERACT",
                 ],
                 operator=Operator.IS,
                 box=box,


### PR DESCRIPTION
PR replaces `K_RETURN` with the correct `INTERACT` binding.
Since `K_RETURN` was tied to outdated map logic, we can safely remove it now.