### PR TITLE
Consolidated multiplier logic into `ElementTypesHandler`

### DIFF
--- a/tests/tuxemon/test_element_types_handler.py
+++ b/tests/tuxemon/test_element_types_handler.py
@@ -1,52 +1,129 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
+import pytest
 
 from tuxemon.db import ElementModel, db
-from tuxemon.element import ElementTypesHandler
+from tuxemon.element import Element, ElementTypesHandler
 
 
-class TestElementTypesHandler(unittest.TestCase):
-    _fire = ElementModel(
+@pytest.fixture
+def elements():
+    fire = ElementModel(
         slug="fire", icon="gfx/ui/icons/element/fire_type.png", types=[]
     )
-    _metal = ElementModel(
+    metal = ElementModel(
         slug="metal", icon="gfx/ui/icons/element/metal_type.png", types=[]
     )
+    aether = ElementModel(
+        slug="aether", icon="gfx/ui/icons/element/aether_type.png", types=[]
+    )
 
-    def setUp(self):
-        db.database["element"] = {"fire": self._fire, "metal": self._metal}
-        self.basic = ElementTypesHandler()
-        self.element1 = "metal"
-        self.element2 = "fire"
-        self.elements = ["metal", "fire"]
-        self.handler = ElementTypesHandler(self.elements)
+    db.database["element"] = {
+        "fire": fire,
+        "metal": metal,
+        "aether": aether,
+    }
 
-    def test_init_with_no_types(self):
-        self.assertEqual(self.basic.current, [])
-        self.assertEqual(self.basic.default, [])
+    return {
+        "fire": Element("fire"),
+        "metal": Element("metal"),
+        "aether": Element("aether"),
+    }
 
-    def test_init_with_types(self):
-        self.assertEqual(len(self.handler.current), 2)
-        self.assertEqual(len(self.handler.default), 2)
 
-    def test_set_types(self):
-        self.basic.set_types(self.elements)
-        self.assertEqual(len(self.basic.current), 2)
+@pytest.fixture
+def handler(elements):
+    return ElementTypesHandler(["metal", "fire"])
 
-    def test_reset_to_default(self):
-        new_element = "metal"
-        self.handler.set_types([new_element])
-        self.handler.reset_to_default()
-        self.assertEqual(len(self.handler.current), 2)
 
-    def test_get_type_slugs(self):
-        self.assertEqual(self.handler.get_type_slugs(), self.elements)
+def test_init_with_no_types():
+    basic = ElementTypesHandler()
+    assert basic.current == []
+    assert basic.default == []
 
-    def test_has_type(self):
-        self.assertTrue(self.handler.has_type(self.element1))
-        self.assertFalse(self.handler.has_type("non_existent_type"))
 
-    def test_primary_type(self):
-        self.assertEqual(self.handler.primary.slug, self.element1)
-        self.assertIsNotNone(self.handler.primary)
+def test_init_with_types(handler):
+    assert len(handler.current) == 2
+    assert len(handler.default) == 2
+
+
+def test_set_types(elements):
+    basic = ElementTypesHandler()
+    basic.set_types([elements["fire"], elements["metal"]])
+    assert len(basic.current) == 2
+
+
+def test_reset_to_default(handler):
+    new_element = Element("metal")
+    handler.set_types([new_element])
+    handler.reset_to_default()
+    assert len(handler.current) == 2
+
+
+def test_get_type_slugs(handler):
+    assert handler.get_type_slugs() == ["metal", "fire"]
+
+
+def test_has_type(handler):
+    assert handler.has_type("metal")
+    assert not handler.has_type("non_existent_type")
+
+
+def test_primary_type(handler):
+    assert handler.primary.slug == "metal"
+    assert handler.primary is not None
+
+
+@pytest.mark.parametrize(
+    "attackers, defenders, expected_fn",
+    [
+        (["fire"], ["metal"], lambda e: e["fire"].lookup_multiplier("metal")),
+        (["metal"], ["fire"], lambda e: e["metal"].lookup_multiplier("fire")),
+        (
+            ["fire", "metal"],
+            ["fire", "metal"],
+            lambda e: (
+                e["fire"].lookup_multiplier("fire")
+                * e["fire"].lookup_multiplier("metal")
+                * e["metal"].lookup_multiplier("fire")
+                * e["metal"].lookup_multiplier("metal")
+            ),
+        ),
+        (
+            ["fire", "aether"],
+            ["metal"],
+            lambda e: e["fire"].lookup_multiplier("metal"),
+        ),
+    ],
+)
+def test_calculate_affinity_score(elements, attackers, defenders, expected_fn):
+    atk = [elements[a] for a in attackers]
+    dfn = [elements[d] for d in defenders]
+    score = ElementTypesHandler.calculate_affinity_score(atk, dfn)
+    assert score == expected_fn(elements)
+
+
+@pytest.mark.parametrize(
+    "defenders, attacker, expected_fn",
+    [
+        (["metal"], "fire", lambda e: e["metal"].lookup_multiplier("fire")),
+        (
+            ["fire", "metal"],
+            "fire",
+            lambda e: e["fire"].lookup_multiplier("fire")
+            * e["metal"].lookup_multiplier("fire"),
+        ),
+        (
+            ["aether", "fire"],
+            "metal",
+            lambda e: e["fire"].lookup_multiplier("metal"),
+        ),
+        (["fire", "metal"], "aether", lambda e: 1.0),
+    ],
+)
+def test_resistance(elements, defenders, attacker, expected_fn):
+    dfn = [elements[d] for d in defenders]
+    score = ElementTypesHandler.calculate_resistance_multiplier_for_types(
+        dfn, attacker
+    )
+    assert score == expected_fn(elements)

--- a/tests/tuxemon/test_formula.py
+++ b/tests/tuxemon/test_formula.py
@@ -5,9 +5,10 @@ import unittest
 from unittest.mock import MagicMock
 
 from tuxemon import prepare
-from tuxemon.element import Element
+from tuxemon.element import Element, ElementTypesHandler
 from tuxemon.formula import (
     calculate_time_based_multiplier,
+    config_combat,
     config_monster,
     modify_stat,
     set_health,
@@ -130,6 +131,7 @@ class TestSetHeight(unittest.TestCase):
 
 class TestSimpleDamageMultiplier(unittest.TestCase):
     def setUp(self):
+        ElementTypesHandler.clear_cache()
         self.fire = MagicMock(spec=Element)
         self.fire.slug = "fire"
         self.water = MagicMock(spec=Element)
@@ -152,14 +154,14 @@ class TestSimpleDamageMultiplier(unittest.TestCase):
         attack_types[0].lookup_multiplier = MagicMock(return_value=2.0)
         attack_types[1].lookup_multiplier = MagicMock(return_value=0.5)
         multiplier = simple_damage_multiplier(attack_types, [target_type])
-        self.assertEqual(multiplier, 0.5)
+        self.assertEqual(multiplier, 1.0)
 
     def test_multiple_target_types(self):
         attack_type = self.fire
         target_types = [self.water, self.grass]
         attack_type.lookup_multiplier = MagicMock(side_effect=[2.0, 0.5])
         multiplier = simple_damage_multiplier([attack_type], target_types)
-        self.assertEqual(multiplier, 2.0)
+        self.assertEqual(multiplier, 1.0)
 
     def test_aether_type(self):
         attack_type = self.aether
@@ -181,6 +183,23 @@ class TestSimpleDamageMultiplier(unittest.TestCase):
             [attack_type], [target_type], additional_factors
         )
         self.assertEqual(round(multiplier, 1), 2.4)
+
+    def test_empty_attack_or_target(self):
+        self.assertEqual(simple_damage_multiplier([], [self.water]), 1.0)
+        self.assertEqual(simple_damage_multiplier([self.fire], []), 1.0)
+
+    def test_clamping(self):
+        self.fire.lookup_multiplier = MagicMock(return_value=10.0)
+        multiplier = simple_damage_multiplier([self.fire], [self.water])
+        min_range, max_range = config_combat.multiplier_range
+        self.assertLessEqual(multiplier, max_range)
+
+    def test_cache_reuse(self):
+        self.fire.lookup_multiplier = MagicMock(return_value=2.0)
+        simple_damage_multiplier([self.fire], [self.water])
+        multiplier = simple_damage_multiplier([self.fire], [self.water])
+        self.fire.lookup_multiplier.assert_called_once()
+        self.assertEqual(multiplier, 2.0)
 
 
 class TestSimpleDamageCalculate(unittest.TestCase):

--- a/tuxemon/element.py
+++ b/tuxemon/element.py
@@ -108,6 +108,8 @@ class Element:
 
 class ElementTypesHandler:
 
+    _multiplier_cache: dict[tuple[str, str], float] = {}
+
     def __init__(self, initial_types: Optional[Sequence[str]] = None):
         pre_types = (
             []
@@ -116,6 +118,53 @@ class ElementTypesHandler:
         )
         self._current_types = pre_types
         self._default_types = list(pre_types)
+
+    @classmethod
+    def calculate_affinity_score(
+        cls, user_types: Sequence[Element], target_types: Sequence[Element]
+    ) -> float:
+        """
+        Return cumulative offensive multiplier of user types against target types.
+        """
+        multiplier = 1.0
+        for _user in user_types:
+            for _target in target_types:
+                if _target and not (
+                    _user.slug == "aether" or _target.slug == "aether"
+                ):
+                    key = (_user.slug, _target.slug)
+                    if key not in cls._multiplier_cache:
+                        cls._multiplier_cache[key] = _user.lookup_multiplier(
+                            _target.slug
+                        )
+                    mult_value = cls._multiplier_cache[key]
+                    multiplier *= mult_value
+        return multiplier
+
+    @classmethod
+    def calculate_resistance_multiplier_for_types(
+        cls, defending_types: Sequence[Element], attacking_slug: str
+    ) -> float:
+        """
+        Return cumulative defensive multiplier of defending types against an
+        attacking type.
+        """
+        multiplier = 1.0
+        for defending_type in defending_types:
+            if defending_type.slug == "aether" or attacking_slug == "aether":
+                continue
+            key = (defending_type.slug, attacking_slug)
+            if key not in cls._multiplier_cache:
+                cls._multiplier_cache[key] = defending_type.lookup_multiplier(
+                    attacking_slug
+                )
+            mult_value = cls._multiplier_cache[key]
+            multiplier *= mult_value
+        return multiplier
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        cls._multiplier_cache.clear()
 
     def set_types(self, new_types: list[Element]) -> None:
         self._current_types = new_types

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -8,8 +8,8 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, final
 
-from tuxemon import formula
 from tuxemon.db import Acquisition, EvolutionStage, StatType
+from tuxemon.element import ElementTypesHandler
 from tuxemon.event import get_monster_by_iid, get_npc
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
@@ -185,8 +185,7 @@ def _determine_seed(mother: Monster, father: Monster) -> Monster:
     vitality_mother = mother.hp_ratio
     vitality_father = father.hp_ratio
     logger.debug(
-        "Vitality ratio "
-        f"Mother: {vitality_mother:.2f}, Father: {vitality_father:.2f}"
+        f"Vitality ratio Mother: {vitality_mother:.2f}, Father: {vitality_father:.2f}"
     )
 
     if vitality_mother > vitality_father:
@@ -196,10 +195,11 @@ def _determine_seed(mother: Monster, father: Monster) -> Monster:
         logger.debug("Seed chosen based on greater vitality: Father")
         return father
 
-    multiplier_mother = formula.calculate_multiplier(
+    # Offensive affinity
+    multiplier_mother = ElementTypesHandler.calculate_affinity_score(
         mother.types.current, father.types.current
     )
-    multiplier_father = formula.calculate_multiplier(
+    multiplier_father = ElementTypesHandler.calculate_affinity_score(
         father.types.current, mother.types.current
     )
     logger.debug(
@@ -213,6 +213,29 @@ def _determine_seed(mother: Monster, father: Monster) -> Monster:
         return mother
     elif multiplier_father > multiplier_mother:
         logger.debug("Seed chosen based on stronger type matchup: Father")
+        return father
+
+    # Defensive resistance
+    resistance_mother = (
+        ElementTypesHandler.calculate_resistance_multiplier_for_types(
+            mother.types.current, father.types.primary.slug
+        )
+    )
+    resistance_father = (
+        ElementTypesHandler.calculate_resistance_multiplier_for_types(
+            father.types.current, mother.types.primary.slug
+        )
+    )
+    logger.debug(
+        f"Resistance Mother vs Father: {resistance_mother:.2f} "
+        f"Father vs Mother: {resistance_father:.2f}"
+    )
+
+    if resistance_mother < resistance_father:
+        logger.debug("Seed chosen based on stronger resistance: Mother")
+        return mother
+    elif resistance_father < resistance_mother:
+        logger.debug("Seed chosen based on stronger resistance: Father")
         return father
 
     logger.debug("Seed chosen randomly: No clear biological dominance")

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-multiplier_cache: dict[tuple[str, str], float] = {}
-
 
 @dataclass
 class CaptureDeviceEffect:
@@ -248,52 +246,17 @@ def simple_damage_multiplier(
     Returns:
         The attack multiplier.
     """
-    multiplier = 1.0
-    for attack_type in attack_types:
-        for target_type in target_types:
-            if target_type and not (
-                attack_type.slug == "aether" or target_type.slug == "aether"
-            ):
-                key = (attack_type.slug, target_type.slug)
-                if key in multiplier_cache:
-                    multiplier = multiplier_cache[key]
-                else:
-                    multiplier = attack_type.lookup_multiplier(
-                        target_type.slug
-                    )
-                    multiplier_cache[key] = multiplier
-                min_range, max_range = config_combat.multiplier_range
-                multiplier = min(max_range, max(min_range, multiplier))
-    # Apply additional factors
+    from tuxemon.element import ElementTypesHandler
+
+    multiplier = ElementTypesHandler.calculate_affinity_score(
+        attack_types, target_types
+    )
+    min_range, max_range = config_combat.multiplier_range
+    multiplier = min(max_range, max(min_range, multiplier))
+
     if additional_factors:
-        factor_multiplier = math.prod(additional_factors.values())
-        multiplier *= factor_multiplier
-    return multiplier
+        multiplier *= math.prod(additional_factors.values())
 
-
-def calculate_multiplier(
-    monster_types: Sequence[Element], opponent_types: Sequence[Element]
-) -> float:
-    """
-    Calculate the multiplier for a monster's types against an opponent's types.
-
-    Parameters:
-        monster (Monster): The monster whose types are being used to
-        calculate it.
-        opponent (Monster): The opponent whose types are being used to
-        calculate it.
-
-    Returns:
-        float: The final multiplier that represents the effectiveness of
-        the monster'stypes against the opponent's types.
-    """
-    multiplier = 1.0
-    for _monster in monster_types:
-        for _opponent in opponent_types:
-            if _opponent and not (
-                _monster.slug == "aether" or _opponent.slug == "aether"
-            ):
-                multiplier *= _monster.lookup_multiplier(_opponent.slug)
     return multiplier
 
 


### PR DESCRIPTION
Changes:
- added a new classmethod `calculate_affinity_score` to `ElementTypesHandler` to compute offensive multipliers between user and target types
- added a new classmethod `calculate_resistance_multiplier_for_types`** to `ElementTypesHandler` to compute cumulative defensive multipliers of defending types against an attacking type
- moved the `_multiplier_cache` into `ElementTypesHandler` so that caching of multipliers is managed directly by the class 
- removed `calculate_multiplier` function from `formula.py` since its functionality is now handled by `ElementTypesHandler.calculate_affinity_score`
- updated `simple_damage_multiplier` in `formula.py` to call the new `ElementTypesHandler.calculate_affinity_score` classmethod instead of the deleted `calculate_multiplier`