### PR TITLE
Rename AppStream metadata to `.metainfo.xml` and update portmidi source

### DIFF
--- a/.github/workflows/appdata_validation.yml
+++ b/.github/workflows/appdata_validation.yml
@@ -15,9 +15,9 @@ jobs:
         sudo apt update
 
     # Command copied from flathub build process
-    - name: Validate appdata file
+    - name: Validate metainfo file
       run: |
         sudo apt install flatpak
         sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         sudo flatpak install -y org.freedesktop.appstream-glib
-        flatpak run --env=G_DEBUG=fatal-criticals org.freedesktop.appstream-glib validate ./buildconfig/flatpak/org.tuxemon.Tuxemon.appdata.xml
+        flatpak run --env=G_DEBUG=fatal-criticals org.freedesktop.appstream-glib validate ./buildconfig/flatpak/org.tuxemon.Tuxemon.metainfo.xml

--- a/buildconfig/flatpak/org.tuxemon.Tuxemon.desktop
+++ b/buildconfig/flatpak/org.tuxemon.Tuxemon.desktop
@@ -3,11 +3,10 @@ Name=Tuxemon
 Name[de_AT]=Tuxemon
 GenericName=Open source monster-fighting RPG
 GenericName[de]=Tuxemon
-Comment=
+Comment=Free and open source monster-fighting RPG
 Exec=org.tuxemon.Tuxemon
 Icon=org.tuxemon.Tuxemon
 Terminal=false
 Type=Application
-Categories=Game
+Categories=Game;RolePlaying;
 StartupNotify=false
-

--- a/buildconfig/flatpak/org.tuxemon.Tuxemon.metainfo.xml
+++ b/buildconfig/flatpak/org.tuxemon.Tuxemon.metainfo.xml
@@ -4,7 +4,12 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>Tuxemon</name>
-  <summary>Tuxemon is a free, open source monster-fighting RPG.</summary>
+  <summary>Tuxemon is a free, open source monster-fighting RPG</summary>
+
+  <developer id="org.tuxemon">
+    <name>Tuxemon Team</name>
+    <url>https://www.tuxemon.org/</url>
+  </developer>
 
   <description>
     <p>Tuxemon is a free, open source monster-fighting RPG. It's in constant development and improving all the time! Contributors of all skill levels are welcome to join.</p>
@@ -35,21 +40,21 @@
       <caption>Overview</caption>
       <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/tuxemon-overworld.png</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <caption>Battle between Tuxemons</caption>
-	  <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/2tuxemon-battle1.png</image>
+      <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/2tuxemon-battle1.png</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <caption>Catching Tuxemons</caption>
-	  <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/tuxemon-battle-caught.png</image>
+      <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/tuxemon-battle-caught.png</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <caption>Overview</caption>
-	  <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/2tuxemon-overworld-talk0.png</image>
+      <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/2tuxemon-overworld-talk0.png</image>
     </screenshot>
-	<screenshot>
+    <screenshot>
       <caption>Tuxecenter</caption>
-	  <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/tuxemon-tuxecenter-heal.png</image>
+      <image>https://github.com/Tuxemon/Tuxemon/raw/development/docs/screenshots/tuxemon-tuxecenter-heal.png</image>
     </screenshot>
   </screenshots>
 
@@ -57,21 +62,20 @@
 
   <provides>
     <binary>Tuxemon</binary>
-    <id>org.tuxemon.Tuxemon</id>
   </provides>
 
   <releases>
-	<release version="0.4.34" date="2022-08-03">
+    <release version="0.4.34" date="2022-08-03">
       <description>
         <p>Bug and Feature Release</p>
         <ul>
-		  <li>2 new cutscenes in Xero campaign by Zhongtiao</li>
-		  <li>Greenwash dungeon added to Spyder campaign by Sanglorian</li>
-		  <li>Battles now start automatically in Spyder campaign if a trainer spots the player</li>
-		  <li>Shopkeepers added to every town in Spyder campaign</li>
-		  <li>Added battle background images for Forest, Cave, and Ocean battles</li>
-		  <li>Many bug fixes</li>
-		  <li>Dancing flowers! Added by freshreplicant</li>
+          <li>2 new cutscenes in Xero campaign by Zhongtiao</li>
+          <li>Greenwash dungeon added to Spyder campaign by Sanglorian</li>
+          <li>Battles now start automatically in Spyder campaign if a trainer spots the player</li>
+          <li>Shopkeepers added to every town in Spyder campaign</li>
+          <li>Added battle background images for Forest, Cave, and Ocean battles</li>
+          <li>Many bug fixes</li>
+          <li>Dancing flowers! Added by freshreplicant</li>
         </ul>
       </description>
     </release>
@@ -93,7 +97,4 @@
   <content_rating type="oars-1.1">
     <content_attribute id="violence-fantasy">moderate</content_attribute>
   </content_rating>
-
-  
 </component>
-

--- a/buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
+++ b/buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
@@ -33,7 +33,7 @@ modules:
       - ln -s /app/share/Tuxemon/org.tuxemon.Tuxemon.py /app/bin/org.tuxemon.Tuxemon.py
     post-install:
       - desktop-file-install --dir=/app/share/applications buildconfig/flatpak/org.tuxemon.Tuxemon.desktop
-      - install -Dm755 buildconfig/flatpak/org.tuxemon.Tuxemon.appdata.xml /app/share/metainfo/org.tuxemon.Tuxemon.appdata.xml
+      - install -Dm755 buildconfig/flatpak/org.tuxemon.Tuxemon.metainfo.xml /app/share/metainfo/org.tuxemon.Tuxemon.metainfo.xml
       - install -Dm755 mods/tuxemon/gfx/icon.png /app/share/icons/hicolor/64x64/apps/icon.png
       - install -Dm755 mods/tuxemon/gfx/icon_128.png /app/share/icons/hicolor/128x128/apps/icon.png
       - install -Dm755 mods/tuxemon/gfx/icon_32.png /app/share/icons/hicolor/32x32/apps/icon.png

--- a/buildconfig/flatpak/portmidi.json
+++ b/buildconfig/flatpak/portmidi.json
@@ -1,11 +1,11 @@
 {
-    "name": "portmidi",
-    "buildsystem": "cmake",
-    "sources": [
-        {
-            "type": "git",
-            "url": "https://github.com/PortMidi/portmidi.git",
-            "tag": "v2.0.3"
-        }
-    ]
+  "name": "portmidi",
+  "buildsystem": "cmake",
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://github.com/PortMidi/portmidi/archive/refs/tags/v2.0.7.tar.gz",
+      "sha256": "43fa65b4ed7ebaa68b0028a538ba8b2ca4dc9b86a7e22ec48842070e010f823f"
+    }
+  ]
 }


### PR DESCRIPTION
**Note on CI workflow:**  
Flatpak build step is configured to check out the `development` branch inside the sandbox. Since `development` does not yet contain the renamed `org.tuxemon.Tuxemon.metainfo.xml` file, the workflow fails with a “cannot stat” error on this branch. This is expected until the PR is merged. Once merged, the file will exist in `development` and the workflow will pass normally.

Changes:
- renamed `org.tuxemon.Tuxemon.appdata.xml` → `org.tuxemon.Tuxemon.metainfo.xml` to comply with current AppStream/Flathub requirements
- added the required `<developer_name>` field
- removed the redundant `<id>` element inside the XML
- fixed the summary string (removed dot) to clear validation warnings
- updated `portmidi.json` to use an archive source instead of git
- bumped to a newer version for reproducible builds and better compatibility

Renaming is necessary because `.appdata.xml` files are deprecated; Flathub CI expects `.metainfo.xml`.