### PR TITLE
Replace deprecated `websockets.legacy` imports with `websockets.asyncio`

### DIFF
--- a/tuxemon/network/websocket_client.py
+++ b/tuxemon/network/websocket_client.py
@@ -7,10 +7,10 @@ import json
 import logging
 import threading
 from queue import Empty, Queue
-from typing import Any, cast
+from typing import Any
 
 import websockets
-from websockets.legacy.protocol import WebSocketCommonProtocol
+from websockets.asyncio.client import ClientConnection
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +78,7 @@ class WebsocketClientWrapper:
     async def _connect_and_listen(self, ip: str, port: int) -> None:
         uri = f"ws://{ip}:{port}"
         try:
-            async with websockets.connect(uri) as raw_websocket:
-                websocket = cast(WebSocketCommonProtocol, raw_websocket)
+            async with websockets.connect(uri) as websocket:
                 logger.info(f"Connected to {uri}!")
                 self.registered = True
                 receive_task = self.loop.create_task(
@@ -95,7 +94,7 @@ class WebsocketClientWrapper:
             self.running.clear()
             logger.info("Connection closed.")
 
-    async def _receive_loop(self, websocket: WebSocketCommonProtocol) -> None:
+    async def _receive_loop(self, websocket: ClientConnection) -> None:
         """Continuously listens for messages from the server."""
         while self.running.is_set():
             try:
@@ -107,7 +106,7 @@ class WebsocketClientWrapper:
                 logger.error(f"Receive error: {e}")
                 break
 
-    async def _send_loop(self, websocket: WebSocketCommonProtocol) -> None:
+    async def _send_loop(self, websocket: ClientConnection) -> None:
         """Continuously checks the send queue and transmits data."""
         while self.running.is_set():
             try:

--- a/tuxemon/network/websocket_server.py
+++ b/tuxemon/network/websocket_server.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import websockets
-from websockets.legacy.server import WebSocketServerProtocol
+from websockets.asyncio.server import ServerConnection
 
 from tuxemon.network.networking import EventType
 
@@ -25,7 +25,7 @@ class WebsocketServerWrapper:
     def __init__(self, game_server: ServerInterface) -> None:
         self.game_server = game_server
         self.incoming_queue: Queue[tuple[str, dict[str, Any]]] = Queue()
-        self.client_registry: dict[str, WebSocketServerProtocol] = {}
+        self.client_registry: dict[str, ServerConnection] = {}
         self.registry: dict[str, dict[str, Any]] = {}
 
     def start_listening(self, port: int) -> None:
@@ -74,9 +74,7 @@ class WebsocketServerWrapper:
 
         self.loop.run_until_complete(start())
 
-    async def _handler(
-        self, websocket: WebSocketServerProtocol, path: str
-    ) -> None:
+    async def _handler(self, websocket: ServerConnection, path: str) -> None:
         """Handles a single new client connection."""
         cuuid = str(uuid4())
         self.client_registry[cuuid] = websocket
@@ -94,7 +92,7 @@ class WebsocketServerWrapper:
             self._handle_disconnect(cuuid)
 
     async def _listen_to_client(
-        self, cuuid: str, websocket: WebSocketServerProtocol
+        self, cuuid: str, websocket: ServerConnection
     ) -> None:
         """Receives messages from a single connected client."""
         async for message in websocket:


### PR DESCRIPTION
Changes:
- removed usage of `websockets.legacy` imports, which are deprecated as of websockets 14.0
- replaced `WebSocketServerProtocol` and `WebSocketCommonProtocol` with `ServerConnection` and `ClientConnection` from `websockets.asyncio`
- eliminated deprecation warnings during test runs
- ensured compatibility with future versions of websockets by following the recommended upgrade path 