### PR TITLE
Refactor Network State Tracking and Connection Lifecycle

### DIFF
--- a/tuxemon/network/client.py
+++ b/tuxemon/network/client.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Optional, TypedDict
 import pygame as pg
 
 from tuxemon.network.networking import (
-    ConnectionState,
     EventType,
     populate_client,
     update_client,
@@ -73,6 +72,26 @@ class TuxemonClient:
     @property
     def registry(self) -> dict[str, Any]:
         return self.client.registry
+
+    def connect_to_host(self, ip_address: str, port: int) -> None:
+        """
+        Sets up the client to attempt connection to a specified host/port.
+        """
+        self.selected_game = (ip_address, port)
+        self.enable_join_multiplayer = True
+        self.listening = True
+
+    def disconnect(self) -> None:
+        """Closes the client connection and resets its state."""
+        if not self.listening:
+            return
+
+        self.client.disconnect()
+        self.listening = False
+        self.enable_join_multiplayer = False
+        self.selected_game = None
+        self.client.registry = {}
+        self.server_list = []
 
     def update(self, time_delta: float) -> None:
         """Synchronizes game state and handles connection updates per frame."""
@@ -152,18 +171,10 @@ class EventDispatcher:
     def dispatch(self, event_dict: dict[str, Any]) -> None:
         try:
             event_data = EventData.from_dict(event_dict)
-            event_type_str = event_data.notify_type
-            if event_type_str is None:
-                logger.warning("Missing notify_type in event data.")
-                return
-            event_enum = EventType.from_notify(event_type_str)
+            event_enum = event_data.type
+
         except Exception as e:
             logger.warning(f"Failed to process incoming event: {e}")
-            return
-
-        if event_enum is None:
-            logger.warning(f"Unknown notify type: {event_type_str}")
-            logger.debug(f"Raw event data: {event_dict}")
             return
 
         euuid = "ws-event"
@@ -577,7 +588,6 @@ class ConnectionManager:
             self.retry_timer = 0
 
         if self.client.client.registered and not self.client.populated:
-            self.game.network_manager.set_state(ConnectionState.CLIENT)
             self.client.sync_manager.populate_player()
 
         if self.ping_timer >= 2:

--- a/tuxemon/network/manager.py
+++ b/tuxemon/network/manager.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from tuxemon.network.client import TuxemonClient
-from tuxemon.network.networking import ConnectionState
 from tuxemon.network.server import TuxemonServer
 
 logger = logging.getLogger(__name__)
@@ -21,18 +20,8 @@ class NetworkManager:
         self.parent = parent
         self.server: Optional[TuxemonServer] = None
         self.client: Optional[TuxemonClient] = None
-        self._state = ConnectionState.DISCONNECTED
-
-    @property
-    def state(self) -> ConnectionState:
-        """Returns the current connection state."""
-        return self._state
-
-    def set_state(self, new_state: ConnectionState) -> None:
-        """Sets the connection state and logs the change if different."""
-        if new_state != self._state:
-            self._state = new_state
-            self._log_connection_state()
+        self._last_host_state = False
+        self._last_client_state = False
 
     def initialize(self) -> None:
         if self.server or self.client:
@@ -52,36 +41,44 @@ class NetworkManager:
         if self.server and self.server.listening:
             self.server.update()
 
-        new_state = self._determine_connection_state()
+        new_host_state = self.is_host()
+        new_client_state = self.is_client()
 
-        # Update state and log changes
-        if new_state != self._state:
-            self._state = new_state
-            self._log_connection_state()
+        if new_host_state != self._last_host_state:
+            logger.info(
+                f"Host state changed: {self._last_host_state} -> {new_host_state}"
+            )
+            self._last_host_state = new_host_state
 
-    def _determine_connection_state(self) -> ConnectionState:
+        if new_client_state != self._last_client_state:
+            logger.info(
+                f"Client state changed: {self._last_client_state} -> {new_client_state}"
+            )
+            self._last_client_state = new_client_state
+
+    def shutdown(self) -> None:
+        """
+        Gracefully stops all network operations (server and client).
+        """
         if self.server and self.server.listening:
-            return ConnectionState.HOST
-        elif self.client and self.client.listening:
-            return ConnectionState.CLIENT
-        return ConnectionState.DISCONNECTED
+            self.server.shutdown()
+            self.server = None
+            logger.info("NetworkManager: Server shutdown complete.")
 
-    def _log_connection_state(self) -> None:
-        if self._state == ConnectionState.HOST:
-            logger.info("NetworkManager: Host connection just established")
-        elif self._state == ConnectionState.CLIENT:
-            logger.info("NetworkManager: Client connection just established")
-        elif self._state == ConnectionState.DISCONNECTED:
-            logger.info("NetworkManager: All connections lost")
+        if self.client and self.client.listening:
+            self.client.disconnect()
+            self.client = None
+            logger.info("NetworkManager: Client disconnected.")
+
+        self.server = None
+        self.client = None
+        logger.info("NetworkManager: All networking systems shut down.")
 
     def is_host(self) -> bool:
-        return self._state == ConnectionState.HOST
+        return self.server is not None and self.server.listening
 
     def is_client(self) -> bool:
-        return self._state == ConnectionState.CLIENT
+        return self.client is not None and self.client.listening
 
     def is_connected(self) -> bool:
-        return self._state in {
-            ConnectionState.HOST,
-            ConnectionState.CLIENT,
-        }
+        return self.is_host() or self.is_client()

--- a/tuxemon/network/networking.py
+++ b/tuxemon/network/networking.py
@@ -25,12 +25,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ConnectionState(Enum):
-    DISCONNECTED = "disconnected"
-    HOST = "host"
-    CLIENT = "client"
-
-
 class EventType(str, Enum):
     PUSH_SELF = "PUSH_SELF"
     CLIENT_MOVE_START = "CLIENT_MOVE_START"
@@ -44,19 +38,6 @@ class EventType(str, Enum):
     CLIENT_START_BATTLE = "CLIENT_START_BATTLE"
     CLIENT_DISCONNECTED = "CLIENT_DISCONNECTED"
     PING = "PING"
-
-    @classmethod
-    def from_notify(cls, notify_type: str) -> Optional[EventType]:
-        if notify_type.startswith("NOTIFY_"):
-            base = notify_type.removeprefix("NOTIFY_")
-            try:
-                return cls(base)
-            except ValueError:
-                return None
-        return None
-
-    def notify(self) -> str:
-        return f"NOTIFY_{self.value}"
 
 
 @dataclass
@@ -116,9 +97,6 @@ class EventData:
     interaction: Optional[str] = (
         None  # Type of interaction (e.g., "talk", "battle") — used in interaction events
     )
-    notify_type: Optional[str] = (
-        None  # Event type string used for dispatching (redundant with `type.name`)
-    )
     map_name: Optional[str] = None  # Name of the map where the event occurred
     char_dict: Optional[CharData] = (
         None  # Snapshot of character state (position, facing, inventory, etc.)
@@ -142,7 +120,6 @@ class EventData:
             "event_number": self.event_number,
             "cuuid": self.cuuid,
             "interaction": self.interaction,
-            "notify_type": self.notify_type,
             "map_name": self.map_name,
             "char_dict": self.char_dict.to_dict() if self.char_dict else None,
             "kb_key": self.kb_key,
@@ -157,7 +134,6 @@ class EventData:
             event_number=data["event_number"],
             cuuid=data.get("cuuid"),
             interaction=data.get("interaction"),
-            notify_type=data.get("notify_type"),
             map_name=data.get("map_name"),
             char_dict=(
                 CharData.from_dict(data["char_dict"])

--- a/tuxemon/network/server.py
+++ b/tuxemon/network/server.py
@@ -96,6 +96,25 @@ class TuxemonServer:
             self.handle_client_disconnected_event,
         )
 
+    def shutdown(self) -> None:
+        """
+        Gracefully stops the server: closes the listening socket and
+        disconnects all active clients.
+        """
+
+        for cuuid in list(self.client_registry.registry.keys()):
+            self.server.disconnect_client(cuuid)
+            event_data = self.event_factory.create_event(
+                EventType.CLIENT_DISCONNECTED, cuuid
+            )
+            self.notify_client(cuuid, event_data)
+
+        self.client_registry.registry.clear()
+        self.listening = False
+        logger.info(
+            "TuxemonServer: Shutdown complete. Server is no longer listening."
+        )
+
     def get_next_event_number(self) -> int:
         """
         Generates and returns the next unique event number for sequencing
@@ -389,9 +408,7 @@ class NotificationManager:
         self.event_factory = event_factory
 
     def notify_client(self, cuuid: str, event_data: EventData) -> None:
-        updated_event = event_data.copy(
-            cuuid=cuuid, notify_type=event_data.type.notify()
-        )
+        updated_event = event_data.copy(cuuid=cuuid)
         json_data = json.dumps(updated_event.to_dict())
 
         for client_id in self.server.registry:
@@ -401,9 +418,7 @@ class NotificationManager:
     def notify_populate_client(
         self, cuuid: str, event_data: EventData
     ) -> None:
-        notify_type = event_data.type.notify()
-
-        event_data_1 = event_data.copy(cuuid=cuuid, notify_type=notify_type)
+        event_data_1 = event_data.copy(cuuid=cuuid)
         json_data_1 = json.dumps(event_data_1.to_dict())
 
         for client_id in self.server.registry:
@@ -418,7 +433,6 @@ class NotificationManager:
                 cuuid=client_id,
                 map_name=char["map_name"],
                 char_dict=char["char_dict"],
-                notify_type=notify_type,
             )
             json_data_2 = json.dumps(event_data_2.to_dict())
             self.server.notify(cuuid, json_data_2)
@@ -430,9 +444,7 @@ class NotificationManager:
             logger.warning(f"Invalid interaction event from CUUID: {cuuid}")
             return
 
-        updated_event = event_data.copy(
-            target=cuuid, notify_type=event_data.type.notify()
-        )
+        updated_event = event_data.copy(target=cuuid)
         json_data = json.dumps(updated_event.to_dict())
         self.server.notify(event_data.target, json_data)
 
@@ -455,7 +467,6 @@ class EventFactory:
         cuuid: str,
         map_name: str = "",
         char_dict: Optional[Union[dict[str, Any], CharData]] = None,
-        notify_type: Optional[str] = None,
         target: Optional[str] = None,
     ) -> EventData:
         return EventData(
@@ -468,6 +479,5 @@ class EventFactory:
                 if isinstance(char_dict, dict)
                 else char_dict
             ),
-            notify_type=notify_type or event_type.notify(),
             target=target,
         )

--- a/tuxemon/network/websocket_server.py
+++ b/tuxemon/network/websocket_server.py
@@ -35,6 +35,21 @@ class WebsocketServerWrapper:
         )
         self.net_thread.start()
 
+    def stop_listening(self) -> None:
+        """Stops the server loop and disconnects all active clients."""
+        for cuuid, websocket in list(self.client_registry.items()):
+            asyncio.run_coroutine_threadsafe(websocket.close(), self.loop)
+            self.client_registry.pop(cuuid, None)
+            self.registry.pop(cuuid, None)
+
+        if self.loop and self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+
+        if self.net_thread:
+            self.net_thread.join(timeout=1)
+
+        logger.info("WebSocket server stopped and all clients disconnected.")
+
     def get_incoming_events(self) -> list[tuple[str, dict[str, Any]]]:
         """Called by TuxemonServer.update() to pull all new client messages."""
         events = []

--- a/tuxemon/states/multiplayer.py
+++ b/tuxemon/states/multiplayer.py
@@ -11,7 +11,6 @@ from tuxemon.animation import Animation, ScheduleType
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PopUpMenu, PygameMenuState
-from tuxemon.network.networking import ConnectionState
 from tuxemon.tools import open_dialog
 
 MenuGameObj = Callable[[], object]
@@ -71,20 +70,13 @@ class MultiplayerMenu(PygameMenuState):
             )
             return
 
-        elif not self.network.is_client():
-            self.network.set_state(ConnectionState.HOST)
-            self.network.server.listening = True
-            self.network.client.selected_game = (
-                "127.0.0.1",
-                self.network.server.server_port,
-            )
-            self.network.client.enable_join_multiplayer = True
-            self.network.client.listening = True
-            self.client.pop_state(self)
-
-            open_dialog(
-                self.client, [T.translate("multiplayer_hosting_ready")]
-            )
+        self.network.server.listening = True
+        self.network.client.connect_to_host(
+            "127.0.0.1",
+            self.network.server.server_port,
+        )
+        self.client.pop_state(self)
+        open_dialog(self.client, [T.translate("multiplayer_hosting_ready")])
 
     def load_server_list(self) -> None:
         """Loads the hardcoded server list and opens the selection menu."""
@@ -109,7 +101,9 @@ class MultiplayerMenu(PygameMenuState):
         if self.network.is_host():
             return
         else:
-            self.network.client.enable_join_multiplayer = True
+            if self.network.client.selected_game:
+                ip, port = self.network.client.selected_game
+                self.network.client.connect_to_host(ip, port)
 
 
 class MultiplayerSelect(PopUpMenu[None]):


### PR DESCRIPTION
Changes:
- removed the old `ConnectionState` enum from `NetworkManager`
- simplified state tracking by checking `TuxemonServer` and `TuxemonClient` listening flags directly
- added `connect_to_host(ip, port)` method to `TuxemonClient` for explicit connection setup
- added `disconnect()` method to `TuxemonClient` for explicit connection teardown
- implemented a `shutdown()` method in `TuxemonServer` to stop listening and disconnect all active clients
- updated `NetworkManager.update()` to remove explicit state management and rely on helper methods
- added `NetworkManager.shutdown()` to call client disconnect and server shutdown
- updated `MultiplayerMenu.host_game()` to start the server and connect the client using `connect_to_host()`
- updated `MultiplayerMenu.join()` to use the client’s new `connect_to_host()` method