### PR TITLE
Improve Plugin System Architecture, Caching, Filtering and Test Coverage

### DIFF
--- a/tests/tuxemon/test_plugin.py
+++ b/tests/tuxemon/test_plugin.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2025 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
 from collections.abc import Iterable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from tuxemon.constants.paths import LIBDIR
 from tuxemon.plugin import (
@@ -13,149 +14,256 @@ from tuxemon.plugin import (
     PluginLoader,
     PluginManager,
     PluginObject,
-    get_available_classes,
     load_directory,
 )
 
 
-class TestPluginManager(unittest.TestCase):
-    def setUp(self):
-        self.discovery = FileSystemPluginDiscovery([], LIBDIR)
-        self.loader = PluginLoader(ImportLibPluginLoader())
-        self.filter = PluginFilter()
-        self.manager = PluginManager(self.discovery, self.loader, self.filter)
-        self.interface = PluginObject
+@pytest.fixture
+def discovery():
+    return FileSystemPluginDiscovery([], LIBDIR)
 
-    def test_init(self):
-        self.assertEqual(self.manager.discovery.folders, [])
-        self.assertEqual(self.manager.modules, [])
 
-    def test_set_plugin_places(self):
-        plugin_folders = ["folder1", "folder2"]
-        discovery = FileSystemPluginDiscovery(plugin_folders, LIBDIR)
-        manager = PluginManager(discovery, self.loader, self.filter)
-        self.assertEqual(manager.discovery.folders, plugin_folders)
+@pytest.fixture
+def loader():
+    return PluginLoader(ImportLibPluginLoader())
 
-    def test_collect_plugins(self):
-        plugin_folders = ["folder1", "folder2"]
 
-        discovery = FileSystemPluginDiscovery(plugin_folders, LIBDIR)
-        discovery.discover_plugins = MagicMock(
-            return_value=["plugin1", "plugin2"]
-        )
+@pytest.fixture
+def plugin_filter():
+    return PluginFilter()
 
-        manager = PluginManager(discovery, self.loader, self.filter)
-        manager.collect_plugins()
 
-        discovery.discover_plugins.assert_called_once()
+@pytest.fixture
+def manager(discovery, loader, plugin_filter):
+    return PluginManager(discovery, loader, plugin_filter)
 
-        filtered_plugins = self.filter.filter_plugins(["plugin1", "plugin2"])
 
-        self.assertEqual(manager.modules, filtered_plugins)
+@pytest.fixture
+def interface():
+    return PluginObject
 
-    def test_get_all_plugins(self):
-        plugins = self.manager.get_all_plugins(interface=self.interface)
-        self.assertIsInstance(plugins, list)
 
-    def test_get_classes_from_module(self):
-        module = MagicMock()
-        classes = self.manager._get_classes_from_module(module, self.interface)
-        self.assertIsInstance(classes, Iterable)
+def test_init(manager):
+    assert manager.discovery.folders == []
+    assert manager.modules == []
 
-    def test_load_directory(self):
-        plugin_folder = Path("folder1")
-        loaded_manager = load_directory([plugin_folder], LIBDIR)
-        self.assertIsInstance(loaded_manager, PluginManager)
 
-    def test_get_available_classes(self):
-        plugin_folder = Path("folder1")
-        manager = load_directory([plugin_folder], LIBDIR)
-        classes = get_available_classes(manager, interface=self.interface)
-        self.assertIsInstance(classes, list)
+@pytest.mark.parametrize(
+    "folders",
+    [
+        ["folder1"],
+        ["folder1", "folder2"],
+        [],
+    ],
+)
+def test_set_plugin_places(folders, loader, plugin_filter):
+    discovery = FileSystemPluginDiscovery(folders, LIBDIR)
+    manager = PluginManager(discovery, loader, plugin_filter)
+    assert manager.discovery.folders == folders
 
-    def test_file_system_plugin_discovery(self):
-        self.assertEqual(self.discovery.folders, [])
-        self.assertEqual(self.discovery.file_extensions, (".py", ".pyc"))
 
-    def test_default_plugin_loader(self):
-        module_name = "test_module"
-        with patch("importlib.import_module") as mock_import_module:
-            self.loader.load_plugin(module_name)
-            mock_import_module.assert_called_once_with(module_name)
+def test_collect_plugins(plugin_filter, loader):
+    discovery = FileSystemPluginDiscovery([Path("folder1")], LIBDIR)
+    discovery.discover_plugin_files = MagicMock(
+        return_value={
+            "plugin1": Path("plugin1.py"),
+            "plugin2": Path("plugin2.py"),
+        }
+    )
 
-    def test_plugin_filter(self):
-        filter = PluginFilter(
-            exclude_classes=["ExcludedPlugin"],
-            include_patterns=["AllowedPattern"],
-        )
+    manager = PluginManager(discovery, loader, plugin_filter)
+    manager.collect_plugins()
 
-        self.assertTrue(filter.is_excluded("ExcludedPlugin"))
-        self.assertFalse(filter.is_excluded("SomeOtherPlugin"))
+    discovery.discover_plugin_files.assert_called_once()
+    assert manager.modules == plugin_filter.filter_plugins(
+        ["plugin1", "plugin2"]
+    )
 
-        class MockPlugin:
-            pass
 
-        self.assertFalse(filter.matches_patterns(MockPlugin))
+def test_collect_plugins_no_plugins_found(loader, plugin_filter):
+    discovery = FileSystemPluginDiscovery([], LIBDIR)
+    discovery.discover_plugins = MagicMock(return_value=[])
 
-    def test_default_plugin_loader_import_failure(self):
-        module_name = "non_existent_module"
-        with patch(
-            "importlib.import_module",
-            side_effect=ImportError("Module not found"),
-        ):
-            with self.assertRaises(ImportError):
-                self.loader.load_plugin(module_name)
+    manager = PluginManager(discovery, loader, plugin_filter)
+    manager.collect_plugins()
 
-    def test_collect_plugins_no_plugins_found(self):
-        discovery = FileSystemPluginDiscovery([], LIBDIR)
-        discovery.discover_plugins = MagicMock(return_value=[])
+    assert manager.modules == []
 
-        manager = PluginManager(discovery, self.loader, self.filter)
-        manager.collect_plugins()
 
-        self.assertEqual(manager.modules, [])
+def test_get_all_plugins(manager, interface):
+    plugins = manager.get_all_plugins(interface=interface)
+    assert isinstance(plugins, list)
 
-    def test_mock_discover_plugins(self):
-        discovery = FileSystemPluginDiscovery([], LIBDIR)
-        discovery.discover_plugins = MagicMock(
-            return_value=["mock_plugin1", "mock_plugin2"]
-        )
 
-        self.assertEqual(
-            discovery.discover_plugins(), ["mock_plugin1", "mock_plugin2"]
-        )
-        discovery.discover_plugins.assert_called_once()
+def test_get_classes_from_module(manager, interface):
+    module = MagicMock()
+    classes = manager._get_classes_from_module(module, interface)
+    assert isinstance(classes, Iterable)
 
-    def test_mock_plugin_loader(self):
-        mock_module = MagicMock()
 
-        with patch(
-            "importlib.import_module", return_value=mock_module
-        ) as mock_import:
-            module = self.loader.load_plugin("mock_plugin")
+def test_load_directory():
+    plugin_folder = Path("folder1")
+    loaded_manager = load_directory([plugin_folder], LIBDIR)
+    assert isinstance(loaded_manager, PluginManager)
 
-            self.assertEqual(module, mock_module)
-            mock_import.assert_called_once_with("mock_plugin")
 
-    def test_mock_plugin_manager(self):
-        discovery = MagicMock()
-        loader = MagicMock()
-        filter = PluginFilter()
-        manager = PluginManager(discovery, loader, filter)
+def test_default_plugin_loader(loader):
+    with patch("importlib.import_module") as mock_import:
+        loader.load_plugin("test_module")
+        mock_import.assert_called_once_with("test_module")
 
-        discovery.discover_plugins.return_value = ["mock_plugin"]
-        loader.load_plugin.return_value = MagicMock()
 
-        manager.collect_plugins()
-        discovery.discover_plugins.assert_called_once()
+def test_default_plugin_loader_import_failure(loader):
+    with patch(
+        "importlib.import_module", side_effect=ImportError("Module not found")
+    ):
+        with pytest.raises(ImportError):
+            loader.load_plugin("non_existent_module")
 
-        filtered_plugins = self.filter.filter_plugins(["mock_plugin"])
 
-        self.assertEqual(manager.modules, filtered_plugins)
-        discovery.discover_plugins.assert_called_once()
+@pytest.mark.parametrize(
+    "exclude, class_name, expected",
+    [
+        (["Excluded"], "Excluded", True),
+        (["Excluded"], "Other", False),
+        ([], "Anything", False),
+    ],
+)
+def test_plugin_filter_exclusion(exclude, class_name, expected):
+    f = PluginFilter(exclude_classes=exclude)
+    assert f.is_excluded(class_name) == expected
 
-    def test_plugin_filter_exclusion(self):
-        filter = PluginFilter(exclude_classes=["ExcludedPlugin"])
 
-        self.assertTrue(filter.is_excluded("ExcludedPlugin"))
-        self.assertFalse(filter.is_excluded("AllowedPlugin"))
+def test_plugin_filter_matches_patterns():
+    f = PluginFilter(include_patterns=["Allowed"])
+
+    class MockPlugin:
+        pass
+
+    assert not f.matches_patterns(MockPlugin)
+
+
+def test_mock_plugin_manager(plugin_filter):
+    discovery = MagicMock()
+    loader = MagicMock()
+    manager = PluginManager(discovery, loader, plugin_filter)
+
+    discovery.discover_plugin_files.return_value = {
+        "mock_plugin": Path("mock_plugin.py")
+    }
+    loader.load_plugin.return_value = MagicMock()
+
+    manager.collect_plugins()
+    discovery.discover_plugin_files.assert_called_once()
+
+    assert manager.modules == plugin_filter.filter_plugins(["mock_plugin"])
+
+
+def test_module_caching(manager):
+    with patch.object(
+        manager.loader, "load_plugin", return_value=MagicMock()
+    ) as mock_load:
+        manager.modules = ["pluginA"]
+        manager.get_all_plugins(interface=PluginObject)
+        manager.get_all_plugins(interface=PluginObject)
+        mock_load.assert_called_once_with("pluginA")
+
+
+def test_class_caching(manager):
+    module = MagicMock()
+    manager.modules = ["pluginA"]
+
+    class Fake:
+        name = "fake"
+
+    with patch.object(manager.loader, "load_plugin", return_value=module):
+        with patch.object(
+            manager, "_get_classes_from_module", return_value=[("Fake", Fake)]
+        ) as mock_scan:
+            manager.get_all_plugins(interface=PluginObject)
+            manager.get_all_plugins(interface=PluginObject)
+
+            mock_scan.assert_called_once()
+
+
+def test_duplicate_class_suppression():
+    class FakePlugin:
+        name = "dup"
+
+    plugins = {"dup": FakePlugin}
+
+    existing_cls = plugins["dup"]
+    new_cls = FakePlugin
+
+    assert existing_cls is new_cls
+
+
+def test_plugin_filter_matches_module_and_class():
+    f = PluginFilter(include_patterns=["allowed"])
+
+    class AllowedPlugin:
+        __module__ = "tuxemon.allowed.plugins"
+        __name__ = "AllowedPlugin"
+
+    assert f.matches_patterns(AllowedPlugin)
+
+
+def test_plugin_filter_rejects_non_matching():
+    f = PluginFilter(include_patterns=["allowed"])
+
+    class NotAllowed:
+        __module__ = "tuxemon.other"
+        __name__ = "Other"
+
+    assert not f.matches_patterns(NotAllowed)
+
+
+def test_real_plugin_loading(tmp_path):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text("")
+
+    plugin_file = plugin_dir / "myplugin.py"
+    plugin_file.write_text(
+        """
+class MyPlugin:
+    name = "myplugin"
+"""
+    )
+
+    import sys
+
+    sys.path.insert(0, str(tmp_path))
+
+    manager = load_directory([plugin_dir], tmp_path, include=["myplugin"])
+    plugins = manager.get_all_plugins(interface=PluginObject)
+
+    assert any(p.plugin_object.__name__ == "MyPlugin" for p in plugins)
+
+
+def test_load_directory_initializes_manager(tmp_path):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+
+    manager = load_directory([plugin_dir], tmp_path)
+
+    assert isinstance(manager, PluginManager)
+    assert manager.discovery.folders == [plugin_dir]
+
+
+def test_get_classes_respects_interface(manager):
+    class Base:
+        pass
+
+    class Child(Base):
+        pass
+
+    module = MagicMock()
+    module.Child = Child
+    module.Base = Base
+
+    classes = manager._get_classes_from_module(module, Base)
+    names = [name for name, _ in classes]
+
+    assert "Base" in names
+    assert "Child" in names

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -15,10 +15,7 @@ from tuxemon.cli.context import InvokeContext
 from tuxemon.cli.exceptions import CommandNotFoundError, ParseError
 from tuxemon.cli.formatter import Formatter
 from tuxemon.constants.paths import get_active_mod_paths, mods_folder
-from tuxemon.plugin import (
-    get_available_classes,
-    load_directory,
-)
+from tuxemon.plugin import load_directory
 
 if TYPE_CHECKING:
     from tuxemon.session import Session
@@ -152,17 +149,22 @@ class CommandProcessor:
 
             logger.info(f"Discovered plugin modules: {pm.modules}")
 
-            for cmd_class in get_available_classes(pm, interface=CLICommand):
+            for plugin in pm.get_all_plugins(interface=CLICommand):
+                cmd_class = plugin.plugin_object
+
                 if (
                     not inspect.isabstract(cmd_class)
                     and cmd_class.usable_from_root
                 ):
                     if cmd_class.name in command_dict:
                         logger.warning(
-                            f"Overwriting command '{cmd_class.name}' from {cmd_class.__module__}"
+                            f"Overwriting command '{cmd_class.name}' "
+                            f"from {cmd_class.__module__}"
                         )
+
                     command_dict[cmd_class.name] = cmd_class()
                     logger.info(f"Registered command: {cmd_class.name}")
+
         except Exception:
             logger.error(
                 "Error loading commands from mod folders", exc_info=True

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -46,6 +46,7 @@ InterfaceValue = TypeVar("InterfaceValue", bound=PluginObject)
 class Plugin(Generic[T]):
     name: str
     plugin_object: T
+    origin: Path
 
 
 class PluginDiscovery(ABC):
@@ -56,6 +57,10 @@ class PluginDiscovery(ABC):
     @abstractmethod
     def discover_plugins(self) -> list[str]:
         """Discovers plugin modules."""
+
+    @abstractmethod
+    def discover_plugin_files(self) -> dict[str, Path]:
+        """Return module_name → file_path mapping."""
 
     @abstractmethod
     def set_folders(self, folders: list[Path]) -> None:
@@ -75,8 +80,11 @@ class FileSystemPluginDiscovery(PluginDiscovery):
         self.file_extensions = file_extensions
 
     def discover_plugins(self) -> list[str]:
-        """Discovers plugin modules from the file system."""
-        modules = []
+        return list(self.discover_plugin_files().keys())
+
+    def discover_plugin_files(self) -> dict[str, Path]:
+        """Return a mapping of module_name → file_path."""
+        modules: dict[str, Path] = {}
         for folder in self.folders:
             folder_path = folder
             if not folder_path.exists():
@@ -84,13 +92,12 @@ class FileSystemPluginDiscovery(PluginDiscovery):
                 continue
 
             module_path = self._get_module_path(folder_path)
-            modules.extend(
-                [
-                    f"{module_path}.{file.stem}"
-                    for file in folder_path.iterdir()
-                    if file.suffix in self.file_extensions and file.is_file()
-                ]
-            )
+
+            for file in folder_path.iterdir():
+                if file.suffix in self.file_extensions and file.is_file():
+                    module_name = f"{module_path}.{file.stem}"
+                    modules[module_name] = file.resolve()
+
         return modules
 
     def set_folders(self, folders: list[Path]) -> None:
@@ -157,7 +164,7 @@ class PluginFilter:
         self.include_patterns_set = set(include_patterns)
 
     def is_excluded(self, class_name: str) -> bool:
-        """Check if a class should be excluded."""
+        """Check if a class should be excluded based on its simple name."""
         return class_name in self.exclude_classes_set
 
     def matches_pattern(self, string: str) -> bool:
@@ -165,17 +172,28 @@ class PluginFilter:
         return any(pattern in string for pattern in self.include_patterns_set)
 
     def matches_patterns(self, class_obj: type) -> bool:
-        """Check if a class matches inclusion patterns."""
-        return self.matches_pattern(str(class_obj))
+        """
+        Check if a class matches inclusion patterns using introspection
+        on its module path and name.
+        """
+        module_path = class_obj.__module__
+        class_name = class_obj.__name__
+
+        # Check if the inclusion patterns match the full module path OR the class name
+        # Example: pattern 'plugins' matches module 'tuxemon.plugins.game'
+        # Example: pattern 'Command' matches class 'LoadCommand'
+        return self.matches_pattern(module_path) or self.matches_pattern(
+            class_name
+        )
 
     def filter_plugins(self, module_names: list[str]) -> list[str]:
-        """Filters plugin modules based on patterns."""
+        """Filters plugin modules based on patterns (using module path)."""
         return [
             module for module in module_names if self.matches_pattern(module)
         ]
 
     def is_valid_plugin(self, class_name: str, class_obj: type) -> bool:
-        """Check if a plugin should be included."""
+        """Check if a plugin should be included by checking exclusion and inclusion."""
         if self.is_excluded(class_name):
             logger.debug(
                 f"Skipping class '{class_name}' because it's in the exclusion list."
@@ -184,7 +202,7 @@ class PluginFilter:
 
         if not self.matches_patterns(class_obj):
             logger.debug(
-                f"Skipping class '{class_name}' because its name does not match an include pattern."
+                f"Skipping class '{class_name}' because its module path or name does not match an include pattern."
             )
             return False
 
@@ -204,12 +222,17 @@ class PluginManager:
         self.loader = loader
         self.filter = filter or PluginFilter()
         self.modules: list[str] = []
+        self._origins: dict[str, Path] = {}
+        self._loaded_modules: dict[str, ModuleType] = {}
+        self._class_cache: dict[tuple[str, type], list[tuple[str, type]]] = {}
 
     def collect_plugins(self) -> None:
         """Collect plugins from the specified folders."""
         logger.debug("Discovering plugins...")
-        raw_modules = self.discovery.discover_plugins()
-        self.modules = self.filter.filter_plugins(raw_modules)
+        module_map = self.discovery.discover_plugin_files()
+        filtered = self.filter.filter_plugins(list(module_map.keys()))
+        self.modules = list(dict.fromkeys(filtered))
+        self._origins = {m: module_map[m] for m in self.modules}
         logger.debug(f"Modules discovered: {self.modules}")
 
     def get_all_plugins(
@@ -218,29 +241,51 @@ class PluginManager:
         """Get all loaded plugins implementing the given interface."""
         imported_plugins: list[Plugin[type[InterfaceValue]]] = []
         for module_name in self.modules:
-            try:
-                module = self.loader.load_plugin(module_name)
-                imported_plugins.extend(
-                    self._get_plugins_from_module(
-                        module, module_name, interface
+            module = self._loaded_modules.get(module_name)
+
+            if module is None:
+                try:
+                    module = self.loader.load_plugin(module_name)
+                    self._loaded_modules[module_name] = module
+
+                except ImportError as e:
+                    logger.error(
+                        f"Skipping module '{module_name}' due to import error: {e}"
                     )
-                )
-            except ImportError as e:
-                logger.error(
-                    f"Skipping module '{module_name}' due to import error: {e}"
-                )
+                    continue  # Skip to the next module
+
+            imported_plugins.extend(
+                self._get_plugins_from_module(module, module_name, interface)
+            )
+
         return imported_plugins
 
     def _get_plugins_from_module(
         self, module: ModuleType, module_name: str, interface: type
     ) -> list[Plugin[type[InterfaceValue]]]:
-        """Retrieves plugins from a given module, filtering by a specific interface."""
+
+        cache_key = (module_name, interface)
+
+        if cache_key in self._class_cache:
+            class_list = self._class_cache[cache_key]
+        else:
+            class_list = [
+                (class_name, class_obj)
+                for class_name, class_obj in self._get_classes_from_module(
+                    module, interface
+                )
+                if self.filter.is_valid_plugin(class_name, class_obj)
+            ]
+
+            self._class_cache[cache_key] = class_list
+
         return [
-            Plugin(f"{module_name}.{class_name}", class_obj)
-            for class_name, class_obj in self._get_classes_from_module(
-                module, interface
+            Plugin(
+                name=f"{module_name}.{class_name}",
+                plugin_object=class_obj,
+                origin=self._origins[module_name],
             )
-            if self.filter.is_valid_plugin(class_name, class_obj)
+            for class_name, class_obj in class_list
         ]
 
     def _get_classes_from_module(
@@ -290,25 +335,6 @@ def load_directory(
     return manager
 
 
-def get_available_classes(
-    plugin_manager: PluginManager, *, interface: type[InterfaceValue]
-) -> Sequence[type[InterfaceValue]]:
-    """
-    Get available classes from a plugin manager.
-
-    Parameter:
-        plugin_manager: Plugin manager with modules already loaded.
-        interface: Superclass or protocol of the returned classes.
-
-    Returns:
-        Sequence of loaded classes.
-    """
-    return [
-        plugin.plugin_object
-        for plugin in plugin_manager.get_all_plugins(interface=interface)
-    ]
-
-
 # Overloads until https://github.com/python/mypy/issues/3737 is fixed
 
 
@@ -340,30 +366,50 @@ def load_plugins(
     interface: Union[type[InterfaceValue], type[PluginObject]] = PluginObject,
 ) -> Mapping[str, Union[type[InterfaceValue], type[PluginObject]]]:
     """
-    Load plugins from a directory and return them by name.
-
-    Parameters:
-        paths: Locations of the modules to load.
-        category: Optional string for debugging info.
-        interface: Superclass or protocol of the returned classes. If no
-            class is given, they are only required to have a `name` attribute.
-
-    Returns:
-        A dictionary mapping the `name` attribute of each class to the class
-        itself.
+    Load plugins from a directory and return them by both:
+      - their declared short name (cls.name)
+      - their fully qualified plugin name (plugin.name)
     """
     classes: dict[str, Union[type[InterfaceValue], type[PluginObject]]] = {}
-    plugins = load_directory(plugin_folders=paths, root_path=root_path)
+    manager = load_directory(plugin_folders=paths, root_path=root_path)
 
-    for cls in get_available_classes(plugins, interface=interface):
-        try:
-            name = cls.name
-        except AttributeError:
+    for plugin in manager.get_all_plugins(interface=interface):
+        cls = plugin.plugin_object
+
+        fq_key = plugin.name
+        short_key = getattr(cls, "name", None)
+
+        if interface is PluginObject and short_key is None:
             logger.error(
-                f"Class {cls.__name__} does not have a `name` attribute"
+                f"Class {cls.__name__} ({fq_key}) does not have a required `name` attribute."
             )
             continue
-        classes[name] = cls
-        logger.info(f"loaded {category}: {cls.name}")
+
+        if fq_key in classes:
+            logger.warning(
+                f"Duplicate fully qualified plugin key '{fq_key}'. Skipping."
+            )
+        else:
+            classes[fq_key] = cls
+
+        if short_key:
+            if short_key in classes:
+                existing_cls = classes[short_key]
+
+                if existing_cls is cls:
+                    continue
+
+                logger.warning(
+                    f"Duplicate short plugin key '{short_key}'. "
+                    f"Existing: {existing_cls.__module__}.{existing_cls.__name__}, "
+                    f"New: {cls.__module__}.{cls.__name__}. Keeping existing."
+                )
+            else:
+                classes[short_key] = cls
+
+        logger.info(
+            f"Loaded {category}: {short_key or cls.__name__} "
+            f"(Keys: {fq_key}{', ' + short_key if short_key else ''})"
+        )
 
     return classes

--- a/tuxemon/state/loader.py
+++ b/tuxemon/state/loader.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tuxemon.constants.paths import get_active_mod_paths, mods_folder
-from tuxemon.plugin import get_available_classes, load_directory
+from tuxemon.plugin import load_directory
 from tuxemon.state.state import State
 
 if TYPE_CHECKING:
@@ -134,7 +134,8 @@ class StateLoader:
             exclude=["State"],
         )
 
-        for state_cls in get_available_classes(pm, interface=State):
+        for plugin in pm.get_all_plugins(interface=State):
+            state_cls = plugin.plugin_object
             try:
                 if not inspect.isabstract(state_cls):
                     repository.add_state(state_cls)

--- a/tuxemon/tuxepedia.py
+++ b/tuxemon/tuxepedia.py
@@ -31,7 +31,7 @@ class MonsterEntry:
     appearance_count: int = 1
     caught_count: int = 0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not isinstance(self.status, SeenStatus):
             try:
                 self.status = SeenStatus(self.status)


### PR DESCRIPTION
Changes:
- added module‑level caching to the plugin manager to avoid repeated imports and reduce unnecessary work
- added class‑level caching so each module is scanned only once per interface, improving performance and preventing redundant introspection
- refactored the plugin filter to use class metadata (`__module__` and `__name__`) instead of relying on string representations of class objects
- improved duplicate plugin detection by suppressing false duplicates when the same class is discovered more than once, while still reporting real conflicts
- cleaned up the plugin discovery and loading pipeline to better separate responsibilities between discovery, loading, filtering, and extraction
- improved error handling during module import so that failures are logged and skipped without interrupting the loading process
- expanded the test suite with new pytest tests covering module caching, class caching, filtering behavior, and end‑to‑end plugin loading using temporary plugin files
- updated existing tests to use real classes instead of mocks where necessary to avoid missing attributes such as `__name__` and `__module__`
- ensured temporary plugin directories created during tests are importable by adding `__init__.py` files and adjusting `sys.path` where required
- improved overall reliability, performance, and maintainability of the plugin system through clearer structure and more comprehensive test coverage