### PR TITLE
Extract and Refactor Technique Cooldown into Dedicated Class

### DIFF
--- a/tests/tuxemon/test_cooldown.py
+++ b/tests/tuxemon/test_cooldown.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.technique.cooldown import Cooldown
+
+
+def test_initial_state():
+    cd = Cooldown(duration=3)
+    assert cd.duration == 3
+    assert cd.remaining == 0
+    assert cd.is_recharging is False
+
+
+@pytest.mark.parametrize("duration", [0, 1, 5, 999])
+def test_trigger_sets_remaining_to_duration(duration):
+    cd = Cooldown(duration=duration)
+    cd.trigger()
+    assert cd.remaining == duration
+    assert cd.is_recharging is (duration > 0)
+
+
+@pytest.mark.parametrize(
+    "start, tick_amount, expected",
+    [
+        (5, 1, 4),
+        (5, 2, 3),
+        (1, 5, 0),  # cannot go below zero
+        (0, 1, 0),  # already zero
+    ],
+)
+def test_tick_reduces_remaining(start, tick_amount, expected):
+    cd = Cooldown(duration=10)
+    cd.remaining = start
+    cd.tick(tick_amount)
+    assert cd.remaining == expected
+
+
+def test_reset_sets_remaining_to_zero():
+    cd = Cooldown(duration=3)
+    cd.remaining = 3
+    cd.reset()
+    assert cd.remaining == 0
+    assert cd.is_recharging is False
+
+
+@pytest.mark.parametrize(
+    "initial, add_amount, max_value, expected",
+    [
+        (0, 1, 5, 1),
+        (1, 2, 5, 3),
+        (3, 10, 5, 5),  # clamp
+        (5, 1, 5, 5),  # already max
+    ],
+)
+def test_add_increases_remaining_but_clamps(
+    initial, add_amount, max_value, expected
+):
+    cd = Cooldown(duration=3)
+    cd.remaining = initial
+    cd.add(add_amount, max_value)
+    assert cd.remaining == expected
+
+
+def test_trigger_overrides_remaining():
+    cd = Cooldown(duration=4)
+    cd.remaining = 99
+    cd.trigger()
+    assert cd.remaining == 4
+
+
+def test_negative_tick_does_not_increase_remaining():
+    cd = Cooldown(duration=5)
+    cd.remaining = 3
+    cd.tick(-10)
+    assert cd.remaining == 3  # unchanged
+
+
+def test_negative_add_does_not_reduce_remaining():
+    cd = Cooldown(duration=5)
+    cd.remaining = 3
+    cd.add(-5, max_value=10)
+    assert cd.remaining == 3  # unchanged

--- a/tuxemon/core/effects/cooldown.py
+++ b/tuxemon/core/effects/cooldown.py
@@ -49,7 +49,7 @@ class CoolDownEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
 
-        if not _is_next_use_valid(self.current_cooldown):
+        if not RECHARGE_RANGE[0] <= self.current_cooldown <= RECHARGE_RANGE[1]:
             raise ValueError(
                 f"{self.name}: {self.current_cooldown} must be between {RECHARGE_RANGE}"
             )
@@ -82,21 +82,17 @@ class CoolDownEffect(CoreEffect):
 
         _update_moves(moves_to_update, self.current_cooldown)
         if self.current_cooldown > 0:
-            tech.current_cooldown -= 1
+            tech.cooldown.tick()
 
         return TechEffectResult(name=tech.name, success=True)
 
 
-def _is_next_use_valid(current_cooldown: int) -> bool:
-    return RECHARGE_RANGE[0] <= current_cooldown <= RECHARGE_RANGE[1]
-
-
 def _update_moves(moves: list[Technique], current_cooldown: int) -> None:
     for move in moves:
+        cd = move.cooldown
+
         if current_cooldown == 0:
-            move.current_cooldown -= 1
+            cd.tick()
         else:
-            if move.current_cooldown <= move.cooldown_duration:
-                move.current_cooldown = min(
-                    move.current_cooldown + current_cooldown, RECHARGE_RANGE[1]
-                )
+            if cd.remaining <= cd.duration:
+                cd.add(current_cooldown, RECHARGE_RANGE[1])

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -335,7 +335,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 tech_enabled = True
 
                 if tech.is_recharging:
-                    tech_name = f"{tech.name} ({abs(tech.current_cooldown)})"
+                    tech_name = f"{tech.name} ({tech.cooldown.remaining})"
                     tech_color = self.unavailable_color
                     tech_enabled = False
 
@@ -463,7 +463,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
                 text_lines = {
                     "accuracy": f"{T.translate('technique_accuracy')} {int(technique.accuracy * 100)}%",
-                    "recharge": f"{T.translate('technique_recharge')} {technique.cooldown_duration} {T.translate('technique_turns')}",
+                    "recharge": f"{T.translate('technique_recharge')} {technique.cooldown.duration} {T.translate('technique_turns')}",
                 }
 
                 # Only add Power if it's not zero

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -163,7 +163,7 @@ class MonsterMovesState(PygameMenuState):
             {
                 "id": technique.tech_id,
                 "types": types_text,
-                "rec": str(technique.cooldown_duration),
+                "rec": str(technique.cooldown.duration),
             },
         )
 

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -164,7 +164,7 @@ class TechniqueMenuState(Menu[Technique]):
                 "acc": int(tech.accuracy * 100),
                 "pot": int(tech.potency * 100),
                 "pow": tech.power,
-                "rec": str(tech.cooldown_duration),
+                "rec": str(tech.cooldown.duration),
             },
         )
         if tech.description and tech.description != f"{tech.slug}_description":

--- a/tuxemon/technique/cooldown.py
+++ b/tuxemon/technique/cooldown.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Cooldown:
+    def __init__(self, duration: int = 0):
+        self.duration = duration
+        self.remaining = 0
+
+    @property
+    def is_recharging(self) -> bool:
+        return self.remaining > 0
+
+    def add(self, amount: int, max_value: int) -> None:
+        if amount < 0:
+            logger.error("Cooldown.add() does not accept negative values")
+            return
+        self.remaining = min(self.remaining + amount, max_value)
+
+    def trigger(self) -> None:
+        self.remaining = self.duration
+
+    def tick(self, amount: int = 1) -> None:
+        if amount < 0:
+            logger.error("Cooldown.tick() does not accept negative values")
+            return
+        self.remaining = max(0, self.remaining - amount)
+
+    def reset(self) -> None:
+        self.remaining = 0

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -23,6 +23,7 @@ from tuxemon.element import ElementTypesHandler
 from tuxemon.locale import T
 from tuxemon.modifiers import ModifiersHandler
 from tuxemon.surfanim import FlipAxes
+from tuxemon.technique.cooldown import Cooldown
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -49,19 +50,18 @@ class Technique:
         self.counter: int = 0
         self.tech_id: int = 0
         self.accuracy: float = 0.0
+        self.cooldown = Cooldown()
         self.visuals = VisualProperties(
             animation=None, flip_axes=FlipAxes.NONE, loop=-1
         )
         self.hit: bool = False
         self.speed: int = 0
-        self.current_cooldown: int = 0
         self.potency: float = 0.0
         self.power: float = 1.0
         self.default_potency: float = 0.0
         self.default_power: float = 1.0
         self.range: Range = Range.melee
         self.healing_power: float = 0.0
-        self.cooldown_duration: int = 0
         self.sound = SoundProperties(sfx=None, volume=1.5)
         self.sort: str = ""
         self.slug: str = ""
@@ -100,7 +100,7 @@ class Technique:
     @property
     def is_recharging(self) -> bool:
         """Returns whether the technique is currently recharging."""
-        return self.current_cooldown > 0
+        return self.cooldown.is_recharging
 
     def load(self, slug: str) -> None:
         """
@@ -135,7 +135,7 @@ class Technique:
         self.speed = results.speed.numeric_value
         self.behaviors = results.behaviors
         self.healing_power = results.healing_power
-        self.cooldown_duration = results.recharge
+        self.cooldown.duration = results.recharge
         self.range = results.range
         self.tech_id = results.tech_id
         self.menu_actions_data = results.menu_actions
@@ -163,12 +163,11 @@ class Technique:
         """
         return self.condition_handler.validate(session=session, target=target)
 
-    def recharge(self) -> None:
-        if self.current_cooldown > 0:
-            self.current_cooldown -= 1
+    def recharge(self, amount: int = 1) -> None:
+        self.cooldown.tick(amount)
 
     def full_recharge(self) -> None:
-        self.current_cooldown = 0
+        self.cooldown.reset()
 
     def use(
         self, session: Session, user: Monster, target: Monster
@@ -184,7 +183,7 @@ class Technique:
             user=user,
             target=target,
         )
-        self.current_cooldown = self.cooldown_duration
+        self.cooldown.trigger()
         if session.client:
             session.client.active_effect_manager.add_technique(self)
         return result


### PR DESCRIPTION
Before this change, all the cooldown logic was tangled directly inside the `Technique` class, which made it hard to reason about and even harder to extend. Pulling cooldowns into their own dedicated class gives us a clean separation of concerns and opens the door for future expansions, like supporting different cooldown types or more advanced recharge behaviors. This refactor lays the groundwork for that flexibility and addresses the need highlighted in #3332.

Changes:
- introduced a standalone `Cooldown` class to encapsulate cooldown logic
- replaced integer-based cooldown handling in `Technique` with the new `Cooldown` object
- updated `Technique.use()`, `Technique.recharge()`, and `Technique.full_recharge()` to use the new API
- ensured cooldown duration is loaded from technique data without overwriting runtime state
- added comprehensive unit tests covering all cooldown behaviors