### PR TITLE
Add unified temporary stat boost system for items, statuses, and techniques

### DIFF
--- a/tests/tuxemon/test_stat_change.py
+++ b/tests/tuxemon/test_stat_change.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import random
+from unittest.mock import patch
+
+import pytest
+
+from tuxemon.db import StatModel
+from tuxemon.monster_dir.stat_utils import apply_stat_modifiers
+from tuxemon.monster_dir.stats import BasicStats
+
+
+class DummyMonster:
+    def __init__(self):
+        self.base_stats = BasicStats(
+            armour=10, dodge=5, hp=100, melee=20, ranged=15, speed=30
+        )
+        self.current_hp = 80
+        self.hp = self.base_stats.hp
+
+    def return_stat(self, stat_type):
+        slug = stat_type
+        return getattr(self.base_stats, slug)
+
+
+class DummySource:
+    def __init__(self):
+        self.temporary_stat_boosts = BasicStats()
+
+
+@pytest.fixture
+def monster():
+    return DummyMonster()
+
+
+@pytest.fixture
+def source():
+    return DummySource()
+
+
+ALL_STATS = ["armour", "dodge", "melee", "ranged", "speed", "hp"]
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+@patch("random.randint", return_value=2)
+def test_step_based_nonlinear_all_stats(_, monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(step=2, max_deviation=0, scaling_mode="nonlinear")
+    }
+    base = getattr(monster.base_stats, stat_slug)
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 2
+    expected_new_value = int(base * 2.0)
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_value_based_add_all_stats(monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(
+            value=5, step=None, operation="+", max_deviation=0
+        )
+    }
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, stat_slug) == 5
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_negative_value_clamped_all_stats(monster, source, stat_slug):
+    base = getattr(monster.base_stats, stat_slug)
+    modifiers = {stat_slug: StatModel(value=-999, step=None, operation="+")}
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, stat_slug) == 1 - base
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+@patch("random.randint", return_value=999)
+def test_step_clamping_all_stats(_, monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(
+            step=6, max_deviation=10, scaling_mode="nonlinear"
+        )
+    }
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 6
+
+
+def test_hp_override(monster, source):
+    modifiers = {"current_hp": StatModel(overridetofull=True)}
+    apply_stat_modifiers(monster, source, modifiers)
+    assert monster.current_hp == monster.base_stats.hp
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+@patch("random.randint", return_value=2)
+def test_step_based_linear_all_stats(_, monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(step=2, max_deviation=0, scaling_mode="linear")
+    }
+    base = getattr(monster.base_stats, stat_slug)
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 2
+    multiplier = 1 + (2 / 6)
+    expected_new_value = int(base * multiplier)
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+@patch("random.randint", return_value=-3)
+def test_step_based_linear_negative(_, monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(step=-3, max_deviation=0, scaling_mode="linear")
+    }
+    base = getattr(monster.base_stats, stat_slug)
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == -3
+    multiplier = 1 + (-3 / 6)
+    expected_new_value = int(base * multiplier)
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+@patch("random.randint", return_value=5)
+def test_step_based_linear_with_deviation(_, monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(step=2, max_deviation=10, scaling_mode="linear")
+    }
+    base = getattr(monster.base_stats, stat_slug)
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 5
+    multiplier = 1 + (5 / 6)
+    expected_new_value = int(base * multiplier)
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+@patch("random.randint", return_value=999)
+def test_step_based_linear_clamping(_, monster, source, stat_slug):
+    modifiers = {
+        stat_slug: StatModel(step=6, max_deviation=10, scaling_mode="linear")
+    }
+    apply_stat_modifiers(monster, source, modifiers)
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 6
+
+
+@patch("random.randint", return_value=2)
+def test_step_based_linear_hp(_, monster, source):
+    modifiers = {
+        "hp": StatModel(step=2, max_deviation=0, scaling_mode="linear")
+    }
+    base = monster.base_stats.hp
+    apply_stat_modifiers(monster, source, modifiers)
+    assert source.temporary_stat_boosts.hp_stage == 2
+    multiplier = 1 + (2 / 6)
+    expected_new_value = int(base * multiplier)
+    expected_boost = expected_new_value - base
+    assert source.temporary_stat_boosts.hp == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_stacking_positive(monster, source, stat_slug):
+    base = getattr(monster.base_stats, stat_slug)
+    with patch("random.randint", return_value=2):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=2, scaling_mode="nonlinear")},
+        )
+    with patch("random.randint", return_value=3):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=3, scaling_mode="nonlinear")},
+        )
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 5
+    expected_new_value = int(base * (7 / 2))
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_stacking_negative(monster, source, stat_slug):
+    base = getattr(monster.base_stats, stat_slug)
+    with patch("random.randint", return_value=-2):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=-2, scaling_mode="nonlinear")},
+        )
+    with patch("random.randint", return_value=-3):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=-3, scaling_mode="nonlinear")},
+        )
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == -5
+    expected_new_value = int(base * (2 / 7))
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_stacking_mixed(monster, source, stat_slug):
+    base = getattr(monster.base_stats, stat_slug)
+    with patch("random.randint", return_value=4):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=4, scaling_mode="nonlinear")},
+        )
+    with patch("random.randint", return_value=-3):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=-3, scaling_mode="nonlinear")},
+        )
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 1
+    expected_new_value = int(base * (3 / 2))
+    expected_boost = expected_new_value - base
+    assert getattr(source.temporary_stat_boosts, stat_slug) == expected_boost
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_stacking_clamping(monster, source, stat_slug):
+    with patch("random.randint", return_value=4):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=4, scaling_mode="nonlinear")},
+        )
+    with patch("random.randint", return_value=4):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=4, scaling_mode="nonlinear")},
+        )
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 6
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_stacking_clamping_negative(monster, source, stat_slug):
+    with patch("random.randint", return_value=-4):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=-4, scaling_mode="nonlinear")},
+        )
+    with patch("random.randint", return_value=-4):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=-4, scaling_mode="nonlinear")},
+        )
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == -6
+
+
+@pytest.mark.parametrize("stat_slug", ALL_STATS)
+def test_reset_cleanup(monster, source, stat_slug):
+    # Apply a boost
+    with patch("random.randint", return_value=2):
+        apply_stat_modifiers(
+            monster,
+            source,
+            {stat_slug: StatModel(step=2, scaling_mode="nonlinear")},
+        )
+    assert getattr(source.temporary_stat_boosts, f"{stat_slug}_stage") == 2
+    source.temporary_stat_boosts = BasicStats()
+    for s in ALL_STATS:
+        assert getattr(source.temporary_stat_boosts, s) == 0
+    for s in ALL_STATS:
+        assert not hasattr(source.temporary_stat_boosts, f"{s}_stage")
+
+
+def test_stress_100_random(monster, source):
+    for _ in range(100):
+        stat_slug = random.choice(ALL_STATS)
+        if random.random() < 0.7:  # 70% step-based
+            step = random.randint(-6, 6)
+            max_dev = random.randint(0, 3)
+            scaling_mode = random.choice(["linear", "nonlinear"])
+            model = StatModel(
+                step=step, max_deviation=max_dev, scaling_mode=scaling_mode
+            )
+        else:  # 30% value-based
+            value = random.randint(-20, 20)
+            max_dev = random.randint(0, 5)
+            op = random.choice(["+", "-", "*", "/"])
+            model = StatModel(
+                value=value, step=None, max_deviation=max_dev, operation=op
+            )
+        apply_stat_modifiers(monster, source, {stat_slug: model})
+        stage_attr = f"{stat_slug}_stage"
+        if hasattr(source.temporary_stat_boosts, stage_attr):
+            stage = getattr(source.temporary_stat_boosts, stage_attr)
+            assert -6 <= stage <= 6
+        if stat_slug != "current_hp":
+            boost = getattr(source.temporary_stat_boosts, stat_slug)
+            base = getattr(monster.base_stats, stat_slug)
+            assert base + boost >= 1
+        assert 0 <= monster.current_hp <= monster.base_stats.hp

--- a/tuxemon/core/effects/buff.py
+++ b/tuxemon/core/effects/buff.py
@@ -41,27 +41,12 @@ class BuffEffect(CoreEffect):
     def apply_item_target(
         self, session: Session, item: Item, target: Monster
     ) -> ItemEffectResult:
+
         if self.statistic not in list(StatType):
             raise ValueError(f"{self.statistic} isn't among {list(StatType)}")
 
-        amount = target.return_stat(StatType(self.statistic))
-        value = int(amount * self.percentage)
-
-        target.base_stats.armour += (
-            value if self.statistic == StatType.armour else 0
-        )
-        target.base_stats.dodge += (
-            value if self.statistic == StatType.dodge else 0
-        )
-        target.base_stats.hp += value if self.statistic == StatType.hp else 0
-        target.base_stats.melee += (
-            value if self.statistic == StatType.melee else 0
-        )
-        target.base_stats.speed += (
-            value if self.statistic == StatType.speed else 0
-        )
-        target.base_stats.ranged += (
-            value if self.statistic == StatType.ranged else 0
-        )
-
+        current_value = target.return_stat(self.statistic)
+        boost_value = int(current_value * self.percentage)
+        stat_name = self.statistic.value  # e.g. "speed", "armour", etc.
+        setattr(item.temporary_stat_boosts, stat_name, boost_value)
         return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/core/effects/statchange.py
+++ b/tuxemon/core/effects/statchange.py
@@ -3,17 +3,25 @@
 from __future__ import annotations
 
 import logging
-import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from tuxemon.core.core_effect import CoreEffect, StatusEffectResult
-from tuxemon.db import EffectPhase, StatType
-from tuxemon.tools import ops_dict
+from tuxemon.core.core_effect import (
+    CoreEffect,
+    ItemEffectResult,
+    StatusEffectResult,
+    TechEffectResult,
+)
+from tuxemon.db import EffectPhase
+from tuxemon.monster_dir.stat_utils import apply_stat_modifiers
+from tuxemon.monster_dir.stats import BasicStats
 
 if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
     from tuxemon.session import Session
     from tuxemon.status.status import Status
+    from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
 
@@ -74,122 +82,48 @@ class StatChangeEffect(CoreEffect):
         self, session: Session, status: Status
     ) -> StatusEffectResult:
         host = status.host
-        if (
-            status.has_phase(EffectPhase.PERFORM_STATUS)
-            and self.name not in status._effect_applied
-        ):
-            status._effect_applied.add("statchange")
 
-            for stat_slug, stat_model in status.stat_modifiers.items():
-                if not stat_model:
-                    continue
-
-                step_delta = stat_model.step
-                raw_value = stat_model.value
-                max_dev = stat_model.max_deviation
-                override = stat_model.overridetofull
-                operation = stat_model.operation
-
-                # Handle HP override
-                if stat_slug == "current_hp" and override:
-                    host.current_hp = host.hp
-                    logger.info(
-                        f"[{status.name}] Overriding current HP > {host.name}: {host.hp}"
-                    )
-                    continue
-
-                new_value = 0
-
-                if step_delta is not None:
-                    scaling_mode = stat_model.scaling_mode
-                    max_step = stat_model.max_step_limit
-
-                    actual_step = (
-                        random.randint(
-                            step_delta - max_dev, step_delta + max_dev
-                        )
-                        if max_dev
-                        else step_delta
-                    )
-
-                    # Clamp actual step to allowable range
-                    actual_step = int(
-                        max(-max_step, min(max_step, actual_step))
-                    )
-
-                    if stat_slug == "current_hp":
-                        base = host.hp
-                    else:
-                        base = getattr(host.base_stats, stat_slug)
-
-                    current = host.return_stat(StatType(stat_slug))
-                    old_step = (current - base) / base
-                    total_step = max(
-                        -max_step,
-                        min(max_step, old_step + actual_step),
-                    )
-
-                    if scaling_mode == "linear":
-                        new_value = int(base * (1 + total_step))
-                    else:
-                        # Nonlinear tiered formula
-                        if total_step > 0:
-                            new_value = int(
-                                base * (max_step + total_step) / max_step
-                            )
-                        else:
-                            new_value = int(
-                                base * max_step / (max_step - total_step)
-                            )
-
-                    logger.debug(
-                        f"[{status.name}] {stat_slug} changed via {scaling_mode} step on {host.name}: "
-                        f"step {old_step:.3f} > {total_step:.3f}, value {current:.2f} > {new_value:.2f}"
-                    )
-
-                else:
-                    # Value-based logic
-                    applied_value = (
-                        random.randint(
-                            int(raw_value - max_dev), int(raw_value + max_dev)
-                        )
-                        if max_dev
-                        else raw_value
-                    )
-
-                    stat_base = (
-                        getattr(host, stat_slug)
-                        if stat_slug == "current_hp"
-                        else getattr(host.base_stats, stat_slug, None)
-                    )
-                    if stat_base is None:
-                        continue
-
-                    if operation not in ops_dict:
-                        logger.warning(
-                            f"Unknown operation '{operation}' in status '{status.name}'"
-                        )
-                        continue
-
-                    op_func = ops_dict.get(operation, lambda a, b: a)
-                    new_value = round(op_func(stat_base, applied_value))
-
-                    logger.debug(
-                        f"[{status.name}] {stat_slug} changed via value on {host.name}: "
-                        f"{stat_base} > {new_value}"
-                    )
-
-                # Safety: Clamp stat values
-                if new_value <= 0 and stat_slug != "current_hp":
-                    new_value = 1
-
-                # Assignment
-                if stat_slug == "current_hp":
-                    host.current_hp = min(new_value, host.hp)
-                elif stat_slug in StatType.__members__:
-                    setattr(host.base_stats, stat_slug, int(new_value))
-
+        if status.has_phase(
+            EffectPhase.PERFORM_STATUS
+        ) and not status.is_already_applied(self.name):
+            apply_stat_modifiers(host, status, status.stat_modifiers)
+            status.mark_applied(self.name)
         elif status.has_phase(EffectPhase.ON_END):
-            host.set_stats()
+            status.temporary_stat_boosts = BasicStats()
 
         return StatusEffectResult(name=status.name, success=True)
+
+    def apply_tech_target(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+        t = tech.target
+
+        if t["own_monster"]:
+            apply_stat_modifiers(user, tech, tech.stat_modifiers)
+
+        if t["enemy_monster"]:
+            apply_stat_modifiers(target, tech, tech.stat_modifiers)
+
+        if t["own_team"]:
+            for mon in session.client.combat_session.get_own_monsters(user):
+                apply_stat_modifiers(mon, tech, tech.stat_modifiers)
+
+        if t["enemy_team"]:
+            for mon in session.client.combat_session.get_own_monsters(target):
+                apply_stat_modifiers(mon, tech, tech.stat_modifiers)
+
+        if t["own_trainer"]:
+            for mon in session.client.combat_session.get_party(user):
+                apply_stat_modifiers(mon, tech, tech.stat_modifiers)
+
+        if t["enemy_trainer"]:
+            for mon in session.client.combat_session.get_party(target):
+                apply_stat_modifiers(mon, tech, tech.stat_modifiers)
+
+        return TechEffectResult(name=tech.name, success=True)
+
+    def apply_item_target(
+        self, session: Session, item: Item, target: Monster
+    ) -> ItemEffectResult:
+        apply_stat_modifiers(target, item, item.stat_modifiers)
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -656,6 +656,10 @@ class ItemModel(BaseModel, BaseLookupModel):
         le=1.0,
     )
     modifiers: list[Modifier] = Field(..., description="Various modifiers")
+    stat_modifiers: dict[str, StatModel] = Field(
+        default_factory=dict,
+        description="Dictionary of stat modifiers keyed by stat name (e.g., 'speed', 'hp')",
+    )
     immunity_to_status: Sequence[str] = Field(
         default_factory=list,
         description="Statuses this item grants immunity to",
@@ -1233,8 +1237,6 @@ class StatModel(BaseModel):
     step: int | None = Field(
         None,
         description="Optional step delta to apply (e.g., +2 step to speed)",
-        ge=-6,
-        le=6,
     )
     max_deviation: int = Field(
         0,
@@ -1256,6 +1258,14 @@ class StatModel(BaseModel):
         "nonlinear",
         description="Defines how step scaling is applied: 'linear' for base*(1+step), 'nonlinear' for tiered scaling",
     )
+
+    @field_validator("step")
+    def validate_step(cls, v: int | None) -> int | None:
+        if v is None:
+            return None
+        if not (-6 <= v <= 6):
+            raise ValueError("step must be between -6 and 6")
+        return v
 
 
 class Range(str, Enum):
@@ -1433,6 +1443,10 @@ class TechniqueModel(BaseModel, BaseLookupModel):
         ..., description="Configuration for the technique's sound playback."
     )
     modifiers: list[Modifier] = Field(..., description="Various modifiers")
+    stat_modifiers: dict[str, StatModel] = Field(
+        default_factory=dict,
+        description="Dictionary of stat modifiers keyed by stat name (e.g., 'speed', 'hp')",
+    )
     use_tech: str | None = Field(
         None,
         description="Slug of what string to display when technique is used",

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -127,7 +127,7 @@ class GetPlayerMonsterAction(EventAction):
                 elif filter_name == "current_hp":
                     field = target.current_hp
                 elif filter_name in list(StatType):
-                    field = target.return_stat(StatType(filter_name))
+                    field = target.return_stat(filter_name)
                 extra = int(self.extra)
                 if value_name in list(Comparison):
                     self.result = compare(value_name, field, extra)

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from pygame.surface import Surface
@@ -23,10 +23,12 @@ from tuxemon.db import (
     MenuAction,
     SoundProperties,
     State,
+    StatModel,
     VisualProperties,
 )
 from tuxemon.locale import T
 from tuxemon.modifiers import ModifiersHandler
+from tuxemon.monster_dir.stats import BasicStats
 from tuxemon.surfanim import FlipAxes
 from tuxemon.user_config import CONFIG
 
@@ -46,7 +48,7 @@ INFINITE_ITEMS: int = -1
 class Item:
     """An item object is an item that can be used either in or out of combat."""
 
-    def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
+    def __init__(self, save_data: Mapping[str, Any] | None = None) -> None:
         save_data = save_data or {}
 
         self.slug: str = ""
@@ -60,7 +62,7 @@ class Item:
         # The path to the sprite to load.
         self.sprite: str = ""
         self.category: ItemCategory = ItemCategory.none
-        self.surface: Optional[Surface] = None
+        self.surface: Surface | None = None
         self.surface_size_original: tuple[int, int] = (0, 0)
 
         self.rarity: ItemRarity = ItemRarity.COMMON
@@ -85,19 +87,21 @@ class Item:
         self.core_assets = get_assets()
         self.effects: Sequence[PluginObject] = []
         self.conditions: Sequence[PluginObject] = []
+        self.stat_modifiers: dict[str, StatModel] = {}
+        self.temporary_stat_boosts: BasicStats = BasicStats()
 
         self.set_state(save_data)
 
     @classmethod
     def create(
-        cls, slug: str, save_data: Optional[Mapping[str, Any]] = None
+        cls, slug: str, save_data: Mapping[str, Any] | None = None
     ) -> Item:
         method = cls(save_data)
         method.load(slug)
         return method
 
     @classmethod
-    def test(cls, save_data: Optional[Mapping[str, Any]] = None) -> Item:
+    def test(cls, save_data: Mapping[str, Any] | None = None) -> Item:
         """Creates an Item instance for testing purposes."""
         method = cls(save_data)
         return method
@@ -154,6 +158,7 @@ class Item:
         self.category = results.category
         self.sprite = results.sprite
         self.usable_in = results.usable_in
+        self.stat_modifiers = results.stat_modifiers
         self.effect_defs = results.effects
         self.conditions = self.core_assets.parse_conditions(results.conditions)
         self.condition_handler = ConditionProcessor(self.conditions)
@@ -240,7 +245,7 @@ class Item:
         return self.condition_handler.validate(session=session, target=target)
 
     def use(
-        self, session: Session, user: NPC, target: Optional[Monster]
+        self, session: Session, user: NPC, target: Monster | None
     ) -> ItemEffectResult:
         """
         Applies the item's effects using EffectProcessor and returns the results.

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -430,27 +430,18 @@ class Monster:
             sprite_type, frame_duration, scale, **kwargs
         )
 
-    def return_stat(self, stat: StatType) -> int:
+    def return_stat(self, stat: StatType | str) -> int:
         """
         Returns a monster stat (eg. melee, armour, etc.).
-
-        Parameters:
-            stat: The stat for the monster to return.
-
-        Returns:
-            value: The stat.
-
+        Accepts either a StatType enum or a string.
         """
-        stat_map: dict[StatType, int] = {
-            StatType.armour: self.armour,
-            StatType.dodge: self.dodge,
-            StatType.hp: self.hp,
-            StatType.melee: self.melee,
-            StatType.ranged: self.ranged,
-            StatType.speed: self.speed,
-        }
+        if isinstance(stat, str):
+            try:
+                stat = StatType(stat.lower())
+            except ValueError:
+                return 0
 
-        return stat_map.get(stat, 0)
+        return getattr(self, stat.value, 0)
 
     def has_type(self, type_slug: str) -> bool:
         """
@@ -523,6 +514,41 @@ class Monster:
             individual_values=self.individual_values,
         )
         self.base_stats = calculator.calculate()
+
+    def get_combat_stats(self) -> BasicStats:
+        """Calculates effective stats for the current combat turn."""
+        combined_temporary_boosts = BasicStats()
+
+        for status in self.status.get_statuses():
+            combined_temporary_boosts += status.temporary_stat_boosts
+
+        held_item = self.item_handler.held_item
+        if held_item:
+            combined_temporary_boosts += held_item.temporary_stat_boosts
+
+        for move in self.moves.get_moves():
+            combined_temporary_boosts += move.temporary_stat_boosts
+
+        calculator = StatCalculator(
+            base_stats=self.base_stats,
+            level=self.level,
+            shape=self.shape,
+            taste_cold=self.taste_cold,
+            taste_warm=self.taste_warm,
+            custom_stats=self.custom_stats,
+            training_points=self.training_points,
+            individual_values=self.individual_values,
+        )
+
+        return calculator.calculate(temporary_boosts=combined_temporary_boosts)
+
+    def clear_all_temporary_boosts(self) -> None:
+        for status in self.status.get_statuses():
+            status.temporary_stat_boosts = BasicStats()
+        for move in self.moves.get_moves():
+            move.temporary_stat_boosts = BasicStats()
+        if self.item_handler.held_item:
+            self.item_handler.held_item.temporary_stat_boosts = BasicStats()
 
     def set_capture(self, amount: int) -> int:
         """
@@ -695,6 +721,9 @@ class Monster:
         """
         Ends combat, recharges all moves and heals statuses.
         """
+        self.clear_all_temporary_boosts()
+        self.types.reset_to_default()
+        self.moves.set_stats()
         self.out_of_range = False
         self.moves.full_recharge_moves()
 

--- a/tuxemon/monster_dir/stat_utils.py
+++ b/tuxemon/monster_dir/stat_utils.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+import random
+from typing import TYPE_CHECKING
+
+from tuxemon.db import StatModel
+from tuxemon.tools import ops_dict
+
+if TYPE_CHECKING:
+    from tuxemon.item.item import Item
+    from tuxemon.monster import Monster
+    from tuxemon.status.status import Status
+    from tuxemon.technique.technique import Technique
+
+logger = logging.getLogger(__name__)
+
+NONLINEAR_TABLE = {
+    -6: 2 / 8,
+    -5: 2 / 7,
+    -4: 2 / 6,
+    -3: 2 / 5,
+    -2: 2 / 4,
+    -1: 2 / 3,
+    0: 1.0,
+    1: 3 / 2,
+    2: 4 / 2,
+    3: 5 / 2,
+    4: 6 / 2,
+    5: 7 / 2,
+    6: 8 / 2,
+}
+
+
+def apply_stat_modifiers(
+    host: Monster,
+    source: Item | Technique | Status,
+    stat_modifiers: dict[str, StatModel],
+) -> None:
+
+    for stat_slug, stat_model in stat_modifiers.items():
+        if not stat_model:
+            continue
+
+        logger.debug(
+            f"[StatChange] Applying modifier to '{stat_slug}' "
+            f"(step={stat_model.step}, value={stat_model.value}, "
+            f"mode={stat_model.scaling_mode})"
+        )
+
+        step_delta = stat_model.step
+        raw_value = stat_model.value
+        max_dev = stat_model.max_deviation
+        override = stat_model.overridetofull
+        scaling_mode = stat_model.scaling_mode
+        max_step_limit = int(stat_model.max_step_limit)
+
+        # HP override
+        if stat_slug == "current_hp" and override:
+            logger.debug(
+                f"[StatChange] HP override → restoring to full ({host.hp})"
+            )
+            host.current_hp = host.hp
+            continue
+
+        # Base stat
+        if stat_slug == "current_hp":
+            base = host.current_hp
+        else:
+            base = getattr(host.base_stats, stat_slug)
+
+        logger.debug(f"[StatChange] Base value for '{stat_slug}' = {base}")
+
+        # STEP-BASED LOGIC
+        if step_delta is not None:
+
+            actual_step = (
+                random.randint(step_delta - max_dev, step_delta + max_dev)
+                if max_dev
+                else step_delta
+            )
+
+            logger.debug(
+                f"[StatChange] Step delta={step_delta}, deviation={max_dev}, "
+                f"actual_step(before clamp)={actual_step}"
+            )
+
+            actual_step = max(
+                -max_step_limit, min(max_step_limit, actual_step)
+            )
+
+            old_stage = getattr(
+                source.temporary_stat_boosts, f"{stat_slug}_stage", 0
+            )
+
+            new_stage = max(
+                -max_step_limit, min(max_step_limit, old_stage + actual_step)
+            )
+
+            logger.debug(
+                f"[StatChange] Old stage={old_stage}, new stage={new_stage}"
+            )
+
+            setattr(
+                source.temporary_stat_boosts, f"{stat_slug}_stage", new_stage
+            )
+
+            if scaling_mode == "linear":
+                multiplier = 1 + (new_stage / max_step_limit)
+            else:
+                multiplier = NONLINEAR_TABLE[int(new_stage)]
+
+            logger.debug(
+                f"[StatChange] Scaling mode={scaling_mode}, multiplier={multiplier}"
+            )
+
+            new_value = int(base * multiplier)
+            boost_value = new_value - base
+
+        # VALUE-BASED LOGIC
+        else:
+            applied_value = (
+                random.randint(
+                    int(raw_value - max_dev), int(raw_value + max_dev)
+                )
+                if max_dev
+                else raw_value
+            )
+
+            logger.debug(
+                f"[StatChange] Value-based: raw={raw_value}, deviation={max_dev}, "
+                f"applied={applied_value}, op={stat_model.operation}"
+            )
+
+            op_func = ops_dict.get(stat_model.operation, lambda a, b: a)
+            new_value = round(op_func(base, applied_value))
+            boost_value = new_value - base
+
+        # Clamp non-HP stats
+        if stat_slug != "current_hp" and new_value <= 0:
+            logger.debug(
+                f"[StatChange] Clamping '{stat_slug}' to minimum value 1 "
+                f"(computed {new_value})"
+            )
+            new_value = 1
+            boost_value = 1 - base
+
+        # Apply result
+        if stat_slug == "current_hp":
+            clamped_hp = max(0, min(new_value, host.hp))
+            logger.debug(
+                f"[StatChange] HP change: {host.current_hp} → {clamped_hp}"
+            )
+            host.current_hp = clamped_hp
+        else:
+            logger.debug(
+                f"[StatChange] Final boost for '{stat_slug}' = {boost_value}"
+            )
+            setattr(source.temporary_stat_boosts, stat_slug, int(boost_value))

--- a/tuxemon/monster_dir/stats.py
+++ b/tuxemon/monster_dir/stats.py
@@ -6,7 +6,7 @@ import logging
 import random
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
-from typing import Any, Optional
+from typing import Any
 
 from tuxemon.formula import config_monster
 from tuxemon.shape import ShapeHandler
@@ -135,15 +135,25 @@ class StatCalculator:
         self.training_points = training_points
         self.individual_values = individual_values
 
-    def calculate(self) -> BasicStats:
+    def calculate(
+        self, temporary_boosts: BasicStats | None = None
+    ) -> BasicStats:
         """Compute final stats from shape, level, taste, and modifiers."""
         raw_stats = self.calculate_raw_stats()
         cold = Taste.get_taste(self.taste_cold)
         warm = Taste.get_taste(self.taste_warm)
         final_stats = self.apply_stat_updates(raw_stats, cold, warm)
+
+        if temporary_boosts:
+            for stat in BasicStats.names():
+                boosted = getattr(final_stats, stat) + getattr(
+                    temporary_boosts, stat
+                )
+                setattr(final_stats, stat, boosted)
+
         return final_stats
 
-    def calculate_raw_stats(self, level: Optional[int] = None) -> BasicStats:
+    def calculate_raw_stats(self, level: int | None = None) -> BasicStats:
         """Calculates stats before taste modifiers are applied."""
         level = level if level is not None else self.level
         stats = BasicStats()
@@ -163,8 +173,8 @@ class StatCalculator:
     def apply_stat_updates(
         self,
         stats: BasicStats,
-        taste_cold: Optional[Taste],
-        taste_warm: Optional[Taste],
+        taste_cold: Taste | None,
+        taste_warm: Taste | None,
     ) -> BasicStats:
         """Returns a new BasicStats object with taste modifiers applied."""
         updated = BasicStats()
@@ -184,8 +194,8 @@ class StatCalculator:
         self,
         stat_name: str,
         stat_value: int,
-        taste_cold: Optional[Taste],
-        taste_warm: Optional[Taste],
+        taste_cold: Taste | None,
+        taste_warm: Taste | None,
     ) -> int:
         """Applies taste modifiers to a single stat value."""
         modified_stat = float(stat_value)

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -881,6 +881,7 @@ class CombatState(CombatAnimations):
             self.client.combat_session.field_monsters.get_all_monsters().values()
         ):
             for monster in monster_party:
+                monster.get_combat_stats()
                 self.animate_hp(monster)
                 self.apply_status_effects(monster)
                 if monster.is_fainted:
@@ -929,13 +930,7 @@ class CombatState(CombatAnimations):
         """Clean combat."""
         for player in self.client.combat_session.players:
             for mon in player.monsters:
-                # reset status stats
-                mon.set_stats()
                 mon.end_combat(self.session)
-                # reset type
-                mon.types.reset_to_default()
-                # reset technique stats
-                mon.moves.set_stats()
 
         self.ai_manager.clear_ai()
 

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from tuxemon.core.asset import get_assets
@@ -25,6 +25,7 @@ from tuxemon.db import (
 )
 from tuxemon.locale import T
 from tuxemon.modifiers import ModifiersHandler
+from tuxemon.monster_dir.stats import BasicStats
 from tuxemon.surfanim import FlipAxes
 
 if TYPE_CHECKING:
@@ -52,12 +53,12 @@ class Status:
         self,
         host: Monster,
         steps: float = 0.0,
-        save_data: Optional[Mapping[str, Any]] = None,
+        save_data: Mapping[str, Any] | None = None,
     ) -> None:
         save_data = save_data or {}
         self._host: Monster = host
         self._steps: float = steps
-        self._linked_monster: Optional[Monster] = None
+        self._linked_monster: Monster | None = None
         self._nr_turn: int = 0
 
         self._effect_applied: set[str] = set()
@@ -66,7 +67,7 @@ class Status:
         self.bond: bool = False
         self.counter: int = 0
         self.cond_id: int = 0
-        self.category: Optional[CategoryStatus] = None
+        self.category: CategoryStatus | None = None
         self.visuals = VisualProperties(
             animation=None, flip_axes=FlipAxes.NONE, loop=-1
         )
@@ -80,10 +81,10 @@ class Status:
         self.step_effect_value: float = 0.0
         self.step_effect_type: StepEffectType = StepEffectType.NONE
         self._step_hp_change: int = 0
-        self.on_positive_status: Optional[ResponseStatus] = None
-        self.on_negative_status: Optional[ResponseStatus] = None
-        self.on_tech_use: Optional[str] = None
-        self.on_item_use: Optional[str] = None
+        self.on_positive_status: ResponseStatus | None = None
+        self.on_negative_status: ResponseStatus | None = None
+        self.on_tech_use: str | None = None
+        self.on_item_use: str | None = None
         self.sound = SoundProperties(sfx=None, volume=1.5)
         self.sort: str = ""
         self.slug: str = ""
@@ -96,6 +97,7 @@ class Status:
         self.core_assets = get_assets()
         self.effects: Sequence[PluginObject] = []
         self.conditions: Sequence[PluginObject] = []
+        self.temporary_stat_boosts: BasicStats = BasicStats()
 
         self.set_state(save_data)
 
@@ -105,7 +107,7 @@ class Status:
         slug: str,
         host: Monster,
         steps: float = 0.0,
-        save_data: Optional[Mapping[str, Any]] = None,
+        save_data: Mapping[str, Any] | None = None,
     ) -> Status:
         method = cls(host, steps, save_data)
         method.load(slug)
@@ -129,7 +131,7 @@ class Status:
         return self._steps
 
     @property
-    def linked_monster(self) -> Optional[Monster]:
+    def linked_monster(self) -> Monster | None:
         """Returns the monster linked to this status effect."""
         return self._linked_monster
 
@@ -287,7 +289,7 @@ class Status:
 
     def tick_steps(
         self, session: Session, steps: float
-    ) -> Optional[StatusEffectResult]:
+    ) -> StatusEffectResult | None:
         """
         Advance the step counter and trigger the status effect if the interval
         is reached. Returns the result if the effect was triggered.
@@ -311,6 +313,14 @@ class Status:
             return self.use(session, EffectPhase.ON_STEP_INTERVAL)
 
         return None
+
+    def is_already_applied(self, effect_name: str) -> bool:
+        """Check if a specific core effect has already been triggered for this status."""
+        return effect_name in self._effect_applied
+
+    def mark_applied(self, effect_name: str) -> None:
+        """Mark a core effect as applied so it doesn't run again."""
+        self._effect_applied.add(effect_name)
 
     def get_state(self) -> Mapping[str, Any]:
         """

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from tuxemon.core.asset import get_assets
@@ -15,6 +15,7 @@ from tuxemon.db import (
     MenuAction,
     Range,
     SoundProperties,
+    StatModel,
     TechBehaviors,
     TechniqueModel,
     VisualProperties,
@@ -22,6 +23,7 @@ from tuxemon.db import (
 from tuxemon.element import ElementTypesHandler
 from tuxemon.locale import T
 from tuxemon.modifiers import ModifiersHandler
+from tuxemon.monster_dir.stats import BasicStats
 from tuxemon.surfanim import FlipAxes
 from tuxemon.technique.cooldown import Cooldown
 
@@ -45,7 +47,7 @@ class Technique:
     Particular skill that tuxemon monsters can use in battle.
     """
 
-    def __init__(self, save_data: Optional[Mapping[str, Any]] = None) -> None:
+    def __init__(self, save_data: Mapping[str, Any] | None = None) -> None:
         save_data = save_data or {}
 
         self.instance_id: UUID = uuid4()
@@ -79,6 +81,8 @@ class Technique:
         self.core_assets = get_assets()
         self.effects: Sequence[PluginObject] = []
         self.conditions: Sequence[PluginObject] = []
+        self.stat_modifiers: dict[str, StatModel] = {}
+        self.temporary_stat_boosts: BasicStats = BasicStats()
 
         # attempts: total times the technique was invoked
         # successes: number of successful uses
@@ -91,7 +95,7 @@ class Technique:
 
     @classmethod
     def create(
-        cls, slug: str, save_data: Optional[Mapping[str, Any]] = None
+        cls, slug: str, save_data: Mapping[str, Any] | None = None
     ) -> Technique:
         method = cls(save_data)
         method.load(slug)
@@ -148,6 +152,7 @@ class Technique:
         self.tech_id = results.tech_id
         self.menu_actions_data = results.menu_actions
         self.tags = results.tags
+        self.stat_modifiers = results.stat_modifiers
 
         self.effect_defs = results.effects
         self.conditions = self.core_assets.parse_conditions(results.conditions)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 from enum import Enum
 from fractions import Fraction
 from functools import lru_cache
-from operator import add, eq, floordiv, ge, gt, le, lt, mul, ne, sub
+from operator import add, eq, ge, gt, le, lt, mul, ne, sub
 from types import UnionType
 from typing import (
     TYPE_CHECKING,
@@ -73,11 +73,18 @@ ValidParameterTypes = Union[
     Sequence[ValidParameterSingleType],
 ]
 
+
+def safe_floordiv(a: float, b: float) -> int:
+    if b == 0:
+        return int(a)  # no-op fallback
+    return int(a // b)
+
+
 ops_dict: Mapping[str, Callable[[float, float], int]] = {
     "+": add,
     "-": sub,
     "*": mul,
-    "/": floordiv,
+    "/": safe_floordiv,
 }
 
 


### PR DESCRIPTION
Changes:
- added `temporary_stat_boosts` field to `Status`, `Item` and `Technique` so all temporary modifiers use the same structure
- updated `StatChangeEffect` to stop modifying base stats and instead store additive boosts in `status.temporary_stat_boosts`
- updated `BuffEffect` to apply percentage buffs as temporary boosts via `item.temporary_stat_boosts` instead of altering base stats
- added new method `Monster.get_combat_stats()` to combine all temporary boosts from statuses, items, and techniques before calculating final combat stats
- updated `StatCalculator.calculate()` to accept `temporary_boosts` and apply them after all permanent stat calculations
- ensured `BasicStats` supports additive combination for stacking boosts
- removed all direct stat mutations from temporary effects to prevent stat drift and ensure consistent combat calculations