### PR TITLE
Remove unintended movement lock in WorldState.pause()

### DIFF
--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -117,9 +117,7 @@ class RandomEncounterAction(EventAction):
             battle_mode=BattleMode.SINGLE,
         )
         session.client.queue_state("CombatState", context=context)
-
-        session.client.movement_manager.lock_controls(player)
-        session.client.movement_manager.stop_char(player)
+        player.cancel_movement()
 
         rgb: ColorLike = WHITE_COLOR
         if self.rgb:

--- a/tuxemon/event/actions/random_horde.py
+++ b/tuxemon/event/actions/random_horde.py
@@ -137,9 +137,7 @@ class RandomHordeAction(EventAction):
             battle_mode=BattleMode.SINGLE,
         )
         session.client.queue_state("CombatState", context=context)
-
-        session.client.movement_manager.lock_controls(player)
-        session.client.movement_manager.stop_char(player)
+        player.cancel_movement()
 
         rgb: ColorLike = WHITE_COLOR
         if self.rgb:

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -103,9 +103,7 @@ class WildEncounterAction(EventAction):
             battle_mode=BattleMode.SINGLE,
         )
         session.client.queue_state("CombatState", context=context)
-
-        session.client.movement_manager.lock_controls(player)
-        session.client.movement_manager.stop_char(player)
+        player.cancel_movement()
 
         rgb: ColorLike = WHITE_COLOR
         if self.rgb:

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -131,7 +131,6 @@ class WorldState(State):
     def pause(self) -> None:
         """Called before another state gets focus"""
         self.client.event_manager.remove_middleware(self.input_translator_mw)
-        self.client.movement_manager.lock_controls(self.player)
         self.client.movement_manager.stop_char(self.player)
 
     def broadcast_player_teleport_change(self) -> None:


### PR DESCRIPTION
Fixes  #3347 

Changes:
- removed the call to `movement_manager.lock_controls()` inside `WorldState.pause()`
- restored normal player movement after interactions and dialog events
- ensured that directional input is no longer permanently disabled after pressing the interact button
- verified that menu navigation and other input paths continue to function normally