### PR TITLE
State stack checks and introduce semantic helper methods

### DIFF
--- a/tests/tuxemon/test_teleporter.py
+++ b/tests/tuxemon/test_teleporter.py
@@ -137,6 +137,7 @@ def test_prepare_teleport_pushes_state(
     teleporter, mock_state_manager, mock_character
 ):
     mock_state_manager.active_states = ["WorldState", "OtherState"]
+    mock_state_manager.is_in_base_map_state.return_value = True
     teleporter.prepare_teleport(mock_character)
     mock_state_manager.push_state_with_timeout.assert_called_once_with(
         "TeleporterState", 15
@@ -147,6 +148,7 @@ def test_prepare_teleport_no_push_when_many_states(
     teleporter, mock_state_manager, mock_character
 ):
     mock_state_manager.active_states = ["A", "B", "C"]
+    mock_state_manager.is_in_base_map_state.return_value = False
     teleporter.prepare_teleport(mock_character)
     mock_state_manager.push_state_with_timeout.assert_not_called()
 

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -393,6 +393,12 @@ class BaseClient(ABC):
         """Push new state, by name, by with timeout"""
         self.state_manager.push_state_with_timeout(state_name, updates)
 
+    def is_in_base_map_state(self, base_count: int | None = None) -> bool:
+        return self.state_manager.is_in_base_map_state(base_count)
+
+    def has_extra_states(self, base_count: int | None = None) -> bool:
+        return self.state_manager.has_extra_states(base_count)
+
     @property
     def active_states(self) -> Sequence[State]:
         """List of active states"""

--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -67,7 +67,7 @@ class ChangeBgAction(EventAction):
             raise RuntimeError
 
         # this function cleans up the previous state without crashing
-        if len(client.active_states) > 2:
+        if client.has_extra_states():
             client.pop_state()
 
         if self.image and self.category:
@@ -90,7 +90,7 @@ class ChangeBgAction(EventAction):
 
         if client.current_state.name != "ImageState":
             if self.background is None:
-                if len(client.active_states) > 2:
+                if client.has_extra_states():
                     client.pop_state()
                     return
             else:

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MAX_ACTIVE_STATES: int = 2
-
 
 @final
 @dataclass
@@ -56,7 +54,7 @@ class EvolutionAction(EventAction):
 
         self.char = character
 
-        if len(self.client.active_states) > MAX_ACTIVE_STATES:
+        if self.client.has_extra_states():
             return
 
         self._pending_map: dict[UUID, str] = {}

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_BASE_STATE_COUNT: int = 2  # BackgroundState + WorldState
 
 StateType = TypeVar("StateType", bound="State")
 
@@ -87,6 +88,16 @@ class StateManager:
         name = state.__name__
         logger.debug(f"loading state: {name}")
         self.state_repository.add_state(state)
+
+    def is_in_base_map_state(self, base_count: int | None = None) -> bool:
+        """Return True if the active state count matches the base map state count."""
+        base_count = base_count or DEFAULT_BASE_STATE_COUNT
+        return len(self.active_states) == base_count
+
+    def has_extra_states(self, base_count: int | None = None) -> bool:
+        """Return True if more than the base map states are active."""
+        base_count = base_count or DEFAULT_BASE_STATE_COUNT
+        return len(self.active_states) > base_count
 
     def update(self, time_delta: float) -> None:
         """

--- a/tuxemon/teleporter.py
+++ b/tuxemon/teleporter.py
@@ -177,7 +177,7 @@ class Teleporter:
         """
         logger.debug(f"Preparing {character.slug} for teleportation...")
 
-        if len(self.state_manager.active_states) == 2:
+        if self.state_manager.is_in_base_map_state():
             self.state_manager.push_state_with_timeout("TeleporterState", 15)
 
         logger.info(f"{character.slug} is prepared for teleportation.")


### PR DESCRIPTION
Changes:
- replaced direct length checks using `len(active_states) == 2` with the semantic helper `is_in_base_map_state`
- replaced hard‑coded comparisons using `len(active_states) > 2` with the new helper `has_extra_states`
- added `is_in_base_map_state` to determine when the active state stack matches the base map configuration
- added `has_extra_states` to detect when additional states are stacked above the base configuration
- centralized base state logic to remove magic numbers and improve readability and maintainability