### PR TITLE
Replace deprecated Pillow `getdata()` usage and modernize test suite

### DIFF
--- a/tests/tuxemon/test_fusion.py
+++ b/tests/tuxemon/test_fusion.py
@@ -1,64 +1,127 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
-from pathlib import Path
-
+import pytest
 from PIL import Image
 
-from tuxemon.fusion import Body, fuse, replace_color
+from tuxemon.fusion import (
+    Body,
+    calculate_face_position,
+    fuse,
+    get_color_mappings,
+    paste_face_onto_body,
+    replace_color,
+    replace_multiple_colors,
+    resize_face_image,
+)
 
 
-class TestFusion(unittest.TestCase):
-    def setUp(self):
-        self.image = Image.new("RGBA", (10, 10), (255, 0, 0, 255))  # Red image
-        self.image_path = "test_image.png"
-        self.image.save(self.image_path)
+@pytest.fixture
+def red_image():
+    return Image.new("RGBA", (10, 10), (255, 0, 0, 255))
 
-        self.body = Body()
-        self.body.name = "test_body"
-        self.body.body_image = self.image
-        self.body.face_image = self.image
-        self.body.primary_colors = [(255, 0, 0)]  # Red
-        self.body.secondary_colors = [(0, 0, 255)]  # Blue
-        self.body.tertiary_colors = [(0, 255, 0)]  # Green
 
-    def tearDown(self):
-        image_path = Path(self.image_path)
-        if image_path.exists():
-            image_path.unlink()
+@pytest.fixture
+def blue_image():
+    return Image.new("RGBA", (10, 10), (0, 0, 255, 255))
 
-    def test_replace_color(self):
-        result_image = replace_color(self.image, (255, 0, 0), (0, 0, 255))
-        data = list(result_image.getdata())
-        for pixel in data:
-            self.assertEqual(pixel, (0, 0, 255, 255))
 
-    def test_body_load(self):
-        json_data = self.body.to_json()
-        new_body = Body()
-        new_body.load(json_data, file=False)
-        self.assertEqual(new_body.name, "test_body")
-        self.assertEqual(new_body.primary_colors, [(255, 0, 0)])
+@pytest.fixture
+def sample_body(red_image):
+    b = Body()
+    b.name = "test"
+    b.body_image = red_image
+    b.face_image = red_image
+    b.primary_colors = [(255, 0, 0)]
+    b.secondary_colors = [(0, 0, 255)]
+    b.tertiary_colors = [(0, 255, 0)]
+    b.head_size = (10, 10)
+    b.face_position = (5, 5)
+    return b
 
-    def test_fuse(self):
-        self.body_image = Image.new(
-            "RGBA", (20, 20), (255, 0, 0, 255)
-        )  # Red image
-        self.face_image = Image.new(
-            "RGBA", (10, 10), (0, 0, 255, 255)
-        )  # Blue image
 
-        self.body = Body()
-        self.body.body_image = self.body_image
-        self.body.face_position = (10, 10)
-        self.body.head_size = (10, 10)
+@pytest.fixture
+def sample_face(blue_image):
+    f = Body()
+    f.name = "face"
+    f.face_image = blue_image
+    f.primary_colors = [(255, 0, 0)]
+    f.secondary_colors = [(0, 0, 255)]
+    f.tertiary_colors = [(0, 255, 0)]
+    f.head_size = (10, 10)
+    return f
 
-        self.face = Body()
-        self.face.face_image = self.face_image
-        self.face.head_size = (10, 10)
-        fused_image = fuse(self.body, self.face, save=False)
 
-        self.assertEqual(fused_image.size, (20, 20))
+def test_get_face_size(sample_body):
+    size = sample_body.get_face_size()
+    assert size == (10, 10)
 
-        pixel = fused_image.getpixel((10, 10))
-        self.assertEqual(pixel, (0, 0, 255, 255))
+
+def test_to_json_and_load(tmp_path, sample_body):
+    json_path = tmp_path / "body.json"
+    sample_body.save(json_path)
+    new_body = Body()
+    new_body.load(str(json_path))
+    assert new_body.name == sample_body.name
+    assert new_body.primary_colors == sample_body.primary_colors
+
+
+def test_get_state(sample_body):
+    state = sample_body.get_state()
+    assert isinstance(state, dict)
+    assert state["name"] == "test"
+
+
+def test_set_state(sample_body):
+    sample_body.set_state({"name": "updated"})
+    assert sample_body.name == "updated"
+
+
+def test_replace_color(red_image):
+    result = replace_color(red_image, (255, 0, 0), (0, 0, 255))
+    width, height = result.size
+    for x in range(width):
+        for y in range(height):
+            r, g, b, a = result.getpixel((x, y))
+            assert (r, g, b) == (0, 0, 255)
+
+
+def test_replace_multiple_colors(red_image):
+    mappings = [((255, 0, 0), (0, 255, 0))]
+    result = replace_multiple_colors(red_image, mappings)
+    width, height = result.size
+    for x in range(width):
+        for y in range(height):
+            r, g, b, a = result.getpixel((x, y))
+            assert (r, g, b) == (0, 255, 0)
+
+
+def test_get_color_mappings(sample_body, sample_face):
+    mappings = get_color_mappings(sample_body, sample_face)
+    assert len(mappings) == 3
+    assert mappings[0] == (
+        sample_body.primary_colors[0],
+        sample_face.primary_colors[0],
+    )
+
+
+def test_resize_face_image(blue_image):
+    resized = resize_face_image(blue_image, (20, 20), (10, 10))
+    assert resized.size == (20, 20)
+
+
+def test_calculate_face_position(sample_body, blue_image):
+    pos = calculate_face_position(sample_body, blue_image)
+    assert pos == (5 - 5, 5 - 5)
+
+
+def test_paste_face_onto_body(red_image, blue_image):
+    result = paste_face_onto_body(red_image, blue_image, (0, 0))
+    assert result.getpixel((0, 0)) == (0, 0, 255, 255)
+
+
+def test_fuse(tmp_path, sample_body, sample_face):
+    sample_body.body_image = Image.new("RGBA", (20, 20), (255, 0, 0, 255))
+    sample_face.face_image = Image.new("RGBA", (10, 10), (0, 0, 255, 255))
+    output = fuse(sample_body, sample_face, save=False)
+    assert output.size == (20, 20)
+    assert output.getpixel((5, 5)) == (0, 0, 255, 255)

--- a/tuxemon/fusion.py
+++ b/tuxemon/fusion.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any
 
 from PIL import Image as PILImage
 from PIL.Image import Image
@@ -41,7 +41,6 @@ class Body:
         >>> # Fuse the sprites.
         >>> fuse(body=sapsnap, face=vivitron)
         >>> fuse(body=vivitron, face=sapsnap)
-
     """
 
     face_image: Image
@@ -106,11 +105,8 @@ class Body:
         Returns:
             A tuple (x, y) of the face size in pixels.
         """
-
-        img = self.face_image
-        img = img.convert("RGBA")
-        self.face_size = img.getdata().size
-
+        img = self.face_image.convert("RGBA")
+        self.face_size = img.size
         return self.face_size
 
     def to_json(self) -> str:
@@ -120,14 +116,14 @@ class Body:
         Returns:
             A json string of the current instance.
         """
-
-        body_dict = self.__dict__
-        del body_dict["body_image"]
-        del body_dict["face_image"]
-
+        body_dict = {
+            k: v
+            for k, v in self.__dict__.items()
+            if k not in ("body_image", "face_image")
+        }
         return json.dumps(body_dict)
 
-    def save(self, filename: Optional[str] = None) -> None:
+    def save(self, filename: str | None = None) -> None:
         """
         Saves the current instance and all its properties to a json file.
 
@@ -198,13 +194,13 @@ class Body:
         if self.face_image_path:
             self.face_image = PILImage.open(self.face_image_path)
 
-    def get_state(self) -> Optional[Mapping[str, Any]]:
+    def get_state(self) -> Mapping[str, Any] | None:
         if self.name:
             return self.__dict__
 
         return None
 
-    def set_state(self, save_data: Optional[Mapping[str, Any]]) -> None:
+    def set_state(self, save_data: Mapping[str, Any] | None) -> None:
         # TODO: There's no point optimising this until Body is actually used.
         if save_data:
             for attr, value in save_data.items():
@@ -228,36 +224,32 @@ def replace_color(
 
     Returns:
         A PIL Image() object of the image with the given colors replaced.
-
     """
     img = image.convert("RGBA")
-    datas = list(img.getdata())
+    raw = bytearray(img.tobytes())
 
-    r = original_color[0]
-    g = original_color[1]
-    b = original_color[2]
+    r, g, b = original_color
+    new_r, new_g, new_b = replacement_color
 
-    new_r = replacement_color[0]
-    new_g = replacement_color[1]
-    new_b = replacement_color[2]
+    for i in range(0, len(raw), 4):
+        cr = raw[i]
+        cg = raw[i + 1]
+        cb = raw[i + 2]
 
-    newData = []
-    for item in datas:
-        if item[0] == r and item[1] == g and item[2] == b:
-            newData.append((new_r, new_g, new_b, 255))
-        else:
-            newData.append(item)
+        if (cr, cg, cb) == (r, g, b):
+            raw[i] = new_r
+            raw[i + 1] = new_g
+            raw[i + 2] = new_b
+            raw[i + 3] = 255  # alpha
 
-    img.putdata(newData)
-
-    return img
+    return PILImage.frombytes("RGBA", img.size, bytes(raw))
 
 
 def fuse(
     body: Body,
     face: Body,
     save: bool = True,
-    filename: Optional[str] = None,
+    filename: str | None = None,
 ) -> Image:
     """Fuses two sprites together given a body and a face.
 
@@ -287,7 +279,6 @@ def fuse(
         >>> # Fuse the sprites.
         >>> fuse(body=sapsnap, face=vivitron)
         >>> fuse(body=vivitron, face=sapsnap)
-
 
     """
     logger.info(


### PR DESCRIPTION
Changes:
- fixed warnings in pytest caused by Pillow deprecating `Image.getdata()`
- updated image‑processing functions to avoid deprecated APIs and ensure future compatibility with Pillow 14+
- modernized several tests to use pytest‑style assertions and fixtures instead of legacy patterns
- reworked color‑replacement tests to avoid deprecated methods and rely on stable pixel‑access APIs
- added new tests to improve coverage of color replacement, multi‑color mapping, and fusion behavior
- cleaned up serialization logic in `Body.to_json()` to avoid mutating internal state