### PR TITLE
Move Loader to Dedicated Module to Avoid Circular Imports

### DIFF
--- a/buildconfig/buildozer/recipes/pygame/__init__.py
+++ b/buildconfig/buildozer/recipes/pygame/__init__.py
@@ -42,15 +42,26 @@ class Pygame2Recipe(CompiledComponentsPythonRecipe):
 
             setup_file = setup_template.format(
                 sdl_includes=(
-                    " -I" + join(self.ctx.bootstrap.build_dir, 'jni', 'SDL', 'include') +
-                    " -L" + join(self.ctx.bootstrap.build_dir, "libs", str(arch)) +
-                    " -L" + png_lib_dir + " -L" + jpeg_lib_dir + " -L" + ndk_lib_dir),
-                sdl_ttf_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_ttf'),
-                sdl_image_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_image'),
-                sdl_mixer_includes="-I"+join(self.ctx.bootstrap.build_dir, 'jni', 'SDL2_mixer'),
-                jpeg_includes="-I"+jpeg_inc_dir,
-                png_includes="-I"+png_inc_dir,
-                freetype_includes=""
+                    " -I"
+                    + join(self.ctx.bootstrap.build_dir, "jni", "SDL", "include")
+                    + " -L"
+                    + join(self.ctx.bootstrap.build_dir, "libs", str(arch))
+                    + " -L"
+                    + png_lib_dir
+                    + " -L"
+                    + jpeg_lib_dir
+                    + " -L"
+                    + ndk_lib_dir
+                ),
+                sdl_ttf_includes="-I"
+                + join(self.ctx.bootstrap.build_dir, "jni", "SDL2_ttf"),
+                sdl_image_includes="-I"
+                + join(self.ctx.bootstrap.build_dir, "jni", "SDL2_image"),
+                sdl_mixer_includes="-I"
+                + join(self.ctx.bootstrap.build_dir, "jni", "SDL2_mixer"),
+                jpeg_includes="-I" + jpeg_inc_dir,
+                png_includes="-I" + png_inc_dir,
+                freetype_includes="",
             )
             open("Setup", "w").write(setup_file)
 

--- a/buildconfig/buildozer/recipes/tuxemon/__init__.py
+++ b/buildconfig/buildozer/recipes/tuxemon/__init__.py
@@ -2,11 +2,12 @@ from pythonforandroid.recipe import PythonRecipe
 
 
 class TuxemonRecipe(PythonRecipe):
-    version = 'development'
-    url = 'https://github.com/Tuxemon/Tuxemon/archive/development.zip'
-    depends = ['setuptools']
-    site_packages_name = 'tuxemon'
+    version = "development"
+    url = "https://github.com/Tuxemon/Tuxemon/archive/development.zip"
+    depends = ["setuptools"]
+    site_packages_name = "tuxemon"
     call_hostpython_via_targetpython = False
     install_in_hostpython = True
+
 
 recipe = TuxemonRecipe()

--- a/buildconfig/setup_cx_freeze.py
+++ b/buildconfig/setup_cx_freeze.py
@@ -13,9 +13,11 @@ DO NOT RUN FROM A VENV.  YOU WILL BE MET WITH INSURMOUNTABLE SORROW.
 import logging
 import os
 import sys
+from pathlib import Path
 
-import yaml
 from cx_Freeze import Executable, setup
+
+from tuxemon.database.yaml_utils import load_yaml
 
 # required so that the tuxemon folder can be found
 # when run from the buildconfig folder
@@ -27,17 +29,17 @@ logger = logging.getLogger(__name__)
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "disk"
 
-def load_config(config_file="build_config.yaml"):
+
+def load_config(config_file: str = "build_config.yaml"):
     try:
-        with open(config_file) as f:
-            config = yaml.safe_load(f)
-        return config
+        return load_yaml(Path(config_file))
     except FileNotFoundError:
         logger.error(f"Configuration file not found: {config_file}")
         sys.exit(1)
-    except yaml.YAMLError as e:
-        logger.error(f"Error parsing YAML file: {e}")
+    except Exception as e:
+        logger.error(f"Error loading configuration: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     config = load_config()

--- a/scripts/jsonify_to_yaml.py
+++ b/scripts/jsonify_to_yaml.py
@@ -21,9 +21,11 @@ Get help/usage information:
 """
 
 import json
-import yaml
 from argparse import ArgumentParser
 from pathlib import Path
+
+from tuxemon.database.yaml_utils import dump_yaml_io
+
 
 def convert_json_to_yaml(json_filepath: Path, force: bool = False) -> None:
     """
@@ -56,19 +58,28 @@ def convert_json_to_yaml(json_filepath: Path, force: bool = False) -> None:
 
     try:
         with yaml_filepath.open("w", encoding="utf-8") as f:
-            yaml.dump(data, f, Dumper=yaml.SafeDumper, sort_keys=False)
+            dump_yaml_io(
+                f,
+                data,
+                sort_keys=False,
+                default_flow_style=False,
+            )
         print(f"Successfully converted '{json_filepath}' → '{yaml_filepath}'.")
     except Exception as e:
         print(f"Error writing YAML to '{yaml_filepath}': {e}")
 
 
-def convert_json_in_directory(directory_path: Path, recursive: bool, force: bool) -> None:
+def convert_json_in_directory(
+    directory_path: Path, recursive: bool, force: bool
+) -> None:
     """
     Walks through a directory and converts all .json files to YAML.
     """
     print(f"Searching for JSON files in '{directory_path}'...")
     found_files = False
-    iterator = directory_path.rglob("*.json") if recursive else directory_path.glob("*.json")
+    iterator = (
+        directory_path.rglob("*.json") if recursive else directory_path.glob("*.json")
+    )
 
     for file_path in iterator:
         found_files = True

--- a/scripts/make_map_migration.py
+++ b/scripts/make_map_migration.py
@@ -1,26 +1,28 @@
 """
-
-Create mapping between tilesets for migrations
-
-duct tape.
+Create mapping between tilesets for migrations.
 
 * Run with a source tileset, destination, and the output filename.
-* The current tile to map *from* is a highlighted with a red box
-* Click the matching time on the destination side, the cursor will advance
-* Use the arrow arrows to move the cursor
-* File is saved after each click
-* The mapping can be verified visually
+* The current tile to map *from* is highlighted with a red box.
+* Click the matching tile on the destination side; the cursor will advance.
+* Use the arrow keys to move the cursor.
+* File is saved after each click.
+* The mapping can be verified visually.
 
 Example:
 
-python scripts/make_map_migration.py mods/tuxemon/gfx/tilesets/My_tuxemon_sheet.png mods/tuxemon/gfx/tilesets/core_outdoor.png txmn-core.yaml
-
+python scripts/make_map_migration.py \
+    mods/tuxemon/gfx/tilesets/My_tuxemon_sheet.png \
+    mods/tuxemon/gfx/tilesets/core_outdoor.png \
+    txmn-core.yaml
 """
 
-import click
+import argparse
+from pathlib import Path
+
 import pygame
 import pygame.gfxdraw
-import yaml
+
+from tuxemon.database.yaml_utils import dump_yaml_path, load_yaml
 
 tilewidth = 16
 tileheight = 16
@@ -49,28 +51,37 @@ def get_tile_by_index(rect, index):
 
 
 def main(src_filepath, dst_filepath, output_filepath):
+    src_filepath = Path(src_filepath)
+    dst_filepath = Path(dst_filepath)
+    output_filepath = Path(output_filepath)
+
     src = pygame.image.load(src_filepath)
     dst = pygame.image.load(dst_filepath)
+
     dst_rect = dst.get_rect()
     dst_rect.right = screen_width
+
     src_rect = src.get_rect()
     src_rect.left = screen_width // 2
+
     tiles_per_row = src_rect.width // tilewidth
     total_tiles = (tiles_per_row * (src_rect.height // tileheight)) - 1
+
     preview_tile_size = (
         tilewidth * preview_scale_factor,
         tileheight * preview_scale_factor,
     )
+
     screen = pygame.display.set_mode((screen_width, screen_height))
     hover = None
     running = True
     src_index = 0
 
+    # Load mapping using your YAML utility
     try:
-        with open(output_filepath, "r") as fp:
-            mapping = yaml.load(fp, yaml.SafeLoader)
+        mapping = load_yaml(output_filepath) or {}
     except FileNotFoundError:
-        mapping = dict()
+        mapping = {}
 
     while running:
         for e in pygame.event.get():
@@ -92,9 +103,17 @@ def main(src_filepath, dst_filepath, output_filepath):
                     source, screen_rect, surf_rect = hover
                     y = (surf_rect[1] // tileheight) * (dst_rect.width // tilewidth)
                     dst_index = (surf_rect[0] // tilewidth) + y
-                    with open(output_filepath, "w") as fp:
-                        yaml.dump(mapping, fp, yaml.SafeDumper)
+
                     mapping[src_index] = dst_index
+
+                    # Save using your YAML utility
+                    dump_yaml_path(
+                        output_filepath,
+                        mapping,
+                        sort_keys=False,
+                        default_flow_style=False,
+                    )
+
                     src_index = min(total_tiles, src_index + 1)
 
             if e.type == pygame.KEYDOWN:
@@ -106,6 +125,7 @@ def main(src_filepath, dst_filepath, output_filepath):
                     src_index = max(0, src_index - tiles_per_row)
                 elif e.key == pygame.K_DOWN:
                     src_index = min(total_tiles, src_index + tiles_per_row)
+
                 dst_index = mapping.get(src_index)
                 if dst_index is None:
                     hover = None
@@ -142,13 +162,14 @@ def main(src_filepath, dst_filepath, output_filepath):
         pygame.display.flip()
 
 
-@click.command()
-@click.argument("source")
-@click.argument("destination")
-@click.argument("output")
-def click_shim(source, destination, output):
-    main(source, destination, output)
+def parse_args():
+    parser = argparse.ArgumentParser(description="Create tileset migration mapping.")
+    parser.add_argument("source", help="Source tileset image")
+    parser.add_argument("destination", help="Destination tileset image")
+    parser.add_argument("output", help="Output YAML mapping file")
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    click_shim()
+    args = parse_args()
+    main(args.source, args.destination, args.output)

--- a/scripts/test_actions.py
+++ b/scripts/test_actions.py
@@ -7,11 +7,11 @@ from unittest.mock import MagicMock
 from tuxemon.constants import paths
 from tuxemon.database.runtime import db
 from tuxemon.event.eventaction import ActionManager
-from tuxemon.event.running import ConditionEvaluator
 from tuxemon.event.eventengine import EventEngine
+from tuxemon.event.running import ConditionEvaluator
 from tuxemon.map.map_loader import TMXMapLoader
-from tuxemon.user_config import CONFIG
 from tuxemon.session import Session
+from tuxemon.user_config import CONFIG
 
 db.load("monster")
 action = ActionManager()

--- a/scripts/validate_monster_evolutions.py
+++ b/scripts/validate_monster_evolutions.py
@@ -1,8 +1,9 @@
-from pathlib import Path
 import json
 from collections import defaultdict
+from pathlib import Path
 
 MONSTER_FOLDER = Path.home() / "Tuxemon/mods/tuxemon/db/monster"
+
 
 def load_monsters(folder: Path):
     monsters = {}
@@ -11,6 +12,7 @@ def load_monsters(folder: Path):
             data = json.load(f)
             monsters[data["slug"]] = data
     return monsters
+
 
 def validate_monsters(monsters):
     errors = []
@@ -32,23 +34,32 @@ def validate_monsters(monsters):
 
             for ref in entry.get("evolves_from", []):
                 if ref not in all_slugs:
-                    errors.append(f"{slug}: evolves_from references unknown monster '{ref}'")
+                    errors.append(
+                        f"{slug}: evolves_from references unknown monster '{ref}'"
+                    )
 
             for ref in entry.get("evolves_into", []):
                 if ref not in all_slugs:
-                    errors.append(f"{slug}: evolves_into references unknown monster '{ref}'")
+                    errors.append(
+                        f"{slug}: evolves_into references unknown monster '{ref}'"
+                    )
 
         # Validate stage progression
         for evo in data.get("evolutions", []):
             target_slug = evo["monster_slug"]
             if target_slug in monsters:
                 from_stage = stage_order.get(data.get("stage", "basic"), -1)
-                to_stage = stage_order.get(monsters[target_slug].get("stage", "basic"), -1)
+                to_stage = stage_order.get(
+                    monsters[target_slug].get("stage", "basic"), -1
+                )
                 if to_stage <= from_stage:
-                    errors.append(f"{slug}: evolves into '{target_slug}' with equal or lower stage ({data.get('stage')} → {monsters[target_slug].get('stage')})")
+                    errors.append(
+                        f"{slug}: evolves into '{target_slug}' with equal or lower stage ({data.get('stage')} → {monsters[target_slug].get('stage')})"
+                    )
 
         # Detect circular evolution
         visited = set()
+
         def dfs(current, path):
             if current in path:
                 cycle = " → ".join(path + [current])
@@ -65,6 +76,7 @@ def validate_monsters(monsters):
 
     return errors
 
+
 def main():
     monsters = load_monsters(MONSTER_FOLDER)
     issues = validate_monsters(monsters)
@@ -75,6 +87,7 @@ def main():
             print(" -", issue)
     else:
         print("\n All monster files passed validation!")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/yaml_beautifier.py
+++ b/scripts/yaml_beautifier.py
@@ -21,7 +21,7 @@ Get help/usage information:
 from argparse import ArgumentParser
 from pathlib import Path
 
-import yaml
+from tuxemon.database.yaml_utils import dump_yaml_path, load_yaml
 
 DEFAULT_INDENT: int = 2
 SORT_KEYS: bool = False
@@ -35,22 +35,17 @@ def beautify_yaml_file(
     """
     print(f"Beautifying '{file_path}' with indent={indent}...")
     try:
-        with file_path.open("r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-
-        with file_path.open("w", encoding="utf-8") as f:
-            yaml.dump(
-                data,
-                f,
-                indent=indent,
-                default_flow_style=False,
-                sort_keys=sort_keys,
-            )
+        data = load_yaml(file_path)
+        dump_yaml_path(
+            file_path,
+            data,
+            indent=indent,
+            default_flow_style=False,
+            sort_keys=sort_keys,
+        )
         print(f"Successfully beautified '{file_path}'.")
     except FileNotFoundError:
         print(f"Error: File not found at '{file_path}'.")
-    except yaml.YAMLError:
-        print(f"Error: Invalid YAML format in '{file_path}'. Please check its syntax.")
     except Exception as e:
         print(f"An unexpected error occurred while processing '{file_path}': {e}")
 

--- a/scripts/yamlify_map_collision_script.py
+++ b/scripts/yamlify_map_collision_script.py
@@ -34,7 +34,7 @@ import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-import yaml
+from tuxemon.database.yaml_utils import dump_yaml_io
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
@@ -62,7 +62,7 @@ def process_collisions(tmx_filename: Path):
     for object_group in root.findall(".//objectgroup[@name='Collisions']"):
         for obj in object_group.findall("object"):
             collision_data = {
-                "x": int(float(obj.get("x", 0))) // 16,  # Dividing by tile size
+                "x": int(float(obj.get("x", 0))) // 16,
                 "y": int(float(obj.get("y", 0))) // 16,
                 "width": int(float(obj.get("width", 0))) // 16,
                 "height": int(float(obj.get("height", 0))) // 16,
@@ -70,11 +70,10 @@ def process_collisions(tmx_filename: Path):
             }
             yaml_doc["collisions"].append(collision_data)
 
-    with yaml_filename.open("w") as yaml_file:
-        yaml.dump(
-            yaml_doc,
+    with yaml_filename.open("w", encoding="utf-8") as yaml_file:
+        dump_yaml_io(
             yaml_file,
-            Dumper=yaml.SafeDumper,
+            yaml_doc,
             default_flow_style=False,
             sort_keys=False,
         )

--- a/scripts/yamlify_map_script.py
+++ b/scripts/yamlify_map_script.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Any, DefaultDict
 from xml.etree.ElementTree import Element
 
-import yaml
+from tuxemon.database.yaml_utils import dump_yaml_io, load_yaml
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
@@ -68,8 +68,7 @@ def extract_events(filename: Path) -> None:
     yaml_filename = filename.with_suffix(".yaml")
 
     try:
-        with yaml_filename.open() as fp:
-            yaml_doc = yaml.load(fp, Loader=yaml.SafeLoader)
+        yaml_doc = load_yaml(yaml_filename)
     except FileNotFoundError:
         yaml_doc = {"events": {}}
 
@@ -84,6 +83,7 @@ def extract_events(filename: Path) -> None:
 
     def process_event(obj: Element) -> None:
         event_node = {}
+
         for names, divisor in [[["x", "width"], tw], [["y", "height"], th]]:
             for name in names:
                 value = obj.attrib.get(name)
@@ -109,8 +109,13 @@ def extract_events(filename: Path) -> None:
     for obj in root.findall(".//object[@type='event']"):
         process_event(obj)
 
-    with yaml_filename.open("w") as fp:
-        yaml.dump(yaml_doc, fp, Dumper=yaml.SafeDumper, sort_keys=False)
+    with yaml_filename.open("w", encoding="utf-8") as fp:
+        dump_yaml_io(
+            fp,
+            yaml_doc,
+            sort_keys=False,
+            default_flow_style=False,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/tuxemon/test_capture.py
+++ b/tests/tuxemon/test_capture.py
@@ -3,8 +3,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tuxemon.database.rules import config_capture
 from tuxemon.formula import (
-    Loader,
     calculate_status_modifier,
     capture,
     shake_check,
@@ -84,7 +84,6 @@ class TestShakeCheck(unittest.TestCase):
 
 class TestCapture(unittest.TestCase):
     def setUp(self):
-        config_capture = Loader.get_config_capture("config_capture.yaml")
         self.max_shake_rate = config_capture.shake_divisor
         self.total_shake = config_capture.total_shakes
 

--- a/tests/tuxemon/test_config.py
+++ b/tests/tuxemon/test_config.py
@@ -18,11 +18,12 @@ from tuxemon.config import (
     TuxemonConfig,
     TuxemonFullConfig,
 )
+from tuxemon.database.yaml_utils import dump_yaml_path
 
 
 def write_yaml(dir_path: Path, data) -> Path:
     p = dir_path / "tuxemon.yaml"
-    p.write_text(yaml.safe_dump(data))
+    dump_yaml_path(p, data)
     return p
 
 

--- a/tests/tuxemon/test_event_loader_map.py
+++ b/tests/tuxemon/test_event_loader_map.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from tuxemon.map.map_loader import YAMLEventLoader, parse_yaml
+from tuxemon.database.yaml_utils import load_yaml
+from tuxemon.map.map_loader import YAMLEventLoader
 
 
 @pytest.fixture
@@ -18,7 +19,7 @@ def loader():
 
 
 def test_parse_yaml_success(yaml_path):
-    result = parse_yaml(yaml_path)
+    result = load_yaml(yaml_path)
     assert isinstance(result, dict)
     assert "events" in result
     assert isinstance(result["events"], dict)

--- a/tests/tuxemon/test_experience_strategies.py
+++ b/tests/tuxemon/test_experience_strategies.py
@@ -18,8 +18,8 @@ from tuxemon.combat.experience_strategies import (
     calculate_experience,
     calculate_experience_base,
 )
+from tuxemon.database.rules import config_monster
 from tuxemon.db import EvolutionStage, ExperienceMethod
-from tuxemon.formula import config_monster
 
 
 class DummyMonster:

--- a/tests/tuxemon/test_folder_maps_yaml.py
+++ b/tests/tuxemon/test_folder_maps_yaml.py
@@ -5,12 +5,9 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from tuxemon.constants.asset_loader import fetch_asset
-from tuxemon.database.runtime import db
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.script.parser import parse_action_string
-from tuxemon.user_config import CONFIG
 
 FOLDER = "maps"
 EVENTS_KEY = "events"
@@ -36,13 +33,14 @@ def get_yaml_files(folder_path: Path) -> Generator[Path, Any, None]:
 
 
 def load_yaml_files(folder_path: str) -> dict[Path, dict]:
-    loaded_data = {}
+    loaded_data: dict[Path, dict] = {}
+
     for file_path in get_yaml_files(Path(folder_path)):
         try:
-            with file_path.open("r") as f:
-                loaded_data[file_path] = yaml.safe_load(f)
-        except yaml.YAMLError as e:
+            loaded_data[file_path] = load_yaml(file_path)
+        except Exception as e:
             raise ValueError(f"Failed to load YAML file: {file_path}") from e
+
     return loaded_data
 
 

--- a/tests/tuxemon/test_formula.py
+++ b/tests/tuxemon/test_formula.py
@@ -4,11 +4,10 @@ import math
 import unittest
 from unittest.mock import MagicMock
 
+from tuxemon.database.rules import config_combat, config_monster
 from tuxemon.element import Element, ElementTypesHandler
 from tuxemon.formula import (
     calculate_time_based_multiplier,
-    config_combat,
-    config_monster,
     modify_stat,
     set_health,
     set_height,

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -3,9 +3,9 @@
 import unittest
 from unittest.mock import MagicMock
 
+from tuxemon.database.rules import config_monster
 from tuxemon.database.runtime import db
 from tuxemon.db import Modifier
-from tuxemon.formula import config_monster
 from tuxemon.monster import Monster
 from tuxemon.monster_dir.stats import IndividualValues
 from tuxemon.shape import ShapeHandler

--- a/tests/tuxemon/test_monster_exp_handler.py
+++ b/tests/tuxemon/test_monster_exp_handler.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 from tuxemon.monster_dir.experience import MonsterExperience
 
 

--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -14,8 +14,8 @@ from tuxemon.combat.reward_system import (
     calculate_money,
     calculate_tps,
 )
+from tuxemon.database.rules import config_monster
 from tuxemon.db import Acquisition, ExperienceMethod
-from tuxemon.formula import config_monster
 from tuxemon.monster import Monster
 from tuxemon.monster_dir.stats import BasicStats
 from tuxemon.monster_dir.status import MonsterStatusHandler

--- a/tests/tuxemon/test_speed_monster.py
+++ b/tests/tuxemon/test_speed_monster.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tuxemon.formula import config_combat, speed_monster
+from tuxemon.database.rules import config_combat
+from tuxemon.formula import speed_monster
 from tuxemon.monster import Monster
 from tuxemon.technique.technique import Technique
 

--- a/tests/tuxemon/test_stat_calculator.py
+++ b/tests/tuxemon/test_stat_calculator.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 from tuxemon.monster_dir.stats import (
     BasicStats,
     CustomStatBoosts,

--- a/tuxemon/ai/ai.py
+++ b/tuxemon/ai/ai.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
-
-import yaml
+from typing import TYPE_CHECKING, Optional
 
 from tuxemon.ai.decision_strategy import (
     TrainerAIDecisionStrategy,
@@ -16,6 +13,7 @@ from tuxemon.ai.decision_strategy import (
 from tuxemon.ai.opponent_evaluator import OpponentEvaluator
 from tuxemon.ai.technique_tracker import TechniqueTracker
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
@@ -112,18 +110,6 @@ class SingleTechnique:
 @dataclass
 class AITechniques:
     techniques: dict[str, SingleTechnique]
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class AIConfigLoader:

--- a/tuxemon/combat/experience_strategies.py
+++ b/tuxemon/combat/experience_strategies.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from tuxemon.database.rules import config_monster
 from tuxemon.db import EvolutionStage, ExperienceMethod
-from tuxemon.formula import config_monster
 
 if TYPE_CHECKING:
     from tuxemon.combat.damage_tracker import DamageTracker

--- a/tuxemon/combat/reward_system.py
+++ b/tuxemon/combat/reward_system.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 from tuxemon.combat.combat_context import CombatType
 from tuxemon.combat.experience_strategies import calculate_experience
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 from tuxemon.locale import T
 from tuxemon.monster_dir.stats import BasicStats
 

--- a/tuxemon/combat/sort_manager.py
+++ b/tuxemon/combat/sort_manager.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tuxemon.formula import config_combat, speed_monster
+from tuxemon.database.rules import config_combat
+from tuxemon.formula import speed_monster
 from tuxemon.monster import Monster
 from tuxemon.npc import NPC
 from tuxemon.technique.technique import Technique

--- a/tuxemon/config.py
+++ b/tuxemon/config.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from typing import Any, Literal, Optional
 
 import pygame
-import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from tuxemon.animation import Animation
+from tuxemon.database.yaml_utils import dump_yaml_io, load_yaml
 from tuxemon.platform.const import buttons, events
 
 Animation.default_transition = "out_quint"
@@ -139,8 +139,7 @@ class TuxemonConfig:
         config_data: dict[str, Any] = TuxemonFullConfig().model_dump()
 
         if config_path and config_path.exists():
-            with config_path.open() as yaml_file:
-                loaded_config = yaml.safe_load(yaml_file) or {}
+            loaded_config = load_yaml(config_path) or {}
 
             for category, defaults in config_data.items():
                 if category in loaded_config and isinstance(defaults, dict):
@@ -148,22 +147,22 @@ class TuxemonConfig:
                 elif category in loaded_config:
                     config_data[category] = loaded_config[category]
 
+        # Validate merged config
         try:
             self.config_model = TuxemonFullConfig.model_validate(config_data)
         except ValidationError as e:
             print(
                 f"Configuration validation failed. Falling back to defaults: {e}"
             )
-            self.config_model = (
-                TuxemonFullConfig()
-            )  # Fallback to clean defaults
+            self.config_model = TuxemonFullConfig()
 
+        # Load attributes
         self.load_config_attributes()
 
-        self.input: InputConfig = InputConfig(self.config_model)
-        self.logging: LoggingConfig = LoggingConfig(self.config_model)
-        self.locale: LocaleConfig = LocaleConfig(self.config_model)
-        self.controller: ControllerConfig = ControllerConfig(self.config_model)
+        self.input = InputConfig(self.config_model)
+        self.logging = LoggingConfig(self.config_model)
+        self.locale = LocaleConfig(self.config_model)
+        self.controller = ControllerConfig(self.config_model)
         self.mods = ["tuxemon"]
 
     def save_config(self) -> None:
@@ -173,9 +172,12 @@ class TuxemonConfig:
 
         config_dict = self.config_model.model_dump()
 
-        with self.config_path.open("w") as yaml_file:
-            yaml.dump(
-                config_dict, yaml_file, default_flow_style=False, indent=4
+        with self.config_path.open("w", encoding="utf-8") as yaml_file:
+            dump_yaml_io(
+                yaml_file,
+                config_dict,
+                default_flow_style=False,
+                indent=4,
             )
 
     def load_config_attributes(self) -> None:
@@ -241,10 +243,10 @@ class TuxemonConfig:
                 "No path specified for reloading configuration."
             )
 
-        with self.config_path.open() as yaml_file:
-            loaded_config = yaml.safe_load(yaml_file) or {}
+        loaded_config = load_yaml(self.config_path) or {}
 
         current_config = self.config_model.model_dump()
+
         for category, defaults in current_config.items():
             if category in loaded_config and isinstance(defaults, dict):
                 defaults.update(loaded_config[category])

--- a/tuxemon/core/effects/capture_combined.py
+++ b/tuxemon/core/effects/capture_combined.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
+from tuxemon.database.rules import config_capdev
 from tuxemon.db import Acquisition, SeenStatus
 
 if TYPE_CHECKING:
@@ -82,7 +83,7 @@ class CaptureCombinedEffect(CoreEffect):
         Calculate the status effectiveness modifier based on the opponent's
         status.
         """
-        capdev_modifier = formula.config_capdev.capdev_modifier
+        capdev_modifier = config_capdev.capdev_modifier
         our_monster = self.client.combat_session.field_monsters.get_monsters(
             self.session.player
         )

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -6,14 +6,12 @@ import logging
 import random
 from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-import yaml
+from typing import TYPE_CHECKING
 
 from tuxemon.constants import paths
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
 from tuxemon.database.runtime import db
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import MonsterModel
 
 if TYPE_CHECKING:
@@ -54,18 +52,6 @@ class ActionConfig:
             raise ValueError("Bounds must be non-negative.")
         if self.level_bounds[0] > self.level_bounds[1]:
             raise ValueError("Lower bound cannot exceed upper bound.")
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/core/effects/food_preference.py
+++ b/tuxemon/core/effects/food_preference.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item

--- a/tuxemon/core/effects/trap.py
+++ b/tuxemon/core/effects/trap.py
@@ -6,14 +6,12 @@ import logging
 import random
 from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-import yaml
+from typing import TYPE_CHECKING
 
 from tuxemon.constants import paths
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
 from tuxemon.database.runtime import db
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import MonsterModel
 
 if TYPE_CHECKING:
@@ -71,18 +69,6 @@ def _lookup_monsters() -> None:
         for mon_name in db.database["monster"]
         if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
     }
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/database/loader.py
+++ b/tuxemon/database/loader.py
@@ -8,10 +8,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
 from pydantic import ValidationError
 
 from tuxemon.database.config import DatabaseConfig
+from tuxemon.database.yaml_utils import load_yaml
 
 if TYPE_CHECKING:
     from tuxemon.db import DataModel
@@ -67,14 +67,13 @@ def load_files(
         return preloaded_data
 
     for entry in directory_path.iterdir():
-        if entry.is_file() and any(entry.suffix == ext for ext in extensions):
+        if entry.is_file() and entry.suffix in extensions:
             try:
-                with entry.open() as fp:
-                    item = (
-                        json.load(fp)
-                        if entry.suffix == ".json"
-                        else yaml.safe_load(fp)
-                    )
+                if entry.suffix == ".json":
+                    with entry.open(encoding="utf-8") as fp:
+                        item = json.load(fp)
+                else:
+                    item = load_yaml(entry)
 
                 if isinstance(item, list):
                     for sub_item in item:
@@ -88,7 +87,6 @@ def load_files(
 
             except (
                 json.JSONDecodeError,
-                yaml.YAMLError,
                 FileNotFoundError,
             ) as e:
                 logger.error(f"Error loading file '{entry}': {e}")

--- a/tuxemon/database/management.py
+++ b/tuxemon/database/management.py
@@ -6,10 +6,10 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
 from pydantic import ValidationError
 
 from tuxemon.database.config import ModMetadata
+from tuxemon.database.yaml_utils import load_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -52,16 +52,16 @@ class ModMetadataLoader:
     def load_metadata(self) -> dict[str, ModMetadata]:
         """Loads and returns metadata for all active mods."""
         metadata: dict[str, ModMetadata] = {}
+
         for mod_directory in self.active_mods:
             mod_path = self.base_path / mod_directory / "mod.yaml"
+
             if not mod_path.exists():
                 logger.error(f"Metadata file missing: '{mod_path}'")
                 continue
 
             try:
-                with mod_path.open() as f:
-                    raw_data = yaml.safe_load(f)
-
+                raw_data = load_yaml(mod_path)
                 validated_meta = ModMetadata(**raw_data)
 
                 if validated_meta.slug != mod_directory:
@@ -76,10 +76,6 @@ class ModMetadataLoader:
                     f"Loaded mod '{mod_directory}' version {validated_meta.version}"
                 )
 
-            except yaml.YAMLError as e:
-                logger.error(
-                    f"Error loading YAML data for '{mod_directory}' mod.yaml: {e}"
-                )
             except ValidationError as e:
                 logger.error(
                     f"Metadata validation failed for '{mod_directory}' mod.yaml. {e}"

--- a/tuxemon/database/rules.py
+++ b/tuxemon/database/rules.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CaptureDeviceEffect:
+    target_attribute: str = ""
+    operation: str = ""
+    value: str | int = 1
+
+
+@dataclass
+class CaptureDeviceConfig:
+    specific_capdev_modifier: float | None = None
+    positive_modifier: float = 1.0
+    negative_modifier: float = 1.2
+    specific_status_modifiers: dict[str, float] | None = None
+    fallback_element_malus: float = 0.2
+    specific_element_modifiers: dict[str, float] | None = None
+    fallback_gender_malus: float = 0.2
+    specific_gender_modifiers: dict[str, float] | None = None
+    fallback_variables_malus: float = 0.2
+    fallback_variables_bonus: float = 1.5
+    specific_variables_modifiers: list[dict[str, Any]] | None = None
+    random_bounds: tuple[float, float] | None = None
+    capdev_persistent_on_success: bool = False
+    capdev_persistent_on_failure: bool = False
+    capdev_effects: list[CaptureDeviceEffect] | None = None
+
+
+@dataclass
+class CaptureDevicesConfig:
+    items: dict[str, CaptureDeviceConfig]
+    status_modifier: float = 1.0
+    capdev_modifier: float = 1.0
+
+
+@dataclass
+class StatWeight:
+    stat: str
+    weight: float
+
+
+@dataclass
+class RangeMapEntry:
+    user_stat: StatWeight
+    target_stat: StatWeight
+
+
+@dataclass
+class CaptureConfig:
+    total_shakes: int
+    shake_constant: int
+    shake_denominator: int
+    shake_divisor: int
+    shake_hp_multiplier: int
+    shake_current_hp_multiplier: int
+    shake_hp_divisor: int
+
+
+@dataclass
+class MonsterConfig:
+    starting_bond: int = 25
+    max_moves: int = 4
+    max_tps: int = 150
+    max_total_tps: int = 300
+    default_tp_gain: int = 1
+    coeff_stats: int = 7
+    bond_range: tuple[int, int] = (0, 100)
+    iv_range: tuple[int, int] = (0, 31)
+    level_range: tuple[int, int] = (0, 100)
+    catch_rate_range: tuple[int, int] = (0, 100)
+    catch_resistance_range: tuple[float, float] = (0.0, 2.0)
+    weight_range: tuple[float, float] = (-0.1, 0.1)
+    height_range: tuple[float, float] = (-0.1, 0.1)
+    bond_modifiers: dict[str, int] = field(default_factory=dict)
+    bond_sentiments: dict[str, tuple[int, int]] = field(default_factory=dict)
+    bond_strings: dict[str, str] = field(default_factory=dict)
+    bond_icons: dict[str, str] = field(default_factory=dict)
+    opposite_tastes: dict[str, list[str]] = field(default_factory=dict)
+    bond_preferences: dict[str, int] = field(default_factory=dict)
+    experience_multipliers: dict[str, float] = field(default_factory=dict)
+    experience_groups: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass
+class CombatConfig:
+    letter_time: float
+    action_time: float
+    multiplier_map: dict[float, str]
+    multiplier_range: tuple[float, float]
+    # speed test
+    speed_factor: float
+    speed_offset: float
+    dodge_modifier: float
+    base_speed_bonus: float
+    min_speed_modifier: float
+    sort_order: list[str]
+
+    def validate_multiplier_map(self) -> None:
+        min_range, max_range = self.multiplier_range
+        for multiplier in self.multiplier_map.keys():
+            if not (min_range <= multiplier <= max_range):
+                raise ValueError(
+                    f"Multiplier {multiplier} is outside the allowed range: {self.multiplier_range}"
+                )
+
+
+class Loader:
+    _config_combat: CombatConfig | None = None
+    _config_monster: MonsterConfig | None = None
+    _config_capture: CaptureConfig | None = None
+    _range_map: dict[str, RangeMapEntry] = {}
+    _capture_devices: CaptureDevicesConfig | None = None
+
+    @classmethod
+    def get_capture_devices(cls, filename: str) -> CaptureDevicesConfig:
+        yaml_path = paths.mods_folder / filename
+        if cls._capture_devices is None:
+            raw_map = load_yaml(yaml_path)
+            items = {}
+
+            for slug, data in raw_map["items"].items():
+                # Parse capdev_effects directly as a list
+                capdev_effects = None
+                if "capdev_effects" in data:
+                    capdev_effects = [
+                        CaptureDeviceEffect(
+                            target_attribute=effect["target_attribute"],
+                            operation=effect["operation"],
+                            value=effect["value"],
+                        )
+                        for effect in data["capdev_effects"]
+                    ]
+
+                # Create a new dictionary excluding "capdev_effects" to avoid duplication
+                filtered_data = {
+                    key: value
+                    for key, value in data.items()
+                    if key != "capdev_effects"
+                }
+
+                items[slug] = CaptureDeviceConfig(
+                    **filtered_data,
+                    capdev_effects=capdev_effects,
+                )
+
+            # Handle global settings
+            status_modifier = raw_map.get("status_modifier", 1.0)
+            capdev_modifier = raw_map.get("capdev_modifier", 1.0)
+            cls._capture_devices = CaptureDevicesConfig(
+                status_modifier=status_modifier,
+                capdev_modifier=capdev_modifier,
+                items=items,
+            )
+        return cls._capture_devices
+
+    @classmethod
+    def get_config_combat(cls, filename: str) -> CombatConfig:
+        yaml_path = paths.mods_folder / filename
+        if cls._config_combat is None:
+            raw_map = load_yaml(yaml_path)
+            cls._config_combat = CombatConfig(**raw_map)
+        return cls._config_combat
+
+    @classmethod
+    def get_config_monster(cls, filename: str) -> MonsterConfig:
+        yaml_path = paths.mods_folder / filename
+        if cls._config_monster is None:
+            raw_map = load_yaml(yaml_path)
+            cls._config_monster = MonsterConfig(**raw_map)
+        return cls._config_monster
+
+    @classmethod
+    def get_config_capture(cls, filename: str) -> CaptureConfig:
+        yaml_path = paths.mods_folder / filename
+        if cls._config_capture is None:
+            raw_map = load_yaml(yaml_path)
+            cls._config_capture = CaptureConfig(**raw_map)
+        return cls._config_capture
+
+    @classmethod
+    def get_range_map(cls, filename: str) -> dict[str, RangeMapEntry]:
+        yaml_path = paths.mods_folder / filename
+        if not cls._range_map:
+            raw_map = load_yaml(yaml_path)
+            cls._range_map = {
+                key: RangeMapEntry(
+                    user_stat=StatWeight(
+                        stat=item[0]["user_stat"], weight=item[0]["weight"]
+                    ),
+                    target_stat=StatWeight(
+                        stat=item[1]["target_stat"], weight=item[1]["weight"]
+                    ),
+                )
+                for key, item in raw_map.items()
+            }
+        return cls._range_map
+
+
+config_combat = Loader.get_config_combat("config_combat.yaml")
+config_monster = Loader.get_config_monster("config_monster.yaml")
+config_capdev = Loader.get_capture_devices("capture_devices.yaml")
+config_capture = Loader.get_config_capture("config_capture.yaml")
+range_map = Loader.get_range_map("range_map.yaml")

--- a/tuxemon/database/utils.py
+++ b/tuxemon/database/utils.py
@@ -2,25 +2,28 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import yaml
+from pathlib import Path
+
 from pydantic import ValidationError
 
 from tuxemon.database.config import DatabaseConfig
+from tuxemon.database.yaml_utils import load_yaml
 
 
 def load_config(config_path: str) -> DatabaseConfig:
     """Loads configuration from a YAML file and validates it against the DatabaseConfig schema."""
     try:
-        with open(config_path) as f:
-            data = yaml.safe_load(f)
+        data = load_yaml(Path(config_path))
         return DatabaseConfig(**data)
     except FileNotFoundError:
         raise FileNotFoundError(
             f"Configuration file '{config_path}' not found."
         )
-    except yaml.YAMLError as e:
-        raise ValueError(f"Invalid YAML in '{config_path}': {e}")
     except ValidationError as e:
         raise ValueError(
             f"Invalid configuration structure in '{config_path}': {e}"
+        )
+    except Exception as e:
+        raise ValueError(
+            f"Unexpected error loading configuration from '{config_path}': {e}"
         )

--- a/tuxemon/database/yaml_utils.py
+++ b/tuxemon/database/yaml_utils.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import IO, Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def load_yaml(filepath: Path) -> Any:
+    try:
+        with filepath.open(encoding="utf-8") as file:
+            return yaml.safe_load(file)
+    except FileNotFoundError:
+        logger.error(f"Config file not found: {filepath}")
+        raise
+    except yaml.YAMLError as exc:
+        logger.error(f"Error parsing YAML file: {exc}")
+        raise
+
+
+def dump_yaml_path(path: Path, data: Any, **kwargs: Any) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, **kwargs)
+
+
+def dump_yaml_io(file: IO[str], data: Any, **kwargs: Any) -> None:
+    yaml.safe_dump(data, file, **kwargs)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -31,7 +31,7 @@ from pydantic import (
 from tuxemon.database.config import EntryNotFoundError
 from tuxemon.database.data import ModData
 from tuxemon.database.registry import validator as has
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 from tuxemon.platform.const import sizes
 from tuxemon.surfanim import FlipAxes
 

--- a/tuxemon/economy/price_policy.py
+++ b/tuxemon/economy/price_policy.py
@@ -6,10 +6,10 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, Union
 
-import yaml
 from pydantic import BaseModel, Field
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,7 @@ def load_policy(
     slug: str, filename: str = "price_policies.yaml"
 ) -> Optional[PricePolicyData]:
     yaml_path = paths.mods_folder / filename
-    with yaml_path.open("r") as f:
-        raw_yaml = yaml.safe_load(f)
+    raw_yaml = load_yaml(yaml_path)
 
     raw_data = raw_yaml.get(slug)
     if not raw_data:

--- a/tuxemon/entity_dir/routing.py
+++ b/tuxemon/entity_dir/routing.py
@@ -6,9 +6,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
-import yaml
-
 from tuxemon.constants.paths import mods_folder
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.platform.const.sizes import KENNEL, LOCKER
 
 if TYPE_CHECKING:
@@ -23,8 +22,7 @@ class RoutingPolicyRegistry:
     @classmethod
     def load_from_file(cls, path: str = "routing_policies.yaml") -> None:
         yaml_path = mods_folder / path
-        with yaml_path.open() as f:
-            raw = yaml.safe_load(f)
+        raw = load_yaml(yaml_path)
         cls._policies = raw
 
     @classmethod

--- a/tuxemon/event/actions/add_combo.py
+++ b/tuxemon/event/actions/add_combo.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Optional, final
 
-import yaml
-
 from tuxemon.constants.paths import mods_folder
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.event.eventaction import EventAction
 from tuxemon.platform.combo_detector import ComboProfile
 from tuxemon.session import Session
@@ -38,18 +36,6 @@ BUTTON_NAME_TO_ID = {
 }
 BUTTON_NAME_TO_ID = {k.upper(): v for k, v in BUTTON_NAME_TO_ID.items()}
 BUTTON_ID_TO_NAME = {v: k for k, v in BUTTON_NAME_TO_ID.items()}
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 @final

--- a/tuxemon/event/actions/celestial_cycles.py
+++ b/tuxemon/event/actions/celestial_cycles.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, final
-
-import yaml
+from typing import final
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.event.eventaction import EventAction
 from tuxemon.locale import T
 from tuxemon.session import Session
@@ -23,18 +21,6 @@ MAX_LENGTH: int = 365
 class CelestialCycle:
     name: str
     phase_data: list[tuple[int, str]]
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -13,10 +13,10 @@ from tuxemon.combat.combat_context import (
     CombatType,
 )
 from tuxemon.combat.utils import check_battle_legal
+from tuxemon.database.rules import config_monster
 from tuxemon.database.runtime import db
 from tuxemon.db import MonsterModel, NpcModel
 from tuxemon.event.eventaction import EventAction
-from tuxemon.formula import config_monster
 from tuxemon.monster import Monster
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.session import Session

--- a/tuxemon/event/actions/replace_party_from_yaml.py
+++ b/tuxemon/event/actions/replace_party_from_yaml.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, final
 
-import yaml
-
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import SeenStatus
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
@@ -25,18 +23,6 @@ logger = logging.getLogger(__name__)
 class Parties:
     name: str
     monsters: list[dict[str, Any]]
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/event/actions/replace_techs_from_yaml.py
+++ b/tuxemon/event/actions/replace_techs_from_yaml.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import logging
 import random
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, final
 
-import yaml
-
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
 from tuxemon.technique.technique import Technique
@@ -23,18 +21,6 @@ logger = logging.getLogger(__name__)
 class Movesets:
     name: str
     techniques: list[dict[str, Any]]
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/event/actions/set_cipher.py
+++ b/tuxemon/event/actions/set_cipher.py
@@ -6,9 +6,8 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, final
 
-import yaml
-
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
 from tuxemon.ui.cipher_processor import CipherProcessor
@@ -79,13 +78,10 @@ class SetCipherAction(EventAction):
             yaml_path = paths.mods_folder / filename
 
             try:
-                with yaml_path.open(encoding="utf-8") as f:
-                    cipher_data = yaml.safe_load(f)
-                    cipher_map = cipher_data.get("cipher_map")
-                    if not cipher_map:
-                        raise ValueError(
-                            f"'cipher_map' key missing in {filename}"
-                        )
+                cipher_data = load_yaml(yaml_path)
+                cipher_map = cipher_data.get("cipher_map")
+                if not cipher_map:
+                    raise ValueError(f"'cipher_map' key missing in {filename}")
             except Exception as e:
                 logger.error(
                     f"Failed to load cipher map from {yaml_path}: {e}"

--- a/tuxemon/event/conditions/check_max_tech.py
+++ b/tuxemon/event/conditions/check_max_tech.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from tuxemon.database.rules import config_monster
 from tuxemon.db import SpatialCondition
 from tuxemon.event.eventcondition import EventCondition
-from tuxemon.formula import config_monster
 from tuxemon.monster import Monster
 from tuxemon.session import Session
 

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -6,13 +6,16 @@ import logging
 import math
 import random
 from collections.abc import Sequence
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-import yaml
-
-from tuxemon.constants import paths
+from tuxemon.database.rules import (
+    CaptureDeviceEffect,
+    config_capdev,
+    config_capture,
+    config_combat,
+    config_monster,
+    range_map,
+)
 from tuxemon.platform.const.sizes import (
     COEFF_DAMAGE,
     COEFF_FEET,
@@ -28,219 +31,6 @@ if TYPE_CHECKING:
     from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class CaptureDeviceEffect:
-    target_attribute: str = ""
-    operation: str = ""
-    value: Union[str, int] = 1
-
-
-@dataclass
-class CaptureDeviceConfig:
-    specific_capdev_modifier: Optional[float] = None
-    positive_modifier: float = 1.0
-    negative_modifier: float = 1.2
-    specific_status_modifiers: Optional[dict[str, float]] = None
-    fallback_element_malus: float = 0.2
-    specific_element_modifiers: Optional[dict[str, float]] = None
-    fallback_gender_malus: float = 0.2
-    specific_gender_modifiers: Optional[dict[str, float]] = None
-    fallback_variables_malus: float = 0.2
-    fallback_variables_bonus: float = 1.5
-    specific_variables_modifiers: Optional[list[dict[str, Any]]] = None
-    random_bounds: Optional[tuple[float, float]] = None
-    capdev_persistent_on_success: bool = False
-    capdev_persistent_on_failure: bool = False
-    capdev_effects: Optional[list[CaptureDeviceEffect]] = None
-
-
-@dataclass
-class CaptureDevicesConfig:
-    items: dict[str, CaptureDeviceConfig]
-    status_modifier: float = 1.0
-    capdev_modifier: float = 1.0
-
-
-@dataclass
-class StatWeight:
-    stat: str
-    weight: float
-
-
-@dataclass
-class RangeMapEntry:
-    user_stat: StatWeight
-    target_stat: StatWeight
-
-
-@dataclass
-class CaptureConfig:
-    total_shakes: int
-    shake_constant: int
-    shake_denominator: int
-    shake_divisor: int
-    shake_hp_multiplier: int
-    shake_current_hp_multiplier: int
-    shake_hp_divisor: int
-
-
-@dataclass
-class MonsterConfig:
-    starting_bond: int = 25
-    max_moves: int = 4
-    max_tps: int = 150
-    max_total_tps: int = 300
-    default_tp_gain: int = 1
-    coeff_stats: int = 7
-    bond_range: tuple[int, int] = (0, 100)
-    iv_range: tuple[int, int] = (0, 31)
-    level_range: tuple[int, int] = (0, 100)
-    catch_rate_range: tuple[int, int] = (0, 100)
-    catch_resistance_range: tuple[float, float] = (0.0, 2.0)
-    weight_range: tuple[float, float] = (-0.1, 0.1)
-    height_range: tuple[float, float] = (-0.1, 0.1)
-    bond_modifiers: dict[str, int] = field(default_factory=dict)
-    bond_sentiments: dict[str, tuple[int, int]] = field(default_factory=dict)
-    bond_strings: dict[str, str] = field(default_factory=dict)
-    bond_icons: dict[str, str] = field(default_factory=dict)
-    opposite_tastes: dict[str, list[str]] = field(default_factory=dict)
-    bond_preferences: dict[str, int] = field(default_factory=dict)
-    experience_multipliers: dict[str, float] = field(default_factory=dict)
-    experience_groups: dict[str, dict[str, Any]] = field(default_factory=dict)
-
-
-@dataclass
-class CombatConfig:
-    letter_time: float
-    action_time: float
-    multiplier_map: dict[float, str]
-    multiplier_range: tuple[float, float]
-    # speed test
-    speed_factor: float
-    speed_offset: float
-    dodge_modifier: float
-    base_speed_bonus: float
-    min_speed_modifier: float
-    sort_order: list[str]
-
-    def validate_multiplier_map(self) -> None:
-        min_range, max_range = self.multiplier_range
-        for multiplier in self.multiplier_map.keys():
-            if not (min_range <= multiplier <= max_range):
-                raise ValueError(
-                    f"Multiplier {multiplier} is outside the allowed range: {self.multiplier_range}"
-                )
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
-
-
-class Loader:
-    _config_combat: Optional[CombatConfig] = None
-    _config_monster: Optional[MonsterConfig] = None
-    _config_capture: Optional[CaptureConfig] = None
-    _range_map: dict[str, RangeMapEntry] = {}
-    _capture_devices: Optional[CaptureDevicesConfig] = None
-
-    @classmethod
-    def get_capture_devices(cls, filename: str) -> CaptureDevicesConfig:
-        yaml_path = paths.mods_folder / filename
-        if cls._capture_devices is None:
-            raw_map = load_yaml(yaml_path)
-            items = {}
-
-            for slug, data in raw_map["items"].items():
-                # Parse capdev_effects directly as a list
-                capdev_effects = None
-                if "capdev_effects" in data:
-                    capdev_effects = [
-                        CaptureDeviceEffect(
-                            target_attribute=effect["target_attribute"],
-                            operation=effect["operation"],
-                            value=effect["value"],
-                        )
-                        for effect in data["capdev_effects"]
-                    ]
-
-                # Create a new dictionary excluding "capdev_effects" to avoid duplication
-                filtered_data = {
-                    key: value
-                    for key, value in data.items()
-                    if key != "capdev_effects"
-                }
-
-                items[slug] = CaptureDeviceConfig(
-                    **filtered_data,
-                    capdev_effects=capdev_effects,
-                )
-
-            # Handle global settings
-            status_modifier = raw_map.get("status_modifier", 1.0)
-            capdev_modifier = raw_map.get("capdev_modifier", 1.0)
-            cls._capture_devices = CaptureDevicesConfig(
-                status_modifier=status_modifier,
-                capdev_modifier=capdev_modifier,
-                items=items,
-            )
-        return cls._capture_devices
-
-    @classmethod
-    def get_config_combat(cls, filename: str) -> CombatConfig:
-        yaml_path = paths.mods_folder / filename
-        if cls._config_combat is None:
-            raw_map = load_yaml(yaml_path)
-            cls._config_combat = CombatConfig(**raw_map)
-        return cls._config_combat
-
-    @classmethod
-    def get_config_monster(cls, filename: str) -> MonsterConfig:
-        yaml_path = paths.mods_folder / filename
-        if cls._config_monster is None:
-            raw_map = load_yaml(yaml_path)
-            cls._config_monster = MonsterConfig(**raw_map)
-        return cls._config_monster
-
-    @classmethod
-    def get_config_capture(cls, filename: str) -> CaptureConfig:
-        yaml_path = paths.mods_folder / filename
-        if cls._config_capture is None:
-            raw_map = load_yaml(yaml_path)
-            cls._config_capture = CaptureConfig(**raw_map)
-        return cls._config_capture
-
-    @classmethod
-    def get_range_map(cls, filename: str) -> dict[str, RangeMapEntry]:
-        yaml_path = paths.mods_folder / filename
-        if not cls._range_map:
-            raw_map = load_yaml(yaml_path)
-            cls._range_map = {
-                key: RangeMapEntry(
-                    user_stat=StatWeight(
-                        stat=item[0]["user_stat"], weight=item[0]["weight"]
-                    ),
-                    target_stat=StatWeight(
-                        stat=item[1]["target_stat"], weight=item[1]["weight"]
-                    ),
-                )
-                for key, item in raw_map.items()
-            }
-        return cls._range_map
-
-
-config_combat = Loader.get_config_combat("config_combat.yaml")
-config_monster = Loader.get_config_monster("config_monster.yaml")
-config_capdev = Loader.get_capture_devices("capture_devices.yaml")
 
 
 def simple_damage_multiplier(
@@ -293,7 +83,6 @@ def simple_damage_calculate(
     Returns:
         A tuple (damage, multiplier).
     """
-    range_map = Loader.get_range_map("range_map.yaml")
 
     if technique.range not in range_map:
         logger.error(
@@ -523,7 +312,6 @@ def shake_check(
     Returns:
         The shake_check value.
     """
-    config_capture = Loader.get_config_capture("config_capture.yaml")
     max_catch_rate = config_monster.catch_rate_range[1]
     shake_constant = config_capture.shake_constant
     shake_denominator = config_capture.shake_denominator
@@ -596,7 +384,6 @@ def capture(shake_check: float) -> tuple[bool, int]:
         (True) if the monster is captured.
         (False) if the monster escapes after a specific number of shakes.
     """
-    config_capture = Loader.get_config_capture("config_capture.yaml")
     total_shakes = config_capture.total_shakes
     shake_divisor = config_capture.shake_divisor
 

--- a/tuxemon/item/recipe.py
+++ b/tuxemon/item/recipe.py
@@ -6,8 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
-
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 
 logger = logging.getLogger(__name__)
@@ -48,9 +47,10 @@ class Recipe:
         Loads a list of Recipe objects from a YAML file.
         """
         recipes: list[Recipe] = []
+
         try:
-            with filepath.open() as file:
-                data = yaml.safe_load(file)
+            data = load_yaml(filepath)
+
             if isinstance(data, list):
                 for recipe_data in data:
                     if isinstance(recipe_data, dict):
@@ -61,14 +61,11 @@ class Recipe:
                         )
             else:
                 logger.debug(
-                    f"Error: YAML file does not contain a list of recipes. Found type: {type(data)}"
+                    f"Error: YAML file does not contain a list of recipes. "
+                    f"Found type: {type(data)}"
                 )
-        except FileNotFoundError:
-            logger.debug(f"Error: The file '{filepath}' was not found.")
-        except yaml.YAMLError as e:
-            logger.debug(f"Error parsing YAML file '{filepath}': {e}")
+
         except Exception as e:
-            logger.debug(
-                f"An unexpected error occurred while loading recipes: {e}"
-            )
+            logger.debug(f"Failed to load recipes from '{filepath}': {e}")
+
         return recipes

--- a/tuxemon/map/map_loader.py
+++ b/tuxemon/map/map_loader.py
@@ -10,12 +10,12 @@ from pathlib import Path
 from typing import Any, Optional
 
 import pytmx
-import yaml
 from natsort import natsorted
 
 from tuxemon.compat import Rect
 from tuxemon.constants.asset_loader import fetch_asset
 from tuxemon.constants.paths import mods_folder
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import BoundingBox, Direction, EventObject, Orientation
 from tuxemon.event.eventparser import EventParser
 from tuxemon.graphics import scaled_image_loader
@@ -43,17 +43,6 @@ RegionTile = tuple[
     tuple[int, int],
     Optional[RegionProperties],
 ]
-
-
-def parse_yaml(path: Path) -> Any:
-    """
-    Parses a large YAML file efficiently using a streaming loader.
-    """
-    with path.open() as fp:
-        try:
-            return yaml.load(fp.read(), Loader=yaml.SafeLoader)
-        except yaml.YAMLError as e:
-            raise ValueError(f"Error parsing YAML file: {e}")
 
 
 class MapLoader:
@@ -290,7 +279,7 @@ class YAMLEventLoader:
         Returns:
             A dictionary with collision coordinates as keys.
         """
-        yaml_data: dict[str, list[dict[str, Any]]] = parse_yaml(path)
+        yaml_data: dict[str, list[dict[str, Any]]] = load_yaml(path)
 
         collision_dict: MutableMapping[
             tuple[int, int], Optional[RegionProperties]
@@ -327,7 +316,7 @@ class YAMLEventLoader:
             of EventObject instances.
         """
         event_parser = EventParser()
-        yaml_data: dict[str, dict[str, dict[str, Any]]] = parse_yaml(path)
+        yaml_data: dict[str, dict[str, dict[str, Any]]] = load_yaml(path)
         events_dict: dict[str, list[EventObject]] = {"event": [], "init": []}
 
         for name, event_data in yaml_data["events"].items():

--- a/tuxemon/map/map_manager.py
+++ b/tuxemon/map/map_manager.py
@@ -9,9 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
-import yaml
-
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import Direction
 
 if TYPE_CHECKING:
@@ -30,24 +29,27 @@ class MapType:
 def load_map_types(filename: str) -> defaultdict[str, MapType]:
     """Loads map types from a YAML file and returns a defaultdict mapping name -> MapType."""
     yaml_path = paths.mods_folder / filename
+
     try:
-        with yaml_path.open(encoding="utf-8") as file:
-            data = yaml.safe_load(file)
-            return defaultdict(
-                lambda: MapType(name="notype"),
-                {
-                    entry["name"]: MapType(**entry)
-                    for entry in data.get("map_types", [])
-                    if "name" in entry
-                },
-            )
+        data = load_yaml(yaml_path)
+
+        return defaultdict(
+            lambda: MapType(name="notype"),
+            {
+                entry["name"]: MapType(**entry)
+                for entry in data.get("map_types", [])
+                if "name" in entry
+            },
+        )
+
     except FileNotFoundError:
         logger.warning(f"Map types file not found at {yaml_path}")
     except Exception as e:
         logger.error(f"Error loading map types: {e}")
 
     return defaultdict(
-        lambda: MapType(name="notype"), {"notype": MapType(name="notype")}
+        lambda: MapType(name="notype"),
+        {"notype": MapType(name="notype")},
     )
 
 

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -8,10 +8,10 @@ from collections.abc import Callable, Generator
 from functools import partial
 from typing import Any, ClassVar, Optional
 
-import yaml
 from pygame.rect import Rect
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
@@ -50,8 +50,7 @@ class NameDataLoader:
     def _load_names(self, file_path: str) -> Any:
         """Loads name data from a YAML file."""
         yaml_path = paths.mods_folder / file_path
-        with yaml_path.open() as file:
-            return yaml.safe_load(file)
+        return load_yaml(yaml_path)
 
     def get_random_name(
         self, gender: str, language: str, fallback_language: str

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from tuxemon import formula
+from tuxemon.database.rules import config_monster
 from tuxemon.database.runtime import db
 from tuxemon.db import (
     Acquisition,
@@ -24,7 +25,6 @@ from tuxemon.db import (
     StatType,
 )
 from tuxemon.element import ElementTypesHandler
-from tuxemon.formula import config_monster
 from tuxemon.fusion import Body
 from tuxemon.locale import T
 from tuxemon.monster_dir.bond import BondHandler

--- a/tuxemon/monster_dir/bond.py
+++ b/tuxemon/monster_dir/bond.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Optional, Union
 
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 
 
 class BondHandler:

--- a/tuxemon/monster_dir/experience.py
+++ b/tuxemon/monster_dir/experience.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 
 logger = logging.getLogger(__name__)
 

--- a/tuxemon/monster_dir/plague.py
+++ b/tuxemon/monster_dir/plague.py
@@ -6,13 +6,12 @@ import logging
 import random
 from collections.abc import Mapping
 from enum import Enum, auto
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
-import yaml
 from pydantic import BaseModel, Field
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import PlagueType
 from tuxemon.locale import T
 
@@ -37,18 +36,6 @@ class InoculationResult(Enum):
     ALREADY_INOCULATED = auto()
     UNKNOWN_PLAGUE = auto()
     NOT_ELIGIBLE = auto()
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class InoculationData(BaseModel):

--- a/tuxemon/monster_dir/stats.py
+++ b/tuxemon/monster_dir/stats.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from typing import Any
 
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
 from tuxemon.shape import ShapeHandler
 from tuxemon.taste import Taste
 

--- a/tuxemon/relationship.py
+++ b/tuxemon/relationship.py
@@ -9,9 +9,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
-import yaml
-
 from tuxemon.constants.paths import mods_folder
+from tuxemon.database.yaml_utils import load_yaml
 
 if TYPE_CHECKING:
     from tuxemon.event.eventbus import EventBus
@@ -41,8 +40,7 @@ class RelationshipConfig:
 
 
 def load_relationship_config(file_path: Path) -> RelationshipConfig:
-    with file_path.open() as f:
-        data = yaml.safe_load(f)
+    data = load_yaml(file_path)
     return RelationshipConfig(**data)
 
 

--- a/tuxemon/save.py
+++ b/tuxemon/save.py
@@ -14,11 +14,11 @@ from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
-import yaml
 from pygame.image import tobytes
 from pygame.surface import Surface
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import dump_yaml_io, load_yaml
 from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.save_state import TIME_FORMAT, SaveData
 from tuxemon.save_upgrader import SAVE_VERSION, upgrade_save
@@ -145,17 +145,21 @@ def dump_data(
         serializer_kwargs: Mapping[str, Any],
     ) -> None:
         serializable_obj = obj.model_dump()
+
         if save_method == SaveMethod.JSON:
             json.dump(serializable_obj, file, **serializer_kwargs)
+
         elif save_method == SaveMethod.CBOR:
             cbor.dump(serializable_obj, file, **serializer_kwargs)
+
         elif save_method == SaveMethod.YAML:
-            yaml.dump(
-                serializable_obj,
+            dump_yaml_io(
                 file,
+                serializable_obj,
                 default_flow_style=False,
                 **serializer_kwargs,
             )
+
         else:
             raise ValueError(f"Unsupported save method: {save_method}")
 
@@ -207,7 +211,7 @@ def load_data(
         elif save_method == SaveMethod.CBOR:
             return cbor.load(file, **serializer_kwargs)
         elif save_method == SaveMethod.YAML:
-            return yaml.safe_load(file)
+            return load_yaml(path)
         else:
             raise ValueError(f"Unsupported save method: {save_method}")
 

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -19,7 +19,7 @@ from pygame.transform import flip as pg_flip
 from tuxemon import graphics
 from tuxemon.animation import Animation, ScheduleType
 from tuxemon.combat.utils import build_hud_text
-from tuxemon.formula import config_combat
+from tuxemon.database.rules import config_combat
 from tuxemon.menu.menu import Menu
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.prepare import SCALE, SCREEN, SCREEN_RECT

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -46,12 +46,12 @@ from tuxemon.combat.combat_context import CombatContext
 from tuxemon.combat.machine import CombatMachine, CombatPhase
 from tuxemon.combat.reward_system import RewardSystem
 from tuxemon.combat.utils import play_outcome_music, track_battles
+from tuxemon.database.rules import config_combat
 from tuxemon.db import (
     EffectPhase,
     ItemCategory,
     OutputBattle,
 )
-from tuxemon.formula import config_combat
 from tuxemon.item.item import Item
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem

--- a/tuxemon/states/phone_contacts.py
+++ b/tuxemon/states/phone_contacts.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import pygame_menu
-import yaml
 from pygame_menu import locals
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_PHONE_CONTACTS
@@ -26,18 +25,6 @@ if TYPE_CHECKING:
     from tuxemon.npc import NPC
 
 logger = logging.getLogger(__name__)
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/states/phone_map.py
+++ b/tuxemon/states/phone_map.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import pygame_menu
-import yaml
 from pygame_menu import locals
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_PHONE_MAP
@@ -29,18 +28,6 @@ logger = logging.getLogger(__name__)
 class NuPhoneMapConfig:
     map_path: str
     map_data: list[tuple[float, float, str]]
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/states/phone_radio.py
+++ b/tuxemon/states/phone_radio.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from functools import partial
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import pygame_menu
-import yaml
 from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_PHONE_CONTACTS
@@ -29,18 +28,6 @@ MIN_FREQ = 88.0
 MAX_FREQ = 108.0
 INITIAL_FREQ = 98.0
 TUNING_TOLERANCE = 0.2
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class Loader:

--- a/tuxemon/states/shop_healing.py
+++ b/tuxemon/states/shop_healing.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from pathlib import Path
 from typing import Any, ClassVar, Literal, Optional
 
-import yaml
 from pydantic import BaseModel, Field
 from pygame.surface import Surface
 
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.quantity import QuantityAndCostMenu
@@ -20,18 +19,6 @@ from tuxemon.session import local_session
 from tuxemon.states.shop_base import ShopMenuState
 
 logger = logging.getLogger(__name__)
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class HealingShopConfig(BaseModel):

--- a/tuxemon/states/shop_training.py
+++ b/tuxemon/states/shop_training.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from pathlib import Path
 from typing import Any, ClassVar, Literal, Optional
 
-import yaml
 from pydantic import BaseModel, Field
 from pygame.surface import Surface
 
 from tuxemon.constants import paths
-from tuxemon.formula import config_monster
+from tuxemon.database.rules import config_monster
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.quantity import QuantityAndCostMenu
@@ -20,18 +19,6 @@ from tuxemon.monster import Monster
 from tuxemon.states.shop_base import ShopMenuState
 
 logger = logging.getLogger(__name__)
-
-
-def load_yaml(filepath: Path) -> Any:
-    try:
-        with filepath.open() as file:
-            return yaml.safe_load(file)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise exc
 
 
 class TrainingShopConfig(BaseModel):

--- a/tuxemon/ui/combat_layout.py
+++ b/tuxemon/ui/combat_layout.py
@@ -6,10 +6,10 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import yaml
 from pygame.rect import Rect
 
 from tuxemon.constants.paths import mods_folder
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.tools import scale_sequence
 
 logger = logging.getLogger(__name__)
@@ -19,27 +19,26 @@ if TYPE_CHECKING:
 
 
 def load_layout_groups(path: Path) -> dict[int, list[str]]:
-    with path.open("r", encoding="utf-8") as file:
-        data = yaml.safe_load(file)
+    data = load_yaml(path)
     raw_groups = data.get("LAYOUT_GROUPS", {})
 
-    layout_groups = {}
+    layout_groups: dict[int, list[str]] = {}
     for key, layout_keys in raw_groups.items():
         try:
             num_players = int(key.split("_")[0])
             layout_groups[num_players] = layout_keys
         except (ValueError, IndexError):
             logger.warning(f"Invalid layout group key: '{key}'")
+
     return layout_groups
 
 
 def load_layouts_from_yaml(
     path: Path,
 ) -> dict[str, dict[str, tuple[int, ...]]]:
-    with path.open("r", encoding="utf-8") as file:
-        data = yaml.safe_load(file)
-
+    data = load_yaml(path)
     raw_layouts = data.get("LAYOUT_COORDINATES", {})
+
     return {
         layout_name: {key: tuple(value) for key, value in layout.items()}
         for layout_name, layout in raw_layouts.items()

--- a/tuxemon/ui/combat_notifier.py
+++ b/tuxemon/ui/combat_notifier.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Optional
 
-from tuxemon.formula import config_combat
+from tuxemon.database.rules import config_combat
 
 if TYPE_CHECKING:
     from tuxemon.menu.alert import AlertManager

--- a/tuxemon/user_config.py
+++ b/tuxemon/user_config.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 
 import logging
 
-import yaml
-
 from tuxemon.config import TuxemonConfig
 from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import dump_yaml_path
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +28,12 @@ def setup_user_environment() -> TuxemonConfig:
     loaded_config = TuxemonConfig(paths.USER_CONFIG_PATH)
 
     try:
-        with paths.USER_CONFIG_PATH.open("w") as fp:
-            yaml.dump(
-                loaded_config.config_model.model_dump(),
-                fp,
-                default_flow_style=False,
-                indent=4,
-            )
+        dump_yaml_path(
+            paths.USER_CONFIG_PATH,
+            loaded_config.config_model.model_dump(),
+            default_flow_style=False,
+            indent=4,
+        )
         logger.info(
             f"Configuration loaded and saved to {paths.USER_CONFIG_PATH}"
         )

--- a/tuxemon/world/weather.py
+++ b/tuxemon/world/weather.py
@@ -9,9 +9,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
 from pydantic import BaseModel, Field, model_validator
 
+from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.db import Temperature, Wind
 from tuxemon.weather import Weather
 
@@ -31,15 +31,8 @@ def load_weather_transition_rules(
 ) -> WeatherTransitionRulesModel:
     """Loads and validates the weather transition rules from a YAML file."""
     try:
-        with filepath.open() as file:
-            data = yaml.safe_load(file)
-            return WeatherTransitionRulesModel(**data)
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {filepath}")
-        raise
-    except yaml.YAMLError as exc:
-        logger.error(f"Error parsing YAML file: {exc}")
-        raise
+        data = load_yaml(filepath)
+        return WeatherTransitionRulesModel(**data)
     except Exception as exc:
         logger.error(f"Error loading WeatherTransitionRulesModel: {exc}")
         raise


### PR DESCRIPTION
Changes:
- moves the loader out of `formula.py` into its own dedicated module
- eliminates circular‑import issues triggered whenever `db.py` (models or utilities) was imported
- places the loader in a more logical, isolated location aligned with its actual responsibility
- centralizes all YAML parsing (`load`, `safe_load`, and manual file‑open patterns) behind the unified `load_yaml` helper for consistent behavior and error handling across the codebase
- simplifies multiple modules by removing duplicated YAML‑loading logic
- fixes #3359, a cross‑platform encoding bug in the data loader by ensuring all JSON/YAML files are opened with `encoding="utf-8"` and by centralizing every YAML read (`yaml.load`, `safe_load`, manual `open()`) behind the new `load_yaml` helper. This prevents Windows systems using non‑UTF‑8 defaults (e.g., Chinese GBK) from mis‑decoding UTF‑8 game data, eliminates the original file‑decoding crash, and unifies all loader behavior across the project