### PR TITLE
Improve action sorting, speed calculation, and queue/history consistency

### DIFF
--- a/tests/tuxemon/test_action_history.py
+++ b/tests/tuxemon/test_action_history.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.combat.action_queue import ActionHistory, EnqueuedAction
+
+
+@pytest.fixture
+def make_action():
+    def _make():
+        return EnqueuedAction(
+            user=MagicMock(), method=MagicMock(), target=MagicMock()
+        )
+
+    return _make
+
+
+@pytest.fixture
+def history():
+    return ActionHistory()
+
+
+@pytest.mark.parametrize(
+    "turns",
+    [
+        [1],
+        [1, 2],
+        [1, 1, 1],
+        [3, 2, 1, 4],
+    ],
+)
+def test_add_action_and_count(history, make_action, turns):
+    for t in turns:
+        history.add_action(t, make_action())
+
+    assert history.count_actions() == len(turns)
+
+
+@pytest.mark.parametrize(
+    "turns,query,expected_count",
+    [
+        ([1, 1, 2], 1, 2),
+        ([2, 2, 2], 2, 3),
+        ([1, 2, 3], 4, 0),
+        ([5, 5, 5, 1], 5, 3),
+    ],
+)
+def test_get_actions_by_turn(
+    history, make_action, turns, query, expected_count
+):
+    for t in turns:
+        history.add_action(t, make_action())
+
+    result = history.get_actions_by_turn(query)
+    assert len(result) == expected_count
+
+
+@pytest.mark.parametrize(
+    "turns,start,end,expected_count",
+    [
+        ([1, 2, 3], 1, 3, 3),
+        ([1, 2, 3], 2, 3, 2),
+        ([1, 2, 3], 3, 3, 1),
+        ([1, 5, 10], 2, 9, 1),
+        ([4, 4, 4], 4, 4, 3),
+        ([1, 2, 3], 10, 20, 0),
+    ],
+)
+def test_get_actions_by_turn_range(
+    history, make_action, turns, start, end, expected_count
+):
+    for t in turns:
+        history.add_action(t, make_action())
+
+    result = history.get_actions_by_turn_range(start, end)
+    assert len(result) == expected_count
+
+
+@pytest.mark.parametrize(
+    "turns,expected_index",
+    [
+        ([1], 0),
+        ([1, 2], 1),
+        ([5, 5, 5], 2),
+        ([3, 1, 4, 2], 3),
+    ],
+)
+def test_get_last_action(history, make_action, turns, expected_index):
+    actions = []
+    for t in turns:
+        a = make_action()
+        actions.append(a)
+        history.add_action(t, a)
+    assert history.get_last_action() == actions[expected_index]
+
+
+def test_get_last_action_empty(history):
+    assert history.get_last_action() is None
+
+
+def test_clear(history, make_action):
+    history.add_action(1, make_action())
+    history.add_action(2, make_action())
+    history.clear()
+    assert history.history == []
+    assert history.count_actions() == 0
+
+
+@pytest.mark.parametrize(
+    "turns",
+    [
+        [],
+        [1],
+        [1, 2],
+        [1, 2, 3, 4],
+    ],
+)
+def test_repr_contains_count(history, make_action, turns):
+    for t in turns:
+        history.add_action(t, make_action())
+    rep = repr(history)
+    assert "ActionHistory(count=" in rep
+    assert "sample=[" in rep
+
+
+def test_order_preserved(history, make_action):
+    a1 = make_action()
+    a2 = make_action()
+    history.add_action(1, a1)
+    history.add_action(1, a2)
+    assert history.get_actions_by_turn(1) == [a1, a2]
+
+
+def test_repr_shows_last_three(history, make_action):
+    for i in range(5):
+        history.add_action(i, make_action())
+
+    rep = repr(history)
+    assert "(2," in rep
+    assert "(3," in rep
+    assert "(4," in rep
+    assert "(0," not in rep
+    assert "(1," not in rep

--- a/tests/tuxemon/test_action_queue.py
+++ b/tests/tuxemon/test_action_queue.py
@@ -1,282 +1,224 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
-from tuxemon.combat.action_queue import EnqueuedAction
-from tuxemon.combat.sort_manager import SortManager
+import pytest
+
+from tuxemon.combat.action_queue import ActionQueue, EnqueuedAction
 from tuxemon.monster import Monster
 from tuxemon.technique.technique import Technique
 
 
-class TestGetActionSortKey(unittest.TestCase):
-    def setUp(self):
-        self.monster = MagicMock(spec=Monster)
-        self.monster.speed = 10.0
-        self.monster.dodge = 5.0
-        self.tech = MagicMock(spec=Technique)
-        self.tech.speed = 0
-        self.tech.sort = "damage"
-
-    def test_none_method(self):
-        action = EnqueuedAction(user=None, method=None, target=self.monster)
-        self.assertEqual(SortManager.get_action_sort_key(action), (0, 0))
-
-    def test_none_user(self):
-        action = EnqueuedAction(
-            user=None, method=self.tech, target=self.monster
-        )
-        self.assertEqual(SortManager.get_action_sort_key(action), (0, 0))
-
-    def test_meta_action(self):
-        self.tech.sort = "meta"
-        action = EnqueuedAction(
-            user=self.monster, method=self.tech, target=self.monster
-        )
-        self.assertEqual(
-            SortManager.get_action_sort_key(action),
-            (SortManager.SORT_ORDER.index("meta"), 0),
-        )
-
-    def test_potion_action(self):
-        self.tech.sort = "potion"
-        action = EnqueuedAction(
-            user=self.monster, method=self.tech, target=self.monster
-        )
-        self.assertEqual(
-            SortManager.get_action_sort_key(action),
-            (SortManager.SORT_ORDER.index("potion"), 0),
-        )
-
-    def test_potion_action_with_none_user(self):
-        self.tech.sort = "potion"
-        action = EnqueuedAction(
-            user=None, method=self.tech, target=self.monster
-        )
-        self.assertEqual(SortManager.get_action_sort_key(action), (0, 0))
-
-    def test_damage_action(self):
-        self.tech.sort = "damage"
-        action = EnqueuedAction(
-            user=self.monster, method=self.tech, target=self.monster
-        )
-        self.assertGreaterEqual(
-            SortManager.get_action_sort_key(action),
-            (SortManager.SORT_ORDER.index("potion"), 0),
-        )
-
-    def test_get_sort_index(self):
-        self.assertEqual(SortManager.get_sort_index("potion"), 0)
-        self.assertEqual(SortManager.get_sort_index("utility"), 1)
-        self.assertEqual(SortManager.get_sort_index("quest"), 2)
-        self.assertEqual(SortManager.get_sort_index("meta"), 3)
-        self.assertEqual(SortManager.get_sort_index("damage"), 4)
-        self.assertEqual(SortManager.get_sort_index("unknown"), 5)
-
-        class TestSortManager(SortManager):
-            SORT_ORDER = []
-
-        self.assertEqual(TestSortManager.get_sort_index("unknown"), 0)
-
-    def test_get_sort_index_empty_string(self):
-        self.assertEqual(
-            SortManager.get_sort_index(""), len(SortManager.SORT_ORDER)
-        )
-
-    def test_get_sort_index_whitespace_string(self):
-        self.assertEqual(
-            SortManager.get_sort_index("   "), len(SortManager.SORT_ORDER)
-        )
+@pytest.fixture
+def monster():
+    m = MagicMock(spec=Monster)
+    m.is_fainted = False
+    return m
 
 
-class TestActionQueue(unittest.TestCase):
-    def setUp(self):
-        self.queue = MagicMock()
-        self.monster1 = MagicMock(name="Monster1", current_hp=100)
-        self.monster2 = MagicMock(name="Monster2", current_hp=100)
-        self.tech1 = MagicMock(name="Technique1")
-        self.item1 = MagicMock(name="Item1")
-        self.condition1 = MagicMock(name="Condition1")
-        self.action1 = MagicMock(
-            user=self.monster1, method=self.tech1, target=self.monster2
-        )
-        self.action2 = MagicMock(
-            user=self.monster2, method=self.item1, target=self.monster1
-        )
-        self.action3 = MagicMock(
-            user=self.monster1, method=self.condition1, target=self.monster2
-        )
-        self.npc1 = MagicMock(name="NPC1")
-
-    def test_enqueue(self):
-        self.queue.enqueue(self.action1, 1)
-        self.queue.enqueue.assert_called_once_with(self.action1, 1)
-
-    def test_dequeue(self):
-        self.queue.dequeue(self.action1)
-        self.queue.dequeue.assert_called_once_with(self.action1)
-
-    def test_pop(self):
-        self.queue.pop()
-        self.queue.pop.assert_called_once()
-
-    def test_is_empty(self):
-        self.queue.is_empty()
-        self.queue.is_empty.assert_called_once()
-
-    def test_clear_queue(self):
-        self.queue.clear_queue()
-        self.queue.clear_queue.assert_called_once()
-
-    def test_clear_history(self):
-        self.queue.clear_history()
-        self.queue.clear_history.assert_called_once()
-
-    def test_clear_pending(self):
-        self.queue.clear_pending()
-        self.queue.clear_pending.assert_called_once()
-
-    def test_sort(self):
-        self.queue.sort()
-        self.queue.sort.assert_called_once()
-
-    def test_swap(self):
-        self.queue.swap(self.monster2, self.monster1)
-        self.queue.swap.assert_called_once_with(self.monster2, self.monster1)
-
-    def test_rewrite(self):
-        self.queue.rewrite(self.monster1, self.tech1)
-        self.queue.rewrite.assert_called_once_with(self.monster1, self.tech1)
-
-    def test_get_last_action_user(self):
-        self.queue.get_last_action(2, self.monster2, "user")
-        self.queue.get_last_action.assert_called_once_with(
-            2, self.monster2, "user"
-        )
-
-    def test_get_last_action_target(self):
-        self.queue.get_last_action(1, self.monster2, "target")
-        self.queue.get_last_action.assert_called_once_with(
-            1, self.monster2, "target"
-        )
-
-    def test_get_all_actions_by_turn(self):
-        self.queue.get_all_actions_by_turn(1)
-        self.queue.get_all_actions_by_turn.assert_called_once_with(1)
-
-    def test_add_pending(self):
-        self.queue.add_pending(self.action1, 1)
-        self.queue.add_pending.assert_called_once_with(self.action1, 1)
-
-    def test_add_pending_multiple(self):
-        self.queue.add_pending(self.action1, 1)
-        self.queue.add_pending(self.action2, 2)
-        self.assertEqual(
-            self.queue.add_pending.call_args_list,
-            [call(self.action1, 1), call(self.action2, 2)],
-        )
-
-    def test_autoclean_pending(self):
-        self.queue.autoclean_pending()
-        self.queue.autoclean_pending.assert_called_once()
-
-    def test_from_pending_to_action(self):
-        self.queue.from_pending_to_action(1)
-        self.queue.from_pending_to_action.assert_called_once_with(1)
-
-    def test_from_pending_to_action_multiple(self):
-        self.queue.from_pending_to_action(1)
-        self.queue.from_pending_to_action.assert_called_once_with(1)
-
-    def test_sort_with_different_methods(self):
-        self.queue.sort()
-        self.queue.sort.assert_called_once()
-
-    def test_swap_no_match(self):
-        self.queue.swap(MagicMock(), MagicMock())
-        self.queue.swap.assert_called_once()
-
-    def test_rewrite_no_match(self):
-        self.queue.rewrite(MagicMock(), MagicMock())
-        self.queue.rewrite.assert_called_once()
+@pytest.fixture
+def monster2():
+    m = MagicMock(spec=Monster)
+    m.is_fainted = False
+    return m
 
 
-class TestActionHistory(unittest.TestCase):
-    def setUp(self):
-        self.history = MagicMock()
-        self.monster1 = MagicMock(name="Monster1")
-        self.monster2 = MagicMock(name="Monster2")
-        self.tech1 = MagicMock(name="Technique1")
-        self.action1 = MagicMock(
-            user=self.monster1, method=self.tech1, target=self.monster2
-        )
-        self.action2 = MagicMock(
-            user=self.monster2,
-            method=MagicMock(name="Item1"),
-            target=self.monster1,
-        )
-        self.action3 = MagicMock(
-            user=self.monster1,
-            method=MagicMock(name="Condition1"),
-            target=self.monster2,
-        )
+@pytest.fixture
+def technique():
+    t = MagicMock(spec=Technique)
+    return t
 
-    def test_add_action(self):
-        self.history.add_action(1, self.action1)
-        self.history.add_action.assert_called_once_with(1, self.action1)
 
-    def test_get_actions_by_turn(self):
-        self.history.get_actions_by_turn.return_value = [
-            self.action1,
-            self.action3,
-        ]
-        self.history.get_actions_by_turn(1)
-        self.history.get_actions_by_turn.assert_called_once_with(1)
+@pytest.fixture
+def action(monster, monster2, technique):
+    return EnqueuedAction(monster, technique, monster2)
 
-    def test_clear(self):
-        self.history.clear()
-        self.history.clear.assert_called_once()
 
-    def test_get_actions_by_turn_range(self):
-        self.history.get_actions_by_turn_range.return_value = [
-            self.action1,
-            self.action2,
-        ]
-        self.history.get_actions_by_turn_range(1, 2)
-        self.history.get_actions_by_turn_range.assert_called_once_with(1, 2)
+@pytest.fixture
+def queue():
+    return ActionQueue()
 
-    def test_count_actions(self):
-        self.history.count_actions.return_value = 3
-        count = self.history.count_actions()
-        self.assertEqual(count, 3)
-        self.history.count_actions.assert_called_once()
 
-    def test_get_last_action(self):
-        self.history.get_last_action.return_value = self.action3
-        last_action = self.history.get_last_action()
-        self.assertEqual(last_action, self.action3)
-        self.history.get_last_action.assert_called_once()
+def test_enqueue_updates_queue_and_history(queue, action):
+    queue.enqueue(action, 1)
+    assert queue.queue == [action]
+    assert queue.history.history == [(1, action)]
 
-    def test_get_last_action_empty(self):
-        self.history.get_last_action.return_value = None
-        last_action = self.history.get_last_action()
-        self.assertIsNone(last_action)
-        self.history.get_last_action.assert_called_once()
 
-    def test_repr(self):
-        expected_repr = f"ActionHistory(count=3, sample=[(1, {self.action1}), (2, {self.action2}), (3, {self.action3})])"
-        self.history.__repr__ = MagicMock(return_value=expected_repr)
-        repr_str = repr(self.history)
-        self.assertEqual(repr_str, expected_repr)
+def test_dequeue_removes_from_queue_and_history(queue, action):
+    queue.enqueue(action, 1)
+    queue.dequeue(action)
+    assert action not in queue.queue
+    assert action not in [a for _, a in queue.history.history]
 
-    def test_repr_less_than_3(self):
-        expected_repr = f"ActionHistory(count=2, sample=[(1, {self.action1}), (2, {self.action2})])"
-        self.history.__repr__ = MagicMock(return_value=expected_repr)
-        repr_str = repr(self.history)
-        self.assertEqual(repr_str, expected_repr)
 
-    def test_repr_empty(self):
-        expected_repr = "ActionHistory(count=0, sample=[])"
-        self.history.__repr__ = MagicMock(return_value=expected_repr)
-        repr_str = repr(self.history)
-        self.assertEqual(repr_str, expected_repr)
+def test_pop_removes_last_action_and_updates_history(
+    queue, monster, monster2, technique
+):
+    a1 = EnqueuedAction(monster, technique, monster2)
+    a2 = EnqueuedAction(monster2, technique, monster)
+    queue.enqueue(a1, 1)
+    queue.enqueue(a2, 1)
+    popped = queue.pop()
+    assert popped == a2
+    assert a2 not in [a for _, a in queue.history.history]
+    assert queue.queue == [a1]
+
+
+def test_clear_queue_removes_actions_from_history(queue, action):
+    queue.enqueue(action, 1)
+    queue.clear_queue()
+    assert queue.queue == []
+    assert queue.history.history == []
+
+
+def test_clear_history_only_clears_history(queue, action):
+    queue.enqueue(action, 1)
+    queue.clear_history()
+    assert queue.queue == [action]
+    assert queue.history.history == []
+
+
+def test_add_pending_and_move_to_action(queue, action):
+    queue.add_pending(action, 2)
+    queue.from_pending_to_action(2)
+    assert queue.queue == [action]
+    assert queue.pending == []
+
+
+def test_autoclean_pending_removes_fainted(
+    queue, monster, monster2, technique
+):
+    alive = monster
+    dead = MagicMock(spec=Monster)
+    dead.is_fainted = True
+    a1 = EnqueuedAction(alive, technique, alive)
+    a2 = EnqueuedAction(dead, technique, alive)
+    a3 = EnqueuedAction(alive, technique, dead)
+    queue.add_pending(a1, 1)
+    queue.add_pending(a2, 1)
+    queue.add_pending(a3, 1)
+    queue.autoclean_pending()
+    assert queue.pending == [(1, a1)]
+
+
+def test_swap_replaces_targets(queue, monster, monster2, technique):
+    action = EnqueuedAction(monster, technique, monster2)
+    queue.enqueue(action, 1)
+    new_target = MagicMock(spec=Monster)
+    queue.swap(monster2, new_target)
+    assert queue.queue[0].target == new_target
+
+
+def test_rewrite_updates_methods(queue, monster, monster2, technique):
+    action = EnqueuedAction(monster, technique, monster2)
+    queue.enqueue(action, 1)
+    new_method = MagicMock(spec=Technique)
+    queue.rewrite(monster, new_method)
+    assert queue.queue[0].method == new_method
+
+
+def test_get_last_action_returns_correct(queue, monster, monster2, technique):
+    a1 = EnqueuedAction(monster, technique, monster2)
+    a2 = EnqueuedAction(monster, technique, monster2)
+    queue.enqueue(a1, 1)
+    queue.enqueue(a2, 1)
+    result = queue.get_last_action(1, monster, "user")
+    assert result == a2
+
+
+def test_get_last_action_returns_none_when_missing(queue, monster):
+    assert queue.get_last_action(1, monster, "user") is None
+
+
+def test_get_all_actions_by_turn(queue, monster, monster2, technique):
+    a1 = EnqueuedAction(monster, technique, monster2)
+    a2 = EnqueuedAction(monster2, technique, monster)
+
+    queue.enqueue(a1, 1)
+    queue.enqueue(a2, 2)
+
+    assert queue.get_all_actions_by_turn(1) == [a1]
+    assert queue.get_all_actions_by_turn(2) == [a2]
+
+
+def test_remove_from_history(queue, action):
+    queue.enqueue(action, 1)
+    queue.remove_from_history(action)
+    assert queue.history.history == []
+
+
+def test_dequeue_raises_on_missing_action(queue, action):
+    with pytest.raises(ValueError):
+        queue.dequeue(action)
+
+
+def test_pop_raises_on_empty_queue(queue):
+    with pytest.raises(IndexError):
+        queue.pop()
+
+
+def test_swap_no_match_does_nothing(queue, action, monster):
+    queue.enqueue(action, 1)
+    queue.swap(MagicMock(), monster)
+    assert queue.queue[0] == action
+
+
+def test_rewrite_no_match_does_nothing(queue, action):
+    queue.enqueue(action, 1)
+    queue.rewrite(MagicMock(), MagicMock())
+    assert queue.queue[0].method == action.method
+
+
+def test_sort_by_speed(queue):
+    fast = MagicMock(spec=Monster)
+    fast.speed = 20
+    fast.dodge = 0
+    fast.is_fainted = False
+    slow = MagicMock(spec=Monster)
+    slow.speed = 5
+    slow.dodge = 0
+    slow.is_fainted = False
+    tech = MagicMock(spec=Technique)
+    tech.sort = "damage"
+    tech.priority = 0
+    tech.speed = 0
+    a_fast = EnqueuedAction(fast, tech, slow)
+    a_slow = EnqueuedAction(slow, tech, fast)
+    queue.enqueue(a_slow, 1)
+    queue.enqueue(a_fast, 1)
+    queue.sort()
+    assert queue.queue[0] == a_fast
+    assert queue.queue[1] == a_slow
+
+
+def test_meta_ignores_speed(queue):
+    fast = MagicMock(spec=Monster, speed=999, dodge=0, is_fainted=False)
+    slow = MagicMock(spec=Monster, speed=1, dodge=0, is_fainted=False)
+    meta = MagicMock(spec=Technique, sort="meta")
+    a_fast = EnqueuedAction(fast, meta, slow)
+    a_slow = EnqueuedAction(slow, meta, fast)
+    queue.enqueue(a_fast, 1)
+    queue.enqueue(a_slow, 1)
+    queue.sort()
+    assert queue.queue[0] in (a_fast, a_slow)
+
+
+def test_pending_moves_then_sorts(queue, monster, monster2, technique):
+    slow = MagicMock(spec=Monster)
+    slow.speed = 1
+    slow.dodge = 0
+    slow.is_fainted = False
+    fast = MagicMock(spec=Monster)
+    fast.speed = 20
+    fast.dodge = 0
+    fast.is_fainted = False
+    technique.sort = "damage"
+    technique.speed = 0
+    a_slow = EnqueuedAction(slow, technique, fast)
+    a_fast = EnqueuedAction(fast, technique, slow)
+    queue.add_pending(a_slow, 2)
+    queue.enqueue(a_fast, 2)
+    queue.from_pending_to_action(2)
+    queue.sort()
+    assert queue.queue[0] == a_fast

--- a/tests/tuxemon/test_get_action_sort_key.py
+++ b/tests/tuxemon/test_get_action_sort_key.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.combat.action_queue import EnqueuedAction
+from tuxemon.combat.sort_manager import ActionSortKey, SortManager
+from tuxemon.monster import Monster
+from tuxemon.technique.technique import Technique
+
+
+@pytest.fixture
+def monster():
+    m = MagicMock(spec=Monster)
+    m.speed = 10.0
+    m.dodge = 5.0
+    return m
+
+
+@pytest.fixture
+def tech():
+    t = MagicMock(spec=Technique)
+    t.speed = 0
+    t.sort = "damage"
+    return t
+
+
+def test_none_method(monster):
+    action = EnqueuedAction(user=None, method=None, target=monster)
+    key = SortManager.get_action_sort_key(action)
+    assert isinstance(key, ActionSortKey)
+    assert key.primary_order == 0
+    assert key.speed == 0
+    assert key.tie_breaker == 0.0
+
+
+def test_none_user(monster, tech):
+    action = EnqueuedAction(user=None, method=tech, target=monster)
+    key = SortManager.get_action_sort_key(action)
+    assert key.primary_order == 0
+    assert key.speed == 0
+    assert key.tie_breaker == 0.0
+
+
+@pytest.mark.parametrize("sort_type", ["meta", "potion"])
+def test_meta_and_potion_actions(monster, tech, sort_type):
+    tech.sort = sort_type
+    action = EnqueuedAction(user=monster, method=tech, target=monster)
+    key = SortManager.get_action_sort_key(action)
+    assert key.primary_order == SortManager.SORT_ORDER.index(sort_type)
+    assert key.speed == 0
+
+
+def test_potion_action_with_none_user(monster, tech):
+    tech.sort = "potion"
+    action = EnqueuedAction(user=None, method=tech, target=monster)
+    key = SortManager.get_action_sort_key(action)
+    assert key.primary_order == 0
+    assert key.speed == 0
+
+
+def test_damage_action(monster, tech):
+    tech.sort = "damage"
+    action = EnqueuedAction(user=monster, method=tech, target=monster)
+    key = SortManager.get_action_sort_key(action)
+    assert key.primary_order == SortManager.SORT_ORDER.index("damage")
+    assert key.speed >= 0
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("potion", 0),
+        ("utility", 1),
+        ("quest", 2),
+        ("meta", 3),
+        ("damage", 4),
+        ("unknown", 5),
+    ],
+)
+def test_get_sort_index(key, expected):
+    assert SortManager.get_sort_index(key) == expected
+
+
+def test_get_sort_index_with_empty_sort_order():
+    class TestSortManager(SortManager):
+        SORT_ORDER = []
+
+    assert TestSortManager.get_sort_index("unknown") == 0
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_get_sort_index_empty_or_whitespace(value):
+    assert SortManager.get_sort_index(value) == len(SortManager.SORT_ORDER)

--- a/tests/tuxemon/test_speed_monster.py
+++ b/tests/tuxemon/test_speed_monster.py
@@ -155,7 +155,7 @@ def test_min_speed_modifier_reset(
     config_combat.min_speed_modifier = 0
     result = speed_monster(monster, technique)
     assert result >= 1
-    assert config_combat.min_speed_modifier == 1
+    assert config_combat.min_speed_modifier == 0
 
 
 def test_negative_dodge_is_clamped(make_monster, make_technique):
@@ -181,3 +181,12 @@ def test_random_seed_reproducibility(make_monster, make_technique):
     random.seed(123)
     r2 = run_speed(monster, technique, n=10)
     assert r1 == r2
+
+
+def test_speed_monster_does_not_mutate_config(make_monster, make_technique):
+    monster = make_monster(0, 0)
+    technique = make_technique(0)
+    config_combat.min_speed_modifier = 0
+    before = config_combat.min_speed_modifier
+    speed_monster(monster, technique)
+    assert config_combat.min_speed_modifier == before

--- a/tuxemon/combat/action_queue.py
+++ b/tuxemon/combat/action_queue.py
@@ -2,8 +2,10 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from tuxemon.combat.sort_manager import SortManager
 from tuxemon.monster import Monster
@@ -14,12 +16,15 @@ from tuxemon.technique.technique import Technique
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class EnqueuedAction:
-    user: Union[Monster, NPC, None]
-    method: Union[Technique, Item, Status, None]
+    user: Monster | NPC | None
+    method: Technique | Item | Status | None
     target: Monster
+    sub_priority: float = field(default_factory=random.random)
 
     def __repr__(self) -> str:
         return f"EnqueuedAction(user={self.user}, method={self.method}, target={self.target})"
@@ -53,7 +58,7 @@ class ActionHistory:
         """Returns the total number of actions recorded in history."""
         return len(self.history)
 
-    def get_last_action(self) -> Optional[EnqueuedAction]:
+    def get_last_action(self) -> EnqueuedAction | None:
         """Retrieves the last action recorded in history."""
         return self.history[-1][1] if self.history else None
 
@@ -73,6 +78,7 @@ class ActionQueue:
         self._action_queue: list[EnqueuedAction] = []
         self._pending_queue: list[tuple[int, EnqueuedAction]] = []
         self._action_history = ActionHistory()
+        self.current_turn = 0
 
     @property
     def queue(self) -> list[EnqueuedAction]:
@@ -89,6 +95,9 @@ class ActionQueue:
         """Returns the pending actions."""
         return self._pending_queue
 
+    def set_current_turn(self, turn: int) -> None:
+        self.current_turn = turn
+
     def enqueue(self, action: EnqueuedAction, turn: int) -> None:
         """Adds an action to the end of the queue and history."""
         self._action_queue.append(action)
@@ -99,40 +108,47 @@ class ActionQueue:
         self._pending_queue.append((turn, action))
 
     def autoclean_pending(self) -> None:
-        """Removes actions from the pending queue under certain conditions."""
-        self._pending_queue = [
-            (turn, pend)
-            for turn, pend in self._pending_queue
-            if not (
-                (
-                    pend.user
-                    and isinstance(pend.user, Monster)
-                    and pend.user.is_fainted
-                )
-                or pend.target.is_fainted
+        """Remove pending actions that are outdated or involve fainted monsters."""
+        current = self.current_turn
+        cleaned = []
+
+        for turn, action in self._pending_queue:
+            user_fainted = (
+                isinstance(action.user, Monster) and action.user.is_fainted
             )
-        ]
+            target_fainted = action.target and action.target.is_fainted
+
+            if turn >= current and not (user_fainted or target_fainted):
+                cleaned.append((turn, action))
+
+        self._pending_queue = cleaned
 
     def from_pending_to_action(self, turn: int) -> None:
         """
         Removes actions from the pending queue and implements them in the
         action queue.
         """
-        for _turn, pend in self._pending_queue[:]:
-            if _turn == turn:
-                self.enqueue(pend, turn)
-                self._pending_queue.remove((turn, pend))
+        to_move = [pend for t, pend in self._pending_queue if t == turn]
+        self._pending_queue = [
+            (t, p) for t, p in self._pending_queue if t != turn
+        ]
+
+        for action in to_move:
+            self.enqueue(action, turn)
 
     def dequeue(self, action: EnqueuedAction) -> None:
         """Removes an action from the queue if it exists."""
         try:
             self._action_queue.remove(action)
+            self.remove_from_history(action)
         except ValueError:
             raise ValueError(f"Action {action} not found in queue")
 
     def pop(self) -> EnqueuedAction:
         """Removes and returns the last action from the queue."""
-        return self._action_queue.pop()
+        action = self._action_queue.pop()
+        self.remove_from_history(action)
+        return action
 
     def is_empty(self) -> bool:
         """Returns True if the queue is empty, False otherwise."""
@@ -140,6 +156,9 @@ class ActionQueue:
 
     def clear_queue(self) -> None:
         """Clears the entire queue."""
+        for _, action in list(self._action_history.history):
+            if action in self._action_queue:
+                self.remove_from_history(action)
         self._action_queue.clear()
 
     def clear_history(self) -> None:
@@ -151,45 +170,54 @@ class ActionQueue:
         self._pending_queue.clear()
 
     def sort(self) -> None:
-        """
-        Sorts the queue based on the action's sort key (game rules).
-        * Techniques that damage are sorted by monster speed (fastest monsters first)
-        * Items are sorted by trainer speed (fastest trainers first)
-        * Actions are ordered from lowest to highest priority, with the highest priority
-        actions last in the queue.
-        """
-        self._action_queue.sort(
-            key=SortManager.get_action_sort_key, reverse=True
-        )
+        """Sort the action queue using cached sort keys for efficiency."""
+        key_cache = {
+            id(action): SortManager.get_action_sort_key(action)
+            for action in self._action_queue
+        }
+
+        self._action_queue.sort(key=lambda a: key_cache[id(a)], reverse=True)
+
+        # Tie-breaker logging
+        for a, b in zip(self._action_queue, self._action_queue[1:]):
+            ka = key_cache[id(a)]
+            kb = key_cache[id(b)]
+
+            if (
+                ka.primary_order == kb.primary_order
+                and ka.speed == kb.speed
+                and a.user
+                and b.user
+            ):
+                logger.debug(
+                    f"Speed Tie: {a.user.name} vs {b.user.name} resolved by tie-breaker."
+                )
 
     def swap(self, old: Monster, new: Monster) -> None:
-        """Swaps the target of all actions in the queue from old to new."""
-        for index, action in enumerate(self._action_queue):
-            if action.target == old:
-                self.__replace(index, action.user, action.method, new)
+        """Redirect all actions targeting 'old' to target 'new'."""
+        for action in self._action_queue:
+            if action.target is old:
+                action.target = new
 
     def rewrite(
-        self, monster: Monster, method: Union[Technique, Item, Status]
+        self, monster: Monster, method: Technique | Item | Status
     ) -> None:
-        """Rewrites the method of all actions in the queue for the given monster."""
-        for index, action in enumerate(self._action_queue):
-            if action.user == monster:
-                self.__replace(index, monster, method, action.target)
+        """Rewrite the method of all actions performed by the given monster."""
+        for action in self._action_queue:
+            if action.user is monster:
+                action.method = method
 
-    def __replace(
-        self,
-        index: int,
-        user: Union[Monster, NPC, None],
-        method: Union[Technique, Item, Status, None],
-        target: Monster,
-    ) -> None:
-        """Replaces an action in the queue at the given index."""
-        new_action = EnqueuedAction(user, method, target)
-        self._action_queue[index] = new_action
+    def remove_from_history(self, action: EnqueuedAction) -> None:
+        """Remove the exact action instance from history."""
+        self._action_history.history = [
+            (t, a)
+            for (t, a) in self._action_history.history
+            if a is not action
+        ]
 
     def get_last_action(
         self, turn: int, monster: Monster, field: str
-    ) -> Optional[EnqueuedAction]:
+    ) -> EnqueuedAction | None:
         """
         Retrieves the last action involving the specified monster in the given turn.
 
@@ -224,3 +252,36 @@ class ActionQueue:
             A list of actions that occurred in the specified turn.
         """
         return self._action_history.get_actions_by_turn(turn)
+
+    def remove_monster_actions(self, monster: Monster) -> None:
+        """Remove all actions involving the given monster from queue, pending, and history."""
+
+        # Remove from main queue
+        self._action_queue = [
+            action
+            for action in self._action_queue
+            if action.user is not monster and action.target is not monster
+        ]
+
+        # Remove from pending queue
+        self._pending_queue = [
+            (t, action)
+            for (t, action) in self._pending_queue
+            if action.user is not monster and action.target is not monster
+        ]
+
+        # Remove from history
+        self._action_history.history = [
+            (t, action)
+            for (t, action) in self._action_history.history
+            if action.user is not monster and action.target is not monster
+        ]
+
+    def schedule_action_in_turns(
+        self, action: EnqueuedAction, turns: int
+    ) -> None:
+        target_turn = self.current_turn + turns
+        self.add_pending(action, target_turn)
+
+    def has_pending_for(self, monster: Monster) -> bool:
+        return any(action.user is monster for _, action in self._pending_queue)

--- a/tuxemon/combat/sort_manager.py
+++ b/tuxemon/combat/sort_manager.py
@@ -2,15 +2,22 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from tuxemon.formula import config_combat, speed_monster
 from tuxemon.monster import Monster
-from tuxemon.npc import NPC
 from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
     from tuxemon.combat.action_queue import EnqueuedAction
+
+
+@dataclass(order=True)
+class ActionSortKey:
+    primary_order: int
+    speed: int
+    tie_breaker: float = field(compare=True)
 
 
 class SortManager:
@@ -25,37 +32,56 @@ class SortManager:
             return len(cls.SORT_ORDER)
 
     @classmethod
-    def get_action_sort_key(cls, action: EnqueuedAction) -> tuple[int, int]:
+    def get_action_sort_key(cls, action: EnqueuedAction) -> ActionSortKey:
         """
-        Returns a tuple representing the sort key for the given action.
+        Compute and return the sort key used to determine this action's
+        position in the turn order.
 
-        The sort key is a tuple of two integers: the primary order and the
-        secondary order. The primary order is determined by the action's sort
-        type, and the secondary order is determined by the user's speed test
-        result (if applicable).
+        The returned value is an ActionSortKey dataclass containing:
+        - primary_order: An integer representing the action category's
+          priority, based on its position in SORT_ORDER. Unknown categories
+          are placed after all known ones.
+        - speed: A secondary sort value representing the user's effective
+          speed for this action. For most techniques this is determined by
+          `speed_test()`. Certain action types (e.g., "meta", "potion")
+          always use a speed of 0.
+        - tie_breaker: A final float used to break ties between actions
+          with identical primary and speed values. This typically comes
+          from the action's `sub_priority`.
 
-        If the action's method is None, or if the action's user is None, the
-        function returns a default sort key of (0, 0).
+        If the action has no method or no user, a default key of
+        ActionSortKey(0, 0, 0.0) is returned.
         """
         if action.method is None or action.user is None:
-            return 0, 0
+            return ActionSortKey(0, 0, 0.0)
 
         action_sort_type = action.method.sort
-        primary_order = cls.get_sort_index(action_sort_type)
+        primary = cls.get_sort_index(action_sort_type)
 
         if action_sort_type in ["meta", "potion"]:
-            return primary_order, 0
+            speed = 0
         else:
-            return primary_order, -speed_test(action)
+            speed = speed_test(action)
+
+        tie = action.sub_priority
+
+        return ActionSortKey(
+            primary_order=primary,
+            speed=speed,
+            tie_breaker=tie,
+        )
 
 
 def speed_test(action: EnqueuedAction) -> int:
     """
     Calculate the speed modifier for the given action.
     """
-    if isinstance(action.user, Monster):
-        if isinstance(action.method, Technique):
-            return speed_monster(action.user, action.method)
-    if isinstance(action.user, NPC):
-        return 10
+    if isinstance(action.user, Monster) and isinstance(
+        action.method, Technique
+    ):
+        return speed_monster(action.user, action.method)
+
+    # NPCs using items, or Status effects, default to 0.
+    # Their turn order is decided by Category (primary_order)
+    # and then the Random Tie-breaker.
     return 0

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -845,27 +845,20 @@ def speed_monster(monster: Monster, technique: Technique) -> int:
     """
     Calculate the speed modifier for the given monster / technique.
     """
-    # Ensure min_speed_modifier is greater than 0
-    if config_combat.min_speed_modifier <= 0:
-        config_combat.min_speed_modifier = 1
+    min_mod = max(config_combat.min_speed_modifier, 1)
+    base_speed = float(max(monster.speed, 0))
 
-    base_speed = float(
-        max(monster.speed, 0)
-    )  # Ensure base_speed is not negative
-
-    # Calculate speed bonus based on technique speed
+    # Calculate modifier based on technique speed
     speed_adjustment = technique.speed * config_combat.speed_factor
     speed_bonus = config_combat.base_speed_bonus + speed_adjustment
+
+    # Base calculation
     speed_modifier = base_speed * speed_bonus
 
-    # Add a controlled random element
-    speed_offset = config_combat.speed_offset
-    random_offset = random.uniform(-speed_offset, speed_offset)
-    speed_modifier += random_offset
+    # Ensure minimum bound
+    speed_modifier = max(speed_modifier, min_mod)
 
-    # Ensure the speed modifier is not negative
-    speed_modifier = max(speed_modifier, config_combat.min_speed_modifier)
-    # Use dodge as a tiebreaker, ensure dodge is not negative
+    # Use dodge as a strategic tiebreaker
     speed_modifier += (
         max(float(monster.dodge), 0) * config_combat.dodge_modifier
     )

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -223,10 +223,10 @@ class CombatState(CombatAnimations):
             pass
 
         elif phase == CombatPhase.HOUSEKEEPING:
-            c_session.next_turn()
-
+            new_turn = c_session.next_turn()
+            c_session.action_queue.set_current_turn(new_turn)
             # fill all battlefield positions, but on round 1, don't ask
-            c_session.fill_battlefield_positions(ask=c_session.turn > 1)
+            c_session.fill_battlefield_positions(ask=new_turn > 1)
             c_session.track_enemy_monsters(self.session)
 
         elif phase == CombatPhase.DECISION:
@@ -492,12 +492,7 @@ class CombatState(CombatAnimations):
         """
         self.hud_manager.unassign(monster.get_owner(), monster)
         self.status_icons.recalculate_icon_positions()
-        action_queue = self.combat_session.action_queue.queue
-        action_queue[:] = [
-            action
-            for action in action_queue
-            if action.user is not monster and action.target is not monster
-        ]
+        self.combat_session.action_queue.remove_monster_actions(monster)
         self.ai_manager.remove_ai(monster)
 
     def perform_action(


### PR DESCRIPTION
**Speed calculation**
- removed random speed offset and minimum‑speed mutation; speed is now deterministic
- simplified speed formula and ensured minimum modifier is enforced cleanly

**Sorting system**
- introduced `ActionSortKey` dataclass with structured ordering (primary, speed, tie‑breaker)
- added stable tie‑breaking using a per‑action random `sub_priority`
- removed special‑case negative speed sorting; now handled by the dataclass ordering

**EnqueuedAction**
- added `sub_priority` field to guarantee deterministic ordering when all other fields match
- kept `__repr__` simple and unchanged

**SortManager**
- reworked `get_action_sort_key` to return `ActionSortKey` instead of a tuple
- unified speed handling and removed old meta/potion tuple logic

**ActionQueue**
- `dequeue` and `pop` now also remove the action from history
- `clear_queue` now cleans history entries tied to queued actions
- `from_pending_to_action` rewritten to avoid repeated list removals
- `autoclean_pending` simplified and made safer
- `rewrite` now mutates the existing action instead of replacing the whole object
- added `remove_from_history` helper for consistency
- sorting now logs speed ties explicitly using the new tie‑breaker system

**ActionHistory**
- no functional changes, but now interacts more consistently with queue cleanup


| Situation | Old System (random added to speed) | New System (fixed speed + tie‑breaker) |
|----------|------------------------------------|----------------------------------------|
| Rockitten Speed 90 vs Pairagrin Speed 55 | Turn 1: Rockitten 90.4, Pairagrin 92.1 → Pairagrin moves first<br>Turn 2: Rockitten 89.7, Pairagrin 54.9 → Rockitten moves first | Rockitten stays 90, Pairagrin stays 55. Rockitten always moves first. |
| Agnite A Speed 45 vs Agnite B Speed 45 | Turn 1: A = 46.2, B = 44.8 → A first<br>Turn 2: A = 44.9, B = 46.1 → B first | Both stay 45. Tie resolved by sub_priority (e.g., 0.12 vs 0.87). |
| Turn‑to‑turn order | Can flip even when speeds differ by 30+ points | Only flips when speeds are exactly equal |