### PR TITLE
Add conditional execution hooks for all effect types to support multi‑turn techniques

### DIFF
--- a/docs/handcrafted/core_effects_list.rst
+++ b/docs/handcrafted/core_effects_list.rst
@@ -6,6 +6,7 @@
 .. autoscriptinfoclass:: tuxemon.core.effects.capture.CaptureEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.capture_combined.CaptureCombinedEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.change_stat.ChangeStatEffect
+.. autoscriptinfoclass:: tuxemon.core.effects.charge.ChargeEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.chargedup.ChargedUpEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.charging.ChargingEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.charmed.CharmedEffect
@@ -40,6 +41,7 @@
 .. autoscriptinfoclass:: tuxemon.core.effects.lifegift.LifeGiftEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.lifeleech.LifeLeechEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.lockdown.LockdownEffect
+.. autoscriptinfoclass:: tuxemon.core.effects.locked.LockedMoveEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.mirror.MirrorEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.money.MoneyEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.move_type.MoveTypeEffect
@@ -52,7 +54,9 @@
 .. autoscriptinfoclass:: tuxemon.core.effects.prickly.PricklyBackEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.prop_damage.PropDamageEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.prop_healing.PropHealingEffect
+.. autoscriptinfoclass:: tuxemon.core.effects.ramp.RampEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.recover.RecoverEffect
+.. autoscriptinfoclass:: tuxemon.core.effects.release.ReleaseEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.remove.RemoveEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.remove_entity.RemoveEntityEffect
 .. autoscriptinfoclass:: tuxemon.core.effects.repellent.RepellentEffect

--- a/tuxemon/core/core_effect.py
+++ b/tuxemon/core/core_effect.py
@@ -53,6 +53,37 @@ class CoreEffect:
     def is_finished(self) -> bool:
         return True
 
+    def should_run_global(
+        self,
+        session: Session,
+    ) -> bool:
+        return True
+
+    def should_run_tech(
+        self,
+        session: Session,
+        tech: Technique,
+        user: Monster | None,
+        target: Monster | None,
+    ) -> bool:
+        return True
+
+    def should_run_item(
+        self,
+        session: Session,
+        item: Item,
+        user: Monster | None,
+        target: Monster | None,
+    ) -> bool:
+        return True
+
+    def should_run_status(
+        self,
+        session: Session,
+        tech: Status,
+    ) -> bool:
+        return True
+
     def apply_globally(self, session: Session) -> EffectResult:
         return EffectResult()
 

--- a/tuxemon/core/core_processor.py
+++ b/tuxemon/core/core_processor.py
@@ -64,10 +64,17 @@ class EffectProcessor:
         meta_result = EffectResult()
         if not self.effects:
             return meta_result
+
         for effect in self.effects:
             if isinstance(effect, CoreEffect):
-                result = effect.apply_globally(session)
-                self._merge_results_global(meta_result, result)
+                if effect.should_run_global(session):
+                    result = effect.apply_globally(session)
+                    self._merge_results_global(meta_result, result)
+                else:
+                    logger.debug(
+                        f"Global effect {effect.name} skipped by should_run()"
+                    )
+
         return meta_result
 
     def process_tech(
@@ -80,16 +87,32 @@ class EffectProcessor:
         meta_result = TechEffectResult(name=source.name)
         if not self.effects:
             return meta_result
+
         for effect in self.effects:
             if isinstance(effect, CoreEffect):
+
+                # Technique with target
                 if user and target:
-                    result = effect.apply_tech_target(
-                        session, source, user, target
-                    )
-                    self._merge_results_technique(meta_result, result)
-                if user is None and target is None:
-                    result = effect.apply_tech(session, source)
-                    self._merge_results_technique(meta_result, result)
+                    if effect.should_run_tech(session, source, user, target):
+                        result = effect.apply_tech_target(
+                            session, source, user, target
+                        )
+                        self._merge_results_technique(meta_result, result)
+                    else:
+                        logger.debug(
+                            f"Tech effect {effect.name} skipped by should_run()"
+                        )
+
+                # Technique without target
+                elif user is None and target is None:
+                    if effect.should_run_tech(session, source, None, None):
+                        result = effect.apply_tech(session, source)
+                        self._merge_results_technique(meta_result, result)
+                    else:
+                        logger.debug(
+                            f"Tech effect {effect.name} (no target) skipped by should_run()"
+                        )
+
         return meta_result
 
     def process_item(
@@ -101,13 +124,30 @@ class EffectProcessor:
         meta_result = ItemEffectResult(name=source.name)
         if not self.effects:
             return meta_result
+
         for effect in self.effects:
             if isinstance(effect, CoreEffect):
+
                 if target:
-                    result = effect.apply_item_target(session, source, target)
+                    if effect.should_run_item(session, source, target, target):
+                        result = effect.apply_item_target(
+                            session, source, target
+                        )
+                        self._merge_results_item(meta_result, result)
+                    else:
+                        logger.debug(
+                            f"Item effect {effect.name} skipped by should_run()"
+                        )
+
                 else:
-                    result = effect.apply_item(session, source)
-                self._merge_results_item(meta_result, result)
+                    if effect.should_run_item(session, source, None, None):
+                        result = effect.apply_item(session, source)
+                        self._merge_results_item(meta_result, result)
+                    else:
+                        logger.debug(
+                            f"Item effect {effect.name} (no target) skipped by should_run()"
+                        )
+
         return meta_result
 
     def process_status(
@@ -118,10 +158,18 @@ class EffectProcessor:
         meta_result = StatusEffectResult(name=source.name)
         if not self.effects:
             return meta_result
+
         for effect in self.effects:
             if isinstance(effect, CoreEffect):
-                result = effect.apply_status(session, source)
-                self._merge_results_status(meta_result, result)
+
+                if effect.should_run_status(session, source):
+                    result = effect.apply_status(session, source)
+                    self._merge_results_status(meta_result, result)
+                else:
+                    logger.debug(
+                        f"Status effect {effect.name} skipped by should_run()"
+                    )
+
         return meta_result
 
     @staticmethod

--- a/tuxemon/core/effects/charge.py
+++ b/tuxemon/core/effects/charge.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.combat.action_queue import EnqueuedAction
+from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.technique.technique import Technique
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
+
+
+@dataclass
+class ChargeEffect(CoreEffect):
+    """
+    Handles the first turn of a two-turn charging technique. This effect marks
+    the monster as charging and schedules the corresponding release technique
+    to execute on the following turn. It is typically paired with a
+    ``release`` effect to complete the multi-turn sequence.
+
+    **Parameters**
+
+    This effect takes no parameters. It simply initiates the charging state
+    and queues the release action for the next turn.
+
+    **Example**
+
+    .. code-block:: json
+
+        "effects": [
+            "charge"
+        ]
+    """
+
+    name = "charge"
+
+    def should_run_tech(
+        self,
+        session: Session,
+        tech: Technique,
+        user: Monster | None,
+        target: Monster | None,
+    ) -> bool:
+        if user is None:
+            return False
+        return not user.is_charging
+
+    def apply_tech_target(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+        combat_session = session.client.combat_session
+        queue = combat_session.action_queue
+        user.is_charging = True
+        user.charged_technique = tech.slug
+        release_tech = Technique.create(tech.slug)
+        release_action = EnqueuedAction(user, release_tech, target)
+        queue.schedule_action_in_turns(release_action, 1)
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/confused.py
+++ b/tuxemon/core/effects/confused.py
@@ -47,9 +47,8 @@ class ConfusedEffect(CoreEffect):
     def apply_status(
         self, session: Session, status: Status
     ) -> StatusEffectResult:
-        CONFUSED_KEY = self.name
+
         host = status.host
-        var = session.client.combat_session.get_variable(CONFUSED_KEY)
 
         if not 0 <= self.chance <= 1:
             raise ValueError(f"{self.chance} must be between 0 and 1")
@@ -57,30 +56,24 @@ class ConfusedEffect(CoreEffect):
         extra: list[str] = []
         tech: list[Technique] = []
 
-        if (
-            status.has_phase(EffectPhase.PRE_CHECKING)
-            and random.random() > self.chance
-        ):
-            if var:
-                session.client.combat_session.set_variable(CONFUSED_KEY, "off")
-            session.client.combat_session.set_variable(CONFUSED_KEY, "on")
-            available_techniques = _get_available_techniques(host)
-            if available_techniques:
-                chosen_technique = random.choice(available_techniques)
-                tech = [chosen_technique]
-            elif status.on_tech_use:
-                replacement_technique = Technique.create(status.on_tech_use)
-                tech = [replacement_technique]
+        if status.has_phase(EffectPhase.PRE_CHECKING):
 
-        if status.has_phase(EffectPhase.PERFORM_TECH):
-            if var:
-                session.client.combat_session.set_variable(CONFUSED_KEY, "off")
-            if var and str(var) == "on":
-                action = session.client.combat_session.get_variable(
-                    "action_tech"
-                )
-                replacement = Technique.create(str(action) or "skip")
-                extra = _get_extra_message(host, replacement)
+            if random.random() < self.chance:
+                host.is_confused = True
+
+                available = _get_available_techniques(host)
+                if available:
+                    tech = [random.choice(available)]
+                elif status.on_tech_use:
+                    tech = [Technique.create(status.on_tech_use)]
+            else:
+                host.is_confused = False
+
+        if status.has_phase(EffectPhase.PERFORM_TECH) and host.is_confused:
+            action = session.client.combat_session.get_variable("action_tech")
+            replacement = Technique.create(str(action) or "skip")
+            extra = _get_extra_message(host, replacement)
+            host.is_confused = False
 
         return StatusEffectResult(
             name=status.name,

--- a/tuxemon/core/effects/locked.py
+++ b/tuxemon/core/effects/locked.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.combat.action_queue import EnqueuedAction
+from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.status.status import Status
+from tuxemon.technique.technique import Technique
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
+
+
+@dataclass
+class LockedMoveEffect(CoreEffect):
+    """
+    Forces a monster to repeat the same technique for a fixed number of turns.
+    During this locked sequence, the monster cannot choose another move. Once
+    the sequence ends, the monster may become confused based on a configurable
+    probability.
+
+    **Parameters**
+
+    - ``turns``: The number of consecutive turns the monster is forced to repeat
+      the same technique. Must be a positive integer.
+    - ``confuse_chance``: A floating-point value between ``0`` and ``1`` that
+      determines the probability of the monster becoming confused after the
+      locked sequence ends.
+
+    **Example**
+
+    .. code-block:: json
+
+        "effects": [
+            "locked 2 0.33"
+        ]
+    """
+
+    name = "locked"
+    turns: int = 2
+    confuse_chance: float = 0.33
+
+    def apply_tech_target(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+
+        combat_session = session.client.combat_session
+        queue = combat_session.action_queue
+        user.locked_turns_left = self.turns
+        user.locked_move = tech.slug
+        user.locked_turns_left -= 1
+
+        # Schedule next forced use
+        if user.locked_turns_left > 0:
+            next_tech = Technique.create(user.locked_move)
+            next_action = EnqueuedAction(user, next_tech, target)
+            queue.schedule_action_in_turns(next_action, 1)
+
+        # End of lock: apply confusion
+        else:
+            user.locked_turns_left = 0
+            user.locked_move = None
+
+            if random.random() < self.confuse_chance:
+                status = Status.create("confused", target, target.steps)
+                result = target.status.apply_status(session, status)
+                if result.applied:
+                    event_bus = session.client.event_bus
+                    event_bus.publish("status_applied")
+                    event_bus.publish("update_party_hud")
+
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/ramp.py
+++ b/tuxemon/core/effects/ramp.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
+    from tuxemon.technique.technique import Technique
+
+
+@dataclass
+class RampEffect(CoreEffect):
+    """
+    Gradually increases a technique's power each consecutive turn it is used,
+    allowing certain moves to grow stronger over time. This effect is commonly
+    used for techniques such as ``Rollout``, ``Ice Ball``, or ``Fury Cutter``,
+    where repeated use amplifies damage output.
+
+    **Parameters**
+
+    - ``multiplier``: The factor applied to the technique's power for each
+      additional consecutive use. A value of ``2.0`` doubles the power each turn,
+      while other values adjust the growth rate accordingly.
+
+    **Example**
+
+    .. code-block:: json
+
+        "effects": [
+            "ramp 2.0"
+        ]
+    """
+
+    name = "ramp"
+    multiplier: float = 2.0
+
+    def apply_tech_target(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+        user.ramp_counter += 1
+        tech.power = int(
+            tech.power * (self.multiplier ** (user.ramp_counter - 1))
+        )
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/release.py
+++ b/tuxemon/core/effects/release.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.session import Session
+    from tuxemon.technique.technique import Technique
+
+
+@dataclass
+class ReleaseEffect(CoreEffect):
+    """
+    Executes the second turn of a two-turn charging technique. This effect
+    performs the stored attack after the charging phase has completed and
+    clears the monster's charging state. It is typically paired with a
+    corresponding charge effect to form a complete multi-turn move.
+
+    **Parameters**
+
+    This effect takes no parameters. It simply resolves the charged attack
+    when the monster is in a charging state.
+
+    **Example**
+
+    .. code-block:: json
+
+        "effects": [
+            "release"
+        ]
+    """
+
+    name = "release"
+
+    def should_run_tech(
+        self,
+        session: Session,
+        tech: Technique,
+        user: Monster | None,
+        target: Monster | None,
+    ) -> bool:
+        if user is None:
+            return False
+        return user.is_charging
+
+    def apply_tech_target(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> TechEffectResult:
+
+        if not user.is_charging:
+            return TechEffectResult(name=tech.name, success=False)
+
+        user.is_charging = False
+        user.charged_technique = None
+        return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -118,9 +118,17 @@ class Monster:
         self.types = ElementTypesHandler()
         self.shape: ShapeHandler = ShapeHandler()
         self.randomly: bool = True
-        self.out_of_range: bool = False
         self.acquisition: Acquisition = Acquisition.UNKNOWN
         self.wild: bool = False
+
+        # Combat Attributes
+        self.out_of_range: bool = False
+        self.is_charging: bool = False
+        self.charged_technique: str | None = None
+        self.locked_turns_left: int = 0
+        self.locked_move: str | None = None
+        self.ramp_counter: int = 0
+        self.is_confused: bool = False
 
         self.status = MonsterStatusHandler()
         self.plague = MonsterPlagueHandler()

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -458,6 +458,12 @@ class CombatState(CombatAnimations):
             )
             monster.moves.recharge_moves()
 
+            if monster.locked_turns_left > 0:
+                continue
+
+            if monster.is_charging:
+                continue
+
             if char in self.combat_session.human_players:
                 # Still add to queue for menu interaction
                 self._decision_queue.append(monster)


### PR DESCRIPTION
waiting:
- [x] #3353

Changes:
- added `should_run_global()` to allow global effects to opt out of execution
- added `should_run_tech()` to allow technique effects to run conditionally based on user, target, or technique state
- added `should_run_item()` to allow item effects to be conditionally skipped
- added `should_run_status()` to allow status effects to decide whether they should execute
- updated `EffectProcessor` to respect these new `should_run_*` methods across all effect-processing paths
- fixed an issue where multi‑turn techniques such as charge and release would execute all their effects in the same turn
- enabled proper sequencing for multi‑turn behaviors including **charge**, **release**, **ramp** and **locked**  by allowing each effect to decide when it should run

Added Effects:
- **ChargeEffect**: initiates a two‑turn move by marking the monster as charging and scheduling the follow‑up action for the next turn
- **ReleaseEffect**: resolves the second turn of a charging move, executing the stored attack and clearing the charging state
- **RampEffect**: increases a technique’s power on consecutive uses, enabling moves that grow stronger each turn
- **LockedMoveEffect**: forces a monster to repeat the same technique for a set number of turns and may apply confusion when the sequence ends