### PR TITLE
Extract `RenderMixin` and `AnimationMixin` From `State`

### DIFF
--- a/tests/tuxemon/test_animation_mixin.py
+++ b/tests/tuxemon/test_animation_mixin.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+from tuxemon.state.animation_mixin import AnimationMixin
+
+
+class Dummy(AnimationMixin):
+    """A simple concrete class to test the mixin."""
+
+    def __init__(self):
+        super().__init__()
+
+
+def test_init_creates_animation_group(monkeypatch):
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.animation_mixin.AnimationGroup", lambda: mock_group
+    )
+    d = Dummy()
+    assert d.anim is mock_group
+    assert d._scheduled_task is None
+
+
+def test_animate_calls_animation_group(monkeypatch):
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.animation_mixin.AnimationGroup", lambda: mock_group
+    )
+    d = Dummy()
+    d.animate("target", x=10)
+
+    mock_group.animate.assert_called_once_with("target", x=10)
+
+
+def test_task_calls_animation_group(monkeypatch):
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.animation_mixin.AnimationGroup", lambda: mock_group
+    )
+    d = Dummy()
+    d.task(lambda: None, interval=1.0)
+    mock_group.task.assert_called_once()
+
+
+def test_chain_animations(monkeypatch):
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.animation_mixin.AnimationGroup", lambda: mock_group
+    )
+    d = Dummy()
+    fn = lambda: None
+    d.chain_animations(fn, start_delay=0.5)
+    mock_group.chain_animations.assert_called_once_with(fn, start_delay=0.5)
+
+
+def test_remove_animations_of(monkeypatch):
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.animation_mixin.AnimationGroup", lambda: mock_group
+    )
+    d = Dummy()
+    d.remove_animations_of("obj")
+    mock_group.remove_of.assert_called_once_with("obj")
+
+
+def test_update_animations(monkeypatch):
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.animation_mixin.AnimationGroup", lambda: mock_group
+    )
+    d = Dummy()
+    d.update_animations(0.16)
+    mock_group.update.assert_called_once_with(0.16)

--- a/tests/tuxemon/test_state.py
+++ b/tests/tuxemon/test_state.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.state.state import State
+
+
+@pytest.fixture(autouse=True)
+def mock_local_session_client(monkeypatch):
+    mock_client = MagicMock()
+    monkeypatch.setattr("tuxemon.session.local_session._client", mock_client)
+
+    return mock_client
+
+
+class DummyState(State):
+    name = "Dummy"
+
+    def draw(self, surface):
+        pass
+
+
+def test_state_initializes_correctly(monkeypatch):
+    mock_event_bus = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.state.get_event_bus", lambda: mock_event_bus
+    )
+    s = DummyState()
+    assert s.start_time == 0.0
+    assert s.current_time == 0.0
+    assert hasattr(s, "sprites")
+    assert hasattr(s, "anim")
+    assert s.event_bus is mock_event_bus
+    assert s.client is not None
+
+
+def test_load_sprite(monkeypatch):
+    mock_sprite = MagicMock()
+    mock_loader = MagicMock(return_value=mock_sprite)
+    mock_group = MagicMock()
+    monkeypatch.setattr("tuxemon.state.state.load_sprite", mock_loader)
+    monkeypatch.setattr("tuxemon.state.state.SpriteGroup", lambda: mock_group)
+    s = DummyState()
+    result = s.load_sprite("hero.png", layer=3)
+    assert result is mock_sprite
+    mock_group.add.assert_called_once_with(mock_sprite, layer=3)
+
+
+def test_load_animated_sprite(monkeypatch):
+    mock_sprite = MagicMock()
+    mock_loader = MagicMock(return_value=mock_sprite)
+    mock_group = MagicMock()
+    monkeypatch.setattr(
+        "tuxemon.state.state.load_animated_sprite", mock_loader
+    )
+    monkeypatch.setattr("tuxemon.state.state.SpriteGroup", lambda: mock_group)
+    s = DummyState()
+    result = s.load_animated_sprite(["a.png", "b.png"], delay=0.1, layer=2)
+    assert result is mock_sprite
+    mock_group.add.assert_called_once_with(mock_sprite, layer=2)
+
+
+def test_process_event_returns_event():
+    s = DummyState()
+    event = MagicMock()
+    assert s.process_event(event) is event
+
+
+def test_update_calls_animation_and_sprite_update(monkeypatch):
+    s = DummyState()
+    s.update_animations = MagicMock()
+    s.sprites.update = MagicMock()
+    s.update(0.16)
+    s.update_animations.assert_called_once_with(0.16)
+    s.sprites.update.assert_called_once_with(0.16)
+
+
+def test_resume_publishes_event(monkeypatch):
+    mock_bus = MagicMock()
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    s = DummyState()
+    s.resume()
+    mock_bus.publish.assert_called_with("state_resume")
+
+
+def test_pause_publishes_event(monkeypatch):
+    mock_bus = MagicMock()
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    s = DummyState()
+    s.pause()
+    mock_bus.publish.assert_called_with("state_pause")
+
+
+def test_shutdown_publishes_event(monkeypatch):
+    mock_bus = MagicMock()
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    s = DummyState()
+    s.shutdown()
+    mock_bus.publish.assert_called_with("state_shutdown")
+
+
+def test_schedule_callback(monkeypatch):
+    s = DummyState()
+    mock_task = MagicMock()
+    s.task = MagicMock(return_value=mock_task)
+    mock_callback = MagicMock()
+    monkeypatch.setattr("random.random", lambda: 0.0)
+    s.schedule_callback(1.0, mock_callback)
+    mock_callback.assert_called_once()
+    s.task.assert_called_once()
+    assert s._scheduled_task is mock_task
+
+
+def test_stop_scheduled_callbacks(monkeypatch):
+    s = DummyState()
+    mock_task = MagicMock()
+    s._scheduled_task = mock_task
+    s.stop_scheduled_callbacks()
+    mock_task.abort.assert_called_once()
+    assert s._scheduled_task is None
+
+
+def test_subscribe(monkeypatch):
+    mock_bus = MagicMock()
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    s = DummyState()
+    s.subscribe("event", lambda: None, priority=5)
+    mock_bus.subscribe.assert_called_once()
+
+
+def test_unsubscribe(monkeypatch):
+    mock_bus = MagicMock()
+    mock_bus.has_listeners_for_event.return_value = True
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    s = DummyState()
+    callback = lambda: None
+    s.unsubscribe("event", callback)
+    mock_bus.unsubscribe.assert_called_once()
+
+
+def test_publish(monkeypatch):
+    mock_bus = MagicMock()
+    mock_bus.has_listeners_for_event.return_value = True
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    s = DummyState()
+    s.publish("event", 1, x=2)
+    mock_bus.publish.assert_called_once_with("event", 1, x=2)
+
+
+def test_replace_events(monkeypatch):
+    mock_bus = MagicMock()
+    monkeypatch.setattr("tuxemon.state.state.get_event_bus", lambda: mock_bus)
+    listener = MagicMock()
+    listener.callback = MagicMock()
+    listener.priority = 3
+    s = DummyState()
+    s.replace_events("event", [listener])
+    mock_bus.clear_event.assert_called_once_with("event")
+    mock_bus.subscribe.assert_called_once_with(
+        "event", listener.callback, priority=3
+    )

--- a/tuxemon/state/animation_mixin.py
+++ b/tuxemon/state/animation_mixin.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from tuxemon.state.animation_group import AnimationGroup
+
+if TYPE_CHECKING:
+    from pygame.sprite import Group
+
+    from tuxemon.animation import (
+        Animation,
+        ScheduledFunction,
+        Task,
+    )
+
+
+class AnimationMixin:
+    """
+    A mixin that provides animation and task scheduling capabilities.
+    Can be used by States, Sprites, or any game object.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.anim = AnimationGroup()
+        self._scheduled_task: Task | None = None
+
+    @property
+    def animations(self) -> Group[Task | Animation]:
+        return self.anim._group
+
+    def animate(self, *targets: Any, **kwargs: Any) -> Animation:
+        """
+        Animate something in this state.
+
+        Animations are processed even while state is inactive.
+
+        Parameters:
+            targets: Targets of the Animation.
+            kwargs: Attributes and their final value.
+
+        Returns:
+            Resulting animation.
+        """
+        return self.anim.animate(*targets, **kwargs)
+
+    def task(
+        self,
+        func: ScheduledFunction,
+        *,
+        on_finish: ScheduledFunction | None = None,
+        on_update: ScheduledFunction | None = None,
+        interval: float = 0,
+        times: int = 1,
+        **kwargs: Any,
+    ) -> Task:
+        return self.anim.task(
+            func,
+            on_finish=on_finish,
+            on_update=on_update,
+            interval=interval,
+            times=times,
+            **kwargs,
+        )
+
+    def chain_animations(
+        self, *fns: Callable[[], Animation], start_delay: float = 0.0
+    ) -> None:
+        self.anim.chain_animations(*fns, start_delay=start_delay)
+
+    def remove_animations_of(self, target: Any) -> None:
+        """
+        Given and object, remove any animations that it is used with.
+
+        Parameters:
+            target: Object whose animations should be removed.
+        """
+        self.anim.remove_of(target)
+
+    def update_animations(self, time_delta: float) -> None:
+        """Must be called in the object's main update loop."""
+        self.anim.update(time_delta)

--- a/tuxemon/state/render_mixin.py
+++ b/tuxemon/state/render_mixin.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pygame.surface import Surface
+
+
+class RenderMixin:
+
+    def draw(self, surface: Surface) -> None:
+        """
+        Render the state to the surface passed. Must be overloaded in children.
+
+        Do not change the state of any game entities. Every draw should be the
+        same for a given game time. Any game changes should be done during
+        update.
+        """

--- a/tuxemon/state/state.py
+++ b/tuxemon/state/state.py
@@ -17,23 +17,18 @@ from tuxemon.graphics import load_animated_sprite, load_sprite
 from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite, SpriteGroup
-from tuxemon.state.animation_group import AnimationGroup
+from tuxemon.state.animation_mixin import AnimationMixin
+from tuxemon.state.render_mixin import RenderMixin
 
 if TYPE_CHECKING:
-    from pygame.sprite import Group
-    from pygame.surface import Surface
+    pass
 
-    from tuxemon.animation import (
-        Animation,
-        ScheduledFunction,
-        Task,
-    )
     from tuxemon.platform.events import PlayerInput
 
 logger = logging.getLogger(__name__)
 
 
-class State(ABC):
+class State(AnimationMixin, RenderMixin, ABC):
     """This is a prototype class for States.
 
     All states should inherit from it. No direct instances of this
@@ -62,18 +57,15 @@ class State(ABC):
 
         Important!  The state must be ready to be drawn after this is called.
         """
+        super().__init__()
         self.start_time = 0.0
         self.current_time = 0.0
-
-        self.anim = AnimationGroup()
 
         # All sprites that draw on the screen
         self.sprites: SpriteGroup[Sprite] = SpriteGroup()
 
         self.client = local_session.client
         self.event_bus = get_event_bus()
-
-        self._scheduled_task: Task | None = None
 
     def __init_subclass__(cls: type[State], **kwargs: Any) -> None:
         """Ensure subclasses define a class variable 'name'."""
@@ -83,10 +75,6 @@ class State(ABC):
             raise TypeError(
                 f"{cls.__name__} must define a class variable 'name'"
             )
-
-    @property
-    def animations(self) -> Group[Task | Animation]:
-        return self.anim._group
 
     def load_sprite(self, filename: str, **kwargs: Any) -> Sprite:
         """Load a sprite and add it to this state."""
@@ -103,54 +91,6 @@ class State(ABC):
         sprite = load_animated_sprite(filenames, delay, **kwargs)
         self.sprites.add(sprite, layer=layer)
         return sprite
-
-    def animate(self, *targets: Any, **kwargs: Any) -> Animation:
-        """
-        Animate something in this state.
-
-        Animations are processed even while state is inactive.
-
-        Parameters:
-            targets: Targets of the Animation.
-            kwargs: Attributes and their final value.
-
-        Returns:
-            Resulting animation.
-        """
-        return self.anim.animate(*targets, **kwargs)
-
-    def task(
-        self,
-        func: ScheduledFunction,
-        *,
-        on_finish: ScheduledFunction | None = None,
-        on_update: ScheduledFunction | None = None,
-        interval: float = 0,
-        times: int = 1,
-        **kwargs: Any,
-    ) -> Task:
-        return self.anim.task(
-            func,
-            on_finish=on_finish,
-            on_update=on_update,
-            interval=interval,
-            times=times,
-            **kwargs,
-        )
-
-    def chain_animations(
-        self, *fns: Callable[[], Animation], start_delay: float = 0.0
-    ) -> None:
-        self.anim.chain_animations(*fns, start_delay=start_delay)
-
-    def remove_animations_of(self, target: Any) -> None:
-        """
-        Given and object, remove any animations that it is used with.
-
-        Parameters:
-            target: Object whose animations should be removed.
-        """
-        self.anim.remove_of(target)
 
     def process_event(self, event: PlayerInput) -> PlayerInput | None:
         """
@@ -182,20 +122,8 @@ class State(ABC):
         Parameters:
             time_delta: Amount of time in fractional seconds since last update.
         """
-        self.anim.update(time_delta)
+        self.update_animations(time_delta)
         self.sprites.update(time_delta)
-
-    def draw(self, surface: Surface) -> None:
-        """
-        Render the state to the surface passed. Must be overloaded in children.
-
-        Do not change the state of any game entities. Every draw should be the
-        same for a given game time. Any game changes should be done during
-        update.
-
-        Parameters:
-            surface: Surface to be rendered onto.
-        """
 
     def resume(self) -> None:
         """


### PR DESCRIPTION
Changes:
- extracted all rendering logic from `State` into a new `RenderMixin`, leaving `State` responsible only for game logic and lifecycle behavior
- extracted animation and task‑scheduling logic into a standalone `AnimationMixin`, making animations reusable across states, sprites, and other game objects
- updated `State` to inherit from both mixins, simplifying its responsibilities and reducing internal complexity
- Cleaned up `State.__init__` so it initializes only state‑specific data while relying on mixins for animation and rendering setup
- ensured `State.update` delegates animation updates to `AnimationMixin` and sprite updates to the sprite group