### PR TITLE
Add Mod-Aware Plugin Loading With Core‑Override Support

### DIFF
--- a/mods/tuxemon/commands/test.py
+++ b/mods/tuxemon/commands/test.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon.cli.clicommand import CLICommand
 from tuxemon.cli.exceptions import ParseError
-from tuxemon.db import SpatialCondition, Operator, BoundingBox
+from tuxemon.db import BoundingBox, Operator, SpatialCondition
 from tuxemon.script.parser import parse_condition_string
 from tuxemon.tools import safe_enum_value
 
@@ -41,9 +41,7 @@ class TestConditionParentCommand(CLICommand):
         Parameters:
             ctx: Contains references to parts of the game and CLI interface.
         """
-        conditions = (
-            ctx.session.client.condition_manager.get_conditions()
-        )
+        conditions = ctx.session.client.condition_manager.get_conditions()
         for condition in conditions:
             command = TestConditionCommand()
             command.name = condition.name
@@ -73,15 +71,13 @@ class TestConditionCommand(CLICommand):
         line = f"is {self.name} {line}"
         try:
             opr, typ, args = parse_condition_string(line)
-            operator = safe_enum_value(
-                Operator, opr, default=Operator.IS
-            )
+            operator = safe_enum_value(Operator, opr, default=Operator.IS)
             cond = SpatialCondition(
                 type=typ,
                 parameters=args,
                 box=BoundingBox(x=0, y=0, width=1, height=1),
                 operator=operator,
-                name="USERINPUT"
+                name="USERINPUT",
             )
         except ValueError:
             raise ParseError

--- a/mods/tuxemon/conditions/README.yaml
+++ b/mods/tuxemon/conditions/README.yaml
@@ -1,0 +1,14 @@
+description: >
+  Place custom condition plugins in this folder.
+  Any condition defined here will override the core condition with the same name.
+
+how_to_use:
+  - Create a .py file defining a class that inherits from CoreCondition.
+  - Set the class attribute "name" to the condition's identifier.
+  - Implement the appropriate test_* method (e.g., test_with_monster).
+  - The engine will automatically load and override matching core conditions.
+
+example:
+  file: debug_condition.py
+  class_name: DebugCondition
+  condition_name: debug_condition

--- a/mods/tuxemon/effects/README.yaml
+++ b/mods/tuxemon/effects/README.yaml
@@ -1,0 +1,13 @@
+description: >
+  Place custom effect plugins in this folder.
+  Any effect defined here will override the core effect with the same name.
+
+how_to_use:
+  - Create a .py file defining a class that inherits from CoreEffect.
+  - Set the class attribute "name" to the effect's identifier.
+  - The engine will automatically load and override matching core effects.
+
+example:
+  file: debug_effect.py
+  class_name: DebugEffect
+  effect_name: debug_effect

--- a/mods/tuxemon/states/README.yaml
+++ b/mods/tuxemon/states/README.yaml
@@ -1,0 +1,14 @@
+description: >
+  Place custom state plugins in this folder.
+  Any state defined here will override the core state with the same name.
+
+how_to_use:
+  - Create a .py file defining a class that inherits from State.
+  - Set the class attribute "name" to the state's identifier.
+  - Implement lifecycle methods such as on_enter, on_exit, process_event, or draw.
+  - The engine will automatically load and override matching core states.
+
+example:
+  file: debug_state.py
+  class_name: DebugState
+  state_name: DebugState

--- a/tests/tuxemon/test_core_manager.py
+++ b/tests/tuxemon/test_core_manager.py
@@ -26,6 +26,20 @@ def temp_dir():
     d.rmdir()
 
 
+@pytest.fixture(autouse=True)
+def no_mod_paths(monkeypatch):
+    monkeypatch.setattr(
+        "tuxemon.constants.paths.get_active_mod_paths", lambda: []
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_mods_folder(monkeypatch, temp_dir):
+    fake_mods = temp_dir / "mods"
+    fake_mods.mkdir(exist_ok=True)
+    monkeypatch.setattr("tuxemon.core.core_manager.mods_folder", fake_mods)
+
+
 @pytest.fixture
 def core_manager(temp_dir):
     path = temp_dir / "tuxemon"
@@ -46,7 +60,6 @@ def effect_manager(temp_dir):
         effect_class,
         path,
         "tuxemon",
-        category="effects",
         root_path=temp_dir.parent,
     )
 
@@ -59,15 +72,16 @@ def condition_manager(temp_dir):
         condition_class,
         path,
         "tuxemon",
-        category="conditions",
         root_path=temp_dir.parent,
     )
 
 
 # CoreManager tests
-@patch("tuxemon.plugin.load_plugins")
-def test_load_plugins(mock_load_plugins, core_manager, temp_dir):
-    mock_load_plugins.return_value = {"TestPlugin": MagicMock()}
+@patch("tuxemon.plugin.PluginManager.from_directory")
+def test_load_plugins(mock_from_directory, core_manager, temp_dir):
+    fake_manager = MagicMock()
+    fake_manager.get_class_map.return_value = {"TestPlugin": MagicMock()}
+    mock_from_directory.return_value = fake_manager
     core_manager.load_plugins(
         core_manager.plugin_interface,
         core_manager.path,

--- a/tests/tuxemon/test_event_action_manager.py
+++ b/tests/tuxemon/test_event_action_manager.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -8,42 +8,57 @@ from tuxemon.event.eventaction import ActionManager
 
 
 @pytest.fixture
-def action_manager():
+def patch_action_plugins(monkeypatch):
+    def _patch(mapping):
+        fake_manager = MagicMock()
+        fake_manager.get_class_map.return_value = mapping
+
+        monkeypatch.setattr(
+            "tuxemon.event.eventaction.PluginManager.from_directory",
+            lambda *args, **kwargs: fake_manager,
+        )
+
+    return _patch
+
+
+@pytest.fixture
+def action_manager(patch_action_plugins):
+    patch_action_plugins({})
     return ActionManager()
 
 
-def test_init(action_manager):
-    with patch("tuxemon.plugin.load_plugins", return_value={}):
-        assert len(action_manager.actions) > 0
+def test_init(patch_action_plugins):
+    # Simulate some plugins being loaded
+    patch_action_plugins({"foo": MagicMock()})
+    mgr = ActionManager()
+    assert len(mgr.actions) > 0
 
 
-def test_get_action(action_manager):
+def test_get_action(patch_action_plugins):
     mock_action = MagicMock(return_value="add_monster")
-    with patch(
-        "tuxemon.plugin.load_plugins",
-        return_value={"add_monster": mock_action},
-    ):
-        result = action_manager.get_action("add_monster", ["monster_slug", 1])
-        assert result is not None
+    patch_action_plugins({"add_monster": mock_action})
+    mgr = ActionManager()
+    result = mgr.get_action("add_monster", ["monster_slug", 1])
+    assert result is not None
 
 
-def test_get_action_not_implemented(action_manager):
-    with patch("tuxemon.plugin.load_plugins", return_value={}):
-        result = action_manager.get_action("action2")
-        assert result is None
+def test_get_action_not_implemented(patch_action_plugins):
+    patch_action_plugins({})
+    mgr = ActionManager()
+    result = mgr.get_action("action2")
+    assert result is None
 
 
-def test_get_action_with_type_error(action_manager):
+def test_get_action_with_type_error(patch_action_plugins):
     mock_action = MagicMock(side_effect=TypeError("Test error"))
-    with patch(
-        "tuxemon.plugin.load_plugins",
-        return_value={"add_monster": mock_action},
-    ):
-        result = action_manager.get_action("add_monster", ["param1", "param2"])
-        assert result is None
+    patch_action_plugins({"add_monster": mock_action})
+    mgr = ActionManager()
+    result = mgr.get_action("add_monster", ["param1", "param2"])
+    assert result is None
 
 
-def test_get_actions(action_manager):
-    with patch("tuxemon.plugin.load_plugins", return_value={}):
-        actions = action_manager.get_actions()
-        assert len(actions) > 0
+def test_get_actions(patch_action_plugins):
+    patch_action_plugins({"dummy": MagicMock()})
+    mgr = ActionManager()
+    actions = mgr.get_actions()
+    assert len(actions) > 0

--- a/tests/tuxemon/test_event_behavior_manager.py
+++ b/tests/tuxemon/test_event_behavior_manager.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
 import pytest
 
 from tuxemon.db import (
@@ -34,11 +36,21 @@ def dummy_event():
 
 
 @pytest.fixture
-def behavior_manager(monkeypatch):
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {},
-    )
+def patch_behavior_plugins(monkeypatch):
+    def _patch(mapping):
+        fake_manager = MagicMock()
+        fake_manager.get_class_map.return_value = mapping
+        monkeypatch.setattr(
+            "tuxemon.event.eventbehavior.PluginManager.from_directory",
+            lambda *args, **kwargs: fake_manager,
+        )
+
+    return _patch
+
+
+@pytest.fixture
+def behavior_manager(patch_behavior_plugins):
+    patch_behavior_plugins({})
     return BehaviorManager(root_path=None)
 
 
@@ -61,32 +73,22 @@ class DummyBehavior(EventBehavior):
         return [cond], [act]
 
 
-def test_get_behavior_success(monkeypatch):
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {"dummy": DummyBehavior},
-    )
-
+def test_get_behavior_success(patch_behavior_plugins):
+    patch_behavior_plugins({"dummy": DummyBehavior})
     mgr = BehaviorManager(root_path=None)
     beh = mgr.get_behavior("dummy")
-
     assert isinstance(beh, DummyBehavior)
 
 
-def test_get_behavior_missing(monkeypatch, caplog):
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {},
-    )
-
+def test_get_behavior_missing(patch_behavior_plugins, caplog):
+    patch_behavior_plugins({})
     mgr = BehaviorManager(root_path=None)
     beh = mgr.get_behavior("unknown")
-
     assert beh is None
     assert "not implemented" in caplog.text.lower()
 
 
-def test_get_behavior_instantiation_error(monkeypatch, caplog):
+def test_get_behavior_instantiation_error(patch_behavior_plugins, caplog):
 
     class BadBehavior(EventBehavior):
         name = "bad"
@@ -97,69 +99,47 @@ def test_get_behavior_instantiation_error(monkeypatch, caplog):
         def expand(self, event, behavior):
             return [], []
 
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {"bad": BadBehavior},
-    )
-
+    patch_behavior_plugins({"bad": BadBehavior})
     mgr = BehaviorManager(root_path=None)
     beh = mgr.get_behavior("bad")
-
     assert beh is None
     assert "error instantiating behavior" in caplog.text.lower()
 
 
-def test_expand_behavior_conditions(monkeypatch, dummy_event):
+def test_expand_behavior_conditions(patch_behavior_plugins, dummy_event):
     dummy_event.behavs = [Behavior(type="dummy", args=[], name="b1")]
-
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {"dummy": DummyBehavior},
-    )
-
+    patch_behavior_plugins({"dummy": DummyBehavior})
     mgr = BehaviorManager(root_path=None)
     conds = expand_behavior_conditions(dummy_event, mgr)
-
     assert len(conds) == 1
     assert isinstance(conds[0], SpatialCondition)
     assert conds[0].type == "dummy_cond"
 
 
-def test_expand_behavior_actions(monkeypatch, dummy_event):
+def test_expand_behavior_actions(patch_behavior_plugins, dummy_event):
     dummy_event.behavs = [Behavior(type="dummy", args=[], name="b1")]
-
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {"dummy": DummyBehavior},
-    )
-
+    patch_behavior_plugins({"dummy": DummyBehavior})
     mgr = BehaviorManager(root_path=None)
     acts = expand_behavior_actions(dummy_event, mgr)
-
     assert len(acts) == 1
     assert isinstance(acts[0], ParameterizableRule)
     assert acts[0].type == "dummy_act"
 
 
-def test_expand_behavior_skips_missing_plugin(monkeypatch, dummy_event):
+def test_expand_behavior_skips_missing_plugin(
+    patch_behavior_plugins, dummy_event
+):
     dummy_event.behavs = [Behavior(type="missing", args=[], name="b1")]
-
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {},
-    )
-
+    patch_behavior_plugins({})
     mgr = BehaviorManager(root_path=None)
-
     conds = expand_behavior_conditions(dummy_event, mgr)
     acts = expand_behavior_actions(dummy_event, mgr)
-
     assert conds == []
     assert acts == []
 
 
 def test_expand_behavior_logs_error_on_plugin_failure(
-    monkeypatch, dummy_event, caplog
+    patch_behavior_plugins, dummy_event, caplog
 ):
 
     class ExplodingBehavior(EventBehavior):
@@ -169,17 +149,10 @@ def test_expand_behavior_logs_error_on_plugin_failure(
             raise RuntimeError("boom")
 
     dummy_event.behavs = [Behavior(type="explode", args=[], name="b1")]
-
-    monkeypatch.setattr(
-        "tuxemon.event.eventbehavior.load_plugins",
-        lambda **kwargs: {"explode": ExplodingBehavior},
-    )
-
+    patch_behavior_plugins({"explode": ExplodingBehavior})
     mgr = BehaviorManager(root_path=None)
-
     conds = expand_behavior_conditions(dummy_event, mgr)
     acts = expand_behavior_actions(dummy_event, mgr)
-
     assert conds == []
     assert acts == []
     assert "error expanding behavior" in caplog.text.lower()

--- a/tests/tuxemon/test_event_condition_manager.py
+++ b/tests/tuxemon/test_event_condition_manager.py
@@ -10,17 +10,24 @@ from tuxemon.event.running import ConditionEvaluator
 
 
 @pytest.fixture
-def mock_load_plugins():
-    with patch("tuxemon.plugin.load_plugins") as mock:
+def mock_plugin_manager():
+    with patch("tuxemon.plugin.PluginManager.from_directory") as mock:
         yield mock
 
 
 @pytest.fixture
-def condition_manager(mock_load_plugins):
-    mock_condition_class = MagicMock()
-    mock_load_plugins.return_value = {"char_at": mock_condition_class}
+def condition_manager(mock_plugin_manager):
+
+    class DummyCondition(EventCondition):
+        name = "char_at"
+
+        def test(self, session, condition_data):
+            return True
+
+    fake_manager = MagicMock()
+    fake_manager.get_class_map.return_value = {"char_at": DummyCondition}
+    mock_plugin_manager.return_value = fake_manager
     manager = ConditionManager()
-    manager._mock_condition_class = mock_condition_class
     return manager
 
 
@@ -46,7 +53,6 @@ def test_get_condition_with_parameters(condition_manager):
     mock_cond_data.type = "char_at"
     mock_cond_data.operator = "is"
     mock_cond_data.parameters = ["hero", 0, "H"]
-    condition_manager._mock_condition_class.return_value = MagicMock()
     condition = condition_manager.get_condition(mock_cond_data)
     assert condition is not None
     assert condition.is_expected is True

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -86,11 +86,9 @@ class BaseClient(ABC):
         self.active_effect_manager = ActiveEffectManager()
 
         self.event_bus = get_event_bus()
-        self.state_repository = StateRepository()
-        loader = StateLoader(
-            base_package="tuxemon.states", lib_dir=paths.LIBDIR
+        self.state_repository = StateRepository.from_loader(
+            StateLoader("tuxemon.states", paths.LIBDIR)
         )
-        loader.auto_state_discovery(self.state_repository)
         self.state_manager = StateManager(
             package="tuxemon.states",
             event=self.event_bus,

--- a/tuxemon/cli/processor.py
+++ b/tuxemon/cli/processor.py
@@ -14,7 +14,7 @@ from tuxemon.cli.clicommand import CLICommand
 from tuxemon.cli.context import InvokeContext
 from tuxemon.cli.exceptions import CommandNotFoundError, ParseError
 from tuxemon.cli.formatter import Formatter
-from tuxemon.constants.paths import get_active_mod_paths, mods_folder
+from tuxemon.constants.paths import get_plugin_paths, mods_folder
 from tuxemon.plugin import PluginManager
 
 if TYPE_CHECKING:
@@ -125,12 +125,11 @@ class CommandProcessor:
         """
         Use plugins to load CLICommand classes from all mod folders.
         """
-        command_folders_to_search = [
-            mod_dir / "commands" for mod_dir in get_active_mod_paths()
-        ]
-        existing_command_folders = [
-            folder for folder in command_folders_to_search if folder.is_dir()
-        ]
+        existing_command_folders = get_plugin_paths(
+            base_path=mods_folder,
+            category="commands",
+            subfolder=None,
+        )
 
         if not existing_command_folders:
             logger.debug("No existing command folders to search.")

--- a/tuxemon/core/core_manager.py
+++ b/tuxemon/core/core_manager.py
@@ -9,12 +9,15 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Generic, Optional, TypeVar
 
-from tuxemon import plugin
-from tuxemon.constants.paths import LIBDIR, get_plugin_paths
+from tuxemon.constants.paths import (
+    LIBDIR,
+    get_plugin_paths,
+    mods_folder,
+)
 from tuxemon.core.core_condition import CoreCondition
 from tuxemon.core.core_effect import CoreEffect
 from tuxemon.db import LogicCondition, Operator, ParameterizableRule
-from tuxemon.plugin import PluginObject
+from tuxemon.plugin import PluginManager, PluginObject
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +51,42 @@ class CoreManager(Generic[LocalInterfaceValue]):
         if root_path is None:
             root_path = LIBDIR.parent
 
-        plugin_folders = get_plugin_paths(path, category, subfolder="core")
+        core_folders = get_plugin_paths(path, category, subfolder="core")
 
-        self.classes.update(
-            plugin.load_plugins(
-                paths=plugin_folders,
-                root_path=root_path,
-                category=category,
-                interface=interface,
-            )
+        mod_folders = get_plugin_paths(
+            base_path=mods_folder,
+            category=category,
+            subfolder=None,
         )
+
+        # Load core plugins
+        core_manager = PluginManager.from_directory(
+            plugin_folders=core_folders,
+            root_path=root_path,
+            include=[
+                f.stem
+                for folder in core_folders
+                for f in folder.glob("*.py")
+                if f.stem != "__init__"
+            ],
+        )
+        core_plugins = core_manager.get_class_map(interface=interface)
+
+        # Load mod plugins
+        mod_manager = PluginManager.from_directory(
+            plugin_folders=mod_folders,
+            root_path=root_path,
+            include=[
+                f.stem
+                for folder in mod_folders
+                for f in folder.glob("*.py")
+                if f.stem != "__init__"
+            ],
+        )
+        mod_plugins = mod_manager.get_class_map(interface=interface)
+
+        self.classes.update(core_plugins)
+        self.classes.update(mod_plugins)
 
     def load_plugin(self, name: str) -> None:
         """Dynamically load a specific plugin by name."""

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
 from typing import Any, ClassVar, Optional
 
 from tuxemon.constants.paths import ACTIONS_PATH, LIBDIR, get_plugin_paths
-from tuxemon.plugin import load_plugins
+from tuxemon.plugin import PluginManager
 from tuxemon.session import Session
 from tuxemon.tools import cast_dataclass_parameters
 
@@ -278,11 +278,13 @@ class ActionManager:
             ACTIONS_PATH, "actions", subfolder="event"
         )
 
-        self.actions = load_plugins(
-            paths=plugin_folders,
+        manager = PluginManager.from_directory(
+            plugin_folders=plugin_folders,
             root_path=root_path,
-            category="actions",
-            interface=EventAction,  # type: ignore[type-abstract]
+        )
+
+        self.actions: Mapping[str, type[EventAction]] = manager.get_class_map(
+            interface=EventAction
         )
 
     def get_action(

--- a/tuxemon/event/eventbehavior.py
+++ b/tuxemon/event/eventbehavior.py
@@ -16,7 +16,7 @@ from tuxemon.db import (
     ParameterizableRule,
     SpatialCondition,
 )
-from tuxemon.plugin import load_plugins
+from tuxemon.plugin import PluginManager
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +48,13 @@ class BehaviorManager:
             BEHAVS_PATH, "behaviors", subfolder="event"
         )
 
-        self.behaviors: Mapping[str, type[EventBehavior]] = load_plugins(
-            paths=plugin_folders,
+        manager = PluginManager.from_directory(
+            plugin_folders=plugin_folders,
             root_path=root_path,
-            category="behaviors",
-            interface=EventBehavior,  # type: ignore[type-abstract]
+        )
+
+        self.behaviors: Mapping[str, type[EventBehavior]] = (
+            manager.get_class_map(interface=EventBehavior)
         )
 
     def get_behavior(self, name: str) -> EventBehavior | None:

--- a/tuxemon/event/eventcondition.py
+++ b/tuxemon/event/eventcondition.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar, Optional
@@ -13,7 +14,7 @@ from tuxemon.constants.paths import (
     get_plugin_paths,
 )
 from tuxemon.db import Operator, SpatialCondition
-from tuxemon.plugin import load_plugins
+from tuxemon.plugin import PluginManager
 from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -54,11 +55,13 @@ class ConditionManager:
             CONDITIONS_PATH, "conditions", subfolder="event"
         )
 
-        self.conditions = load_plugins(
-            paths=plugin_folders,
+        manager = PluginManager.from_directory(
+            plugin_folders=plugin_folders,
             root_path=root_path,
-            category="conditions",
-            interface=EventCondition,
+        )
+
+        self.conditions: Mapping[str, type[EventCondition]] = (
+            manager.get_class_map(interface=EventCondition)
         )
 
     def get_condition(

--- a/tuxemon/plugin.py
+++ b/tuxemon/plugin.py
@@ -17,11 +17,12 @@ from typing import (
     Generic,
     Protocol,
     TypeVar,
-    overload,
     runtime_checkable,
 )
 
-from tuxemon.constants.paths import PLUGIN_INCLUDE_PATTERNS
+from tuxemon.constants.paths import (
+    PLUGIN_INCLUDE_PATTERNS,
+)
 
 logger = logging.getLogger(__name__)
 log_hdlr = logging.StreamHandler(sys.stdout)
@@ -232,12 +233,13 @@ class PluginManager:
         plugin_folders: list[Path],
         root_path: Path,
         exclude: list[str] = ["IPlugin"],
-        include: list[str] = PLUGIN_INCLUDE_PATTERNS,
+        include: list[str] | None = None,
     ) -> PluginManager:
         discovery = FileSystemPluginDiscovery(plugin_folders, root_path)
         loader = PluginLoader(ImportLibPluginLoader())
         filter = PluginFilter(
-            exclude_classes=exclude, include_patterns=include
+            exclude_classes=exclude,
+            include_patterns=include or PLUGIN_INCLUDE_PATTERNS,
         )
 
         manager = cls(discovery, loader, filter)
@@ -347,83 +349,49 @@ class PluginManager:
         self.discovery.set_folders(folders)
         self.reload()
 
+    def get_class_map(
+        self,
+        interface: type[InterfaceValue] | type[PluginObject] = PluginObject,
+    ) -> Mapping[str, type]:
+        """
+        Return a mapping of plugin keys → plugin classes.
+        Includes:
+        - fully qualified plugin name (module.Class)
+        - short plugin name (cls.name), if present
+        """
+        classes: dict[str, type] = {}
 
-# Overloads until https://github.com/python/mypy/issues/3737 is fixed
+        for plugin in self.get_all_plugins(interface=interface):
+            cls = plugin.plugin_object
 
+            fq_key = plugin.name
+            short_key = getattr(cls, "name", None)
 
-@overload
-def load_plugins(
-    paths: list[Path],
-    root_path: Path,
-    category: str = "plugins",
-) -> Mapping[str, type[PluginObject]]:
-    pass
+            if interface is PluginObject and short_key is None:
+                logger.error(
+                    f"Class {cls.__name__} ({fq_key}) does not have a required `name` attribute."
+                )
+                continue
 
-
-@overload
-def load_plugins(
-    paths: list[Path],
-    root_path: Path,
-    category: str = "plugins",
-    *,
-    interface: type[InterfaceValue],
-) -> Mapping[str, type[InterfaceValue]]:
-    pass
-
-
-def load_plugins(
-    paths: list[Path],
-    root_path: Path,
-    category: str = "plugins",
-    *,
-    interface: type[InterfaceValue] | type[PluginObject] = PluginObject,
-) -> Mapping[str, type[InterfaceValue] | type[PluginObject]]:
-    """
-    Load plugins from a directory and return them by both:
-      - their declared short name (cls.name)
-      - their fully qualified plugin name (plugin.name)
-    """
-    classes: dict[str, type[InterfaceValue] | type[PluginObject]] = {}
-
-    manager = PluginManager.from_directory(
-        plugin_folders=paths,
-        root_path=root_path,
-    )
-
-    for plugin in manager.get_all_plugins(interface=interface):
-        cls = plugin.plugin_object
-
-        fq_key = plugin.name
-        short_key = getattr(cls, "name", None)
-
-        if interface is PluginObject and short_key is None:
-            logger.error(
-                f"Class {cls.__name__} ({fq_key}) does not have a required `name` attribute."
-            )
-            continue
-
-        if fq_key not in classes:
-            classes[fq_key] = cls
-        else:
-            logger.warning(
-                f"Duplicate fully qualified plugin key '{fq_key}'. Skipping."
-            )
-
-        if short_key:
-            if short_key not in classes:
-                classes[short_key] = cls
+            # Fully qualified key
+            if fq_key not in classes:
+                classes[fq_key] = cls
             else:
-                existing_cls = classes[short_key]
-                if existing_cls is not cls:
-                    logger.warning(
-                        f"Duplicate short plugin key '{short_key}'. "
-                        f"Existing: {existing_cls.__module__}.{existing_cls.__name__}, "
-                        f"New: {cls.__module__}.{cls.__name__}. Keeping existing."
-                    )
+                logger.warning(
+                    f"Duplicate fully qualified plugin key '{fq_key}'. Skipping."
+                )
 
-        logger.debug(
-            f"Loaded {category}: {short_key or cls.__name__} "
-            f"(Keys: {fq_key}{', ' + short_key if short_key else ''})"
-        )
+            # Short key
+            if short_key:
+                if short_key not in classes:
+                    classes[short_key] = cls
+                else:
+                    existing_cls = classes[short_key]
+                    if existing_cls is not cls:
+                        logger.warning(
+                            f"Duplicate short plugin key '{short_key}'. "
+                            f"Existing: {existing_cls.__module__}.{existing_cls.__name__}, "
+                            f"New: {cls.__module__}.{cls.__name__}. Keeping existing."
+                        )
 
-    return classes
+        return classes

--- a/tuxemon/state/loader.py
+++ b/tuxemon/state/loader.py
@@ -2,15 +2,11 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import inspect
 import logging
-import sys
-from collections.abc import Generator
-from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tuxemon.constants.paths import get_active_mod_paths, mods_folder
+from tuxemon.constants.paths import get_plugin_paths, mods_folder
 from tuxemon.plugin import PluginManager
 from tuxemon.state.state import State
 
@@ -22,8 +18,7 @@ logger = logging.getLogger(__name__)
 
 class StateLoader:
     """
-    Handles the discovery, loading, and initial registration of game state
-    classes.
+    Discovers and registers game state classes using the new plugin system.
     """
 
     def __init__(self, base_package: str, lib_dir: Path) -> None:
@@ -39,115 +34,74 @@ class StateLoader:
         self.base_package = base_package
         self.lib_dir = lib_dir
 
-    @staticmethod
-    def _collect_states_from_module(
-        import_name: str,
-    ) -> Generator[type[State], None, None]:
-        """
-        Given a module, return all classes in it that are a game state.
-        """
-        if import_name not in sys.modules:
-            try:
-                import_module(import_name)
-            except ImportError as e:
-                logger.error(
-                    f"Failed to import module {import_name} during state collection: {e}"
-                )
-                return
-
-        classes = inspect.getmembers(sys.modules[import_name], inspect.isclass)
-
-        for c in (i[1] for i in classes):
-            if issubclass(c, object) and c.__name__ != "State":
-                try:
-                    from .state import State as RealState
-
-                    if issubclass(c, RealState) and not inspect.isabstract(c):
-                        yield c
-                except ImportError:
-                    logger.warning(
-                        "Could not import base 'State' class for type checking during discovery."
-                    )
-
-    def collect_states_from_path(
+    def _build_plugin_manager(
         self,
-        folder: Path,
-    ) -> Generator[type[State], None, None]:
+        folders: list[Path],
+        include: list[str] | None = None,
+        exclude: list[str] = ["State"],
+    ) -> PluginManager:
         """
-        Load states from disk, but do not register them.
-
-        Parameters:
-            folder: Folder to load from.
-
-        Yields:
-            Each game state class.
+        Helper to create a PluginManager configured for state discovery.
         """
-        try:
-            import_name = f"{self.base_package}.{folder.name}"
-            import_module(import_name)
-            yield from self._collect_states_from_module(import_name)
-        except Exception as e:
-            template = (
-                "{} failed to load or is not a valid game state package: {}"
-            )
-            logger.error(template.format(folder.name, e))
-            raise
+        return PluginManager.from_directory(
+            plugin_folders=folders,
+            root_path=mods_folder.parent,
+            include=include,
+            exclude=exclude,
+        )
 
     def auto_state_discovery(self, repository: StateRepository) -> None:
         """
-        Discover and register game states from the main states folder and mod states folders.
-        Only loads top-level modules from the main states folder.
+        Discover and register game states from core and mod folders using
+        the new plugin architecture.
         """
         state_folder = self.lib_dir / Path(*self.base_package.split(".")[1:])
         logger.info(f"Initiating game state discovery from {state_folder}")
 
-        plugin_folders = []
+        plugin_folders: list[Path] = []
+        core_includes: list[str] = []
 
-        # Include top-level .py files from main states folder
         if state_folder.is_dir():
-            top_level_modules = [
+            plugin_folders.append(state_folder)
+            core_includes = [
                 f.stem
                 for f in state_folder.glob("*.py")
                 if f.is_file() and f.stem != "State"
             ]
-            plugin_folders.append(state_folder)
         else:
             logger.warning(
                 f"State discovery path does not exist: {state_folder}"
             )
 
-        # Include mod states folders
-        mod_state_folders = [
-            mod_path / "states"
-            for mod_path in get_active_mod_paths()
-            if (mod_path / "states").is_dir()
-        ]
-        plugin_folders.extend(mod_state_folders)
+        mod_state_folders = get_plugin_paths(
+            base_path=mods_folder,
+            category="states",
+            subfolder=None,
+        )
 
-        pm = PluginManager.from_directory(
-            plugin_folders=plugin_folders,
-            root_path=mods_folder.parent,
-            include=(
-                top_level_modules
-                if plugin_folders and plugin_folders[0] == state_folder
-                else []
-            ),
+        mod_includes = [
+            f.stem
+            for folder in mod_state_folders
+            for f in folder.glob("*.py")
+            if f.is_file() and f.stem != "__init__"
+        ]
+
+        core_pm = self._build_plugin_manager(
+            folders=[state_folder],
+            include=core_includes,
             exclude=["State"],
         )
 
-        for plugin in pm.get_all_plugins(interface=State):
-            state_cls = plugin.plugin_object
-            try:
-                if not inspect.isabstract(state_cls):
-                    repository.add_state(state_cls)
-                    state_name = getattr(state_cls, "name", state_cls.__name__)
-                    logger.info(f"Registered state: {state_name}")
-                else:
-                    logger.debug(
-                        f"Skipped abstract state: {state_cls.__name__}"
-                    )
-            except Exception:
-                logger.error(
-                    f"Error registering state '{state_cls.__name__}'",
-                    exc_info=True,
-                )
+        mod_pm = self._build_plugin_manager(
+            folders=mod_state_folders,
+            include=mod_includes,
+            exclude=["State"],
+        )
+
+        # Register core states first
+        for plugin in core_pm.get_all_plugins(interface=State):
+            repository.add_state(plugin.plugin_object)
+
+        # Mods override core
+        for plugin in mod_pm.get_all_plugins(interface=State):
+            repository.add_state(plugin.plugin_object)

--- a/tuxemon/state/repository.py
+++ b/tuxemon/state/repository.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from tuxemon.state.loader import StateLoader
     from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,12 @@ logger = logging.getLogger(__name__)
 class StateRepository:
     def __init__(self) -> None:
         self._state_dict: dict[str, type[State]] = {}
+
+    @classmethod
+    def from_loader(cls, loader: StateLoader) -> StateRepository:
+        repo = cls()
+        loader.auto_state_discovery(repo)
+        return repo
 
     def add_state(self, state: type[State], strict: bool = False) -> None:
         """


### PR DESCRIPTION
Changes:
- updated the plugin loading system so it now loads both core plugins and plugins provided by active mods
- added support for loading effects and conditions defined inside mods, including newly added YAML definitions
- core plugins are loaded first, then mod plugins are loaded afterward
- if a mod provides an effect or condition with the same name as a core one, the mod version now cleanly overrides the core version
- introduced explicit include lists when loading plugins to ensure only valid Python plugin files are considered
- no changes were made to dynamic loading or unloading logic; only the initial plugin discovery and precedence rules were updated
- refactored plugin system: removed the old `load_plugins()` helper and migrated all plugin loading to `PluginManager.from_directory()` + `get_class_map()`, this eliminates redundant logic, standardizes plugin discovery, and provides a single, consistent entry point for loading plugin classes