### PR TITLE
Add Multi‑Hit Support to Techniques (TechEffectResult Hit Count + Temporary Text Feedback)

### DIFF
--- a/mods/tuxemon/db/technique/air_chain.json
+++ b/mods/tuxemon/db/technique/air_chain.json
@@ -7,9 +7,6 @@
       "parameters": [
         "3"
       ]
-    },
-    {
-      "type": "damage"
     }
   ],
   "speed": "slow",

--- a/mods/tuxemon/db/technique/electric_multibite.json
+++ b/mods/tuxemon/db/technique/electric_multibite.json
@@ -14,9 +14,6 @@
       "parameters": [
         "2"
       ]
-    },
-    {
-      "type": "damage"
     }
   ],
   "speed": "fast",

--- a/mods/tuxemon/db/technique/leaf_barrage.json
+++ b/mods/tuxemon/db/technique/leaf_barrage.json
@@ -7,9 +7,6 @@
       "parameters": [
         "2"
       ]
-    },
-    {
-      "type": "damage"
     }
   ],
   "speed": "slow",

--- a/mods/tuxemon/db/technique/rocky_barrage.json
+++ b/mods/tuxemon/db/technique/rocky_barrage.json
@@ -7,9 +7,6 @@
       "parameters": [
         "3"
       ]
-    },
-    {
-      "type": "damage"
     }
   ],
   "speed": "normal",

--- a/mods/tuxemon/db/technique/stabilo.json
+++ b/mods/tuxemon/db/technique/stabilo.json
@@ -7,9 +7,6 @@
       "parameters": [
         "3"
       ]
-    },
-    {
-      "type": "damage"
     }
   ],
   "speed": "normal",

--- a/mods/tuxemon/db/technique/webs_wind.json
+++ b/mods/tuxemon/db/technique/webs_wind.json
@@ -14,9 +14,6 @@
       "parameters": [
         "5"
       ]
-    },
-    {
-      "type": "damage"
     }
   ],
   "speed": "normal",

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1991,6 +1991,9 @@ msgstr "{target} is immune to {method}"
 msgid "combat_state_immune_multiple"
 msgstr "{target} are immune to {method}"
 
+msgid "combat_multiattack"
+msgstr "Hit {hit_count} time(s)!"
+
 # Generic notifications
 msgid "empty_slot"
 msgstr "Empty Slot"

--- a/tests/tuxemon/test_combat_notifier.py
+++ b/tests/tuxemon/test_combat_notifier.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.ui.combat_notifier import CombatNotifier, TextAnimationManager
+
+
+@pytest.fixture
+def state():
+    s = MagicMock()
+    s.client.push_state = MagicMock()
+    s.task = MagicMock()
+    return s
+
+
+@pytest.fixture
+def alert_manager():
+    a = MagicMock()
+    a.alert = MagicMock()
+    return a
+
+
+@pytest.fixture
+def text_area():
+    return MagicMock()
+
+
+@pytest.fixture
+def notifier(state, alert_manager):
+    return CombatNotifier(
+        state=state,
+        text_anim_manager=TextAnimationManager(),
+        alert_manager=alert_manager,
+        lock_update=True,
+    )
+
+
+def test_show_message_queues_text_animation(notifier, text_area):
+    notifier.show_message_and_wait_for_input("Hello!", text_area)
+    assert len(notifier.text_anim.text_queue) == 1
+    anim, duration = notifier.text_anim.text_queue[0]
+    anim()
+    notifier.alert_manager.alert.assert_called_once_with("Hello!", text_area)
+
+
+def test_show_message_schedules_wait_for_input(notifier, state, text_area):
+    notifier.show_message_and_wait_for_input("Test", text_area)
+    assert state.task.call_count == 1
+    args, kwargs = state.task.call_args
+    assert "WaitForInputState" in str(args[0])
+
+
+def test_show_message_no_lock_does_not_schedule(notifier, state, text_area):
+    notifier.show_message_and_wait_for_input(
+        "Test", text_area, override_lock=False
+    )
+    state.task.assert_not_called()
+
+
+def test_trigger_xp_and_wait_for_input(notifier, state, text_area):
+    notifier.text_anim.add_xp_message("XP +10")
+    notifier.text_anim.add_xp_message("XP +20")
+    notifier.trigger_xp_and_wait_for_input(text_area, delay=1.0)
+    assert state.task.call_count == 2
+
+
+def test_show_message_ignores_empty(notifier, text_area):
+    notifier.show_message_and_wait_for_input("", text_area)
+    assert len(notifier.text_anim.text_queue) == 0
+    notifier.alert_manager.alert.assert_not_called()
+
+
+def test_show_message_override_lock_true(notifier, state, text_area):
+    notifier.show_message_and_wait_for_input(
+        "Test", text_area, override_lock=True
+    )
+    state.task.assert_called_once()
+
+
+def test_show_message_override_lock_false(notifier, state, text_area):
+    notifier.show_message_and_wait_for_input(
+        "Test", text_area, override_lock=False
+    )
+    state.task.assert_not_called()
+
+
+def test_trigger_xp_schedules_two_tasks(notifier, state, text_area):
+    notifier.text_anim.add_xp_message("XP +10")
+    notifier.trigger_xp_and_wait_for_input(text_area, delay=1.0)
+    assert state.task.call_count == 2
+
+
+def test_trigger_xp_clears_pending_duration(notifier, state, text_area):
+    notifier.text_anim.add_xp_message("XP +10")
+    notifier.trigger_xp_and_wait_for_input(text_area, delay=1.0)
+    after_cb = state.task.call_args_list[1][0][0]
+    notifier.text_anim._pending_xp_duration = 5.0
+    after_cb()
+    assert notifier.text_anim._pending_xp_duration is None

--- a/tests/tuxemon/test_combat_ui.py
+++ b/tests/tuxemon/test_combat_ui.py
@@ -1,121 +1,116 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
 from unittest.mock import MagicMock
+
+import pytest
 
 from tuxemon.tools import scale
 from tuxemon.ui.combat_bars import CombatBars
 
 
-class TestCombatBars(unittest.TestCase):
+@pytest.fixture
+def combat_ui():
+    return CombatBars()
 
-    def setUp(self):
-        self.combat_ui = CombatBars()
-        self.graphics = MagicMock()
-        self.graphics.hud.hp_bar_player = True
-        self.graphics.hud.hp_bar_opponent = True
-        self.graphics.hud.exp_bar_player = True
-        self.graphics.hud.hp_bar_width = 70
-        self.graphics.hud.hp_bar_height = 8
-        self.graphics.hud.hp_player_top = 18
-        self.graphics.hud.hp_opponent_top = 12
-        self.graphics.hud.exp_bar_height = 6
-        self.graphics.hud.exp_bar_top = 31
-        self.graphics.hud.bar_right_padding = 8
 
-    def test_init(self):
-        self.assertEqual(self.combat_ui._hp_bars, {})
-        self.assertEqual(self.combat_ui._exp_bars, {})
+@pytest.fixture
+def graphics():
+    g = MagicMock()
+    g.hud.hp_bar_player = True
+    g.hud.hp_bar_opponent = True
+    g.hud.exp_bar_player = True
+    g.hud.hp_bar_width = 70
+    g.hud.hp_bar_height = 8
+    g.hud.hp_player_top = 18
+    g.hud.hp_opponent_top = 12
+    g.hud.exp_bar_height = 6
+    g.hud.exp_bar_top = 31
+    g.hud.bar_right_padding = 8
+    return g
 
-    def test_draw_bars_hp_and_exp(self):
-        monster_player = MagicMock()
-        monster_player.hp_ratio = 0.75
-        monster_player.experience_progress_percent = 0.5
 
-        monster_opponent = MagicMock()
-        monster_opponent.hp_ratio = 0.5
-        monster_opponent.experience_progress_percent = 0.0
+def test_init(combat_ui):
+    assert combat_ui._hp_bars == {}
+    assert combat_ui._exp_bars == {}
 
-        hud = {
-            monster_player: MagicMock(player=True, image=MagicMock()),
-            monster_opponent: MagicMock(player=False, image=MagicMock()),
-        }
 
-        self.combat_ui._hp_bars = {
-            monster: MagicMock() for monster in hud.keys()
-        }
-        self.combat_ui._exp_bars = {
-            monster: MagicMock() for monster in hud.keys()
-        }
+@pytest.mark.parametrize(
+    "hp_ratio, exp_ratio",
+    [
+        (0.75, 0.5),  # player
+        (0.5, 0.0),  # opponent
+    ],
+)
+def test_draw_bars_hp_and_exp(combat_ui, graphics, hp_ratio, exp_ratio):
+    monster = MagicMock()
+    monster.hp_ratio = hp_ratio
+    monster.experience_progress_percent = exp_ratio
 
-        self.combat_ui.create_rect_for_bar = MagicMock(
-            return_value=MagicMock()
-        )
+    is_player = exp_ratio > 0
 
-        self.combat_ui.draw_bars(hud, self.graphics)
+    hud = {monster: MagicMock(player=is_player, image=MagicMock())}
 
-        for monster, sprite in hud.items():
-            if sprite.player:
-                self.combat_ui._hp_bars[monster].draw.assert_called_once_with(
-                    sprite.image,
-                    self.combat_ui.create_rect_for_bar.return_value,
-                )
-                self.combat_ui._exp_bars[monster].draw.assert_called_once_with(
-                    sprite.image,
-                    self.combat_ui.create_rect_for_bar.return_value,
-                )
-            else:
-                self.combat_ui._hp_bars[monster].draw.assert_called_once_with(
-                    sprite.image,
-                    self.combat_ui.create_rect_for_bar.return_value,
-                )
-                self.assertFalse(self.combat_ui._exp_bars[monster].draw.called)
+    combat_ui._hp_bars = {monster: MagicMock()}
+    combat_ui._exp_bars = {monster: MagicMock()}
+    combat_ui.create_rect_for_bar = MagicMock(return_value=MagicMock())
+    combat_ui.draw_bars(hud, graphics)
+    combat_ui._hp_bars[monster].draw.assert_called_once()
 
-    def test_create_rect_for_bar(self):
-        hud = MagicMock()
-        hud.image.get_width.return_value = 100
-        rect = self.combat_ui.create_rect_for_bar(hud, 70, 8, 0, 8)
-        self.assertEqual(rect.width, scale(70))
-        self.assertEqual(rect.height, scale(8))
-        self.assertEqual(rect.right, hud.image.get_width() - scale(8))
-        self.assertEqual(rect.top, scale(0))
+    if is_player:
+        combat_ui._exp_bars[monster].draw.assert_called_once()
+    else:
+        assert not combat_ui._exp_bars[monster].draw.called
 
-    def test_get_hp_bar_initializes_with_monster_value(self):
-        monster = MagicMock()
-        monster.hp_ratio = 0.6
-        bar = self.combat_ui.get_hp_bar(monster)
-        self.assertEqual(bar.value, 0.6)
 
-    def test_get_exp_bar_initializes_with_monster_value(self):
-        monster = MagicMock()
-        monster.experience_progress_percent = 0.4
-        bar = self.combat_ui.get_exp_bar(monster)
-        self.assertEqual(bar.value, 0.4)
+def test_create_rect_for_bar(combat_ui):
+    hud = MagicMock()
+    hud.image.get_width.return_value = 100
+    rect = combat_ui.create_rect_for_bar(hud, 70, 8, 0, 8)
+    assert rect.width == scale(70)
+    assert rect.height == scale(8)
+    assert rect.right == 100 - scale(8)
+    assert rect.top == scale(0)
 
-    def test_remove_monster_clears_bars(self):
-        monster = MagicMock()
-        monster.hp_ratio = 0.5
-        monster.experience_progress_percent = 0.3
-        self.combat_ui.get_hp_bar(monster)
-        self.combat_ui.get_exp_bar(monster)
-        self.assertIn(monster, self.combat_ui._hp_bars)
-        self.assertIn(monster, self.combat_ui._exp_bars)
 
-        self.combat_ui.remove_monster(monster)
-        self.assertNotIn(monster, self.combat_ui._hp_bars)
-        self.assertNotIn(monster, self.combat_ui._exp_bars)
+@pytest.mark.parametrize("ratio", [0.0, 0.4, 0.6, 1.0])
+def test_get_hp_bar_initializes_with_monster_value(combat_ui, ratio):
+    monster = MagicMock()
+    monster.hp_ratio = ratio
+    bar = combat_ui.get_hp_bar(monster)
+    assert bar.value == ratio
 
-    def test_clear_all_removes_all_bars(self):
-        m1, m2 = MagicMock(), MagicMock()
-        m1.hp_ratio, m1.experience_progress_percent = 0.5, 0.2
-        m2.hp_ratio, m2.experience_progress_percent = 0.8, 0.7
-        self.combat_ui.get_hp_bar(m1)
-        self.combat_ui.get_exp_bar(m1)
-        self.combat_ui.get_hp_bar(m2)
-        self.combat_ui.get_exp_bar(m2)
-        self.assertTrue(self.combat_ui._hp_bars)
-        self.assertTrue(self.combat_ui._exp_bars)
 
-        self.combat_ui.clear_all()
-        self.assertEqual(self.combat_ui._hp_bars, {})
-        self.assertEqual(self.combat_ui._exp_bars, {})
+@pytest.mark.parametrize("ratio", [0.0, 0.2, 0.4, 0.9])
+def test_get_exp_bar_initializes_with_monster_value(combat_ui, ratio):
+    monster = MagicMock()
+    monster.experience_progress_percent = ratio
+    bar = combat_ui.get_exp_bar(monster)
+    assert bar.value == ratio
+
+
+def test_remove_monster_clears_bars(combat_ui):
+    monster = MagicMock()
+    monster.hp_ratio = 0.5
+    monster.experience_progress_percent = 0.3
+    combat_ui.get_hp_bar(monster)
+    combat_ui.get_exp_bar(monster)
+    assert monster in combat_ui._hp_bars
+    assert monster in combat_ui._exp_bars
+    combat_ui.remove_monster(monster)
+    assert monster not in combat_ui._hp_bars
+    assert monster not in combat_ui._exp_bars
+
+
+def test_clear_all_removes_all_bars(combat_ui):
+    m1, m2 = MagicMock(), MagicMock()
+    m1.hp_ratio, m1.experience_progress_percent = 0.5, 0.2
+    m2.hp_ratio, m2.experience_progress_percent = 0.8, 0.7
+    combat_ui.get_hp_bar(m1)
+    combat_ui.get_exp_bar(m1)
+    combat_ui.get_hp_bar(m2)
+    combat_ui.get_exp_bar(m2)
+    assert combat_ui._hp_bars
+    assert combat_ui._exp_bars
+    combat_ui.clear_all()
+    assert combat_ui._hp_bars == {}
+    assert combat_ui._exp_bars == {}

--- a/tests/tuxemon/test_text_animation_manager.py
+++ b/tests/tuxemon/test_text_animation_manager.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.ui.combat_notifier import TextAnimationManager
+
+
+@pytest.fixture
+def manager():
+    return TextAnimationManager()
+
+
+def test_add_text_animation_queues_items(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 1.5)
+    assert len(manager.text_queue) == 1
+    anim, duration = manager.text_queue[0]
+    assert duration == 1.5
+
+
+def test_update_text_animation_triggers_when_time_runs_out(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 1.0)
+    manager.update_text_animation(1.1)
+    fn.assert_called_once()
+    assert len(manager.text_queue) == 0
+    assert manager._text_time_left == 1.0
+
+
+def test_update_text_animation_does_not_trigger_too_early(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 2.0)
+    manager.update_text_animation(1.0)
+    fn.assert_called_once()
+
+
+def test_multiple_animations_trigger_in_order(manager):
+    fn1 = MagicMock()
+    fn2 = MagicMock()
+    manager.add_text_animation(fn1, 1.0)
+    manager.add_text_animation(fn2, 2.0)
+    manager.update_text_animation(1.1)
+    fn1.assert_called_once()
+    fn2.assert_not_called()
+    manager.update_text_animation(2.1)
+    fn2.assert_called_once()
+
+
+def test_xp_messages_are_batched(manager):
+    manager.add_xp_message("XP +10")
+    manager.add_xp_message("XP +20")
+    alert = MagicMock()
+    text_area = MagicMock()
+    manager.trigger_xp_animation(alert, text_area)
+    assert len(manager.text_queue) == 1
+    anim, duration = manager.text_queue[0]
+    anim()
+    alert.assert_called_once_with("XP +10\nXP +20", text_area)
+    assert manager._xp_messages == []
+    assert manager._pending_xp_duration == duration
+
+
+def test_zero_duration_triggers_immediately(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 0)
+    manager.update_text_animation(0.01)
+    fn.assert_called_once()
+
+
+def test_multiple_zero_duration_animations(manager):
+    fn1 = MagicMock()
+    fn2 = MagicMock()
+    fn3 = MagicMock()
+    manager.add_text_animation(fn1, 0)
+    manager.add_text_animation(fn2, 0)
+    manager.add_text_animation(fn3, 0)
+    manager.update_text_animation(0.01)
+    fn1.assert_called_once()
+    fn2.assert_not_called()
+    fn3.assert_not_called()
+    manager.update_text_animation(0.01)
+    fn2.assert_called_once()
+    manager.update_text_animation(0.01)
+    fn3.assert_called_once()
+
+
+def test_time_left_set_to_duration_of_popped_animation(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 3.5)
+    manager.update_text_animation(0.01)
+    assert manager._text_time_left == 3.5
+
+
+def test_trigger_xp_animation_sets_pending_duration(manager):
+    manager.add_xp_message("XP +10")
+    manager.add_xp_message("XP +20")
+    alert = MagicMock()
+    text_area = MagicMock()
+    manager.trigger_xp_animation(alert, text_area)
+    assert manager._xp_messages == []
+    assert manager._pending_xp_duration is not None
+
+
+def test_xp_animation_calls_alert(manager):
+    manager.add_xp_message("XP +10")
+    alert = MagicMock()
+    text_area = MagicMock()
+    manager.trigger_xp_animation(alert, text_area)
+    anim, duration = manager.text_queue[0]
+    anim()
+    alert.assert_called_once_with("XP +10", text_area)

--- a/tuxemon/core/core_effect.py
+++ b/tuxemon/core/core_effect.py
@@ -27,6 +27,7 @@ class TechEffectResult(EffectResult):
     damage: int = 0
     element_multiplier: float = 0.0
     should_tackle: bool = False
+    hit_count: int = 1
 
 
 @dataclass

--- a/tuxemon/core/effects/multiattack.py
+++ b/tuxemon/core/effects/multiattack.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -43,27 +45,36 @@ class MultiAttackEffect(CoreEffect):
     def apply_tech_target(
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
-        combat_session = session.client.combat_session
-        combat_session.set_tech_hit(user)
-        # Track previous actions with the same technique, user, and target
-        turn = combat_session.turn
-        action_queue = combat_session.action_queue
-        log = action_queue.history.get_actions_by_turn(turn)
-        track = [
-            action
-            for action in log
-            if action.method == tech
-            and action.user == user
-            and action.target == target
-        ]
-        # Check if the technique has been used the maximum number of times
-        done = len(track) < self.times
-        # Check if the technique hits
-        hit = tech.accuracy >= combat_session.get_tech_hit(user)
-        # If the technique is done and hits, enqueue the action
-        if done and hit:
-            combat_session.enqueue_action(user, tech, target)
+        combat = session.client.combat_session
+
+        hit_count = 0
+        total_damage = 0
+        extras: list[str] = []
+
+        for _ in range(self.times):
+            combat.set_tech_hit(user)
+            hit_roll = combat.get_tech_hit(user)
+            hit = tech.accuracy >= hit_roll
+
+            if not hit:
+                break
+
+            hit_count += 1
+            dmg, _ = formula.simple_damage_calculate(tech, user, target)
+            total_damage += dmg
+
+        success = hit_count > 0
+
+        if success:
+            params = {"hit_count": hit_count}
+            extract_text = T.format("combat_multiattack", params)
+            extras = [extract_text]
 
         return TechEffectResult(
-            name=tech.name, should_tackle=done, success=done
+            name=tech.name,
+            success=success,
+            should_tackle=success,
+            damage=total_damage,
+            extras=extras,
+            hit_count=hit_count,
         )

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -207,8 +207,8 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return
             self.combat_session.swap_tracker.register(added)
             self.combat_session.enqueue_action(self.monster, swap, added)
-            self.client.remove_state_by_name("MonsterMenuState")
-            self.client.remove_state_by_name("MainCombatMenuState")
+            self.client.pop_state()
+            self.client.pop_state()
 
         def validate_monster(menu_item: Monster) -> bool:
             if menu_item.is_fainted:


### PR DESCRIPTION
Changes:
- added a new `hit_count` field to `TechEffectResult` so techniques can report how many times they hit
- updated multi‑hit techniques to calculate and return the correct number of hits
- multi‑hit animations are **not enabled yet** because they depend on another PR that hasn’t been merged #3358
- due to a known bug where the last message stays stuck in the text area, full animation feedback is temporarily disabled
- the game now shows a simple text message like **“Hit X times!”** so players still get feedback