### PR TITLE
Refactor Technique Stat System into Base, Custom, and Current Layers

### DIFF
--- a/tests/tuxemon/test_formula.py
+++ b/tests/tuxemon/test_formula.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import math
-import unittest
 from unittest.mock import MagicMock
+
+import pytest
 
 from tuxemon.element import Element, ElementTypesHandler
 from tuxemon.formula import (
     calculate_time_based_multiplier,
     config_combat,
     config_monster,
-    modify_stat,
+    modify_monster_custom_stat,
+    modify_technique_custom_stat,
     set_health,
     set_height,
     set_weight,
@@ -18,363 +20,462 @@ from tuxemon.formula import (
     simple_heal,
 )
 from tuxemon.monster import Monster
+from tuxemon.monster_dir.stats import CustomStatBoosts
 from tuxemon.platform.const.sizes import COEFF_DAMAGE
+from tuxemon.technique.stats import (
+    TechniqueBaseStats,
+    TechniqueCustomBoosts,
+)
 from tuxemon.technique.technique import Technique
 
 
-class TestSimpleHeal(unittest.TestCase):
-    def setUp(self):
-        self.monster = MagicMock(spec=Monster)
-        self.monster.level = 0.0
-        self.technique = MagicMock(spec=Technique)
-        self.technique.healing_power = 0.0
-
-    def test_simple_heal_no_factors(self):
-        self.technique.healing_power = 5
-        self.monster.level = 10
-        expected_heal = (
-            COEFF_DAMAGE + self.monster.level * self.technique.healing_power
-        )
-        actual_heal = simple_heal(self.technique, self.monster)
-        self.assertEqual(int(expected_heal), actual_heal)
-
-    def test_simple_heal_with_factors(self):
-        self.technique.healing_power = 3
-        self.monster.level = 15
-        factors = {"boost": 1.2, "penalty": 0.8}
-        expected_multiplier = math.prod(factors.values())
-        expected_heal = (
-            COEFF_DAMAGE + self.monster.level * self.technique.healing_power
-        ) * expected_multiplier
-        actual_heal = simple_heal(self.technique, self.monster, factors)
-        self.assertEqual(int(expected_heal), actual_heal)
-
-    def test_simple_heal_empty_factors(self):
-        self.technique.healing_power = 2
-        self.monster.level = 20
-        factors = {}
-        expected_heal = (
-            COEFF_DAMAGE + self.monster.level * self.technique.healing_power
-        )
-        actual_heal = simple_heal(self.technique, self.monster, factors)
-        self.assertEqual(int(expected_heal), actual_heal)
-
-
-class TestCalculateTimeBasedMultiplier(unittest.TestCase):
-    def test_mid_peak(self):
-        result = calculate_time_based_multiplier(12, 12, 1.5, 8, 20)
-        self.assertEqual(result, 1.5)
-
-    def test_peak_off(self):
-        result = calculate_time_based_multiplier(2, 12, 1.5, 8, 20)
-        self.assertEqual(result, 0.0)
-
-    def test_negative_hours(self):
-        result = calculate_time_based_multiplier(-5, -10, 1.5, -8, -2)
-        self.assertEqual(result, 0.0)
-
-    def test_zero_max_multiplier(self):
-        result = calculate_time_based_multiplier(12, 12, 0, 8, 20)
-        self.assertEqual(result, 0.0)
-
-
-class TestSetWeight(unittest.TestCase):
-    def setUp(self):
-        self.monster = MagicMock(spec=Monster, weight=0)
-        self.minor, self.major = config_monster.weight_range
-
-    def test_set_weight_zero(self):
-        weight = set_weight(self.monster, 0)
-        self.assertEqual(weight, 0)
-
-    def test_set_weight_positive(self):
-        weight = set_weight(self.monster, 100)
-        self.assertGreaterEqual(weight, 100 * (1 + self.minor))
-        self.assertLessEqual(weight, 100 * (1 + self.major))
-
-    def test_set_weight_negative(self):
-        weight = set_weight(self.monster, -50)
-        self.assertGreaterEqual(weight, -50 * (1 + self.major))
-        self.assertLessEqual(weight, -50 * (1 + self.minor))
-
-    def test_set_weight_randomness(self):
-        weights = [set_weight(self.monster, 75) for _ in range(100)]
-        self.assertGreaterEqual(len(set(weights)), 1)
-
-
-class TestSetHeight(unittest.TestCase):
-    def setUp(self):
-        self.monster = MagicMock(spec=Monster, height=0)
-        self.minor, self.major = config_monster.height_range
-
-    def test_set_height_zero(self):
-        height = set_height(self.monster, 0)
-        self.assertEqual(height, 0)
-
-    def test_set_height_positive(self):
-        height = set_height(self.monster, 100)
-        self.assertGreaterEqual(height, 100 * (1 + self.minor))
-        self.assertLessEqual(height, 100 * (1 + self.major))
-
-    def test_set_height_negative(self):
-        height = set_height(self.monster, -50)
-        self.assertGreaterEqual(height, -50 * (1 + self.major))
-        self.assertLessEqual(height, -50 * (1 + self.minor))
-
-    def test_set_height_randomness(self):
-        heights = [set_height(self.monster, 75) for _ in range(100)]
-        self.assertGreaterEqual(len(set(heights)), 1)
-
-
-class TestSimpleDamageMultiplier(unittest.TestCase):
-    def setUp(self):
-        ElementTypesHandler.clear_cache()
-        self.fire = MagicMock(spec=Element)
-        self.fire.slug = "fire"
-        self.water = MagicMock(spec=Element)
-        self.water.slug = "water"
-        self.grass = MagicMock(spec=Element)
-        self.grass.slug = "grass"
-        self.aether = MagicMock(spec=Element)
-        self.aether.slug = "aether"
-
-    def test_basic_multiplier(self):
-        attack_type = self.fire
-        target_type = self.water
-        attack_type.lookup_multiplier = MagicMock(return_value=2.0)
-        multiplier = simple_damage_multiplier([attack_type], [target_type])
-        self.assertEqual(multiplier, 2.0)
-
-    def test_multiple_attack_types(self):
-        attack_types = [self.fire, self.grass]
-        target_type = self.water
-        attack_types[0].lookup_multiplier = MagicMock(return_value=2.0)
-        attack_types[1].lookup_multiplier = MagicMock(return_value=0.5)
-        multiplier = simple_damage_multiplier(attack_types, [target_type])
-        self.assertEqual(multiplier, 1.0)
-
-    def test_multiple_target_types(self):
-        attack_type = self.fire
-        target_types = [self.water, self.grass]
-        attack_type.lookup_multiplier = MagicMock(side_effect=[2.0, 0.5])
-        multiplier = simple_damage_multiplier([attack_type], target_types)
-        self.assertEqual(multiplier, 1.0)
-
-    def test_aether_type(self):
-        attack_type = self.aether
-        target_type = self.water
-        multiplier = simple_damage_multiplier([attack_type], [target_type])
-        self.assertEqual(multiplier, 1.0)
-
-        attack_type = self.fire
-        target_type = self.aether
-        multiplier = simple_damage_multiplier([attack_type], [target_type])
-        self.assertEqual(multiplier, 1.0)
-
-    def test_additional_factors(self):
-        attack_type = self.fire
-        target_type = self.water
-        attack_type.lookup_multiplier = MagicMock(return_value=2.0)
-        additional_factors = {"boost": 1.5, "nerf": 0.8}
-        multiplier = simple_damage_multiplier(
-            [attack_type], [target_type], additional_factors
-        )
-        self.assertEqual(round(multiplier, 1), 2.4)
-
-    def test_empty_attack_or_target(self):
-        self.assertEqual(simple_damage_multiplier([], [self.water]), 1.0)
-        self.assertEqual(simple_damage_multiplier([self.fire], []), 1.0)
-
-    def test_clamping(self):
-        self.fire.lookup_multiplier = MagicMock(return_value=10.0)
-        multiplier = simple_damage_multiplier([self.fire], [self.water])
-        min_range, max_range = config_combat.multiplier_range
-        self.assertLessEqual(multiplier, max_range)
-
-    def test_cache_reuse(self):
-        self.fire.lookup_multiplier = MagicMock(return_value=2.0)
-        simple_damage_multiplier([self.fire], [self.water])
-        multiplier = simple_damage_multiplier([self.fire], [self.water])
-        self.fire.lookup_multiplier.assert_called_once()
-        self.assertEqual(multiplier, 2.0)
-
-
-class TestSimpleDamageCalculate(unittest.TestCase):
-    def setUp(self):
-        self.mock_technique = MagicMock()
-        self.mock_user = MagicMock()
-        self.mock_target = MagicMock()
-
-        self.fire = MagicMock(spec=Element)
-        self.fire.slug = "fire"
-        self.water = MagicMock(spec=Element)
-        self.water.slug = "water"
-
-        self.mock_user.level = 10
-        self.mock_technique.power = 50
-
-        self.mock_technique.types.current = [self.fire]
-        self.fire.lookup_multiplier = MagicMock(return_value=2.0)
-
-        self.mock_target.types.current = [self.water]
-        self.fire.lookup_multiplier = MagicMock(return_value=2.0)
-
-    def test_valid_melee_damage(self):
-        self.mock_technique.range = "melee"
-        self.mock_user.melee = 30
-        self.mock_target.armour = 20
-
-        damage, multiplier = simple_damage_calculate(
-            self.mock_technique, self.mock_user, self.mock_target
-        )
-
-        self.assertIsInstance(damage, int)
-        self.assertGreater(damage, 0)
-        self.assertGreater(multiplier, 0.0)
-
-    def test_valid_touch_damage(self):
-        self.mock_technique.range = "touch"
-        self.mock_user.melee = 25
-        self.mock_target.dodge = 10
-
-        damage, multiplier = simple_damage_calculate(
-            self.mock_technique, self.mock_user, self.mock_target
-        )
-
-        self.assertGreater(damage, 0)
-        self.assertGreater(multiplier, 0.0)
-
-    def test_additional_factors_applied(self):
-        self.mock_technique.range = "ranged"
-        self.mock_user.ranged = 40
-        self.mock_target.dodge = 15
-
-        additional_factors = {"weather_bonus": 0.2}
-
-        damage, multiplier = simple_damage_calculate(
-            self.mock_technique,
-            self.mock_user,
-            self.mock_target,
-            additional_factors=additional_factors,
-        )
-
-        self.assertGreater(damage, 0)
-        self.assertAlmostEqual(multiplier, 0.2, delta=0.2)
-
-    def test_level_based_damage(self):
-        self.mock_technique.range = "reliable"
-        self.mock_user.level = 15
-        self.mock_target.resist = 3
-
-        damage, multiplier = simple_damage_calculate(
-            self.mock_technique, self.mock_user, self.mock_target
-        )
-
-        self.assertGreater(damage, 0)
-        self.assertGreater(multiplier, 0.0)
-
-
-class TestModifyStat(unittest.TestCase):
-
-    def setUp(self):
-        self.monster = MagicMock(spec=Monster)
-        self.monster.custom_stats = MagicMock()
-        self.monster.set_stats = MagicMock()
-
-    def test_add_operation(self):
-        self.monster.custom_stats.armour = 10
-        stat = "armour"
-        value = 5.0
-        operation = "add"
-        expected_value = 15
-        modify_stat(self.monster, stat, value, operation)
-        self.assertEqual(self.monster.custom_stats.armour, expected_value)
-        self.monster.set_stats.assert_called_once()
-
-    def test_multiply_operation(self):
-        self.monster.armour = 10
-        self.monster.custom_stats.armour = 0
-        stat = "armour"
-        value = 1.5
-        operation = "multiply"
-        expected_value = 15
-        modify_stat(self.monster, stat, value, operation)
-        self.assertEqual(self.monster.custom_stats.armour, expected_value)
-        self.monster.set_stats.assert_called_once()
-
-    def test_invalid_operation(self):
-        stat = "armour"
-        value = 5.0
-        operation = "invalid"
-        with self.assertRaises(ValueError):
-            modify_stat(self.monster, stat, value, operation)
-
-    def test_unrecognized_stat(self):
-        stat = "unknown"
-        value = 5.0
-        operation = "add"
-        modify_stat(self.monster, stat, value, operation)
-        self.monster.set_stats.assert_not_called()
-
-    def test_modify_stat_calls_set_stats(self):
-        self.monster.custom_stats.armour = 10
-        stat = "armour"
-        value = 5.0
-        operation = "add"
-        modify_stat(self.monster, stat, value, operation)
-        self.monster.set_stats.assert_called_once()
-
-
-class TestSetHealth(unittest.TestCase):
-    def setUp(self):
-        self.monster = MagicMock(
-            spec=Monster, hp=100, current_hp=100, is_fainted=False
-        )
-
-    def test_set_health_direct(self):
-        set_health(self.monster, 50)
-        self.assertEqual(self.monster.current_hp, 50)
-
-    def test_set_health_percentage(self):
-        set_health(self.monster, 0.5)
-        self.assertEqual(self.monster.current_hp, 50)
-
-    def test_adjust_health_add(self):
-        set_health(self.monster, 10, adjust=True)
-        self.assertEqual(self.monster.current_hp, 100)
-
-    def test_adjust_health_subtract(self):
-        set_health(self.monster, -30, adjust=True)
-        self.assertEqual(self.monster.current_hp, 70)
-
-    def test_hp_max_limit(self):
-        for value in [1.5, 9999]:
-            set_health(self.monster, value)
-            self.assertEqual(self.monster.current_hp, self.monster.hp)
-
-    def test_faint_triggered_on_zero_hp(self):
-        set_health(self.monster, -200, adjust=True)
-        self.assertEqual(self.monster.current_hp, 0)
-
-    def test_set_health_to_zero(self):
-        self.monster.is_fainted = True
-        set_health(self.monster, 0)
-        self.assertEqual(self.monster.current_hp, 0)
-
-    def test_hp_min_limit(self):
-        for value in [-100, -200]:
-            self.monster.is_fainted = True
-            set_health(self.monster, value, adjust=True)
-            self.assertEqual(self.monster.current_hp, 0)
-
-    def test_set_health_percentage(self):
-        for value in [0.5, 0.25]:
-            set_health(self.monster, value)
-            self.assertEqual(
-                self.monster.current_hp, int(self.monster.hp * value)
-            )
-
-    def test_adjust_health_cap(self):
-        for value in [50, 200]:
-            set_health(self.monster, value, adjust=True)
-            self.assertEqual(self.monster.current_hp, self.monster.hp)
+# TestSimpleHeal
+@pytest.fixture
+def heal_env():
+    monster = MagicMock(spec=Monster)
+    technique = MagicMock(spec=Technique)
+    monster.level = 0.0
+    technique.healing_power = 0.0
+    return technique, monster
+
+
+def test_simple_heal_no_factors(heal_env):
+    tech, mon = heal_env
+    tech.healing_power = 5
+    mon.level = 10
+    expected = COEFF_DAMAGE + mon.level * tech.healing_power
+    assert simple_heal(tech, mon) == int(expected)
+
+
+def test_simple_heal_with_factors(heal_env):
+    tech, mon = heal_env
+    tech.healing_power = 3
+    mon.level = 15
+    factors = {"boost": 1.2, "penalty": 0.8}
+    expected = (COEFF_DAMAGE + mon.level * tech.healing_power) * math.prod(
+        factors.values()
+    )
+    assert simple_heal(tech, mon, factors) == int(expected)
+
+
+def test_simple_heal_empty_factors(heal_env):
+    tech, mon = heal_env
+    tech.healing_power = 2
+    mon.level = 20
+    expected = COEFF_DAMAGE + mon.level * tech.healing_power
+    assert simple_heal(tech, mon, {}) == int(expected)
+
+
+# TestCalculateTimeBasedMultiplier
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ((12, 12, 1.5, 8, 20), 1.5),
+        ((2, 12, 1.5, 8, 20), 0.0),
+        ((-5, -10, 1.5, -8, -2), 0.0),
+        ((12, 12, 0, 8, 20), 0.0),
+    ],
+)
+def test_time_based_multiplier(args, expected):
+    assert calculate_time_based_multiplier(*args) == expected
+
+
+# TestSetWeight
+@pytest.fixture
+def weight_env():
+    monster = MagicMock(spec=Monster, weight=0)
+    minor, major = config_monster.weight_range
+    return monster, minor, major
+
+
+def test_set_weight_zero(weight_env):
+    mon, minor, major = weight_env
+    assert set_weight(mon, 0) == 0
+
+
+def test_set_weight_positive(weight_env):
+    mon, minor, major = weight_env
+    w = set_weight(mon, 100)
+    assert w >= 100 * (1 + minor)
+    assert w <= 100 * (1 + major)
+
+
+def test_set_weight_negative(weight_env):
+    mon, minor, major = weight_env
+    w = set_weight(mon, -50)
+    assert w >= -50 * (1 + major)
+    assert w <= -50 * (1 + minor)
+
+
+def test_set_weight_randomness(weight_env):
+    mon, minor, major = weight_env
+    weights = [set_weight(mon, 75) for _ in range(100)]
+    assert len(set(weights)) >= 1
+
+
+# TestSetHeight
+@pytest.fixture
+def height_env():
+    monster = MagicMock(spec=Monster, height=0)
+    minor, major = config_monster.height_range
+    return monster, minor, major
+
+
+def test_set_height_zero(height_env):
+    mon, minor, major = height_env
+    assert set_height(mon, 0) == 0
+
+
+def test_set_height_positive(height_env):
+    mon, minor, major = height_env
+    h = set_height(mon, 100)
+    assert h >= 100 * (1 + minor)
+    assert h <= 100 * (1 + major)
+
+
+def test_set_height_negative(height_env):
+    mon, minor, major = height_env
+    h = set_height(mon, -50)
+    assert h >= -50 * (1 + major)
+    assert h <= -50 * (1 + minor)
+
+
+def test_set_height_randomness(height_env):
+    mon, minor, major = height_env
+    heights = [set_height(mon, 75) for _ in range(100)]
+    assert len(set(heights)) >= 1
+
+
+# TestSimpleDamageMultiplier
+@pytest.fixture
+def elements():
+    ElementTypesHandler.clear_cache()
+    fire = MagicMock(spec=Element)
+    fire.slug = "fire"
+    water = MagicMock(spec=Element)
+    water.slug = "water"
+    grass = MagicMock(spec=Element)
+    grass.slug = "grass"
+    aether = MagicMock(spec=Element)
+    aether.slug = "aether"
+    return fire, water, grass, aether
+
+
+def test_basic_multiplier(elements):
+    fire, water, *_ = elements
+    fire.lookup_multiplier = MagicMock(return_value=2.0)
+    assert simple_damage_multiplier([fire], [water]) == 2.0
+
+
+@pytest.mark.parametrize(
+    "vals,expected",
+    [
+        ((2.0, 0.5), 1.0),
+    ],
+)
+def test_multiple_attack_types(elements, vals, expected):
+    fire, water, grass, _ = elements
+    fire.lookup_multiplier = MagicMock(return_value=vals[0])
+    grass.lookup_multiplier = MagicMock(return_value=vals[1])
+    assert simple_damage_multiplier([fire, grass], [water]) == expected
+
+
+def test_multiple_target_types(elements):
+    fire, water, grass, _ = elements
+    fire.lookup_multiplier = MagicMock(side_effect=[2.0, 0.5])
+    assert simple_damage_multiplier([fire], [water, grass]) == 1.0
+
+
+def test_aether_type(elements):
+    fire, water, _, aether = elements
+    assert simple_damage_multiplier([aether], [water]) == 1.0
+    assert simple_damage_multiplier([fire], [aether]) == 1.0
+
+
+def test_additional_factors(elements):
+    fire, water, *_ = elements
+    fire.lookup_multiplier = MagicMock(return_value=2.0)
+    factors = {"boost": 1.5, "nerf": 0.8}
+    assert round(simple_damage_multiplier([fire], [water], factors), 1) == 2.4
+
+
+@pytest.mark.parametrize(
+    "atk,tgt",
+    [
+        ([], ["water"]),
+        (["fire"], []),
+    ],
+)
+def test_empty_attack_or_target(elements, atk, tgt):
+    fire, water, *_ = elements
+    atk = [fire] if atk else []
+    tgt = [water] if tgt else []
+    assert simple_damage_multiplier(atk, tgt) == 1.0
+
+
+def test_clamping(elements):
+    fire, water, *_ = elements
+    fire.lookup_multiplier = MagicMock(return_value=10.0)
+    mult = simple_damage_multiplier([fire], [water])
+    _, max_range = config_combat.multiplier_range
+    assert mult <= max_range
+
+
+def test_cache_reuse(elements):
+    fire, water, *_ = elements
+    fire.lookup_multiplier = MagicMock(return_value=2.0)
+    simple_damage_multiplier([fire], [water])
+    mult = simple_damage_multiplier([fire], [water])
+    fire.lookup_multiplier.assert_called_once()
+    assert mult == 2.0
+
+
+# TestSimpleDamageCalculate
+@pytest.fixture
+def dmg_env():
+    tech = MagicMock()
+    user = MagicMock()
+    target = MagicMock()
+
+    fire = MagicMock(spec=Element)
+    fire.slug = "fire"
+    water = MagicMock(spec=Element)
+    water.slug = "water"
+
+    user.level = 10
+    tech.power = 50
+
+    tech.types.current = [fire]
+    fire.lookup_multiplier = MagicMock(return_value=2.0)
+
+    target.types.current = [water]
+    fire.lookup_multiplier = MagicMock(return_value=2.0)
+
+    return tech, user, target
+
+
+def test_valid_melee_damage(dmg_env):
+    tech, user, target = dmg_env
+    tech.range = "melee"
+    user.melee = 30
+    target.armour = 20
+    dmg, mult = simple_damage_calculate(tech, user, target)
+    assert isinstance(dmg, int)
+    assert dmg > 0
+    assert mult > 0.0
+
+
+def test_valid_touch_damage(dmg_env):
+    tech, user, target = dmg_env
+    tech.range = "touch"
+    user.melee = 25
+    target.dodge = 10
+    dmg, mult = simple_damage_calculate(tech, user, target)
+    assert dmg > 0
+    assert mult > 0.0
+
+
+def test_additional_factors_applied(dmg_env):
+    tech, user, target = dmg_env
+    tech.range = "ranged"
+    user.ranged = 40
+    target.dodge = 15
+    factors = {"weather_bonus": 0.2}
+    dmg, mult = simple_damage_calculate(
+        tech, user, target, additional_factors=factors
+    )
+    assert dmg > 0
+    assert pytest.approx(mult, abs=0.2) == 0.2
+
+
+def test_level_based_damage(dmg_env):
+    tech, user, target = dmg_env
+    tech.range = "reliable"
+    user.level = 15
+    target.resist = 3
+    dmg, mult = simple_damage_calculate(tech, user, target)
+    assert dmg > 0
+    assert mult > 0.0
+
+
+# TestModifyMonsterCustomStat
+@pytest.fixture
+def monster():
+    m = MagicMock(spec=Monster)
+    m.custom_stats = CustomStatBoosts()
+    m.set_stats = MagicMock()
+    return m
+
+
+@pytest.mark.parametrize(
+    "initial,amount,op,expected",
+    [
+        (10, 5.0, "add", 15),
+    ],
+)
+def test_add_operation(monster, initial, amount, op, expected):
+    monster.custom_stats.armour = initial
+    modify_monster_custom_stat(monster, "armour", amount, op)
+    assert monster.custom_stats.armour == expected
+    monster.set_stats.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "base,initial,amount,op,expected",
+    [
+        (10, 0, 1.5, "multiply", 15),
+    ],
+)
+def test_multiply_operation(monster, base, initial, amount, op, expected):
+    monster.armour = base
+    monster.custom_stats.armour = initial
+    modify_monster_custom_stat(monster, "armour", amount, op)
+    assert monster.custom_stats.armour == expected
+    monster.set_stats.assert_called_once()
+
+
+def test_invalid_operation(monster):
+    with pytest.raises(ValueError):
+        modify_monster_custom_stat(monster, "armour", 5.0, "invalid")
+
+
+def test_unrecognized_stat(monster):
+    with pytest.raises(AttributeError):
+        modify_monster_custom_stat(monster, "unknown", 5.0, "add")
+
+
+def test_modify_monster_custom_stat_calls_set_stats(monster):
+    monster.custom_stats.armour = 10
+    modify_monster_custom_stat(monster, "armour", 5.0, "add")
+    monster.set_stats.assert_called_once()
+
+
+# TestModifyTechniqueCustomStat
+@pytest.fixture
+def tech():
+    t = MagicMock(spec=Technique)
+    t.custom_boosts = TechniqueCustomBoosts()
+    t.base_stats = TechniqueBaseStats(
+        power=10.0,
+        potency=5.0,
+        accuracy=0.8,
+        healing_power=3.0,
+    )
+    t.reset_current_stats = MagicMock()
+    return t
+
+
+@pytest.mark.parametrize(
+    "initial,amount,op,expected",
+    [
+        (10.0, 5.0, "add", 15.0),
+    ],
+)
+def test_add_operation_tech(tech, initial, amount, op, expected):
+    tech.custom_boosts.power = initial
+    modify_technique_custom_stat(tech, "power", amount, op)
+    assert tech.custom_boosts.power == expected
+    tech.reset_current_stats.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "initial,amount,op,expected",
+    [
+        (0.0, 1.5, "multiply", 15.0),
+    ],
+)
+def test_multiply_operation_tech(tech, initial, amount, op, expected):
+    tech.custom_boosts.power = initial
+    modify_technique_custom_stat(tech, "power", amount, op)
+    assert tech.custom_boosts.power == expected
+    tech.reset_current_stats.assert_called_once()
+
+
+def test_invalid_operation_tech(tech):
+    with pytest.raises(ValueError):
+        modify_technique_custom_stat(tech, "power", 5.0, "invalid")
+
+
+def test_unrecognized_stat_tech(tech):
+    with pytest.raises(AttributeError):
+        modify_technique_custom_stat(tech, "unknown", 5.0, "add")
+
+
+def test_modify_technique_custom_stat_calls_reset(tech):
+    tech.custom_boosts.power = 10.0
+    modify_technique_custom_stat(tech, "power", 5.0, "add")
+    tech.reset_current_stats.assert_called_once()
+
+
+# TestSetHealth
+@pytest.fixture
+def monster_hp():
+    return MagicMock(spec=Monster, hp=100, current_hp=100, is_fainted=False)
+
+
+def test_set_health_direct(monster_hp):
+    set_health(monster_hp, 50)
+    assert monster_hp.current_hp == 50
+
+
+def test_set_health_percentage(monster_hp):
+    set_health(monster_hp, 0.5)
+    assert monster_hp.current_hp == 50
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (10, 100),
+    ],
+)
+def test_adjust_health_add(monster_hp, value, expected):
+    set_health(monster_hp, value, adjust=True)
+    assert monster_hp.current_hp == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (-30, 70),
+    ],
+)
+def test_adjust_health_subtract(monster_hp, value, expected):
+    set_health(monster_hp, value, adjust=True)
+    assert monster_hp.current_hp == expected
+
+
+@pytest.mark.parametrize("value", [1.5, 9999])
+def test_hp_max_limit(monster_hp, value):
+    set_health(monster_hp, value)
+    assert monster_hp.current_hp == monster_hp.hp
+
+
+def test_faint_triggered_on_zero_hp(monster_hp):
+    set_health(monster_hp, -200, adjust=True)
+    assert monster_hp.current_hp == 0
+
+
+def test_set_health_to_zero(monster_hp):
+    monster_hp.is_fainted = True
+    set_health(monster_hp, 0)
+    assert monster_hp.current_hp == 0
+
+
+@pytest.mark.parametrize("value", [-100, -200])
+def test_hp_min_limit(monster_hp, value):
+    monster_hp.is_fainted = True
+    set_health(monster_hp, value, adjust=True)
+    assert monster_hp.current_hp == 0
+
+
+@pytest.mark.parametrize("value", [0.5, 0.25])
+def test_set_health_percentage_param(monster_hp, value):
+    set_health(monster_hp, value)
+    assert monster_hp.current_hp == int(monster_hp.hp * value)
+
+
+@pytest.mark.parametrize("value", [50, 200])
+def test_adjust_health_cap(monster_hp, value):
+    set_health(monster_hp, value, adjust=True)
+    assert monster_hp.current_hp == monster_hp.hp

--- a/tests/tuxemon/test_monster_moves_handler.py
+++ b/tests/tuxemon/test_monster_moves_handler.py
@@ -144,7 +144,7 @@ def test_update_moves(handler, monster):
 
 
 @pytest.mark.parametrize(
-    "method", ["recharge_moves", "full_recharge_moves", "set_stats"]
+    "method", ["recharge_moves", "full_recharge_moves", "reset_current_stats"]
 )
 @patch.object(MonsterMovesHandler, "is_eligible", return_value=True)
 def test_recharge_and_stats(_mock, handler, monster, technique, method):

--- a/tuxemon/core/effects/grabbed.py
+++ b/tuxemon/core/effects/grabbed.py
@@ -58,10 +58,11 @@ class GrabbedEffect(CoreEffect):
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             done = True
         elif status.has_phase(EffectPhase.ON_END):
-            host.moves.set_stats()
+            host.moves.reset_current_stats()
 
         if done and moves:
             for move in moves:
-                move.potency = move.default_potency / self.divisor
-                move.power = move.default_power / self.divisor
+                move.stats.potency = move.default_stats.potency / self.divisor
+                move.stats.power = move.default_stats.power / self.divisor
+
         return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/core/effects/stuck.py
+++ b/tuxemon/core/effects/stuck.py
@@ -60,10 +60,11 @@ class StuckEffect(CoreEffect):
         if status.has_phase(EffectPhase.PERFORM_STATUS):
             done = True
         elif status.has_phase(EffectPhase.ON_END):
-            host.moves.set_stats()
+            host.moves.reset_current_stats()
 
         if done and moves:
             for move in moves:
-                move.potency = move.default_potency / self.divisor
-                move.power = move.default_power / self.divisor
+                move.stats.potency = move.default_stats.potency / self.divisor
+                move.stats.power = move.default_stats.power / self.divisor
+
         return StatusEffectResult(name=status.name, success=done)

--- a/tuxemon/event/actions/modify_monster_stats.py
+++ b/tuxemon/event/actions/modify_monster_stats.py
@@ -9,7 +9,7 @@ from typing import Optional, Union, final
 
 from tuxemon.db import StatType
 from tuxemon.event.eventaction import EventAction
-from tuxemon.formula import modify_stat
+from tuxemon.formula import modify_monster_custom_stat
 from tuxemon.monster import Monster
 from tuxemon.session import Session
 from tuxemon.tools import get_valid_uuid
@@ -73,7 +73,7 @@ class ModifyMonsterStatsAction(EventAction):
             monster: Monster, stat: StatType, amount: float
         ) -> None:
             method = "multiply" if isinstance(amount, float) else "add"
-            modify_stat(monster, stat.value, amount, method)
+            modify_monster_custom_stat(monster, stat.value, amount, method)
 
         if self.variable is None:
             for mon in player.monsters:

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -873,7 +873,7 @@ def speed_monster(monster: Monster, technique: Technique) -> int:
     return int(speed_modifier)
 
 
-def modify_stat(
+def modify_monster_custom_stat(
     monster: Monster, stat: str, value: float, operation: str
 ) -> None:
     """
@@ -885,29 +885,53 @@ def modify_stat(
         value: The value to apply.
         operation: "add" for integer addition, "multiply" for float scaling.
     """
-    logger.info(f"{value} {operation} operation on {stat}")
+    logger.debug(f"{value} {operation} operation on {stat}")
 
-    stat_map = {
-        "armour": "armour",
-        "dodge": "dodge",
-        "hp": "hp",
-        "melee": "melee",
-        "speed": "speed",
-        "ranged": "ranged",
-    }
+    if not hasattr(monster.custom_stats, stat):
+        raise AttributeError(f"Unknown stat '{stat}'")
 
-    stat_attr = stat_map.get(stat)
+    current_value = getattr(monster.custom_stats, stat)
 
-    if stat_attr:
-        current_value = getattr(monster.custom_stats, stat_attr, 0)
+    if operation == "add":
+        new_value = current_value + int(value)
+    elif operation == "multiply":
+        base_value = getattr(monster, stat) * value
+        new_value = current_value + int(base_value)
+    else:
+        raise ValueError(f"Invalid operation: {operation}")
 
-        if operation == "add":
-            new_value = current_value + int(value)
-        elif operation == "multiply":
-            base_value = getattr(monster, stat_attr) * value
-            new_value = current_value + int(base_value)
-        else:
-            raise ValueError(f"Invalid operation: {operation}")
+    setattr(monster.custom_stats, stat, new_value)
+    monster.set_stats()
 
-        setattr(monster.custom_stats, stat_attr, new_value)
-        monster.set_stats()
+
+def modify_technique_custom_stat(
+    tech: Technique, stat: str, value: float, operation: str
+) -> None:
+    """
+    Permanently modify a technique's custom boosts.
+
+    Parameters:
+        tech: The Technique instance.
+        stat: One of: "power", "potency", "accuracy", "healing_power".
+        value: The value to apply.
+        operation: "add" or "multiply".
+    """
+    logger.debug(
+        f"{value} {operation} operation on technique custom stat '{stat}'"
+    )
+
+    if not hasattr(tech.custom_boosts, stat):
+        raise AttributeError(f"Unknown stat '{stat}'")
+
+    current_value = getattr(tech.custom_boosts, stat)
+
+    if operation == "add":
+        new_value = current_value + value
+    elif operation == "multiply":
+        base_value = getattr(tech.base_stats, stat)
+        new_value = current_value + (base_value * value)
+    else:
+        raise ValueError(f"Invalid operation: {operation}")
+
+    setattr(tech.custom_boosts, stat, new_value)
+    tech.reset_current_stats()

--- a/tuxemon/monster.py
+++ b/tuxemon/monster.py
@@ -725,7 +725,7 @@ class Monster:
         """
         self.clear_all_temporary_boosts()
         self.types.reset_to_default()
-        self.moves.set_stats()
+        self.moves.reset_current_stats()
         self.out_of_range = False
         self.moves.full_recharge_moves()
 

--- a/tuxemon/monster_dir/moves.py
+++ b/tuxemon/monster_dir/moves.py
@@ -299,9 +299,9 @@ class MonsterMovesHandler:
         for move in self.moves:
             move.full_recharge()
 
-    def set_stats(self) -> None:
+    def reset_current_stats(self) -> None:
         for move in self.moves:
-            move.set_stats()
+            move.reset_current_stats()
 
     def find_tech_by_id(self, instance_id: UUID) -> Optional[Technique]:
         """Finds a technique among the monster's moves which has the given id."""

--- a/tuxemon/technique/stats.py
+++ b/tuxemon/technique/stats.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TechniqueBaseStats:
+    """
+    The immutable, base statistical attributes loaded from the database.
+    (The Source of Truth/Defaults).
+    """
+
+    accuracy: float = 0.0
+    potency: float = 0.0
+    power: float = 1.0
+    healing_power: float = 0.0
+
+
+@dataclass
+class TechniqueCustomBoosts:
+    """
+    Persistent, user- or modder-defined additive boosts to technique stats.
+    (Loaded from the Save File).
+    """
+
+    power: float = 0.0
+    potency: float = 0.0
+    accuracy: float = 0.0
+    healing_power: float = 0.0
+
+    def to_dict(self) -> Mapping[str, Any]:
+        """Convert boosts to a dict for saving."""
+        return {
+            "accuracy_boost": self.accuracy,
+            "potency_boost": self.potency,
+            "power_boost": self.power,
+            "healing_power_boost": self.healing_power,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> TechniqueCustomBoosts:
+        """Create boosts from loaded dict."""
+        return cls(
+            accuracy=data.get("accuracy_boost", 0.0),
+            potency=data.get("potency_boost", 0.0),
+            power=data.get("power_boost", 0.0),
+            healing_power=data.get("healing_power_boost", 0.0),
+        )
+
+
+@dataclass
+class TechniqueCurrentStats:
+    """
+    The current, dynamic statistical attributes that can be modified in battle.
+    (Reset to Base + Boosts outside of battle).
+    """
+
+    potency: float = 0.0
+    accuracy: float = 0.0
+    power: float = 0.0
+    healing_power: float = 0.0

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -64,7 +64,7 @@ class Technique:
         # Custom: Persistent boosts from save file (additive layer)
         self.custom_boosts: TechniqueCustomBoosts = TechniqueCustomBoosts()
         # Current: Dynamic stats used in battle (mutable)
-        self.stats: TechniqueCurrentStats = TechniqueCurrentStats()
+        self.stats = self.compute_stats()
 
         self.cooldown = Cooldown()
         self.visuals = VisualProperties(
@@ -159,15 +159,7 @@ class Technique:
         Returns the baseline stats (base + custom boosts),
         without any temporary battle modifiers.
         """
-        return TechniqueCurrentStats(
-            power=self.base_stats.power + self.custom_boosts.power,
-            potency=self.base_stats.potency + self.custom_boosts.potency,
-            accuracy=self.base_stats.accuracy + self.custom_boosts.accuracy,
-            healing_power=(
-                self.base_stats.healing_power
-                + self.custom_boosts.healing_power
-            ),
-        )
+        return self.compute_stats()
 
     def load(self, slug: str) -> None:
         """
@@ -218,6 +210,15 @@ class Technique:
 
         self.visuals = results.visuals
         self.sound = results.sound
+
+    def compute_stats(self) -> TechniqueCurrentStats:
+        return TechniqueCurrentStats(
+            power=self.base_stats.power + self.custom_boosts.power,
+            potency=self.base_stats.potency + self.custom_boosts.potency,
+            accuracy=self.base_stats.accuracy + self.custom_boosts.accuracy,
+            healing_power=self.base_stats.healing_power
+            + self.custom_boosts.healing_power,
+        )
 
     def can_use(self, session: Session, target: Monster) -> bool:
         if self.is_recharging:
@@ -271,15 +272,7 @@ class Technique:
         Reset current stats to Base + Custom Boosts.
         Called after battle or when technique is refreshed.
         """
-        self.stats = TechniqueCurrentStats(
-            power=self.base_stats.power + self.custom_boosts.power,
-            potency=self.base_stats.potency + self.custom_boosts.potency,
-            accuracy=self.base_stats.accuracy + self.custom_boosts.accuracy,
-            healing_power=(
-                self.base_stats.healing_power
-                + self.custom_boosts.healing_power
-            ),
-        )
+        self.stats = self.compute_stats()
 
     def get_state(self) -> Mapping[str, Any]:
         """

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -26,6 +26,11 @@ from tuxemon.modifiers import ModifiersHandler
 from tuxemon.monster_dir.stats import BasicStats
 from tuxemon.surfanim import FlipAxes
 from tuxemon.technique.cooldown import Cooldown
+from tuxemon.technique.stats import (
+    TechniqueBaseStats,
+    TechniqueCurrentStats,
+    TechniqueCustomBoosts,
+)
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
@@ -52,19 +57,22 @@ class Technique:
 
         self.instance_id: UUID = uuid4()
         self.tech_id: int = 0
-        self.accuracy: float = 0.0
+
+        # Technique Stats
+        # Base: Immutable stats from DB (source of truth)
+        self.base_stats: TechniqueBaseStats = TechniqueBaseStats()
+        # Custom: Persistent boosts from save file (additive layer)
+        self.custom_boosts: TechniqueCustomBoosts = TechniqueCustomBoosts()
+        # Current: Dynamic stats used in battle (mutable)
+        self.stats: TechniqueCurrentStats = TechniqueCurrentStats()
+
         self.cooldown = Cooldown()
         self.visuals = VisualProperties(
             animation=None, flip_axes=FlipAxes.NONE, loop=-1
         )
         self.hit: bool = False
         self.speed: int = 0
-        self.potency: float = 0.0
-        self.power: float = 1.0
-        self.default_potency: float = 0.0
-        self.default_power: float = 1.0
         self.range: Range = Range.melee
-        self.healing_power: float = 0.0
         self.sound = SoundProperties(sfx=None, volume=1.5)
         self.sort: str = ""
         self.slug: str = ""
@@ -90,7 +98,6 @@ class Technique:
         self.attempts: int = 0
         self.successes: int = 0
         self.failures: int = 0
-
         self.set_state(save_data)
 
     @classmethod
@@ -114,6 +121,54 @@ class Technique:
         """Returns whether the technique is currently recharging."""
         return self.cooldown.is_recharging
 
+    @property
+    def power(self) -> float:
+        return self.stats.power
+
+    @power.setter
+    def power(self, value: float) -> None:
+        self.stats.power = value
+
+    @property
+    def potency(self) -> float:
+        return self.stats.potency
+
+    @potency.setter
+    def potency(self, value: float) -> None:
+        self.stats.potency = value
+
+    @property
+    def accuracy(self) -> float:
+        return self.stats.accuracy
+
+    @accuracy.setter
+    def accuracy(self, value: float) -> None:
+        self.stats.accuracy = value
+
+    @property
+    def healing_power(self) -> float:
+        return self.stats.healing_power
+
+    @healing_power.setter
+    def healing_power(self, value: float) -> None:
+        self.stats.healing_power = value
+
+    @property
+    def default_stats(self) -> TechniqueCurrentStats:
+        """
+        Returns the baseline stats (base + custom boosts),
+        without any temporary battle modifiers.
+        """
+        return TechniqueCurrentStats(
+            power=self.base_stats.power + self.custom_boosts.power,
+            potency=self.base_stats.potency + self.custom_boosts.potency,
+            accuracy=self.base_stats.accuracy + self.custom_boosts.accuracy,
+            healing_power=(
+                self.base_stats.healing_power
+                + self.custom_boosts.healing_power
+            ),
+        )
+
     def load(self, slug: str) -> None:
         """
         Loads and sets this technique's attributes from the technique
@@ -136,17 +191,17 @@ class Technique:
 
         # types
         self.types = ElementTypesHandler(results.types)
-        # technique stats
-        self.accuracy = results.accuracy
-        self.potency = results.potency
-        self.power = results.power
 
-        self.default_potency = results.potency
-        self.default_power = results.power
+        self.base_stats = TechniqueBaseStats(
+            accuracy=results.accuracy,
+            potency=results.potency,
+            power=results.power,
+            healing_power=results.healing_power,
+        )
+        self.reset_current_stats()
 
         self.speed = results.speed.numeric_value
         self.behaviors = results.behaviors
-        self.healing_power = results.healing_power
         self.cooldown.duration = results.recharge
         self.range = results.range
         self.tech_id = results.tech_id
@@ -211,12 +266,20 @@ class Technique:
         """
         return self.types.has_type(type_slug)
 
-    def set_stats(self) -> None:
+    def reset_current_stats(self) -> None:
         """
-        Reset technique stats default value.
+        Reset current stats to Base + Custom Boosts.
+        Called after battle or when technique is refreshed.
         """
-        self.potency = self.default_potency
-        self.power = self.default_power
+        self.stats = TechniqueCurrentStats(
+            power=self.base_stats.power + self.custom_boosts.power,
+            potency=self.base_stats.potency + self.custom_boosts.potency,
+            accuracy=self.base_stats.accuracy + self.custom_boosts.accuracy,
+            healing_power=(
+                self.base_stats.healing_power
+                + self.custom_boosts.healing_power
+            ),
+        )
 
     def get_state(self) -> Mapping[str, Any]:
         """
@@ -230,6 +293,10 @@ class Technique:
 
         save_data["instance_id"] = self.instance_id.hex
 
+        boosts_data = self.custom_boosts.to_dict()
+        if any(boosts_data.values()):
+            save_data["custom_boosts"] = boosts_data
+
         return save_data
 
     def set_state(self, save_data: Mapping[str, Any]) -> None:
@@ -240,6 +307,12 @@ class Technique:
             return
 
         self.load(save_data["slug"])
+
+        if "custom_boosts" in save_data:
+            self.custom_boosts = TechniqueCustomBoosts.from_dict(
+                save_data["custom_boosts"]
+            )
+        self.reset_current_stats()
 
         for key, value in save_data.items():
             if key == "instance_id" and value:


### PR DESCRIPTION
waiting:
- [x] #3352

Changes:
- extracted technique stats into three dedicated dataclasses: `TechniqueBaseStats`, `TechniqueCustomBoosts` and `TechniqueCurrentStats`
- made base stats immutable and loaded only from the database
- added persistent custom stat boosts with proper save/load support through to_dict and from_dict
- added current stats for temporary, battle‑only modifications
- implemented reset_current_stats to rebuild current stats from base + custom values
- updated technique logic to use the new stat layers consistently
- added modify_technique_custom_stat for permanent stat changes with validation and automatic stat refresh
- updated save format for technique custom boosts while keeping backward compatibility