### PR TITLE
Add `set_transparent` Method to Toggle Menu Transparency

### DIFF
--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -655,6 +655,13 @@ class Menu(Generic[T], State):
 
         self.sprites.draw(surface)
 
+    def set_transparent(self, is_transparent: bool) -> None:
+        """Sets the menu's transparency state."""
+        self.transparent = is_transparent
+
+        if not self.transparent:
+            self.load_graphics()
+
     def set_font(
         self,
         size: int = FONT_SIZE,


### PR DESCRIPTION
Changes:
- added `set_transparent(is_transparent)` method to allow runtime switching between transparent and opaque menu states
- ensures background and border graphics reload correctly when switching from transparent → opaque by invoking `load_graphics()` as needed
- prevents unnecessary reloads when switching to transparent, relying on existing draw‑time checks
- fixes initialization gap where menus created as transparent previously lacked loaded background/border graphics when later made opaque