### PR TITLE
Refactor menu input flow and extract `PygameMenu` input handling into a dedicated handler

### DIFF
--- a/tests/tuxemon/test_menu_cursor.py
+++ b/tests/tuxemon/test_menu_cursor.py
@@ -1,131 +1,140 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
 from unittest.mock import MagicMock
 
 import pygame
+import pytest
 
 from tuxemon.menu.cursor import MenuCursorController
 from tuxemon.sprite import SpriteGroup
 
 
-class TestMenuCursorController(unittest.TestCase):
+@pytest.fixture(scope="module", autouse=True)
+def pygame_env():
+    pygame.init()
+    pygame.display.set_mode((0, 0))
+    yield
+    pygame.quit()
 
-    @classmethod
-    def setUpClass(cls):
-        pygame.init()
-        pygame.display.set_mode((0, 0))
 
-    @classmethod
-    def tearDownClass(cls):
-        pygame.quit()
+@pytest.fixture
+def menu_sprites():
+    return SpriteGroup()
 
-    def setUp(self):
-        self.cursor_filename = "gfx/arrow.png"
-        self.menu_sprites = SpriteGroup()
-        self.get_selected_item = MagicMock(return_value=None)
-        self.animate = MagicMock(return_value=None)
-        self.duration = 1.0
-        self.remove_animations = MagicMock()
-        self.controller = MenuCursorController(
-            self.cursor_filename,
-            self.menu_sprites,
-            self.get_selected_item,
-            self.animate,
-            self.duration,
-            self.remove_animations,
+
+@pytest.fixture
+def controller(menu_sprites):
+    cursor_filename = "gfx/arrow.png"
+    get_selected_item = MagicMock(return_value=None)
+    animate = MagicMock(return_value=None)
+    duration = 1.0
+    remove_animations = MagicMock()
+    ctrl = MenuCursorController(
+        cursor_filename,
+        menu_sprites,
+        get_selected_item,
+        animate,
+        duration,
+        remove_animations,
+    )
+    return ctrl
+
+
+def test_init(controller, menu_sprites):
+    assert controller.arrow is not None
+    assert controller.sprites is menu_sprites
+    assert controller.get_item is controller.get_item
+    assert controller.animate is controller.animate
+    assert controller.duration == 1.0
+    assert controller.remove_animations is controller.remove_animations
+
+
+def test_get_margin(controller):
+    margin = controller.get_margin()
+    assert isinstance(margin, tuple)
+    assert len(margin) == 2
+
+
+def test_show_cursor(controller):
+    controller.hide_cursor()
+    controller.show_cursor()
+    assert controller.arrow in controller.sprites
+
+
+def test_hide_cursor(controller):
+    controller.show_cursor()
+    controller.hide_cursor()
+    assert controller.arrow not in controller.sprites
+
+
+@pytest.mark.parametrize("animate_flag", [True, False])
+def test_trigger_cursor_update(controller, animate_flag):
+    item = MagicMock()
+    item.rect.midleft = (10, 20)
+    controller.get_item.return_value = item
+    animation = controller.trigger_cursor_update(animate=animate_flag)
+    assert animation is None
+
+    if animate_flag:
+        controller.animate.assert_called_once()
+        controller.remove_animations.assert_called_once_with(
+            controller.arrow.rect
         )
-        self.arrow = self.controller.arrow
-        self.sprites = self.controller.sprites
+    else:
+        controller.animate.assert_not_called()
 
-    def test_init(self):
-        self.assertIsNotNone(self.controller.arrow)
-        self.assertEqual(self.controller.sprites, self.menu_sprites)
-        self.assertEqual(self.controller.get_item, self.get_selected_item)
-        self.assertEqual(self.controller.animate, self.animate)
-        self.assertEqual(self.controller.duration, self.duration)
-        self.assertEqual(
-            self.controller.remove_animations, self.remove_animations
-        )
 
-    def test_get_margin(self):
-        margin = self.controller.get_margin()
-        self.assertIsInstance(margin, tuple)
-        self.assertEqual(len(margin), 2)
+def test_trigger_cursor_update_no_item(controller):
+    controller.get_item.return_value = None
+    animation = controller.trigger_cursor_update(animate=True)
+    assert animation is None
 
-    def test_show_cursor(self):
-        self.controller.hide_cursor()
-        self.controller.show_cursor()
-        self.assertIn(self.arrow, self.sprites)
 
-    def test_hide_cursor(self):
-        self.controller.show_cursor()
-        self.controller.hide_cursor()
-        self.assertNotIn(self.arrow, self.sprites)
+def test_update_selection_focus(controller):
+    previous_item = MagicMock()
+    new_item = MagicMock()
+    controller.update_selection_focus(previous_item, new_item)
+    assert previous_item.in_focus is False
+    assert new_item.in_focus is True
+    previous_item.update_image.assert_called_once()
+    new_item.update_image.assert_called_once()
 
-    def test_trigger_cursor_update_animated(self):
-        item = MagicMock()
-        item.rect.midleft = (10, 20)
-        self.get_selected_item.return_value = item
-        animation = self.controller.trigger_cursor_update(animate=True)
-        self.assertIsNone(animation)
-        self.animate.assert_called_once()
-        self.remove_animations.assert_called_once_with(
-            self.controller.arrow.rect
-        )
 
-    def test_trigger_cursor_update_not_animated(self):
-        item = MagicMock()
-        item.rect.midleft = (10, 20)
-        self.get_selected_item.return_value = item
-        animation = self.controller.trigger_cursor_update(animate=False)
-        self.assertIsNone(animation)
-        self.animate.assert_not_called()
+def test_update_selection_focus_no_previous_item(controller):
+    new_item = MagicMock()
+    controller.update_selection_focus(None, new_item)
+    assert new_item.in_focus is True
+    new_item.update_image.assert_called_once()
 
-    def test_update_selection_focus(self):
-        previous_item = MagicMock()
-        new_item = MagicMock()
-        self.controller.update_selection_focus(previous_item, new_item)
-        previous_item.in_focus = False
-        new_item.in_focus = True
-        previous_item.update_image.assert_called_once()
-        new_item.update_image.assert_called_once()
 
-    def test_update_focus(self):
-        item = MagicMock()
-        self.controller._update_focus(item, True)
-        item.in_focus = True
-        item.update_image.assert_called_once()
+def test_update_selection_focus_no_new_item(controller):
+    previous_item = MagicMock()
+    controller.update_selection_focus(previous_item, None)
+    assert previous_item.in_focus is False
+    previous_item.update_image.assert_called_once()
 
-    def test_ensure_cursor_visible(self):
-        self.controller._ensure_cursor_visible(True)
-        self.assertIn(self.arrow, self.sprites)
-        self.controller._ensure_cursor_visible(False)
-        self.assertNotIn(self.arrow, self.sprites)
 
-    def test_trigger_cursor_update_no_item(self):
-        self.get_selected_item.return_value = None
-        animation = self.controller.trigger_cursor_update(animate=True)
-        self.assertIsNone(animation)
+def test_update_focus(controller):
+    item = MagicMock()
+    controller._update_focus(item, True)
+    assert item.in_focus is True
+    item.update_image.assert_called_once()
 
-    def test_update_selection_focus_no_previous_item(self):
-        new_item = MagicMock()
-        self.controller.update_selection_focus(None, new_item)
-        new_item.in_focus = True
-        new_item.update_image.assert_called_once()
 
-    def test_update_selection_focus_no_new_item(self):
-        previous_item = MagicMock()
-        self.controller.update_selection_focus(previous_item, None)
-        previous_item.in_focus = False
-        previous_item.update_image.assert_called_once()
+def test_ensure_cursor_visible(controller):
+    controller._ensure_cursor_visible(True)
+    assert controller.arrow in controller.sprites
+    controller._ensure_cursor_visible(False)
+    assert controller.arrow not in controller.sprites
 
-    def test_ensure_cursor_visible_already_visible(self):
-        self.controller.show_cursor()
-        self.controller._ensure_cursor_visible(True)
-        self.assertIn(self.arrow, self.sprites)
 
-    def test_ensure_cursor_visible_already_hidden(self):
-        self.controller.hide_cursor()
-        self.controller._ensure_cursor_visible(False)
-        self.assertNotIn(self.arrow, self.sprites)
+def test_ensure_cursor_visible_already_visible(controller):
+    controller.show_cursor()
+    controller._ensure_cursor_visible(True)
+    assert controller.arrow in controller.sprites
+
+
+def test_ensure_cursor_visible_already_hidden(controller):
+    controller.hide_cursor()
+    controller._ensure_cursor_visible(False)
+    assert controller.arrow not in controller.sprites

--- a/tests/tuxemon/test_menu_input_handler1.py
+++ b/tests/tuxemon/test_menu_input_handler1.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import Mock
+
+import pytest
+
+from tuxemon.menu.input_handler import MenuInputHandler
+from tuxemon.platform.const import buttons, intentions
+
+
+def make_event(button, pressed=True, value=None):
+    event = Mock()
+    event.button = button
+    event.pressed = pressed
+    event.value = value
+    return event
+
+
+def fake_menu_items(items):
+    menu_items = Mock()
+
+    menu_items_list = items
+
+    menu_items.__iter__ = lambda self=menu_items: iter(menu_items_list)
+    menu_items.__getitem__ = lambda self, i: menu_items_list[i]
+    menu_items.__len__ = lambda self: len(menu_items_list)
+
+    menu_items.rect = Mock()
+    menu_items.rect.left = 0
+    menu_items.rect.top = 0
+    menu_items.rect.collidepoint.return_value = False
+
+    menu_items.update_rect_from_parent = Mock()
+
+    return menu_items
+
+
+@pytest.fixture
+def menu():
+    menu = Mock()
+    menu.state_controller.is_enabled.return_value = True
+    menu.escape_key_exits = True
+    menu.touch_aware = True
+
+    item1 = Mock(enabled=True)
+    item1.rect.collidepoint.return_value = False
+
+    item2 = Mock(enabled=True)
+    item2.rect.collidepoint.return_value = False
+
+    menu.menu_items = fake_menu_items([item1, item2])
+    menu.selected_index = 0
+    menu.get_selected_item.return_value = item1
+
+    return menu
+
+
+@pytest.fixture
+def handler(menu):
+    return MenuInputHandler(menu)
+
+
+@pytest.mark.parametrize(
+    "button",
+    [
+        buttons.B,
+        buttons.BACK,
+        intentions.MENU_CANCEL,
+    ],
+)
+def test_escape_buttons_always_consume(handler, menu, button):
+    event = make_event(button)
+    assert handler.handle_event(event) is None
+
+
+@pytest.mark.parametrize(
+    "button",
+    [
+        buttons.A,
+        intentions.SELECT,
+    ],
+)
+def test_confirm_buttons_always_consume(handler, menu, button):
+    event = make_event(button)
+    assert handler.handle_event(event) is None
+
+
+@pytest.mark.parametrize(
+    "button",
+    [
+        buttons.UP,
+        buttons.DOWN,
+        buttons.LEFT,
+        buttons.RIGHT,
+    ],
+)
+def test_cursor_buttons_always_consume(handler, menu, button):
+    event = make_event(button)
+    assert handler.handle_event(event) is None
+
+
+def test_unhandled_button_propagates(handler, menu):
+    FAKE_BUTTON = object()
+    event = make_event(FAKE_BUTTON)
+    assert handler.handle_event(event) is event
+
+
+def test_no_enabled_items_prevents_confirm(handler, menu):
+    for item in menu.menu_items:
+        item.enabled = False
+
+    event = make_event(buttons.A, pressed=True)
+    result = handler.handle_event(event)
+
+    assert result is None
+    menu.on_menu_selection.assert_not_called()
+
+
+def test_empty_menu_prevents_interaction(handler, menu):
+    menu.menu_items = fake_menu_items([])
+
+    event = make_event(buttons.A, pressed=True)
+    result = handler.handle_event(event)
+
+    assert result is None
+    menu.on_menu_selection.assert_not_called()
+
+
+def test_disabled_menu_prevents_interaction(handler, menu):
+    menu.state_controller.is_enabled.return_value = False
+
+    event = make_event(buttons.A, pressed=True)
+    result = handler.handle_event(event)
+
+    assert result is None
+    menu.on_menu_selection.assert_not_called()
+
+
+def test_mouse_propagates_when_touch_aware_off(handler, menu):
+    menu.touch_aware = False
+    event = make_event(buttons.MOUSELEFT, value=(10, 10))
+    assert handler.handle_event(event) is event
+
+
+def test_mouse_click_outside_rect_propagates(handler, menu):
+    menu.menu_items.rect.collidepoint.return_value = False
+    event = make_event(buttons.MOUSELEFT, value=(999, 999))
+    assert handler.handle_event(event) is event
+
+
+def test_mouse_click_on_enabled_item_selects(handler, menu):
+    menu.menu_items.rect.collidepoint.return_value = True
+    menu.menu_items[1].rect.collidepoint.return_value = True
+
+    event = make_event(buttons.MOUSELEFT, value=(5, 5))
+    result = handler.handle_event(event)
+
+    assert result is None
+    menu.change_selection.assert_called_once_with(1)
+    menu.on_menu_selection.assert_called_once()
+
+
+def test_mouse_click_hits_no_item_propagates(handler, menu):
+    menu.menu_items.rect.collidepoint.return_value = True
+    for item in menu.menu_items:
+        item.rect.collidepoint.return_value = False
+
+    event = make_event(buttons.MOUSELEFT, value=(5, 5))
+    assert handler.handle_event(event) is event
+
+
+def test_mouse_invalid_position_raises(handler, menu):
+    event = make_event(buttons.MOUSELEFT, value="invalid")
+    with pytest.raises(ValueError):
+        handler.handle_event(event)

--- a/tests/tuxemon/test_menu_input_handler2.py
+++ b/tests/tuxemon/test_menu_input_handler2.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import Mock
+
+import pytest
+
+from tuxemon.menu.input_handler import PygameMenuInputHandler
+from tuxemon.platform.const import buttons, intentions
+
+
+@pytest.fixture
+def state():
+    state = Mock()
+
+    state.state_controller.is_interactive.return_value = True
+
+    state.menu.is_enabled.return_value = True
+    state.menu.update = Mock()
+    state.menu.get_selected_widget.return_value = "widget"
+
+    state.escape_key_exits = True
+
+    state.open = True
+
+    state.selected_widget = None
+
+    return state
+
+
+@pytest.fixture
+def handler(state):
+    return PygameMenuInputHandler(state)
+
+
+def make_event(button, pressed=True):
+    event = Mock()
+    event.button = button
+    event.pressed = pressed
+    return event
+
+
+def test_non_interactive_propagates(handler, state):
+    state.state_controller.is_interactive.return_value = False
+    event = make_event(buttons.A)
+    assert handler.handle_event(event) is event
+
+
+def test_disabled_menu_propagates(handler, state):
+    state.menu.is_enabled.return_value = False
+    event = make_event(buttons.A)
+    assert handler.handle_event(event) is event
+
+
+@pytest.mark.parametrize(
+    "button",
+    [
+        buttons.B,
+        buttons.BACK,
+        intentions.MENU_CANCEL,
+    ],
+)
+def test_escape_consumes_when_escape_key_exits_false(handler, state, button):
+    state.escape_key_exits = False
+    event = make_event(button)
+    assert handler.handle_event(event) is None
+
+
+@pytest.mark.parametrize(
+    "button",
+    [
+        buttons.B,
+        buttons.BACK,
+        intentions.MENU_CANCEL,
+    ],
+)
+def test_escape_propagates_when_escape_key_exits_true(handler, state, button):
+    state.escape_key_exits = True
+    event = make_event(button)
+    handler._convert_event = Mock(return_value=None)
+    assert handler.handle_event(event) is event
+
+
+def test_conversion_failure_propagates(handler, state):
+    handler._convert_event = Mock(return_value=None)
+    event = make_event(buttons.A)
+    assert handler.handle_event(event) is event
+
+
+def test_conversion_exception_propagates(handler, state):
+    handler._convert_event = Mock(side_effect=Exception("boom"))
+    event = make_event(buttons.A)
+    assert handler.handle_event(event) is event
+
+
+def test_menu_updates_when_open_and_pressed(handler, state):
+    pygame_event = Mock()
+    handler._convert_event = Mock(return_value=pygame_event)
+
+    event = make_event(buttons.A, pressed=True)
+    result = handler.handle_event(event)
+
+    assert result is None
+    state.menu.update.assert_called_once_with([pygame_event])
+    assert state.selected_widget == "widget"
+
+
+def test_menu_does_not_update_when_not_pressed(handler, state):
+    pygame_event = Mock()
+    handler._convert_event = Mock(return_value=pygame_event)
+
+    event = make_event(buttons.A, pressed=False)
+    result = handler.handle_event(event)
+
+    assert result is None
+    state.menu.update.assert_not_called()
+
+
+def test_menu_does_not_update_when_closed(handler, state):
+    state.open = False
+    pygame_event = Mock()
+    handler._convert_event = Mock(return_value=pygame_event)
+
+    event = make_event(buttons.A, pressed=True)
+    result = handler.handle_event(event)
+
+    assert result is None
+    state.menu.update.assert_not_called()
+
+
+def test_menu_update_exception_is_logged_and_consumed(handler, state):
+    pygame_event = Mock()
+    handler._convert_event = Mock(return_value=pygame_event)
+
+    state.menu.update.side_effect = Exception("update failed")
+
+    event = make_event(buttons.A, pressed=True)
+    result = handler.handle_event(event)
+
+    assert result is None
+    assert state.selected_widget is None

--- a/tuxemon/menu/events.py
+++ b/tuxemon/menu/events.py
@@ -1,22 +1,27 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from typing import Final, Optional
+from collections.abc import Callable
+from typing import Final
 
 import pygame
+from pygame.event import Event
 
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 
-_EVENT_MAP: Final = {
-    buttons.UP: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_UP),
-    buttons.DOWN: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_DOWN),
-    buttons.LEFT: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_LEFT),
-    buttons.RIGHT: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHT),
-    buttons.BACK: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE),
-    buttons.A: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN),
-    buttons.B: pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE),
+_EVENT_MAP: Final[dict[int, Callable[[], Event]]] = {
+    buttons.UP: lambda: Event(pygame.KEYDOWN, key=pygame.K_UP),
+    buttons.DOWN: lambda: Event(pygame.KEYDOWN, key=pygame.K_DOWN),
+    buttons.LEFT: lambda: Event(pygame.KEYDOWN, key=pygame.K_LEFT),
+    buttons.RIGHT: lambda: Event(pygame.KEYDOWN, key=pygame.K_RIGHT),
+    buttons.BACK: lambda: Event(pygame.KEYDOWN, key=pygame.K_ESCAPE),
+    buttons.A: lambda: Event(pygame.KEYDOWN, key=pygame.K_RETURN),
+    buttons.B: lambda: Event(pygame.KEYDOWN, key=pygame.K_ESCAPE),
 }
 
 
-def playerinput_to_event(event: PlayerInput) -> Optional[pygame.event.Event]:
-    return _EVENT_MAP.get(event.button)
+def playerinput_to_event(event: PlayerInput) -> Event | None:
+    factory = _EVENT_MAP.get(event.button)
+    if not factory:
+        return None
+    return factory()

--- a/tuxemon/menu/input_handler.py
+++ b/tuxemon/menu/input_handler.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+from tuxemon.menu.events import playerinput_to_event
+from tuxemon.platform.const import buttons, intentions
+
+if TYPE_CHECKING:
+    from pygame.event import Event
+
+    from tuxemon.menu.menu import Menu, PygameMenuState
+    from tuxemon.platform.events import PlayerInput
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", covariant=True)
+
+
+class InputHandler(Protocol):
+    def handle_event(self, event: PlayerInput) -> PlayerInput | None: ...
+
+
+class MenuInputHandler(InputHandler):
+    """
+    Handles input events for a Menu instance.
+
+    Returns:
+        None if the event was handled and should not propagate further.
+        The original event otherwise.
+    """
+
+    def __init__(self, menu: Menu[T]) -> None:
+        self._menu = menu
+
+    def handle_event(self, event: PlayerInput) -> PlayerInput | None:
+        if (
+            self._handle_escape(event)
+            or self._handle_confirm(event)
+            or self._handle_cursor(event)
+            or self._handle_mouse(event)
+        ):
+            return None
+        return event
+
+    def _menu_interactable(self) -> bool:
+        items = self._menu.menu_items
+        return (
+            self._menu.state_controller.is_enabled()
+            and len(items) > 0
+            and any(item.enabled for item in items)
+        )
+
+    def _valid_press(self, event: PlayerInput) -> bool:
+        return event.pressed and self._menu_interactable()
+
+    def _handle_escape(self, event: PlayerInput) -> bool:
+        if event.button not in (
+            buttons.B,
+            buttons.BACK,
+            intentions.MENU_CANCEL,
+        ):
+            return False
+
+        if event.pressed and self._menu.escape_key_exits:
+            self._menu.close()
+
+        return True
+
+    def _handle_confirm(self, event: PlayerInput) -> bool:
+        if event.button not in (buttons.A, intentions.SELECT):
+            return False
+
+        if self._valid_press(event):
+            self._menu.menu_select_sound.play()
+            selected = self._menu.get_selected_item()
+            if selected:
+                self._menu.on_menu_selection(selected)
+
+        return True
+
+    def _handle_cursor(self, event: PlayerInput) -> bool:
+        if event.button not in (
+            buttons.UP,
+            buttons.DOWN,
+            buttons.LEFT,
+            buttons.RIGHT,
+        ):
+            return False
+
+        if self._valid_press(event):
+            new_index = self._menu.menu_items.determine_cursor_movement(
+                self._menu.selected_index,
+                event,
+            )
+            if new_index != self._menu.selected_index:
+                self._menu.change_selection(new_index)
+
+        return True
+
+    def _handle_mouse(self, event: PlayerInput) -> bool:
+        if event.button != buttons.MOUSELEFT:
+            return False
+
+        if not self._menu.touch_aware:
+            return False
+
+        if not self._menu_interactable():
+            return False
+
+        mouse_pos = event.value
+        if not isinstance(mouse_pos, (tuple, list)) or len(mouse_pos) != 2:
+            raise ValueError(f"Invalid mouse_pos received: {mouse_pos}")
+
+        if hasattr(self._menu.menu_items, "update_rect_from_parent"):
+            self._menu.menu_items.update_rect_from_parent()
+
+        group_rect = self._menu.menu_items.rect
+
+        if not group_rect.collidepoint(mouse_pos):
+            return False  # allow propagation
+
+        local_pos = (
+            mouse_pos[0] - group_rect.left,
+            mouse_pos[1] - group_rect.top,
+        )
+
+        for index, item in enumerate(self._menu.menu_items):
+            if not item.enabled:
+                continue
+            if item.rect.collidepoint(local_pos):
+                self._menu.change_selection(index)
+                selected = self._menu.get_selected_item()
+                if not selected:
+                    raise RuntimeError(
+                        "Menu selection was None despite enabled item being clicked"
+                    )
+                self._menu.on_menu_selection(selected)
+                return True
+
+        return False
+
+
+class PygameMenuInputHandler(InputHandler):
+    """
+    Handles PlayerInput events for a PygameMenuState.
+
+    Returns:
+        None if the event was handled and should not propagate further.
+        The original event otherwise.
+    """
+
+    def __init__(self, state: PygameMenuState) -> None:
+        self._state = state
+
+    def handle_event(self, event: PlayerInput) -> PlayerInput | None:
+        if not self._state.state_controller.is_interactive():
+            return event
+
+        if not self._state.menu.is_enabled():
+            return event
+
+        if self._escape_consumes(event):
+            logger.debug("Escape consumed by PygameMenuInputHandler")
+            return None
+
+        try:
+            pygame_event = self._convert_event(event)
+        except Exception as e:
+            logger.error(f"Error converting PlayerInput to pygame event: {e}")
+            return event
+
+        if pygame_event is None:
+            return event
+
+        if self._state.open and event.pressed:
+            try:
+                self._state.menu.update([pygame_event])
+                self._state.selected_widget = (
+                    self._state.menu.get_selected_widget()
+                )
+            except Exception as e:
+                logger.error(f"Unexpected error in menu event processing: {e}")
+
+        return None
+
+    def _escape_consumes(self, event: PlayerInput) -> bool:
+        """
+        Escape buttons consume the event only when escape_key_exits is False.
+        """
+        if event.button not in (
+            buttons.B,
+            buttons.BACK,
+            intentions.MENU_CANCEL,
+        ):
+            return False
+
+        # If escape_key_exits is True, PygameMenuState handles closing itself.
+        # If escape_key_exits is False, we consume the event here.
+        return not self._state.escape_key_exits
+
+    def _convert_event(self, event: PlayerInput) -> Event | None:
+        """
+        Converts PlayerInput → pygame.Event using the adapter.
+        Returns None when the event cannot be mapped. Exceptions are caught by the caller.
+        """
+        try:
+            return playerinput_to_event(event)
+        except Exception as e:
+            logger.error(f"Error converting PlayerInput to pygame event: {e}")
+            return None

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import partial
@@ -29,10 +28,12 @@ from tuxemon.constants.asset_loader import fetch_asset
 from tuxemon.graphics import ColorLike, load_and_scale, load_image
 from tuxemon.menu.controller import MenuController
 from tuxemon.menu.cursor import MenuCursor, MenuCursorController
-from tuxemon.menu.events import playerinput_to_event
+from tuxemon.menu.input_handler import (
+    MenuInputHandler,
+    PygameMenuInputHandler,
+)
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.theme import get_sound_engine, get_theme
-from tuxemon.platform.const import buttons, intentions
 from tuxemon.platform.const.graphics import (
     BACKGROUND_COLOR,
     FONT_COLOR,
@@ -46,7 +47,6 @@ from tuxemon.platform.const.graphics import (
     UNAVAILABLE_COLOR,
     UNAVAILABLE_COLOR_SHOP,
 )
-from tuxemon.platform.events import PlayerInput
 from tuxemon.prepare import SCREEN_RECT
 from tuxemon.sprite import (
     RelativeGroup,
@@ -101,6 +101,7 @@ class PygameMenuState(State):
         theme = theme or get_theme()
         self._initialize_attributes()
         self._create_menu(width, height, theme, sound_engine, **kwargs)
+        self._input_handler = PygameMenuInputHandler(self)
 
     def _initialize_attributes(self) -> None:
         """
@@ -207,26 +208,7 @@ class PygameMenuState(State):
         Returns:
             Optional[PlayerInput]: The processed event or None if it's not handled.
         """
-        if (
-            not self.state_controller.is_interactive()
-            or not self.menu.is_enabled()
-        ):
-            return event
-
-        if (
-            event.button in {buttons.B, buttons.BACK, intentions.MENU_CANCEL}
-            and not self.escape_key_exits
-        ):
-            return None
-
-        try:
-            pygame_event = playerinput_to_event(event)
-            if self.open and event.pressed and pygame_event is not None:
-                self.menu.update([pygame_event])
-                self.selected_widget = self.menu.get_selected_widget()
-        except Exception as e:
-            logger.error(f"Unexpected error in menu event processing: {e}")
-        return event if pygame_event is None else None
+        return self._input_handler.handle_event(event)
 
     def draw(self, surface: Surface) -> None:
         """
@@ -400,7 +382,7 @@ class Menu(Generic[T], State):
         self.font = self.set_font()  # load default font
         self.load_graphics()  # load default graphics
         self.reload_sounds()  # load default sounds
-        self._input_handler: InputHandler = MenuInputHandler(self)
+        self._input_handler = MenuInputHandler(self)
         self._text_renderer = TextRenderer(
             font=self.font,
             font_filename=self.font_filename,
@@ -420,13 +402,6 @@ class Menu(Generic[T], State):
     @property
     def dialog(self) -> AlertManager:
         return self.client.alert_manager
-
-    def set_input_handler(self, handler: InputHandler) -> None:
-        """
-        Sets a new input handler for the menu, enabling dynamic replacement
-        of input processing logic.
-        """
-        self._input_handler = handler
 
     def create_new_menu_items_group(self) -> None:
         """
@@ -984,165 +959,3 @@ class PopUpMenu(Menu[T]):
             ScheduleType.ON_UPDATE,
         )
         return ani
-
-
-class InputHandler(ABC):
-    @abstractmethod
-    def handle_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        pass
-
-
-class MenuInputHandler(InputHandler):
-    """
-    Handles input events for a Menu instance.
-    """
-
-    def __init__(self, menu: Menu[T]) -> None:
-        self._menu = menu
-
-    def handle_event(self, event: PlayerInput) -> Optional[PlayerInput]:
-        """
-        Processes a single player input event.
-
-        This function is only called when the player provides input such
-        as pressing a key or clicking the mouse.
-
-        Since this is part of a chain of event handlers, the return value
-        from this method becomes input for the next one. Returning None
-        signifies that this method has dealt with an event and wants it
-        exclusively. Return the event and others can use it as well.
-
-        You should return None if you have handled input here.
-
-        Returns:
-            Passed input if not handled here. ``None`` otherwise.
-        """
-        if self._handle_escape_key(event):
-            return None
-        if self._handle_selection_confirm(event):
-            return None
-        if self._handle_cursor_movement(event):
-            return None
-        if self._handle_mouse_selection(event):
-            return None
-        return event
-
-    def _handle_escape_key(self, event: PlayerInput) -> bool:
-        """Handles events related to closing the menu."""
-        if event.button in (buttons.B, buttons.BACK, intentions.MENU_CANCEL):
-            if event.pressed and self._menu.escape_key_exits:
-                self._menu.close()
-            return True
-        return False
-
-    def _get_valid_change_condition(self, event: PlayerInput) -> bool:
-        """Determines if a menu change is currently valid."""
-        menu_items = self._menu.menu_items
-        disabled = all(not i.enabled for i in menu_items)
-        return (
-            event.pressed
-            and self._menu.state_controller.is_enabled()
-            and not disabled
-            and len(menu_items) > 0
-        )
-
-    def _handle_selection_confirm(self, event: PlayerInput) -> bool:
-        """Handles events related to confirming a menu selection."""
-        if event.button in (buttons.A, intentions.SELECT):
-            if self._get_valid_change_condition(event):
-                self._menu.menu_select_sound.play()
-                selected = self._menu.get_selected_item()
-                if selected:
-                    self._menu.on_menu_selection(selected)
-            return True
-        return False
-
-    def _handle_cursor_movement(self, event: PlayerInput) -> bool:
-        """Handles events related to moving the menu cursor."""
-        if event.button in (
-            buttons.UP,
-            buttons.DOWN,
-            buttons.LEFT,
-            buttons.RIGHT,
-        ):
-            if self._get_valid_change_condition(event):
-                index = self._menu.menu_items.determine_cursor_movement(
-                    self._menu.selected_index,
-                    event,
-                )
-                if self._menu.selected_index != index:
-                    self._menu.change_selection(index)
-            return True
-        return False
-
-    def _handle_mouse_selection(self, event: PlayerInput) -> bool:
-        """
-        Handles events related to mouse/touch selection of menu items.
-
-        TODOs:
-        - Handle click/drag interactions
-        - Add support for screen scaling
-        - Consider generalizing into a widget system
-
-        Parameters:
-            event: A PlayerInput event corresponding to MOUSELEFT.
-
-        Returns:
-            True if the event was handled, False otherwise.
-        """
-        if event.button == buttons.MOUSELEFT:
-            if self._menu.touch_aware and self._get_valid_change_condition(
-                event
-            ):
-                mouse_pos = event.value
-                if (
-                    not isinstance(mouse_pos, (list, tuple))
-                    or len(mouse_pos) != 2
-                ):
-                    raise ValueError(
-                        f"Invalid mouse_pos received: {mouse_pos}"
-                    )
-                if mouse_pos is None:
-                    logger.warning(
-                        f"Received unexpected mouse_pos value: {mouse_pos}"
-                    )
-                    return True  # Still consume the event, but log a warning
-
-                if hasattr(self._menu.menu_items, "update_rect_from_parent"):
-                    self._menu.menu_items.update_rect_from_parent()
-                else:
-                    logger.debug(
-                        "menu_items does not implement update_rect_from_parent"
-                    )
-                    return True  # Gracefully skip processing, but log a debug message
-
-                # Adjust mouse position relative to menu_items group
-                mouse_pos = [
-                    a - b
-                    for a, b in zip(
-                        mouse_pos,
-                        self._menu.menu_items.rect.topleft,
-                    )
-                ]
-
-                if not self._menu.menu_items.rect.collidepoint(mouse_pos):
-                    logger.debug(
-                        "Mouse click was outside the bounds of menu items."
-                    )
-                    return True
-
-                for index, item in enumerate(
-                    [i for i in self._menu.menu_items if i.enabled]
-                ):
-                    if item.rect.collidepoint(mouse_pos):
-                        self._menu.change_selection(index)
-                        selected = self._menu.get_selected_item()
-                        if selected:
-                            self._menu.on_menu_selection(selected)
-                        else:
-                            raise RuntimeError(
-                                "Menu selection was None despite enabled item being clicked"
-                            )
-                        return True
-            return True  # Mouse click occurred but not processed
-        return False


### PR DESCRIPTION
Changes:
- replaced the abstract base class with a Protocol and simplified the event‑handling chain
- centralized menu‑interaction checks into `_menu_interactable` and `_valid_press`, reducing duplication
- streamlined mouse handling and removed unnecessary event consumption.
- simplified cursor and selection logic with clearer naming and more direct control flow
- extracted all PygameMenu‑specific input processing from `PygameMenuState` into a standalone `PygameMenuInputHandler`, improving separation of concerns