### PR TITLE
Refactor `ConditionProcessor` to use explicit validation methods

### DIFF
--- a/tests/tuxemon/test_core_processor.py
+++ b/tests/tuxemon/test_core_processor.py
@@ -14,6 +14,7 @@ from tuxemon.core.core_effect import (
 from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
 from tuxemon.monster import Monster
 from tuxemon.session import Session
+from tuxemon.technique.technique import Technique
 
 
 @pytest.fixture
@@ -156,12 +157,12 @@ def target_monster():
 
 def test_no_conditions(session, target_monster):
     processor = ConditionProcessor([])
-    assert processor.validate(session, target_monster)
+    assert processor.validate_monster(session, target_monster).passed
 
 
 def test_no_target(session, core_condition):
     processor = ConditionProcessor([core_condition])
-    assert not processor.validate(session, None)
+    assert not processor.validate_monster(session, None).passed
 
 
 @pytest.mark.parametrize(
@@ -185,13 +186,15 @@ def test_condition_variants(
     core_condition.is_expected = is_expected
     core_condition.test_with_monster.return_value = test_result
     processor = ConditionProcessor([core_condition])
-    assert processor.validate(session, target_monster) == expected
+    assert (
+        processor.validate_monster(session, target_monster).passed == expected
+    )
 
 
 def test_invalid_condition_type(session, target_monster):
     invalid_condition = MagicMock()
     processor = ConditionProcessor([invalid_condition])
-    assert not processor.validate(session, target_monster)
+    assert not processor.validate_monster(session, target_monster).passed
 
 
 def test_multiple_conditions_all_pass(session, core_condition, target_monster):
@@ -201,7 +204,7 @@ def test_multiple_conditions_all_pass(session, core_condition, target_monster):
     another.is_expected = True
     another.test_with_monster.return_value = True
     processor = ConditionProcessor([core_condition, another])
-    assert processor.validate(session, target_monster)
+    assert processor.validate_monster(session, target_monster).passed
 
 
 def test_multiple_conditions_one_fails(
@@ -213,14 +216,14 @@ def test_multiple_conditions_one_fails(
     another.is_expected = True
     another.test_with_monster.return_value = False
     processor = ConditionProcessor([core_condition, another])
-    assert not processor.validate(session, target_monster)
+    assert not processor.validate_monster(session, target_monster).passed
 
 
 def test_method_invocation_count(session, core_condition, target_monster):
     core_condition.is_expected = True
     core_condition.test_with_monster.return_value = True
     processor = ConditionProcessor([core_condition])
-    processor.validate(session, target_monster)
+    processor.validate_monster(session, target_monster)
     core_condition.test_with_monster.assert_called_once_with(
         session, target_monster
     )
@@ -228,4 +231,24 @@ def test_method_invocation_count(session, core_condition, target_monster):
 
 def test_empty_conditions_with_none_target(session):
     processor = ConditionProcessor([])
-    assert processor.validate(session, None)
+    assert processor.validate_monster(session, None).passed
+
+
+def test_dispatch_to_technique_method(session):
+    cond = MagicMock(spec=CoreCondition)
+    cond.is_expected = True
+    cond.test_with_tech.return_value = True
+    target = MagicMock(spec=Technique)
+    processor = ConditionProcessor([cond])
+    assert processor.validate_tech(session, target)
+    cond.test_with_tech.assert_called_once_with(session, target)
+
+
+def test_monster_overrides_technique_method(session):
+    cond = MagicMock(spec=CoreCondition)
+    cond.is_expected = True
+    cond.test_with_monster.return_value = True
+    target = MagicMock(spec=Monster)
+    processor = ConditionProcessor([cond])
+    assert processor.validate_monster(session, target).passed
+    cond.test_with_monster.assert_called_once()

--- a/tuxemon/core/core_condition.py
+++ b/tuxemon/core/core_condition.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from tuxemon.session import Session
 from tuxemon.tools import cast_dataclass_parameters
 
 if TYPE_CHECKING:
+    from tuxemon.db import SpatialCondition
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
     from tuxemon.status.status import Status
@@ -32,59 +33,26 @@ class CoreCondition:
     def __post_init__(self) -> None:
         cast_dataclass_parameters(self)
 
+    def test(self, session: Session, condition: SpatialCondition) -> bool:
+        """Test conditions related to SpatialCondition's attributes."""
+        return False
+
     def test_with_monster(self, session: Session, target: Monster) -> bool:
         """Test conditions related to a Monster's attributes."""
-        logger.info(f"Testing {target.name} for condition {self.name}")
+        logger.debug(f"Testing {target.name} for condition {self.name}")
         return True
 
     def test_with_item(self, session: Session, target: Item) -> bool:
         """Test conditions related to a Item's attributes."""
-        logger.info(f"Testing {target.name} for condition {self.name}")
+        logger.debug(f"Testing {target.name} for condition {self.name}")
         return True
 
     def test_with_tech(self, session: Session, target: Technique) -> bool:
         """Test conditions related to a Technique's attributes."""
-        logger.info(f"Testing {target.name} for condition {self.name}")
+        logger.debug(f"Testing {target.name} for condition {self.name}")
         return True
 
     def test_with_status(self, session: Session, target: Status) -> bool:
         """Test conditions related to a Status's attributes."""
-        logger.info(f"Testing {target.name} for condition {self.name}")
-        return True
-
-    def test_multiple_targets(
-        self, session: Session, targets: list[Any]
-    ) -> bool:
-        """
-        Validate all conditions for multiple targets using the appropriate test methods.
-        """
-        if not targets:
-            logger.warning("No targets provided for validation.")
-            return False
-
-        failed_targets = []
-
-        for target in targets:
-            target_type = target.__class__.__name__.lower()
-            test_method_name = f"test_with_{target_type}"
-
-            test_method = getattr(self, test_method_name, None)
-            if test_method is None:
-                logger.warning(
-                    f"Missing test method '{test_method_name}' for target: {target}"
-                )
-                failed_targets.append(target)
-                continue
-
-            try:
-                if not test_method(session, target):
-                    failed_targets.append(target)
-            except Exception as e:
-                logger.error(f"Error while testing target {target_type}: {e}")
-                failed_targets.append(target)
-
-        if failed_targets:
-            logger.info(f"Validation failed for targets: {failed_targets}")
-            return False
-
+        logger.debug(f"Testing {target.name} for condition {self.name}")
         return True

--- a/tuxemon/core/core_processor.py
+++ b/tuxemon/core/core_processor.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional, Union
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
 
 from tuxemon.core.core_condition import CoreCondition
 from tuxemon.core.core_effect import (
@@ -17,6 +18,7 @@ from tuxemon.core.core_effect import (
 from tuxemon.plugin import PluginObject
 
 if TYPE_CHECKING:
+    from tuxemon.db import SpatialCondition
     from tuxemon.item.item import Item
     from tuxemon.monster import Monster
     from tuxemon.session import Session
@@ -24,6 +26,13 @@ if TYPE_CHECKING:
     from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConditionValidationResult:
+    passed: bool
+    missing_methods: list[str]
+    errors: list[str]
 
 
 class EffectProcessor:
@@ -166,41 +175,74 @@ class ConditionProcessor:
     def __init__(self, conditions: Sequence[PluginObject]) -> None:
         self.conditions = conditions
 
-    def _validate_condition(
+    def _call(
         self,
         session: Session,
-        condition: PluginObject,
-        target: Union[Monster, Item, Status, Technique],
+        condition: CoreCondition,
+        method_name: str,
+        target: object,
     ) -> bool:
-        """
-        Validate conditions dynamically based on the target's attributes.
-        """
-        if not isinstance(condition, CoreCondition):
-            return False
-
-        target_type = target.__class__.__name__.lower()
-        test_method_name = f"test_with_{target_type}"
-
-        try:
-            test_method = getattr(condition, test_method_name)
-            return condition.is_expected == bool(test_method(session, target))
-        except AttributeError:
+        method = getattr(condition, method_name, None)
+        if method is None:
             logger.error(
-                f"Missing required method: {test_method_name} for {target_type}"
+                f"Missing required method: {method_name} in {condition}"
             )
             return False
+        return condition.is_expected == bool(method(session, target))
 
-    def validate(
+    def _validate(
         self,
         session: Session,
-        target: Optional[Union[Monster, Item, Status, Technique]],
-    ) -> bool:
-        if not self.conditions:
-            return True
-        if target is None:
-            return False
+        target: object,
+        method_name: str,
+    ) -> ConditionValidationResult:
+        result = ConditionValidationResult(True, [], [])
 
-        return all(
-            self._validate_condition(session, condition, target)
-            for condition in self.conditions
-        )
+        for cond in self.conditions:
+            if not isinstance(cond, CoreCondition):
+                result.passed = False
+                result.errors.append("Condition is not a CoreCondition")
+                continue
+
+            method = getattr(cond, method_name, None)
+            if method is None:
+                result.passed = False
+                result.missing_methods.append(method_name)
+                continue
+
+            try:
+                ok = bool(method(session, target))
+            except Exception as e:
+                result.passed = False
+                result.errors.append(str(e))
+                continue
+
+            if cond.is_expected != ok:
+                result.passed = False
+
+        return result
+
+    def validate(
+        self, session: Session, target: SpatialCondition | None
+    ) -> ConditionValidationResult:
+        return self._validate(session, target, "test")
+
+    def validate_monster(
+        self, session: Session, target: Monster | None
+    ) -> ConditionValidationResult:
+        return self._validate(session, target, "test_with_monster")
+
+    def validate_item(
+        self, session: Session, target: Item | None
+    ) -> ConditionValidationResult:
+        return self._validate(session, target, "test_with_item")
+
+    def validate_tech(
+        self, session: Session, target: Technique | None
+    ) -> ConditionValidationResult:
+        return self._validate(session, target, "test_with_tech")
+
+    def validate_status(
+        self, session: Session, target: Status | None
+    ) -> ConditionValidationResult:
+        return self._validate(session, target, "test_with_status")

--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -12,7 +12,11 @@ from pygame.surface import Surface
 from tuxemon import graphics
 from tuxemon.core.asset import get_assets
 from tuxemon.core.core_effect import ItemEffectResult
-from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
+from tuxemon.core.core_processor import (
+    ConditionProcessor,
+    ConditionValidationResult,
+    EffectProcessor,
+)
 from tuxemon.database.runtime import db
 from tuxemon.db import (
     ExperienceMethod,
@@ -244,7 +248,17 @@ class Item:
         """
         Check if the target meets all conditions that the item has on it's use.
         """
-        return self.condition_handler.validate(session=session, target=target)
+        return self.condition_handler.validate_monster(
+            session=session, target=target
+        ).passed
+
+    def debug_validate_monster(
+        self, session: Session, target: Monster
+    ) -> ConditionValidationResult:
+        """Developer API: returns full structured validation result."""
+        return self.condition_handler.validate_monster(
+            session=session, target=target
+        )
 
     def use(
         self, session: Session, user: NPC, target: Monster | None

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -9,7 +9,11 @@ from uuid import UUID, uuid4
 
 from tuxemon.core.asset import get_assets
 from tuxemon.core.core_effect import StatusEffectResult
-from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
+from tuxemon.core.core_processor import (
+    ConditionProcessor,
+    ConditionValidationResult,
+    EffectProcessor,
+)
 from tuxemon.database.runtime import db
 from tuxemon.db import (
     CategoryStatus,
@@ -211,7 +215,17 @@ class Status:
         """
         Check if the target meets all conditions that the status has on its use.
         """
-        return self.condition_handler.validate(session=session, target=target)
+        return self.condition_handler.validate_monster(
+            session=session, target=target
+        ).passed
+
+    def debug_validate_monster(
+        self, session: Session, target: Monster
+    ) -> ConditionValidationResult:
+        """Developer API: returns full structured validation result."""
+        return self.condition_handler.validate_monster(
+            session=session, target=target
+        )
 
     def set_linked_monster(self, monster: Monster) -> None:
         """Assigns a linked monster that benefits from this status."""

--- a/tuxemon/technique/technique.py
+++ b/tuxemon/technique/technique.py
@@ -9,7 +9,11 @@ from uuid import UUID, uuid4
 
 from tuxemon.core.asset import get_assets
 from tuxemon.core.core_effect import TechEffectResult
-from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
+from tuxemon.core.core_processor import (
+    ConditionProcessor,
+    ConditionValidationResult,
+    EffectProcessor,
+)
 from tuxemon.database.runtime import db
 from tuxemon.db import (
     MenuAction,
@@ -173,7 +177,17 @@ class Technique:
         """
         Check if the target meets all conditions that the technique has on its use.
         """
-        return self.condition_handler.validate(session=session, target=target)
+        return self.condition_handler.validate_monster(
+            session=session, target=target
+        ).passed
+
+    def debug_validate_monster(
+        self, session: Session, target: Monster
+    ) -> ConditionValidationResult:
+        """Developer API: returns full structured validation result."""
+        return self.condition_handler.validate_monster(
+            session=session, target=target
+        )
 
     def recharge(self, amount: int = 1) -> None:
         self.cooldown.tick(amount)


### PR DESCRIPTION
Changes:
- introduced explicit validation entry points for each target type, replacing dynamic method lookup
- added shared `_validate` and `_call` helpers to centralize logic and improve error reporting
- improved clarity and maintainability by making required condition methods explicit
- replaced boolean validation with a `ConditionValidationResult` object to expose detailed errors and missing methods  
- added optional `debug_validate_*` entry points to access full validation diagnostics without breaking the existing boolean API