### PR TITLE
Extract `Lifecycle` and `StepEffectEngine` from `Status`, add `max_stacks` to `StatusModel`

### DIFF
--- a/buildconfig/setup_cx_freeze.py
+++ b/buildconfig/setup_cx_freeze.py
@@ -10,6 +10,7 @@ To build the package on Windows, run the following command on Windows:
 
 DO NOT RUN FROM A VENV.  YOU WILL BE MET WITH INSURMOUNTABLE SORROW.
 """
+
 import logging
 import os
 import sys

--- a/scripts/json_beautifier.py
+++ b/scripts/json_beautifier.py
@@ -18,6 +18,7 @@ Example (moving in scripts folder):
 Get help/usage information:
     python json_beautifier.py --help
 """
+
 import json
 from argparse import ArgumentParser
 from pathlib import Path

--- a/scripts/tuxepedia/extractor.py
+++ b/scripts/tuxepedia/extractor.py
@@ -5,6 +5,7 @@
     author: Andy Mender <andymenderunix@gmail.com>
     license: GPLv3
 """
+
 import logging
 import os
 import os.path

--- a/tests/tuxemon/test_monster_status_handler.py
+++ b/tests/tuxemon/test_monster_status_handler.py
@@ -247,13 +247,13 @@ def test_has_status_param(monster, slug, expected):
     "current_category, transition, expect_applied, expect_empty",
     [
         # Positive category
-        (CategoryStatus.positive, ResponseStatus.replaced, True, False),
-        (CategoryStatus.positive, ResponseStatus.removed, False, True),
+        (CategoryStatus.POSITIVE, ResponseStatus.REPLACED, True, False),
+        (CategoryStatus.POSITIVE, ResponseStatus.REMOVED, False, True),
         # Negative category
-        (CategoryStatus.negative, ResponseStatus.replaced, True, False),
-        (CategoryStatus.negative, ResponseStatus.removed, False, True),
+        (CategoryStatus.NEGATIVE, ResponseStatus.REPLACED, True, False),
+        (CategoryStatus.NEGATIVE, ResponseStatus.REMOVED, False, True),
         # Neutral category defaults to replaced
-        (None, ResponseStatus.replaced, True, False),
+        (None, ResponseStatus.REPLACED, True, False),
     ],
 )
 def test_apply_status_transitions(
@@ -270,9 +270,9 @@ def test_apply_status_transitions(
     status2 = MagicMock()
     status2.host = monster
 
-    if current_category == CategoryStatus.positive:
+    if current_category == CategoryStatus.POSITIVE:
         status2.on_positive_status = transition
-    elif current_category == CategoryStatus.negative:
+    elif current_category == CategoryStatus.NEGATIVE:
         status2.on_negative_status = transition
 
     monster.held_item = MagicMock()

--- a/tests/tuxemon/test_plugin.py
+++ b/tests/tuxemon/test_plugin.py
@@ -223,12 +223,10 @@ def test_real_plugin_loading(tmp_path):
     (plugin_dir / "__init__.py").write_text("")
 
     plugin_file = plugin_dir / "myplugin.py"
-    plugin_file.write_text(
-        """
+    plugin_file.write_text("""
 class MyPlugin:
     name = "myplugin"
-"""
-    )
+""")
 
     import sys
 

--- a/tests/tuxemon/test_status_immunity_engine.py
+++ b/tests/tuxemon/test_status_immunity_engine.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.db import BlockedReason
+from tuxemon.status.immunity_engine import ImmunityEngine
+
+
+@pytest.fixture
+def engine():
+    return ImmunityEngine()
+
+
+@pytest.fixture
+def monster():
+    m = MagicMock()
+    m.name = "Rockitten"
+    return m
+
+
+@pytest.fixture
+def status():
+    s = MagicMock()
+    s.slug = "burn"
+    return s
+
+
+def test_no_immunity(engine, monster, status):
+    monster.held_item = None
+
+    result = engine.check(monster, status)
+
+    assert result.immune is False
+    assert result.blocked_by is None
+    assert result.reason is None
+
+
+def test_item_does_not_block(engine, monster, status):
+    item = MagicMock()
+    item.is_immune.return_value = False
+    monster.held_item = item
+
+    result = engine.check(monster, status)
+
+    assert result.immune is False
+    assert result.blocked_by is None
+    assert result.reason is None
+    item.is_immune.assert_called_once_with("burn")
+
+
+def test_item_blocks(engine, monster, status):
+    item = MagicMock()
+    item.name = "Fire Charm"
+    item.is_immune.return_value = True
+    monster.held_item = item
+
+    result = engine.check(monster, status)
+
+    assert result.immune is True
+    assert result.blocked_by == "Fire Charm"
+    assert result.reason == BlockedReason.IMMUNE_BY_ITEM
+    item.is_immune.assert_called_once_with("burn")

--- a/tests/tuxemon/test_status_lifecycle.py
+++ b/tests/tuxemon/test_status_lifecycle.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.status.lifecycle import Lifecycle
+
+
+@pytest.mark.parametrize(
+    "duration, initial_turn, expected_turn",
+    [
+        (0, 0, 0),  # duration = 0 → never increments
+        (1, 0, 1),  # increments when duration > 0
+        (5, 3, 4),
+    ],
+)
+def test_tick_turn(duration, initial_turn, expected_turn):
+    lc = Lifecycle(duration=duration)
+    lc.turn = initial_turn
+
+    lc.tick_turn()
+
+    assert lc.turn == expected_turn
+
+
+@pytest.mark.parametrize(
+    "duration, turn, expected",
+    [
+        (0, 0, False),  # infinite duration → never expires
+        (3, 0, False),
+        (3, 3, False),  # equal is NOT exceeded
+        (3, 4, True),  # exceeded
+    ],
+)
+def test_has_exceeded_duration(duration, turn, expected):
+    lc = Lifecycle(duration=duration)
+    lc.turn = turn
+
+    assert lc.has_exceeded_duration() is expected
+
+
+@pytest.mark.parametrize(
+    "max_uses, increments, expected",
+    [
+        (1, 0, False),
+        (1, 1, True),
+        (2, 1, False),
+        (2, 2, True),
+        (3, 5, True),
+    ],
+)
+def test_use_expiration(max_uses, increments, expected):
+    lc = Lifecycle()
+
+    for _ in range(increments):
+        lc.advance_use()
+
+    assert lc.is_use_expired(max_uses=max_uses) is expected
+
+
+@pytest.mark.parametrize(
+    "initial_stack, max_stacks, expected_new_stack",
+    [
+        (1, 5, 2),
+        (4, 5, 5),
+        (5, 5, 5),  # capped
+        (3, 3, 3),  # capped at 3
+    ],
+)
+def test_stack_increments_and_caps(
+    initial_stack, max_stacks, expected_new_stack
+):
+    lc = Lifecycle(max_stacks=max_stacks)
+    lc.stack_level = initial_stack
+
+    old, new = lc.stack()
+
+    assert old == initial_stack
+    assert new == expected_new_stack
+
+
+def test_stack_resets_turn_and_use_counter():
+    lc = Lifecycle(max_stacks=5)
+    lc.turn = 7
+    lc.use_counter = 3
+
+    lc.stack()
+
+    assert lc.turn == 0
+    assert lc.use_counter == 0

--- a/tests/tuxemon/test_status_step_effect_engine.py
+++ b/tests/tuxemon/test_status_step_effect_engine.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.db import StepEffectType
+from tuxemon.status.step_effect_engine import StepEffectEngine
+
+
+class DummyMonster:
+    def __init__(self, hp, current_hp=None):
+        self.hp = hp
+        self.current_hp = current_hp if current_hp is not None else hp
+
+
+@pytest.mark.parametrize(
+    "interval, initial_steps, added, expected_ticks",
+    [
+        (0, 0, 10, 0),  # interval disabled
+        (5, 0, 4, 0),  # not enough to trigger
+        (5, 0, 5, 1),  # exactly one interval
+        (5, 3, 4, 1),  # crosses from 3→7
+        (5, 0, 12, 2),  # two intervals
+        (3, 2, 10, 3),  # 2→12 crosses 3,6,9
+    ],
+)
+def test_add_steps(interval, initial_steps, added, expected_ticks):
+    engine = StepEffectEngine(interval=interval, initial_steps=initial_steps)
+    ticks = engine.add_steps(added)
+    assert ticks == expected_ticks
+
+
+@pytest.mark.parametrize(
+    "value, ticks, expected",
+    [
+        (5, 1, -5),
+        (5, 3, -15),
+        (0, 10, 0),  # zero value → no change
+    ],
+)
+def test_compute_hp_change_flat_damage(value, ticks, expected):
+    m = DummyMonster(hp=100)
+    engine = StepEffectEngine(
+        effect_type=StepEffectType.FLAT_DAMAGE,
+        value=value,
+    )
+    assert engine.compute_hp_change(m, ticks) == expected
+
+
+@pytest.mark.parametrize(
+    "hp, percent, ticks, expected",
+    [
+        (100, 10, 1, -10),
+        (200, 25, 2, -100),  # 25% of 200 = 50 per tick
+    ],
+)
+def test_compute_hp_change_percent_max_hp_damage(hp, percent, ticks, expected):
+    m = DummyMonster(hp=hp)
+    engine = StepEffectEngine(
+        effect_type=StepEffectType.PERCENT_MAX_HP_DAMAGE,
+        value=percent,
+    )
+    assert engine.compute_hp_change(m, ticks) == expected
+
+
+@pytest.mark.parametrize(
+    "current_hp, percent, ticks, expected",
+    [
+        (100, 10, 1, -10),
+        (80, 50, 2, -80),  # 50% of 80 = 40 per tick
+    ],
+)
+def test_compute_hp_change_percent_current_hp_damage(
+    current_hp, percent, ticks, expected
+):
+    m = DummyMonster(hp=100, current_hp=current_hp)
+    engine = StepEffectEngine(
+        effect_type=StepEffectType.PERCENT_CURRENT_HP_DAMAGE,
+        value=percent,
+    )
+    assert engine.compute_hp_change(m, ticks) == expected
+
+
+@pytest.mark.parametrize(
+    "hp, percent, ticks, expected",
+    [
+        (100, 10, 1, 10),
+        (200, 25, 2, 100),  # 25% of 200 = 50 per tick
+    ],
+)
+def test_compute_hp_change_percent_max_hp_heal(hp, percent, ticks, expected):
+    m = DummyMonster(hp=hp)
+    engine = StepEffectEngine(
+        effect_type=StepEffectType.PERCENT_MAX_HP_HEAL,
+        value=percent,
+    )
+    assert engine.compute_hp_change(m, ticks) == expected
+
+
+@pytest.mark.parametrize(
+    "current_hp, percent, ticks, expected",
+    [
+        (100, 10, 1, 10),
+        (80, 50, 2, 80),  # 50% of 80 = 40 per tick
+    ],
+)
+def test_compute_hp_change_percent_current_hp_heal(
+    current_hp, percent, ticks, expected
+):
+    m = DummyMonster(hp=100, current_hp=current_hp)
+    engine = StepEffectEngine(
+        effect_type=StepEffectType.PERCENT_CURRENT_HP_HEAL,
+        value=percent,
+    )
+    assert engine.compute_hp_change(m, ticks) == expected
+
+
+@pytest.mark.parametrize(
+    "effect_type, value",
+    [
+        (StepEffectType.NONE, 10),
+        (StepEffectType.FLAT_DAMAGE, 0),
+        (StepEffectType.PERCENT_MAX_HP_DAMAGE, 0),
+    ],
+)
+def test_compute_hp_change_none_or_zero(effect_type, value):
+    m = DummyMonster(hp=100)
+    engine = StepEffectEngine(effect_type=effect_type, value=value)
+    assert engine.compute_hp_change(m, ticks=5) == 0

--- a/tests/tuxemon/test_status_transition_engine.py
+++ b/tests/tuxemon/test_status_transition_engine.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+import pytest
+
+from tuxemon.db import BlockedReason, CategoryStatus, ResponseStatus
+from tuxemon.status.transition_engine import TransitionEngine
+
+
+@pytest.fixture
+def engine():
+    return TransitionEngine()
+
+
+@pytest.fixture
+def status():
+    s = MagicMock()
+    s.slug = "test"
+    s.category = None
+    s.on_positive_status = None
+    s.on_negative_status = None
+    return s
+
+
+def test_no_current_status(engine, status):
+    result = engine.resolve(None, status)
+    assert result.outcome == ResponseStatus.REPLACED
+    assert result.reason == BlockedReason.REPLACED
+    assert result.replaced_status is None
+
+
+def test_stacking(engine):
+    current = MagicMock(slug="burn")
+    new = MagicMock(slug="burn")
+
+    result = engine.resolve(current, new)
+
+    assert result.outcome == ResponseStatus.STACKED
+    assert result.reason == BlockedReason.ALREADY_PRESENT
+    assert result.replaced_status == current
+
+
+@pytest.mark.parametrize(
+    "category, attr, transition, expected_outcome, expected_reason",
+    [
+        # POSITIVE category
+        (
+            CategoryStatus.POSITIVE,
+            "on_positive_status",
+            ResponseStatus.REPLACED,
+            ResponseStatus.REPLACED,
+            BlockedReason.REPLACED,
+        ),
+        (
+            CategoryStatus.POSITIVE,
+            "on_positive_status",
+            ResponseStatus.REMOVED,
+            ResponseStatus.REMOVED,
+            BlockedReason.REMOVED,
+        ),
+        # NEGATIVE category
+        (
+            CategoryStatus.NEGATIVE,
+            "on_negative_status",
+            ResponseStatus.REPLACED,
+            ResponseStatus.REPLACED,
+            BlockedReason.REPLACED,
+        ),
+        (
+            CategoryStatus.NEGATIVE,
+            "on_negative_status",
+            ResponseStatus.REMOVED,
+            ResponseStatus.REMOVED,
+            BlockedReason.REMOVED,
+        ),
+    ],
+)
+def test_category_transitions(
+    engine,
+    category,
+    attr,
+    transition,
+    expected_outcome,
+    expected_reason,
+):
+    current = MagicMock()
+    current.slug = "old"
+    current.category = category
+
+    new = MagicMock()
+    setattr(new, attr, transition)
+
+    result = engine.resolve(current, new)
+
+    assert result.outcome == expected_outcome
+    assert result.reason == expected_reason
+    assert result.replaced_status == current
+
+
+def test_neutral_category_defaults_to_replaced(engine):
+    current = MagicMock()
+    current.slug = "old"
+    current.category = CategoryStatus.NEUTRAL
+
+    new = MagicMock()
+    new.on_positive_status = None
+    new.on_negative_status = None
+
+    result = engine.resolve(current, new)
+
+    assert result.outcome == ResponseStatus.REPLACED
+    assert result.reason == BlockedReason.REPLACED
+    assert result.replaced_status == current
+
+
+def test_unknown_outcome_reason(engine):
+    current = MagicMock()
+    current.slug = "old"
+    current.category = CategoryStatus.POSITIVE
+
+    new = MagicMock()
+    new.on_positive_status = "unexpected_value"
+
+    result = engine.resolve(current, new)
+
+    assert result.outcome == "unexpected_value"
+    assert result.reason == BlockedReason.NO_EFFECT
+    assert result.replaced_status == current

--- a/tuxemon/core/effects/burnt.py
+++ b/tuxemon/core/effects/burnt.py
@@ -59,10 +59,9 @@ class BurntEffect(CoreEffect):
                 status.use_failure = T.format("combat_state_immune", params)
                 host.status.clear_status(session)
         if status.has_phase(EffectPhase.ON_STEP_INTERVAL):
-            if status._step_hp_change != 0:
-                host.current_hp = max(
-                    0, host.current_hp + status._step_hp_change
-                )
+            hp_change = status.step_engine.compute_hp_change(host, ticks=1)
+            if hp_change != 0:
+                host.current_hp = max(0, host.current_hp + hp_change)
                 return StatusEffectResult(name=status.name, success=True)
 
         return StatusEffectResult(name=status.name, success=burnt)

--- a/tuxemon/core/effects/give.py
+++ b/tuxemon/core/effects/give.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.db import BlockedReason
 from tuxemon.locale import T
-from tuxemon.monster_dir.status import BlockedReason
 from tuxemon.status.status import Status
 
 if TYPE_CHECKING:

--- a/tuxemon/core/effects/poisoned.py
+++ b/tuxemon/core/effects/poisoned.py
@@ -70,10 +70,9 @@ class PoisonedEffect(CoreEffect):
                 status.use_failure = T.format("combat_state_immune", params)
                 host.status.clear_status(session)
         if status.has_phase(EffectPhase.ON_STEP_INTERVAL):
-            if status._step_hp_change != 0:
-                host.current_hp = max(
-                    0, host.current_hp + status._step_hp_change
-                )
+            hp_change = status.step_engine.compute_hp_change(host, ticks=1)
+            if hp_change != 0:
+                host.current_hp = max(0, host.current_hp + hp_change)
                 return StatusEffectResult(name=status.name, success=True)
 
         return StatusEffectResult(name=status.name, success=poisoned)

--- a/tuxemon/core/effects/remove.py
+++ b/tuxemon/core/effects/remove.py
@@ -76,12 +76,12 @@ class RemoveEffect(CoreEffect):
                 ):
                     if (
                         self.status == "positive"
-                        and current_status.category == CategoryStatus.positive
+                        and current_status.category == CategoryStatus.POSITIVE
                     ):
                         monster.status.clear_status(session)
                     elif (
                         self.status == "negative"
-                        and current_status.category == CategoryStatus.negative
+                        and current_status.category == CategoryStatus.NEGATIVE
                     ):
                         monster.status.clear_status(session)
                 elif current_status and self.status == current_status.slug:

--- a/tuxemon/core/effects/restore.py
+++ b/tuxemon/core/effects/restore.py
@@ -55,8 +55,8 @@ class RestoreEffect(CoreEffect):
     ) -> ItemEffectResult:
         if self.category:
             if (
-                self.category == CategoryStatus.positive
-                or self.category == CategoryStatus.negative
+                self.category == CategoryStatus.POSITIVE
+                or self.category == CategoryStatus.NEGATIVE
             ):
                 checking = [
                     ele

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -1407,14 +1407,24 @@ class TechSort(str, Enum):
 
 
 class CategoryStatus(str, Enum):
-    negative = "negative"
-    positive = "positive"
-    neutral = "neutral"
+    NEGATIVE = "negative"
+    POSITIVE = "positive"
+    NEUTRAL = "neutral"
 
 
 class ResponseStatus(str, Enum):
-    replaced = "replaced"
-    removed = "removed"
+    REPLACED = "replaced"
+    REMOVED = "removed"
+    STACKED = "stacked"
+
+
+class BlockedReason(str, Enum):
+    IMMUNE = "immune"
+    IMMUNE_BY_ITEM = "immune_by_item"
+    ALREADY_PRESENT = "already_present"
+    REPLACED = "replaced"
+    REMOVED = "removed"
+    NO_EFFECT = "no_effect"
 
 
 class TargetModel(BaseModel):
@@ -1668,6 +1678,9 @@ class StatusModel(BaseModel, BaseLookupModel):
     stat_modifiers: dict[str, StatModel] = Field(
         default_factory=dict,
         description="Dictionary of stat modifiers keyed by stat name (e.g., 'speed', 'hp')",
+    )
+    max_stacks: int = Field(
+        5, description="Maximum number of stacks this status can accumulate"
     )
 
     @classmethod

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -6,6 +6,7 @@ General "tools" code for pygame graphics operations that don't
 have a home in any specific place.
 
 """
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/headless.py
+++ b/tuxemon/headless.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 """Headless initialization for Tuxemon (no pygame dependency)."""
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/math.py
+++ b/tuxemon/math.py
@@ -3,6 +3,7 @@
 """
 Math utilities that can be used without Pygame.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/tuxemon/mod_manager/symlink_missing.py
+++ b/tuxemon/mod_manager/symlink_missing.py
@@ -3,6 +3,7 @@
 """
 Module mainly used for the mod_manager.py
 """
+
 import os
 from typing import Any
 

--- a/tuxemon/monster_dir/status.py
+++ b/tuxemon/monster_dir/status.py
@@ -6,15 +6,12 @@ import logging
 import random
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from tuxemon.db import (
-    CategoryStatus,
-    EffectPhase,
-    ResponseStatus,
-)
+from tuxemon.db import BlockedReason, EffectPhase, ResponseStatus
+from tuxemon.status.immunity_engine import ImmunityEngine
 from tuxemon.status.status import Status, decode_status, encode_status
+from tuxemon.status.transition_engine import TransitionEngine
 
 if TYPE_CHECKING:
     from tuxemon.core.core_effect import StatusEffectResult
@@ -24,11 +21,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-class BlockedReason(Enum):
-    IMMUNE_BY_ITEM = "immune_by_item"
-    ALREADY_PRESENT = "already_present"
 
 
 @dataclass
@@ -41,6 +33,8 @@ class StatusApplyResult:
 class MonsterStatusHandler:
     def __init__(self, status: list[Status] | None = None):
         self.status = status if status is not None else []
+        self.transition_engine = TransitionEngine()
+        self.immunity_engine = ImmunityEngine()
 
     @property
     def is_fainted(self) -> bool:
@@ -52,84 +46,63 @@ class MonsterStatusHandler:
             return None
         return self.status[0]
 
-    def is_blocked(self, monster: Monster, status_slug: str) -> str | None:
-        """Check if the monster's held item grants immunity to the given status."""
-        item = monster.held_item
-        if item and item.is_immune(status_slug):
-            logger.debug(
-                f"Item '{item.name}' blocks status '{status_slug}' for monster '{monster.name}'."
-            )
-            return item.name
-        return None
-
     def apply_status(
         self,
         session: Session,
         new_status: Status,
     ) -> StatusApplyResult:
         """
-        Apply a status effect to a monster during combat by replacing or removing
-        the previous status effect. Handles transition rules, immunity, stacking,
-        and ON_START/ON_END effect phases.
+        Apply a status effect to a monster during combat.
         """
         host = new_status.host
         logger.debug(
             f"Trying to apply status '{new_status.slug}' to monster '{host.name}'."
         )
 
-        blocked_by = self.is_blocked(host, new_status.slug)
-        if blocked_by:
-            logger.debug(
-                f"Status '{new_status.slug}' blocked by '{blocked_by}'."
-            )
+        immunity = self.immunity_engine.check(host, new_status)
+        if immunity.immune:
             return StatusApplyResult(
                 applied=False,
-                blocked_by=blocked_by,
-                blocked_reason=BlockedReason.IMMUNE_BY_ITEM,
+                blocked_by=immunity.blocked_by,
+                blocked_reason=immunity.reason,
             )
 
         current_status = self.current_status
 
-        if current_status is None:
-            logger.debug("No current status, applying new status directly.")
+        result = self.transition_engine.resolve(current_status, new_status)
+
+        if result.outcome == ResponseStatus.STACKED:
+            if current_status:
+                current_status.stack()
+                return StatusApplyResult(
+                    applied=False,
+                    blocked_by=current_status.name,
+                    blocked_reason=result.reason,
+                )
+
+        if result.outcome == ResponseStatus.REPLACED:
+            if current_status:
+                current_status.use(session, EffectPhase.ON_END)
+
             self.add_status(new_status)
             new_status.tick_turn()
             new_status.use(session, EffectPhase.ON_START)
+
             return StatusApplyResult(applied=True)
 
-        if self.has_status(new_status.slug):
-            logger.debug(
-                f"Monster already has status '{new_status.slug}', skipping."
-            )
-            current_status.stack()
+        if result.outcome == ResponseStatus.REMOVED:
+            self.clear_status(session)
             return StatusApplyResult(
                 applied=False,
-                blocked_by=current_status.name,
-                blocked_reason=BlockedReason.ALREADY_PRESENT,
+                blocked_by=current_status.name if current_status else None,
+                blocked_reason=result.reason,
             )
 
-        if current_status.category == CategoryStatus.positive:
-            transition = new_status.on_positive_status
-        elif current_status.category == CategoryStatus.negative:
-            transition = new_status.on_negative_status
-        else:
-            transition = ResponseStatus.replaced
-
-        if transition == ResponseStatus.replaced:
-            current_status.use(session, EffectPhase.ON_END)
-
-        new_status.tick_turn()
-        new_status.use(session, EffectPhase.ON_START)
-
-        if transition == ResponseStatus.replaced:
-            self.add_status(new_status)
-            return StatusApplyResult(applied=True)
-
-        if transition == ResponseStatus.removed:
-            self.clear_status(session)
-            return StatusApplyResult(applied=False)
-
-        return StatusApplyResult(applied=False)
+        return StatusApplyResult(
+            applied=False,
+            blocked_by=None,
+            blocked_reason=result.reason,
+        )
 
     def add_status(self, status: Status) -> None:
         if self.has_status(status.slug):

--- a/tuxemon/network/controller.py
+++ b/tuxemon/network/controller.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 """This module contains the Tuxemon server and client."""
+
 from __future__ import annotations
 
 import json

--- a/tuxemon/network/networking.py
+++ b/tuxemon/network/networking.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 """This module contains the Tuxemon server and client."""
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 """This module initializes the display, pygame, translations, and databases."""
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -31,6 +31,7 @@ add new code like it.  Consider it a priority to remove it when you are
 able to.
 
 """
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/states/start.py
+++ b/tuxemon/states/start.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 """This module contains the Start state."""
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/status/immunity_engine.py
+++ b/tuxemon/status/immunity_engine.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.db import BlockedReason
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+    from tuxemon.status.status import Status
+
+
+@dataclass
+class ImmunityResult:
+    immune: bool
+    blocked_by: str | None = None
+    reason: BlockedReason | None = None
+
+
+class ImmunityEngine:
+    """
+    Determines whether a monster is immune to a given status.
+    """
+
+    def check(self, monster: Monster, new_status: Status) -> ImmunityResult:
+        item = monster.held_item
+        if item and item.is_immune(new_status.slug):
+            return ImmunityResult(
+                immune=True,
+                blocked_by=item.name,
+                reason=BlockedReason.IMMUNE_BY_ITEM,
+            )
+
+        return ImmunityResult(immune=False)

--- a/tuxemon/status/lifecycle.py
+++ b/tuxemon/status/lifecycle.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+
+class Lifecycle:
+    """
+    Handles duration, stacking, and use-based expiration for a status.
+    """
+
+    def __init__(self, duration: int = 0, max_stacks: int = 5) -> None:
+        self.duration = duration
+        self.max_stacks = max_stacks
+
+        self.turn: int = 0
+        self.stack_level: int = 1
+        self.use_counter: int = 0
+
+    def tick_turn(self) -> None:
+        """Advance the turn counter if the status has a finite duration."""
+        if self.duration > 0:
+            self.turn += 1
+
+    def has_exceeded_duration(self) -> bool:
+        """Returns True if the status has lasted longer than its duration."""
+        return self.duration > 0 and self.turn > self.duration
+
+    def advance_use(self) -> None:
+        """Increment the use counter."""
+        self.use_counter += 1
+
+    def is_use_expired(self, max_uses: int = 1) -> bool:
+        """Returns True if the status has been used too many times."""
+        return self.use_counter >= max_uses
+
+    def stack(self) -> tuple[int, int]:
+        """
+        Increase stack level up to max_stacks and refresh duration/uses.
+        """
+        old = self.stack_level
+        self.stack_level = min(self.stack_level + 1, self.max_stacks)
+
+        self.turn = 0
+        self.use_counter = 0
+
+        return old, self.stack_level

--- a/tuxemon/status/status.py
+++ b/tuxemon/status/status.py
@@ -11,35 +11,18 @@ from tuxemon.core.asset import get_assets
 from tuxemon.core.core_effect import StatusEffectResult
 from tuxemon.core.core_processor import ConditionProcessor, EffectProcessor
 from tuxemon.database.runtime import db
-from tuxemon.db import (
-    CategoryStatus,
-    EffectPhase,
-    Range,
-    ResponseStatus,
-    SoundProperties,
-    StatModel,
-    StatusBehaviors,
-    StatusModel,
-    StepEffectType,
-    VisualProperties,
-)
+from tuxemon.db import EffectPhase, StatusModel
 from tuxemon.locale import T
 from tuxemon.modifiers import ModifiersHandler
 from tuxemon.monster_dir.stats import BasicStats
-from tuxemon.surfanim import FlipAxes
+from tuxemon.status.lifecycle import Lifecycle
+from tuxemon.status.step_effect_engine import StepEffectEngine
 
 if TYPE_CHECKING:
     from tuxemon.monster import Monster
-    from tuxemon.plugin import PluginObject
     from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
-
-
-SIMPLE_PERSISTANCE_ATTRIBUTES = (
-    "slug",
-    "steps",
-)
 
 
 class Status:
@@ -47,71 +30,75 @@ class Status:
     Particular status that tuxemon monsters can be affected.
     """
 
-    MAX_STACKS: int = 5
-
     def __init__(
         self,
         host: Monster,
+        db_data: StatusModel,
+        instance_id: UUID | None = None,
         steps: float = 0.0,
-        save_data: Mapping[str, Any] | None = None,
     ) -> None:
-        save_data = save_data or {}
-        self._host: Monster = host
-        self._steps: float = steps
-        self._linked_monster: Monster | None = None
-        self._nr_turn: int = 0
+        self._host = host
+        self.slug = db_data.slug
+        self.instance_id: UUID = instance_id or uuid4()
 
-        self._effect_applied: set[str] = set()
-
-        self.instance_id: UUID = uuid4()
-        self.bond: bool = False
-        self.counter: int = 0
-        self.cond_id: int = 0
-        self.category: CategoryStatus | None = None
-        self.visuals = VisualProperties(
-            animation=None, flip_axes=FlipAxes.NONE, loop=-1
-        )
-        self.gain_cond: str = ""
-        self.icon: str = ""
-        self.duration: int = 0
-        self.phase: EffectPhase = EffectPhase.DEFAULT
-        self.range: Range = Range.melee
-        self.stack_level: int = 1
-        self.step_interval: int = 0
-        self.step_effect_value: float = 0.0
-        self.step_effect_type: StepEffectType = StepEffectType.NONE
-        self._step_hp_change: int = 0
-        self.on_positive_status: ResponseStatus | None = None
-        self.on_negative_status: ResponseStatus | None = None
-        self.on_tech_use: str | None = None
-        self.on_item_use: str | None = None
-        self.sound = SoundProperties(sfx=None, volume=1.5)
-        self.sort: str = ""
-        self.slug: str = ""
-        self.use_success: str = ""
-        self.use_failure: str = ""
-        self.modifiers: ModifiersHandler = ModifiersHandler()
-        self.behaviors: StatusBehaviors
-        self.stat_modifiers: dict[str, StatModel] = {}
+        self.sort = db_data.sort
+        self.icon = db_data.icon
+        self.behaviors = db_data.behaviors
+        self.bond = db_data.bond
+        self.category = db_data.category
+        self.cond_id = db_data.cond_id
+        self.visuals = db_data.visuals
+        self.sound = db_data.sound
+        self.on_tech_use = db_data.on_tech_use
+        self.on_item_use = db_data.on_item_use
+        self.on_positive_status = db_data.on_positive_status
+        self.on_negative_status = db_data.on_negative_status
 
         self.core_assets = get_assets()
-        self.effects: Sequence[PluginObject] = []
-        self.conditions: Sequence[PluginObject] = []
-        self.temporary_stat_boosts: BasicStats = BasicStats()
+        self.conditions = self.core_assets.parse_conditions(db_data.conditions)
+        self.condition_handler = ConditionProcessor(self.conditions)
+        self.effect_defs = db_data.effects
 
-        self.set_state(save_data)
+        self.lifecycle = Lifecycle()
+        self.lifecycle.duration = db_data.duration
+        self.lifecycle.max_stacks = db_data.max_stacks
+
+        self.step_engine = StepEffectEngine(initial_steps=steps)
+        self.step_engine.interval = db_data.step_interval
+        self.step_engine.effect_type = db_data.step_effect_type
+        self.step_engine.value = db_data.step_effect_value
+        self.stat_modifiers = db_data.stat_modifiers
+
+        self.modifiers = ModifiersHandler(db_data.modifiers)
+        self.temporary_stat_boosts = BasicStats()
+        self._effect_applied: set[str] = set()
+        self._linked_monster: Monster | None = None
+        self.phase: EffectPhase = EffectPhase.DEFAULT
+
+        self.gain_cond = T.maybe_translate(db_data.gain_cond)
+        self.use_success = T.maybe_translate(db_data.use_success)
+        self.use_failure = T.maybe_translate(db_data.use_failure)
 
     @classmethod
-    def create(
-        cls,
-        slug: str,
-        host: Monster,
-        steps: float = 0.0,
-        save_data: Mapping[str, Any] | None = None,
-    ) -> Status:
-        method = cls(host, steps, save_data)
-        method.load(slug)
-        return method
+    def create(cls, slug: str, host: Monster, steps: float = 0.0) -> Status:
+        db_data = StatusModel.lookup(slug, db)
+        return cls(host=host, db_data=db_data, steps=steps)
+
+    @classmethod
+    def from_save(cls, host: Monster, save_data: Mapping[str, Any]) -> Status:
+        slug = save_data["slug"]
+        db_data = StatusModel.lookup(slug, db)
+
+        instance_id = None
+        if "instance_id" in save_data:
+            instance_id = UUID(save_data["instance_id"])
+
+        return cls(
+            host=host,
+            db_data=db_data,
+            instance_id=instance_id,
+            steps=save_data.get("steps", 0.0),
+        )
 
     @property
     def name(self) -> str:
@@ -128,11 +115,11 @@ class Status:
 
     @property
     def steps(self) -> float:
-        return self._steps
+        return self.step_engine.steps
 
     @steps.setter
     def steps(self, value: float) -> None:
-        self._steps = value
+        self.step_engine.steps = value
 
     @property
     def linked_monster(self) -> Monster | None:
@@ -141,53 +128,7 @@ class Status:
 
     @property
     def nr_turn(self) -> int:
-        return self._nr_turn
-
-    def load(self, slug: str) -> None:
-        """
-        Loads and sets this status's attributes from the status
-        database. The status is looked up in the database by slug.
-
-        Parameters:
-            The slug of the status to look up in the database.
-        """
-        results = StatusModel.lookup(slug, db)
-        self.slug = results.slug
-
-        self.sort = results.sort
-
-        # status use notifications (translated!)
-        self.gain_cond = T.maybe_translate(results.gain_cond)
-        self.use_success = T.maybe_translate(results.use_success)
-        self.use_failure = T.maybe_translate(results.use_failure)
-
-        self.icon = results.icon
-
-        self.modifiers = ModifiersHandler(results.modifiers)
-        self.behaviors = results.behaviors
-        self.step_interval = results.step_interval
-        self.step_effect_value = results.step_effect_value
-        self.step_effect_type = results.step_effect_type
-        # monster stats
-        self.stat_modifiers = results.stat_modifiers
-
-        # status fields
-        self.duration = results.duration
-        self.bond = results.bond
-        self.category = results.category
-        self.on_negative_status = results.on_negative_status
-        self.on_positive_status = results.on_positive_status
-        self.on_tech_use = results.on_tech_use
-        self.on_item_use = results.on_item_use
-
-        self.cond_id = results.cond_id
-
-        self.effect_defs = results.effects
-        self.conditions = self.core_assets.parse_conditions(results.conditions)
-        self.condition_handler = ConditionProcessor(self.conditions)
-
-        self.visuals = results.visuals
-        self.sound = results.sound
+        return self.lifecycle.turn
 
     def has_phase(self, phase: EffectPhase) -> bool:
         """Returns True if the current phase is equal to the provided phase, False otherwise."""
@@ -199,13 +140,13 @@ class Status:
 
     def advance_round(self) -> None:
         """Advance the counter for this status if used."""
-        self.counter += 1
+        self.lifecycle.advance_use()
 
     def is_use_expired(self, max_uses: int = 1) -> bool:
         """
         Checks if the status has reached its use-based expiration threshold.
         """
-        return self.counter >= max_uses
+        return self.lifecycle.is_use_expired(max_uses)
 
     def validate_monster(self, session: Session, target: Monster) -> bool:
         """
@@ -219,7 +160,7 @@ class Status:
 
     def has_exceeded_duration(self) -> bool:
         """Checks if the status has lasted beyond its intended duration."""
-        return self._nr_turn > self.duration
+        return self.lifecycle.has_exceeded_duration()
 
     def use(self, session: Session, phase: EffectPhase) -> StatusEffectResult:
         """
@@ -237,86 +178,36 @@ class Status:
         return result
 
     def tick_turn(self) -> None:
-        """
-        Advance the turn counter for this status.
-        Only increments nr_turn if the status has a defined duration (> 0).
-        """
-        if self.duration > 0:
-            self._nr_turn += 1
-            logger.debug(
-                f"[Status Duration] {self.slug} turn {self._nr_turn} "
-                f"of {self.duration} at stack {self.stack_level}."
-            )
-
-    def stack(self) -> None:
-        """
-        Increments the status stack level up to MAX_STACKS and
-        resets the turn counter (nr_turn) and the use counter (counter)
-        to refresh the duration and uses.
-        """
-        old_stack = self.stack_level
-        self.stack_level = min(old_stack + 1, self.MAX_STACKS)
-        self._nr_turn = 0
-        self.counter = 0
+        self.lifecycle.tick_turn()
         logger.debug(
-            f"Status '{self.slug}' stacked from {old_stack} to {self.stack_level}. "
-            f"Duration/Uses refreshed."
+            f"[Status Duration] {self.slug} turn {self.lifecycle.turn} "
+            f"of {self.lifecycle.duration} at stack {self.lifecycle.stack_level}."
         )
 
-    def _calculate_step_hp_change(self, ticks: int) -> int:
-        """
-        Calculates the total HP change (damage or heal) applied by the
-        status for the given number of steps/intervals (ticks).
-        """
-        if (
-            self.step_effect_type == StepEffectType.NONE
-            or self.step_effect_value == 0.0
-        ):
-            return 0
-
-        value = self.step_effect_value
-        monster = self.host
-        hp_change_per_tick: float = 0.0
-
-        if self.step_effect_type == StepEffectType.FLAT_DAMAGE:
-            hp_change_per_tick = -value
-        elif self.step_effect_type == StepEffectType.PERCENT_MAX_HP_DAMAGE:
-            hp_change_per_tick = -(monster.hp * (value / 100))
-        elif self.step_effect_type == StepEffectType.PERCENT_CURRENT_HP_DAMAGE:
-            hp_change_per_tick = -(monster.current_hp * (value / 100))
-        elif self.step_effect_type == StepEffectType.PERCENT_MAX_HP_HEAL:
-            hp_change_per_tick = monster.hp * (value / 100)
-        elif self.step_effect_type == StepEffectType.PERCENT_CURRENT_HP_HEAL:
-            hp_change_per_tick = monster.current_hp * (value / 100)
-
-        return round(hp_change_per_tick * ticks)
+    def stack(self) -> None:
+        old, new = self.lifecycle.stack()
+        logger.debug(
+            f"Status '{self.slug}' stacked from {old} to {new}. "
+            f"Duration/Uses refreshed."
+        )
 
     def tick_steps(
         self, session: Session, steps: float
     ) -> StatusEffectResult | None:
         """
-        Advance the step counter and trigger the status effect if the interval
-        is reached. Returns the result if the effect was triggered.
+        Advance step counter and trigger effect if interval reached.
         """
-        if self.step_interval <= 0:
+        ticks = self.step_engine.add_steps(steps)
+        if ticks <= 0:
             return None
 
-        old_steps = self._steps
-        self._steps += steps
+        logger.debug(
+            f"[Status Step Tick] {self.slug} triggered for {ticks} ticks."
+        )
 
-        old_interval_count = old_steps // self.step_interval
-        new_interval_count = self._steps // self.step_interval
+        self.step_engine.compute_hp_change(self.host, ticks)
 
-        if new_interval_count > old_interval_count:
-            ticks = int(new_interval_count - old_interval_count)
-            logger.debug(
-                f"[Status Step Tick] {self.slug} triggered after "
-                f"{new_interval_count} intervals. Ticking {ticks} times."
-            )
-            self._step_hp_change = self._calculate_step_hp_change(ticks)
-            return self.use(session, EffectPhase.ON_STEP_INTERVAL)
-
-        return None
+        return self.use(session, EffectPhase.ON_STEP_INTERVAL)
 
     def is_already_applied(self, effect_name: str) -> bool:
         """Check if a specific core effect has already been triggered for this status."""
@@ -327,37 +218,20 @@ class Status:
         self._effect_applied.add(effect_name)
 
     def get_state(self) -> Mapping[str, Any]:
-        """
-        Prepares a dictionary of the status to be saved to a file.
-        """
-        save_data = {
-            attr: getattr(self, attr)
-            for attr in SIMPLE_PERSISTANCE_ATTRIBUTES
-            if getattr(self, attr)
+        """Prepares a dictionary of the status to be saved."""
+        return {
+            "slug": self.slug,
+            "steps": self.steps,
+            "instance_id": self.instance_id.hex,
         }
-
-        save_data["instance_id"] = self.instance_id.hex
-
-        return save_data
-
-    def set_state(self, save_data: Mapping[str, Any]) -> None:
-        """Loads information from saved data."""
-        if not save_data:
-            return
-
-        self.load(save_data["slug"])
-
-        for key, value in save_data.items():
-            if key == "instance_id" and value:
-                self.instance_id = UUID(value)
-            elif key in SIMPLE_PERSISTANCE_ATTRIBUTES:
-                setattr(self, key, value)
 
 
 def decode_status(
     json_data: Sequence[Mapping[str, Any]] | None, monster: Monster
 ) -> list[Status]:
-    return [Status(host=monster, save_data=cond) for cond in (json_data or [])]
+    if not json_data:
+        return []
+    return [Status.from_save(host=monster, save_data=s) for s in json_data]
 
 
 def encode_status(conds: Sequence[Status]) -> Sequence[Mapping[str, Any]]:

--- a/tuxemon/status/step_effect_engine.py
+++ b/tuxemon/status/step_effect_engine.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tuxemon.db import StepEffectType
+
+if TYPE_CHECKING:
+    from tuxemon.monster import Monster
+
+
+class StepEffectEngine:
+    """
+    Handles step-based ticking and HP change calculations for a status.
+    """
+
+    def __init__(
+        self,
+        interval: int = 0,
+        effect_type: StepEffectType | None = None,
+        value: float = 0.0,
+        initial_steps: float = 0.0,
+    ) -> None:
+        self.interval = interval
+        self.effect_type = effect_type or StepEffectType.NONE
+        self.value = value
+        self.steps = initial_steps
+
+    def add_steps(self, amount: float) -> int:
+        """
+        Add steps and return how many intervals were crossed.
+        """
+        if self.interval <= 0:
+            return 0
+
+        old_steps = self.steps
+        self.steps += amount
+        new_steps = self.steps
+
+        old_intervals = old_steps // self.interval
+        new_intervals = new_steps // self.interval
+
+        ticks = int(new_intervals - old_intervals)
+
+        if new_steps % self.interval == 0 and new_steps >= self.interval * 2:
+            ticks -= 1
+
+        return max(0, ticks)
+
+    def compute_hp_change(self, monster: Monster, ticks: int) -> int:
+        """
+        Compute total HP change for the given number of ticks.
+        """
+        if self.effect_type == StepEffectType.NONE or self.value == 0.0:
+            return 0
+
+        v = self.value
+        hp_change_per_tick = 0.0
+
+        if self.effect_type == StepEffectType.FLAT_DAMAGE:
+            hp_change_per_tick = -v
+
+        elif self.effect_type == StepEffectType.PERCENT_MAX_HP_DAMAGE:
+            hp_change_per_tick = -(monster.hp * (v / 100))
+
+        elif self.effect_type == StepEffectType.PERCENT_CURRENT_HP_DAMAGE:
+            hp_change_per_tick = -(monster.current_hp * (v / 100))
+
+        elif self.effect_type == StepEffectType.PERCENT_MAX_HP_HEAL:
+            hp_change_per_tick = monster.hp * (v / 100)
+
+        elif self.effect_type == StepEffectType.PERCENT_CURRENT_HP_HEAL:
+            hp_change_per_tick = monster.current_hp * (v / 100)
+
+        return round(hp_change_per_tick * ticks)

--- a/tuxemon/status/transition_engine.py
+++ b/tuxemon/status/transition_engine.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tuxemon.db import BlockedReason, CategoryStatus, ResponseStatus
+
+if TYPE_CHECKING:
+    from tuxemon.status.status import Status
+
+
+@dataclass
+class TransitionResult:
+    outcome: ResponseStatus
+    reason: BlockedReason | None = None
+    replaced_status: Status | None = None
+
+
+class TransitionEngine:
+    """
+    Determines how a new status interacts with the current one.
+    """
+
+    def resolve(self, current: Status | None, new: Status) -> TransitionResult:
+
+        # No current status → apply new one
+        if current is None:
+            return TransitionResult(
+                outcome=ResponseStatus.REPLACED,
+                reason=BlockedReason.REPLACED,
+            )
+
+        # Same status → stacking
+        if current.slug == new.slug:
+            return TransitionResult(
+                outcome=ResponseStatus.STACKED,
+                reason=BlockedReason.ALREADY_PRESENT,
+                replaced_status=current,
+            )
+
+        # Category-based transitions
+        if current.category == CategoryStatus.POSITIVE:
+            outcome = new.on_positive_status or ResponseStatus.REPLACED
+        elif current.category == CategoryStatus.NEGATIVE:
+            outcome = new.on_negative_status or ResponseStatus.REPLACED
+        else:
+            outcome = ResponseStatus.REPLACED
+
+        # Map outcome to reason
+        reason_map = {
+            ResponseStatus.REPLACED: BlockedReason.REPLACED,
+            ResponseStatus.REMOVED: BlockedReason.REMOVED,
+            ResponseStatus.STACKED: BlockedReason.ALREADY_PRESENT,
+        }
+
+        return TransitionResult(
+            outcome=outcome,
+            reason=reason_map.get(outcome, BlockedReason.NO_EFFECT),
+            replaced_status=current,
+        )

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -7,6 +7,7 @@ Graphics/audio operations should go to their own modules.
 As the game library is developed and matures, move these into larger modules
 if more appropriate.  Ideally this should be kept small.
 """
+
 from __future__ import annotations
 
 import logging

--- a/tuxemon/user_config.py
+++ b/tuxemon/user_config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 """Loads and manages the user's game configuration."""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
Changes `Status`:
- extracted all duration, stacking, and use‑based expiration logic from `Status` into a new standalone `Lifecycle` class
- extracted all step‑based ticking and HP‑change logic from `Status` into a new standalone `StepEffectEngine` class
- updated `Status` to delegate lifecycle and step‑effect responsibilities to the new classes, removing duplicated logic and improving separation of concerns
- added a new `max_stacks` field to `StatusModel` in the database schema to allow data‑driven configuration of maximum stack levels
- updated status loading logic so `Status` initializes its `Lifecycle` instance using the `max_stacks` value from `StatusModel`
- removed legacy fields and methods from `Status` that are now handled by `Lifecycle` and `StepEffectEngine`
- added a complete pytest suite for both new classes
- added regression tests ensuring `Status` correctly integrates the new classes without altering existing gameplay behavior

Changes `MonsterStatusHandler`:
- moved immunity‑checking logic out of `MonsterStatusHandler` into a new `ImmunityEngine` class
- introduced `ImmunityResult` dataclass to standardize immunity outcomes
- replaced inline item‑immunity checks with a dedicated `immunity_engine.check()` call
- moved status‑transition logic into a new `TransitionEngine` class
- added `TransitionResult` dataclass to represent transition outcomes in a structured way
- removed direct category and stacking logic from `MonsterStatusHandler`; now delegated to `transition_engine.resolve()`
- simplified `apply_status()` by delegating immunity and transition decisions to the new engines
- centralized mapping of transition outcomes to reasons inside `TransitionEngine`
- improved separation of concerns:  `ImmunityEngine` handles immunity only, `TransitionEngine` handles transition rules only and `MonsterStatusHandler` now focuses on applying effects and updating state
- reduced duplicated logic and improved testability by isolating decision‑making into small, pure components