### PR TITLE
Refactor `Element` and `Shape` Systems to Use Single‑Phase Initialization, Centralized Loading, and Immutable Templates

### DIFF
--- a/tests/tuxemon/test_element_types_handler.py
+++ b/tests/tuxemon/test_element_types_handler.py
@@ -26,9 +26,9 @@ def elements():
     }
 
     return {
-        "fire": Element("fire"),
-        "metal": Element("metal"),
-        "aether": Element("aether"),
+        "fire": Element.get("fire"),
+        "metal": Element.get("metal"),
+        "aether": Element.get("aether"),
     }
 
 
@@ -50,15 +50,14 @@ def test_init_with_types(handler):
 
 def test_set_types(elements):
     basic = ElementTypesHandler()
-    basic.set_types([elements["fire"], elements["metal"]])
-    assert len(basic.current) == 2
+    basic.set_types(["fire", "metal"])
+    assert basic.get_type_slugs() == ["fire", "metal"]
 
 
 def test_reset_to_default(handler):
-    new_element = Element("metal")
-    handler.set_types([new_element])
+    handler.set_types(["metal"])
     handler.reset_to_default()
-    assert len(handler.current) == 2
+    assert handler.get_type_slugs() == ["metal", "fire"]
 
 
 def test_get_type_slugs(handler):
@@ -128,3 +127,173 @@ def test_resistance(elements, defenders, attacker, expected_fn):
         dfn, attacker
     )
     assert score == expected_fn(elements)
+
+
+def test_lookup_multiplier_missing_entry(elements):
+    fire = elements["fire"]
+    assert fire.lookup_multiplier("nonexistent") == 1.0
+
+
+def test_set_types_with_unknown_slug():
+    handler = ElementTypesHandler()
+    handler.set_types(["unknown_slug"])
+    assert handler.get_type_slugs() == ["unknown_slug"]
+    elem = Element.get("unknown_slug")
+    assert elem.slug == "unknown_slug"
+    assert elem.types == []
+
+
+def test_primary_raises_on_empty():
+    handler = ElementTypesHandler()
+    with pytest.raises(ValueError):
+        _ = handler.primary
+
+
+def test_affinity_aether_user(elements):
+    atk = [elements["aether"]]
+    dfn = [elements["fire"]]
+    score = ElementTypesHandler.calculate_affinity_score(atk, dfn)
+    assert score == 1.0
+
+
+def test_affinity_aether_target(elements):
+    atk = [elements["fire"]]
+    dfn = [elements["aether"]]
+    score = ElementTypesHandler.calculate_affinity_score(atk, dfn)
+    assert score == 1.0
+
+
+def test_resistance_aether_defender(elements):
+    dfn = [elements["aether"]]
+    score = ElementTypesHandler.calculate_resistance_multiplier_for_types(
+        dfn, "fire"
+    )
+    assert score == 1.0
+
+
+def test_resistance_aether_attacker(elements):
+    dfn = [elements["fire"]]
+    score = ElementTypesHandler.calculate_resistance_multiplier_for_types(
+        dfn, "aether"
+    )
+    assert score == 1.0
+
+
+def test_element_get_uses_cache(elements):
+    fire1 = Element.get("fire")
+    fire2 = Element.get("fire")
+    assert fire1 is fire2
+
+
+def test_element_cache_clears(elements):
+    fire1 = Element.get("fire")
+    Element.clear_cache()
+    fire2 = Element.get("fire")
+    assert fire1 is not fire2
+
+
+def test_multiplier_cache_reuse(elements):
+    ElementTypesHandler.clear_cache()
+
+    score1 = ElementTypesHandler.calculate_affinity_score(
+        [elements["fire"]], [elements["metal"]]
+    )
+    assert ("fire", "metal") in ElementTypesHandler._multiplier_cache
+
+    old_value = ElementTypesHandler._multiplier_cache[("fire", "metal")]
+    elements["fire"].lookup_multiplier = lambda slug: 9999
+
+    score2 = ElementTypesHandler.calculate_affinity_score(
+        [elements["fire"]], [elements["metal"]]
+    )
+
+    assert score2 == old_value
+
+
+def test_element_name_translation(monkeypatch):
+    monkeypatch.setattr("tuxemon.locale.T.translate", lambda slug: f"X_{slug}")
+    elem = Element.get("fire")
+    assert elem.name == "X_fire"
+
+
+def test_element_name_empty_slug(monkeypatch):
+    monkeypatch.setattr("tuxemon.locale.T.translate", lambda slug: f"X_{slug}")
+    elem = Element("", "", [])
+    assert elem.name == ""
+
+
+def test_reset_to_default_mixed_slugs(elements):
+    handler = ElementTypesHandler(["fire", "metal"])
+    handler.set_types(["aether"])
+    handler.reset_to_default()
+    assert handler.get_type_slugs() == ["fire", "metal"]
+
+
+def test_ordering_preserved_in_current(elements):
+    handler = ElementTypesHandler(["fire", "metal"])
+    assert handler.get_type_slugs() == ["fire", "metal"]
+
+
+def test_ordering_preserved_after_set_types(elements):
+    handler = ElementTypesHandler(["metal", "fire"])
+    handler.set_types(["aether", "fire"])
+    assert handler.get_type_slugs() == ["aether", "fire"]
+
+
+def test_ordering_preserved_after_reset(elements):
+    handler = ElementTypesHandler(["fire", "metal"])
+    handler.set_types(["metal"])
+    handler.reset_to_default()
+    assert handler.get_type_slugs() == ["fire", "metal"]
+
+
+def test_affinity_multi_type_with_aether(elements):
+    Element.clear_cache()
+    elements = {
+        "fire": Element.get("fire"),
+        "metal": Element.get("metal"),
+        "aether": Element.get("aether"),
+    }
+
+    atk = [elements["aether"], elements["fire"]]
+    dfn = [elements["metal"]]
+    score = ElementTypesHandler.calculate_affinity_score(atk, dfn)
+
+    assert score == 1.0
+
+
+def test_resistance_multi_type_with_aether(elements):
+    Element.clear_cache()
+    elements = {
+        "fire": Element.get("fire"),
+        "metal": Element.get("metal"),
+        "aether": Element.get("aether"),
+    }
+
+    dfn = [elements["aether"], elements["fire"]]
+    score = ElementTypesHandler.calculate_resistance_multiplier_for_types(
+        dfn, "metal"
+    )
+
+    assert score == 1.0
+
+
+def test_affinity_aether_in_middle(elements):
+    atk = [elements["fire"], elements["aether"], elements["metal"]]
+    dfn = [elements["fire"]]
+    score = ElementTypesHandler.calculate_affinity_score(atk, dfn)
+    expected = elements["fire"].lookup_multiplier("fire") * elements[
+        "metal"
+    ].lookup_multiplier("fire")
+    assert score == expected
+
+
+def test_resistance_aether_in_middle(elements):
+    dfn = [elements["fire"], elements["aether"], elements["metal"]]
+    score = ElementTypesHandler.calculate_resistance_multiplier_for_types(
+        dfn, "fire"
+    )
+    expected = elements["fire"].lookup_multiplier("fire") * elements[
+        "metal"
+    ].lookup_multiplier("fire")
+    assert score == expected

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -335,14 +335,13 @@ def test_item_conditions(setup_evolution, use_item, expected):
 @pytest.mark.parametrize(
     "monster_type,evo_type,expected",
     [
-        ("metal", "metal", True),  # match
-        ("metal", "water", False),  # mismatch
+        ("metal", "metal", True),
+        ("metal", "water", False),
     ],
 )
 def test_element_conditions(setup_evolution, monster_type, evo_type, expected):
     mon, _, _ = setup_evolution
-    element = MagicMock(slug=monster_type)
-    mon.types.set_types([element])
+    mon.types.set_types([monster_type])
     evo = MonsterEvolutionItemModel(monster_slug="botbot", element=evo_type)
     context = {"map_inside": True}
     assert mon.evolution_handler.can_evolve(evo, context) == expected
@@ -473,17 +472,16 @@ def test_party_gender_conditions(
 @pytest.mark.parametrize(
     "party_type,evo_types,expected",
     [
-        ("earth", {"earth": 1}, True),  # match
-        ("water", {"fire": 1}, False),  # mismatch
+        ("earth", {"earth": 1}, True),
+        ("water", {"fire": 1}, False),
     ],
 )
 def test_party_type_conditions(
     setup_evolution, party_type, evo_types, expected
 ):
     mon, player, _ = setup_evolution
-    element = MagicMock(slug=party_type)
     for m in player.party._monsters:
-        m.types.set_types([element])
+        m.types.set_types([party_type])
     evo = MonsterEvolutionItemModel(
         monster_slug="rockat",
         party_conditions=PartyConditionsModel(monster_types=evo_types),

--- a/tests/tuxemon/test_shape_handler.py
+++ b/tests/tuxemon/test_shape_handler.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.database.runtime import db
+from tuxemon.db import AttributesModel, ShapeModel
+from tuxemon.shape import Shape, ShapeHandler
+
+
+@pytest.fixture
+def shape_models():
+    db.database["shape"] = {
+        "piscine": ShapeModel(
+            slug="piscine",
+            attributes=AttributesModel(
+                armour=1, dodge=2, hp=3, melee=4, ranged=5, speed=10
+            ),
+        ),
+        "hunter": ShapeModel(
+            slug="hunter",
+            attributes=AttributesModel(
+                armour=10, dodge=1, hp=20, melee=3, ranged=2, speed=1
+            ),
+        ),
+    }
+    Shape.clear_cache()
+    return db.database["shape"]
+
+
+def test_shape_get_loads_from_db(shape_models):
+    shape = Shape.get("piscine")
+    assert shape.slug == "piscine"
+    assert shape.attributes.speed == 10
+
+
+def test_shape_get_uses_cache(shape_models):
+    s1 = Shape.get("piscine")
+    s2 = Shape.get("piscine")
+    assert s1 is s2
+
+
+def test_shape_fallback_when_missing(shape_models):
+    missing = Shape.get("unknown")
+    assert missing.slug == "unknown"
+    assert missing.attributes.hp == 1  # default fallback
+
+
+def test_shape_clear_cache(shape_models):
+    s1 = Shape.get("piscine")
+    Shape.clear_cache()
+    s2 = Shape.get("piscine")
+    assert s1 is not s2
+
+
+def test_load_all_shapes(shape_models):
+    Shape.clear_cache()
+    Shape.load_all_shapes()
+    all_shapes = Shape.get_all_shapes()
+    assert set(all_shapes.keys()) == {"piscine", "hunter"}
+
+
+def test_handler_copies_attributes(shape_models):
+    handler = ShapeHandler("piscine")
+    template = Shape.get("piscine")
+
+    # Must be equal but NOT the same object
+    assert handler.attributes.hp == template.attributes.hp
+    assert handler.attributes is not template.attributes
+
+
+def test_handler_slug(shape_models):
+    handler = ShapeHandler("hunter")
+    assert handler.slug == "hunter"
+
+
+def test_movement_cost(shape_models):
+    handler = ShapeHandler("piscine")
+    assert handler.movement_cost(10) == 10 / 10  # speed=10
+
+
+def test_melee_damage(shape_models):
+    handler = ShapeHandler("piscine")
+    assert handler.melee_damage(5) == 5 + 4  # melee=4
+
+
+def test_ranged_damage(shape_models):
+    handler = ShapeHandler("piscine")
+    assert handler.ranged_damage(5) == 5 + 5  # ranged=5
+
+
+def test_dodge_chance(shape_models):
+    handler = ShapeHandler("piscine")
+    assert handler.dodge_chance(0.1) == 0.1 + (2 * 0.02)
+
+
+def test_armour_reduction(shape_models):
+    handler = ShapeHandler("hunter")
+    assert handler.armour_reduction(15) == 15 - 10  # armour=10
+
+
+def test_armour_reduction_never_negative(shape_models):
+    handler = ShapeHandler("hunter")
+    assert handler.armour_reduction(5) == 0
+
+
+def test_apply_modifier_changes_local_only(shape_models):
+    handler = ShapeHandler("piscine")
+    template = Shape.get("piscine")
+
+    handler.apply_modifier(speed=+5, melee=-2)
+
+    assert handler.attributes.speed == template.attributes.speed + 5
+    assert handler.attributes.melee == template.attributes.melee - 2
+
+    # Template must remain unchanged
+    assert template.attributes.speed == 10
+    assert template.attributes.melee == 4
+
+
+def test_apply_modifier_ignores_unknown_fields(shape_models):
+    handler = ShapeHandler("piscine")
+    handler.apply_modifier(nonexistent=10)
+    assert True
+
+
+def test_default_shape_when_none_provided(shape_models):
+    handler = ShapeHandler(None)
+    assert handler.slug == "default"
+    assert handler.attributes.hp == 1

--- a/tuxemon/core/effects/move_type.py
+++ b/tuxemon/core/effects/move_type.py
@@ -46,12 +46,13 @@ class MoveTypeEffect(CoreEffect):
     ) -> TechEffectResult:
 
         if self.direction == "own_monster":
-            tech.types.set_types(user.types.current)
+            slugs = user.types.get_type_slugs()
         elif self.direction == "enemy_monster":
-            tech.types.set_types(target.types.current)
+            slugs = target.types.get_type_slugs()
         else:
             raise ValueError(
                 f"{self.direction} must be 'own_monster' or 'enemy_monster'"
             )
 
+        tech.types.set_types(slugs)
         return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/switch.py
+++ b/tuxemon/core/effects/switch.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
 from tuxemon.database.runtime import db
-from tuxemon.element import Element
 from tuxemon.locale import T
 
 if TYPE_CHECKING:
@@ -67,9 +66,8 @@ class SwitchEffect(CoreEffect):
         hit = session.client.combat_session.get_tech_hit(user)
 
         tech.hit = tech.accuracy >= hit
-
         if not tech.hit:
-            return TechEffectResult(name=tech.name, success=tech.hit)
+            return TechEffectResult(name=tech.name, success=False)
 
         objectives = self.objectives.split(":")
         monsters = session.client.combat_session.get_target_monsters(
@@ -77,33 +75,33 @@ class SwitchEffect(CoreEffect):
         )
 
         if self.element == "random":
-            new_type = Element(random.choice(elements))
+            new_slug = random.choice(elements)
         else:
-            new_type = Element(self.element)
+            new_slug = self.element
 
         messages = []
         for monster in monsters:
-            if monster.has_type(new_type.slug):
-                messages.append(get_failure_message(monster, new_type))
+            if monster.has_type(new_slug):
+                messages.append(get_failure_message(monster, new_slug))
             else:
-                monster.types.set_types([new_type])
-                messages.append(get_extra_message(monster, new_type))
+                monster.types.set_types([new_slug])
+                messages.append(get_extra_message(monster, new_slug))
 
         extra = ["\n".join(messages)]
-        return TechEffectResult(name=tech.name, success=tech.hit, extras=extra)
+        return TechEffectResult(name=tech.name, success=True, extras=extra)
 
 
-def get_extra_message(monster: Monster, new_type: Element) -> str:
+def get_extra_message(monster: Monster, slug: str) -> str:
     params = {
         "target": monster.name.upper(),
-        "types": T.translate(new_type.slug).upper(),
+        "types": T.translate(slug).upper(),
     }
     return T.format("combat_state_switch", params)
 
 
-def get_failure_message(monster: Monster, new_type: Element) -> str:
+def get_failure_message(monster: Monster, slug: str) -> str:
     params = {
         "target": monster.name.upper(),
-        "type": T.translate(new_type.slug).upper(),
+        "type": T.translate(slug).upper(),
     }
     return T.format("combat_state_switch_fail", params)

--- a/tuxemon/core/effects/switch_type.py
+++ b/tuxemon/core/effects/switch_type.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
 from tuxemon.database.runtime import db
-from tuxemon.element import Element
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
@@ -52,10 +51,12 @@ class SwitchTypeEffect(CoreEffect):
         self, session: Session, item: Item, target: Monster
     ) -> ItemEffectResult:
         elements = list(db.database["element"])
+
         if self.element != "random":
             if not target.has_type(self.element):
-                target.types.set_types([Element(self.element)])
+                target.types.set_types([self.element])
         else:
-            random_target_element = random.choice(elements)
-            target.types.set_types([Element(random_target_element)])
+            random_slug = random.choice(elements)
+            target.types.set_types([random_slug])
+
         return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/element.py
+++ b/tuxemon/element.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import Optional
 
 from tuxemon.database.runtime import db
 from tuxemon.db import ElementItemModel, ElementModel
@@ -18,30 +17,15 @@ class Element:
 
     _elements: dict[str, Element] = {}
 
-    def __init__(self, slug: Optional[str] = None) -> None:
-        self.slug: str = ""
-        self.icon: str = ""
-        self.types: Sequence[ElementItemModel] = []
-
-        if slug:
-            self.load(slug)
-
-    def load(self, slug: str) -> None:
-        """Loads an element."""
-
-        if slug in Element._elements:
-            cached_element = Element._elements[slug]
-            self.slug = slug
-            self.types = cached_element.types
-            self.icon = cached_element.icon
-            return
-
-        results = ElementModel.lookup(slug, db)
+    def __init__(
+        self,
+        slug: str,
+        icon: str,
+        types: Sequence[ElementItemModel],
+    ) -> None:
         self.slug = slug
-        self.types = results.types
-        self.icon = results.icon
-
-        Element._elements[slug] = self
+        self.icon = icon
+        self.types = list(types)
 
     @property
     def name(self) -> str:
@@ -49,17 +33,32 @@ class Element:
         return T.translate(self.slug) if self.slug else ""
 
     @classmethod
-    def get_element(cls, slug: str) -> Optional[Element]:
-        """Retrieves an Element object by its slug."""
-        return cls._elements.get(slug)
+    def get(cls, slug: str) -> Element:
+        """
+        Retrieve an Element from cache or load it from the database.
+        """
+        if slug in cls._elements:
+            return cls._elements[slug]
+
+        try:
+            results = ElementModel.lookup(slug, db)
+            icon = results.icon
+            types = results.types
+        except Exception:
+            logger.warning(f"Element {slug} not found, using empty fallback.")
+            icon = ""
+            types = []
+
+        element = cls(slug, icon, types)
+        cls._elements[slug] = element
+        return element
 
     @classmethod
     def load_all_elements(cls) -> None:
         """Loads all elements from the database into the cache."""
         try:
-            all_element_slugs = list(db.database["element"])
-            for slug in all_element_slugs:
-                cls(slug)
+            for slug in db.database["element"]:
+                cls.get(slug)
         except Exception as e:
             logger.error(f"Failed to load all elements: {e}")
 
@@ -80,10 +79,10 @@ class Element:
             f"Element(slug={self.slug}, "
             f"name={self.name}, "
             f"types={self.types}, "
-            f"icon={self.icon}, "
+            f"icon={self.icon})"
         )
 
-    def lookup_field(self, element: str, field: str) -> Optional[float]:
+    def lookup_field(self, element: str, field: str) -> float | None:
         """Looks up the element against for this element."""
         for item in self.types:
             if item.against == element and hasattr(item, field):
@@ -102,17 +101,21 @@ class Element:
 
 
 class ElementTypesHandler:
+    """
+    Handles element type sets and affinity/resistance calculations.
+    Uses Element templates via Element.get and caches multipliers.
+    """
 
     _multiplier_cache: dict[tuple[str, str], float] = {}
 
-    def __init__(self, initial_types: Optional[Sequence[str]] = None):
-        pre_types = (
-            []
-            if initial_types is None
-            else [Element(ele) for ele in initial_types]
-        )
-        self._current_types = pre_types
-        self._default_types = list(pre_types)
+    def __init__(self, initial_types: Sequence[str] | None = None):
+        if initial_types is None:
+            pre_types: list[Element] = []
+        else:
+            pre_types = [Element.get(slug) for slug in initial_types]
+
+        self._current_types: list[Element] = pre_types
+        self._default_types: list[Element] = list(pre_types)
 
     @classmethod
     def calculate_affinity_score(
@@ -161,8 +164,8 @@ class ElementTypesHandler:
     def clear_cache(cls) -> None:
         cls._multiplier_cache.clear()
 
-    def set_types(self, new_types: list[Element]) -> None:
-        self._current_types = new_types
+    def set_types(self, new_types: Sequence[str]) -> None:
+        self._current_types = [Element.get(slug) for slug in new_types]
 
     def reset_to_default(self) -> None:
         self._current_types = list(self._default_types)

--- a/tuxemon/shape.py
+++ b/tuxemon/shape.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any
 
 from tuxemon.database.runtime import db
 from tuxemon.db import AttributesModel, ShapeModel
@@ -12,63 +12,47 @@ logger = logging.getLogger(__name__)
 
 
 class Shape:
-    """A shape holds all the values (speed, ranged, etc.)."""
+    """A shape holds all the base values (speed, ranged, etc.)."""
 
     _shapes: dict[str, Shape] = {}
 
-    def __init__(self, slug: Optional[str] = None) -> None:
-        self.slug = slug or "default"
-        self.attributes = AttributesModel(
-            armour=1, dodge=1, hp=1, melee=1, ranged=1, speed=1
-        )
-        if slug:
-            self.load(slug)
-
-    def load(self, slug: str) -> None:
-        """Loads shape."""
-
-        if slug in Shape._shapes:
-            cached_shape = Shape._shapes[slug]
-            self.slug = slug
-            self.attributes = cached_shape.attributes
-            return
-
-        results = ShapeModel.lookup(slug, db)
-        self.attributes = results.attributes
-
-        Shape._shapes[slug] = self
+    def __init__(self, slug: str, attributes: AttributesModel) -> None:
+        self.slug = slug
+        self.attributes = attributes
 
     @classmethod
-    def get_shape(cls, slug: str) -> Optional[Shape]:
+    def get(cls, slug: str) -> Shape:
         """
-        Retrieves a Shape object by its slug.
-
-        Parameters:
-            slug: The unique identifier for the shape.
-
-        Returns:
-            The Shape object if found, otherwise None.
+        Retrieve a Shape from cache or load it from the database.
         """
-        return cls._shapes.get(slug)
+        if slug in cls._shapes:
+            return cls._shapes[slug]
+
+        try:
+            results = ShapeModel.lookup(slug, db)
+            attributes = results.attributes
+        except Exception:
+            logger.warning(f"Shape {slug} not found, using default.")
+            attributes = AttributesModel(
+                armour=1, dodge=1, hp=1, melee=1, ranged=1, speed=1
+            )
+
+        shape = cls(slug, attributes)
+        cls._shapes[slug] = shape
+        return shape
 
     @classmethod
     def load_all_shapes(cls) -> None:
         """Loads all shapes from the database into the cache."""
         try:
-            all_shape_slugs = list(db.database["shape"])
-            for slug in all_shape_slugs:
-                cls(slug)
+            for slug in db.database["shape"]:
+                cls.get(slug)
         except Exception as e:
             logger.error(f"Failed to load all shapes: {e}")
 
     @classmethod
     def get_all_shapes(cls) -> dict[str, Shape]:
-        """
-        Returns all loaded shapes.
-
-        Returns:
-            A dictionary of all loaded Shape objects.
-        """
+        """Returns all loaded shapes."""
         if not cls._shapes:
             cls.load_all_shapes()
         return cls._shapes
@@ -84,20 +68,60 @@ class Shape:
 
 class ShapeHandler:
     """
-    Handles the shape-related attributes and calculations.
+    Provides gameplay logic derived from a Shape template.
+    Each handler owns its own working copy of attributes,
+    so mutations never affect the global Shape cache.
     """
 
-    def __init__(self, shape_slug: Optional[str] = None):
-        self._shape = Shape(shape_slug)
+    def __init__(self, shape_slug: str | None = None):
+        slug = shape_slug or "default"
+        template = Shape.get(slug)
+
+        self._slug = slug
+        self._attributes = AttributesModel(
+            armour=template.attributes.armour,
+            dodge=template.attributes.dodge,
+            hp=template.attributes.hp,
+            melee=template.attributes.melee,
+            ranged=template.attributes.ranged,
+            speed=template.attributes.speed,
+        )
 
     @property
     def slug(self) -> str:
-        return self._shape.slug
+        return self._slug
 
     @property
     def attributes(self) -> AttributesModel:
-        return self._shape.attributes
+        return self._attributes
 
-    def update_shape_attributes(self, new_attributes: AttributesModel) -> None:
-        """Updates the shape attributes."""
-        self._shape.attributes = new_attributes
+    def movement_cost(self, base_cost: int) -> float:
+        """Lower cost if speed is high."""
+        return base_cost / max(1, self._attributes.speed)
+
+    def melee_damage(self, weapon_damage: int) -> int:
+        """Shape influences melee output."""
+        return weapon_damage + self._attributes.melee
+
+    def ranged_damage(self, weapon_damage: int) -> int:
+        """Shape influences ranged output."""
+        return weapon_damage + self._attributes.ranged
+
+    def dodge_chance(self, base_chance: float) -> float:
+        """Shape modifies dodge probability."""
+        return base_chance + (self._attributes.dodge * 0.02)
+
+    def armour_reduction(self, incoming_damage: int) -> int:
+        """Shape armour reduces incoming damage."""
+        reduction = self._attributes.armour
+        return max(0, incoming_damage - reduction)
+
+    def apply_modifier(self, **kwargs: dict[str, Any]) -> None:
+        """
+        Apply temporary or permanent modifiers to this instance only.
+        Example: handler.apply_modifier(speed=+1, melee=-2)
+        """
+        for key, delta in kwargs.items():
+            if hasattr(self._attributes, key):
+                current = getattr(self._attributes, key)
+                setattr(self._attributes, key, current + delta)


### PR DESCRIPTION
Changes:
- removed legacy two‑phase initialization patterns (`__init__` + `load`) from both `Element` and `Shape`
- introduced explicit, single‑phase constructors requiring fully defined data (`slug`, `icon`, `types` for `Element`; `slug`, `attributes` for `Shape`)
- centralized all database loading logic into `Element.get` and `Shape.get`, replacing scattered implicit loading
- replaced old `load` and `get_element` / `get_shape` helpers with unified `get` methods that handle caching, DB lookup, and fallback behavior
- standardized fallback behavior: missing entries now log warnings and create safe default objects instead of partially initialized instances
- ensured cached `Element` and `Shape` objects are immutable templates; no instance ever mutates the global cache
- updated all handlers (`ElementTypesHandler`, `ShapeHandler`) to rely on the new `get` API instead of constructing objects directly
- ensured all type and attribute collections are stored as concrete lists for consistency and predictability
- improved type hints across both systems for clarity and correctness
- simplified `load_all_*` methods to use the new `get` logic
- cleaned up `__repr__` implementations for clearer debugging output
- added new gameplay‑related methods to `ShapeHandler` (movement cost, melee/ranged damage, dodge chance, armour reduction)
- added `apply_modifier` to `ShapeHandler` for safe, instance‑local stat adjustments
- removed legacy behaviors where instances mutated themselves based on cached templates
- improved consistency in handler state: all working copies are now isolated from global templates