### PR TITLE
Splitting `tuxepedia.py` Into a Modular Folder Structure

### DIFF
--- a/tests/tuxemon/test_actions.py
+++ b/tests/tuxemon/test_actions.py
@@ -14,7 +14,7 @@ from tuxemon.math import Vector2
 from tuxemon.platform.const.sizes import MOVERATE_RANGE
 from tuxemon.player import Player
 from tuxemon.session import local_session
-from tuxemon.tuxepedia import TuxepediaManager
+from tuxemon.tuxepedia.manager import TuxepediaManager
 from tuxemon.user_config import CONFIG
 
 

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -62,14 +62,14 @@ def test_evolve_monster_success(setup_evolution):
     new_mon.transfer_properties_from = MagicMock()
     new_mon.moves.learn_by_method = MagicMock()
     player.party.replace_monster = MagicMock(return_value=True)
-    player.tuxepedia.add_entry = MagicMock()
+    player.tuxepedia.register_caught = MagicMock()
     evo.evolve_monster(new_mon)
     new_mon.transfer_properties_from.assert_called_with(mon)
     new_mon.moves.learn_by_method.assert_called_with(
         new_mon, "SpecialBeam", LearningMethod.EVOLUTION
     )
     player.party.replace_monster.assert_called_with(mon, new_mon)
-    player.tuxepedia.add_entry.assert_called_with("rockat", SeenStatus.caught)
+    player.tuxepedia.register_caught.assert_called_with("rockat")
 
 
 def test_evolve_monster_not_eligible(setup_evolution):
@@ -90,7 +90,7 @@ def test_evolve_monster_replace_fails(setup_evolution):
     player.party.replace_monster = MagicMock(return_value=False)
     player.tuxepedia = MagicMock()
     evo.evolve_monster(new_mon)
-    assert not player.tuxepedia.add_entry.called
+    assert not player.tuxepedia.register_caught.called
 
 
 def test_no_owner(setup_evolution):

--- a/tests/tuxemon/test_trade_manager.py
+++ b/tests/tuxemon/test_trade_manager.py
@@ -215,12 +215,8 @@ def test_execute_trade_updates_party_and_ownership(
 def test_execute_trade_updates_tuxepedia(manager, players_and_monsters):
     player_a, player_b, monster_a, monster_b = players_and_monsters
     manager.execute_trade(monster_a, monster_b)
-    player_a.tuxepedia.add_entry.assert_called_once_with(
-        monster_b.slug, SeenStatus.caught
-    )
-    player_b.tuxepedia.add_entry.assert_called_once_with(
-        monster_a.slug, SeenStatus.caught
-    )
+    player_a.tuxepedia.register_caught.assert_called_once_with(monster_b.slug)
+    player_b.tuxepedia.register_caught.assert_called_once_with(monster_a.slug)
 
 
 def test_execute_trade_publishes_event(manager, players_and_monsters):
@@ -270,9 +266,7 @@ def test_execute_scripted_trade_success(
     player_a.party.replace_monster.assert_called_once_with(monster_a, fake_mon)
     assert fake_mon.acquisition is not None
     fake_mon.set_capture.assert_called_once()
-    player_a.tuxepedia.add_entry.assert_called_once_with(
-        "new_slug", SeenStatus.caught
-    )
+    player_a.tuxepedia.register_caught.assert_called_once_with("new_slug")
     assert len(manager.global_trade_log) == 1
     record = manager.global_trade_log[0]
     assert record.monster_given == monster_a.slug

--- a/tests/tuxemon/test_tuxepedia.py
+++ b/tests/tuxemon/test_tuxepedia.py
@@ -5,18 +5,18 @@ from unittest.mock import ANY, Mock
 import pytest
 
 from tuxemon.db import SeenStatus
-from tuxemon.tuxepedia import (
+from tuxemon.tuxepedia.data import TuxepediaData
+from tuxemon.tuxepedia.manager import (
     EVENT_MONSTER_ADDED,
     EVENT_MONSTER_REMOVED,
     EVENT_MONSTER_STATUS_UPDATED,
     EVENT_TUXEPEDIA_RESET,
     MonsterEntry,
-    TuxepediaData,
     TuxepediaManager,
-    TuxepediaReporter,
     decode_tuxepedia,
     encode_tuxepedia,
 )
+from tuxemon.tuxepedia.reporter import TuxepediaReporter
 
 
 # TestMonsterEntry
@@ -24,13 +24,13 @@ from tuxemon.tuxepedia import (
     "initial_status,initial_appearance,update_to,expected_status,expected_appearance,expected_caught",
     [
         # init defaults
-        (SeenStatus.seen, 1, None, SeenStatus.seen, 1, 0),
+        (SeenStatus.SEEN, 1, None, SeenStatus.SEEN, 1, 0),
         # update to caught
-        (SeenStatus.seen, 1, SeenStatus.caught, SeenStatus.caught, 2, 1),
+        (SeenStatus.SEEN, 1, SeenStatus.CAUGHT, SeenStatus.CAUGHT, 2, 1),
         # cannot downgrade caught to seen
-        (SeenStatus.caught, 1, SeenStatus.seen, SeenStatus.caught, 1, 0),
+        (SeenStatus.CAUGHT, 1, SeenStatus.SEEN, SeenStatus.CAUGHT, 1, 0),
         # reset entry
-        (SeenStatus.caught, 5, "reset", SeenStatus.seen, 1, 0),
+        (SeenStatus.CAUGHT, 5, "reset", SeenStatus.SEEN, 1, 0),
     ],
 )
 def test_monster_entry_behaviors(
@@ -57,9 +57,9 @@ def test_monster_entry_behaviors(
 @pytest.fixture
 def data():
     initial_entries = {
-        "rockitten": MonsterEntry(SeenStatus.seen, 2),
-        "nut": MonsterEntry(SeenStatus.caught, 5),
-        "flowey": MonsterEntry(SeenStatus.seen, 1),
+        "rockitten": MonsterEntry(SeenStatus.SEEN, 2),
+        "nut": MonsterEntry(SeenStatus.CAUGHT, 5),
+        "flowey": MonsterEntry(SeenStatus.SEEN, 1),
     }
     return TuxepediaData(initial_entries)
 
@@ -72,9 +72,9 @@ def test_init():
 @pytest.mark.parametrize(
     "slug,expected_status,expected_appearance,expected_caught,is_registered",
     [
-        ("nut", SeenStatus.caught, 5, 0, True),
-        ("rockitten", SeenStatus.seen, 2, 0, True),
-        ("flowey", SeenStatus.seen, 1, 0, True),
+        ("nut", SeenStatus.CAUGHT, 5, 0, True),
+        ("rockitten", SeenStatus.SEEN, 2, 0, True),
+        ("flowey", SeenStatus.SEEN, 1, 0, True),
         ("unknown", None, 0, 0, False),
     ],
 )
@@ -114,9 +114,9 @@ def manager(event_bus):
         # Case 1: add new entry as seen
         (
             "rockitten",
-            SeenStatus.seen,
+            SeenStatus.SEEN,
             EVENT_MONSTER_ADDED,
-            SeenStatus.seen,
+            SeenStatus.SEEN,
             1,
             0,
             None,
@@ -124,9 +124,9 @@ def manager(event_bus):
         # Case 2: update existing entry to caught
         (
             "rockitten",
-            SeenStatus.caught,
+            SeenStatus.CAUGHT,
             EVENT_MONSTER_STATUS_UPDATED,
-            SeenStatus.caught,
+            SeenStatus.CAUGHT,
             2,
             1,
             None,
@@ -134,9 +134,9 @@ def manager(event_bus):
         # Case 3: remove entry
         (
             "nut",
-            SeenStatus.caught,
+            SeenStatus.CAUGHT,
             EVENT_MONSTER_REMOVED,
-            SeenStatus.caught,
+            SeenStatus.CAUGHT,
             1,
             0,
             None,
@@ -144,9 +144,9 @@ def manager(event_bus):
         # Case 4: remove non-existent entry (error expected)
         (
             "ghost",
-            SeenStatus.seen,
+            SeenStatus.SEEN,
             EVENT_MONSTER_REMOVED,
-            SeenStatus.seen,
+            SeenStatus.SEEN,
             0,
             0,
             ValueError,
@@ -165,9 +165,12 @@ def test_add_update_remove(
     expect_error,
 ):
     if expected_event == EVENT_MONSTER_STATUS_UPDATED:
-        manager.add_entry(slug, status=SeenStatus.seen)
+        manager.register_seen(slug)
     elif expected_event == EVENT_MONSTER_REMOVED and expect_error is None:
-        manager.add_entry(slug, status=status)
+        if status == SeenStatus.CAUGHT:
+            manager.register_caught(slug)
+        else:
+            manager.register_seen(slug)
 
     if expect_error:
         with pytest.raises(expect_error):
@@ -177,7 +180,10 @@ def test_add_update_remove(
     if expected_event == EVENT_MONSTER_REMOVED:
         manager.remove_entry(slug)
     else:
-        manager.add_entry(slug, status=status)
+        if status == SeenStatus.CAUGHT:
+            manager.register_caught(slug)
+        else:
+            manager.register_seen(slug)
 
     if expected_event == EVENT_MONSTER_REMOVED:
         assert slug not in manager.data.entries
@@ -215,9 +221,9 @@ def test_reset(
     expected_remaining,
     expected_removed,
 ):
-    manager.add_entry("caught_mon", status=SeenStatus.caught)
-    manager.add_entry("seen_mon_1")
-    manager.add_entry("seen_mon_2")
+    manager.register_caught("caught_mon")
+    manager.register_seen("seen_mon_1")
+    manager.register_seen("seen_mon_2")
 
     manager.reset(remove_seen_only=remove_seen_only)
 
@@ -239,9 +245,9 @@ def test_reset(
 @pytest.fixture
 def reporter():
     initial_entries = {
-        "rockitten": MonsterEntry(SeenStatus.seen, 5),
-        "nut": MonsterEntry(SeenStatus.caught, 10),
-        "flowey": MonsterEntry(SeenStatus.seen, 2),
+        "rockitten": MonsterEntry(SeenStatus.SEEN, 5),
+        "nut": MonsterEntry(SeenStatus.CAUGHT, 10),
+        "flowey": MonsterEntry(SeenStatus.SEEN, 2),
     }
     data = TuxepediaData(initial_entries)
     return TuxepediaReporter(data)
@@ -254,8 +260,8 @@ def test_get_most_frequent_monsters(reporter):
 
 def test_get_monster_status_distribution(reporter):
     distribution = reporter.get_monster_status_distribution()
-    assert distribution[SeenStatus.seen] == 2
-    assert distribution[SeenStatus.caught] == 1
+    assert distribution[SeenStatus.SEEN] == 2
+    assert distribution[SeenStatus.CAUGHT] == 1
 
 
 def test_get_unregistered_monsters(reporter):
@@ -287,18 +293,18 @@ def test_completeness_report(
     [
         # Case 1: simple seen + caught
         {
-            "rockitten": {"status": SeenStatus.seen, "appearance_count": 1},
-            "nut": {"status": SeenStatus.caught, "appearance_count": 2},
+            "rockitten": {"status": SeenStatus.SEEN, "appearance_count": 1},
+            "nut": {"status": SeenStatus.CAUGHT, "appearance_count": 2},
         },
         # Case 2: larger counts
         {
-            "ghost": {"status": SeenStatus.seen, "appearance_count": 5},
-            "dragon": {"status": SeenStatus.caught, "appearance_count": 10},
+            "ghost": {"status": SeenStatus.SEEN, "appearance_count": 5},
+            "dragon": {"status": SeenStatus.CAUGHT, "appearance_count": 10},
         },
         # Case 3: only seen monsters
         {
-            "flowey": {"status": SeenStatus.seen, "appearance_count": 3},
-            "leafy": {"status": SeenStatus.seen, "appearance_count": 7},
+            "flowey": {"status": SeenStatus.SEEN, "appearance_count": 3},
+            "leafy": {"status": SeenStatus.SEEN, "appearance_count": 7},
         },
     ],
 )
@@ -306,7 +312,10 @@ def test_encode_decode_roundtrip(entries, event_bus):
     manager = TuxepediaManager(event_bus)
     for slug, info in entries.items():
         for _ in range(info["appearance_count"]):
-            manager.add_entry(slug, status=info["status"])
+            if info["status"] == SeenStatus.CAUGHT:
+                manager.register_caught(slug)
+            else:
+                manager.register_seen(slug)
 
     json_data = encode_tuxepedia(manager)
     new_manager = decode_tuxepedia(json_data, event_bus)
@@ -335,4 +344,4 @@ def test_decode_with_raw_string_status(event_bus):
     manager = decode_tuxepedia(json_data, event_bus)
     entry = manager.data.entries["rockitten"]
     assert isinstance(entry.status, SeenStatus)
-    assert entry.status == SeenStatus.seen
+    assert entry.status == SeenStatus.SEEN

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -431,7 +431,7 @@ class CombatSession:
             if other_player.is_player and other_player != player:
                 var = self.get_variable(monster.slug)
                 if var is None:
-                    other_player.tuxepedia.add_entry(monster.slug)
+                    other_player.tuxepedia.register_seen(monster.slug)
                     self.set_variable(monster.slug, True)
 
     def initialize_hit_chances(self) -> None:

--- a/tuxemon/core/effects/capture.py
+++ b/tuxemon/core/effects/capture.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
-from tuxemon.db import Acquisition, SeenStatus
+from tuxemon.db import Acquisition
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
@@ -77,7 +77,7 @@ class CaptureEffect(CoreEffect):
         formula.on_capture_success(item, target, self.session.player)
         if self.session.player.tuxepedia.is_seen(target.slug):
             self.client.combat_session.set_variable("new_tuxepedia", True)
-        self.session.player.tuxepedia.add_entry(target.slug, SeenStatus.caught)
+        self.session.player.tuxepedia.register_caught(target.slug)
         target.capture_device = item.slug
         target.wild = False
         target.set_acquisition(Acquisition.CAPTURED)

--- a/tuxemon/core/effects/capture_combined.py
+++ b/tuxemon/core/effects/capture_combined.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
 from tuxemon.database.rules import config_capdev
-from tuxemon.db import Acquisition, SeenStatus
+from tuxemon.db import Acquisition
 
 if TYPE_CHECKING:
     from tuxemon.item.item import Item
@@ -114,7 +114,7 @@ class CaptureCombinedEffect(CoreEffect):
     def _apply_capture_effects(self, item: Item, target: Monster) -> None:
         if self.session.player.tuxepedia.is_seen(target.slug):
             self.client.combat_session.set_variable("new_tuxepedia", True)
-        self.session.player.tuxepedia.add_entry(target.slug, SeenStatus.caught)
+        self.session.player.tuxepedia.register_caught(target.slug)
         target.capture_device = item.slug
         target.wild = False
         target.set_acquisition(Acquisition.CAPTURED)

--- a/tuxemon/core/effects/park.py
+++ b/tuxemon/core/effects/park.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, ItemEffectResult
-from tuxemon.db import SeenStatus
 from tuxemon.technique.technique import Technique
 
 if TYPE_CHECKING:
@@ -125,7 +124,7 @@ class ParkEffect(CoreEffect):
 
         if self.session.player.tuxepedia.is_seen(target.slug):
             self.client.combat_session.set_variable("new_tuxepedia", True)
-        self.session.player.tuxepedia.add_entry(target.slug, SeenStatus.caught)
+        self.session.player.tuxepedia.register_caught(target.slug)
         target.capture_device = item.slug
         target.wild = False
         self.session.player.party.add_monster(

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -109,9 +109,9 @@ class OutputBattle(str, Enum):
 
 
 class SeenStatus(str, Enum):
-    unseen = "unseen"
-    seen = "seen"
-    caught = "caught"
+    UNSEEN = "unseen"
+    SEEN = "seen"
+    CAUGHT = "caught"
 
 
 class StatType(str, Enum):

--- a/tuxemon/event/actions/add_monster.py
+++ b/tuxemon/event/actions/add_monster.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Optional, final
 
 from tuxemon.database.runtime import db
-from tuxemon.db import SeenStatus
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
 from tuxemon.session import Session
@@ -67,5 +66,5 @@ class AddMonsterAction(EventAction):
             monster.money_modifier = self.money
 
         trainer.party.add_monster(monster, len(trainer.monsters))
-        trainer.tuxepedia.add_entry(monster.slug, SeenStatus.caught)
+        trainer.tuxepedia.register_caught(monster.slug)
         player.game_variables.set(self.name, monster.instance_id.hex)

--- a/tuxemon/event/actions/replace_party_from_yaml.py
+++ b/tuxemon/event/actions/replace_party_from_yaml.py
@@ -9,7 +9,6 @@ from typing import Any, final
 
 from tuxemon.constants import paths
 from tuxemon.database.yaml_utils import load_yaml
-from tuxemon.db import SeenStatus
 from tuxemon.event.eventaction import EventAction
 from tuxemon.monster import Monster
 from tuxemon.platform.const.sizes import PARTY_LIMIT
@@ -107,7 +106,7 @@ class ReplacePartyFromYamlAction(EventAction):
 
             monster = Monster.spawn_base(slug, level)
             monster.set_capture(today_ordinal())
-            character.tuxepedia.add_entry(monster.slug, SeenStatus.caught)
+            character.tuxepedia.register_caught(monster.slug)
 
             if "experience_modifier" in entry:
                 monster.set_experience_modifier(

--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -52,5 +52,10 @@ class SetTuxepediaAction(EventAction):
             raise ValueError(f"{self.monster_slug} isn't a monster")
 
         monster_name = T.translate(self.monster_slug)
-        character.tuxepedia.add_entry(self.monster_slug, label)
+
+        if label == SeenStatus.SEEN:
+            character.tuxepedia.register_seen(self.monster_slug)
+        elif label == SeenStatus.CAUGHT:
+            character.tuxepedia.register_caught(self.monster_slug)
+
         logger.info(f"Tuxepedia: {monster_name} is registered as {label}!")

--- a/tuxemon/event/conditions/tuxepedia.py
+++ b/tuxemon/event/conditions/tuxepedia.py
@@ -9,7 +9,7 @@ from tuxemon.db import MonsterModel, SpatialCondition
 from tuxemon.event.eventcondition import EventCondition
 from tuxemon.session import Session
 from tuxemon.tools import compare
-from tuxemon.tuxepedia import TuxepediaReporter
+from tuxemon.tuxepedia.reporter import TuxepediaReporter
 
 lookup_cache: dict[str, MonsterModel] = {}
 

--- a/tuxemon/monster_dir/evolution.py
+++ b/tuxemon/monster_dir/evolution.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from tuxemon.db import (
     LearningMethod,
     MonsterEvolutionItemModel,
-    SeenStatus,
 )
 from tuxemon.monster_dir.evolution_conditions import (
     check_bond,
@@ -103,7 +102,7 @@ class Evolution:
                 )
 
         if owner.party.replace_monster(self.monster, new_monster):
-            owner.tuxepedia.add_entry(new_monster.slug, SeenStatus.caught)
+            owner.tuxepedia.register_caught(new_monster.slug)
             logger.info(f"{self.monster} evolved into {new_monster}")
         else:
             logger.warning(f"Failed to evolve {self.monster}")

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -35,7 +35,7 @@ from tuxemon.save_state import NPCState
 from tuxemon.step_tracker import StepTrackerManager, decode_steps, encode_steps
 from tuxemon.teleporter import TeleportFaint
 from tuxemon.tracker import TrackingData, decode_tracking, encode_tracking
-from tuxemon.tuxepedia import (
+from tuxemon.tuxepedia.manager import (
     TuxepediaManager,
     decode_tuxepedia,
     encode_tuxepedia,

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -21,7 +21,7 @@ from tuxemon.platform.const.sizes import U_KM, U_MI
 from tuxemon.platform.events import PlayerInput
 from tuxemon.prepare import SCALE, SCREEN_SIZE
 from tuxemon.tools import fix_measure, format_playtime
-from tuxemon.tuxepedia import TuxepediaReporter
+from tuxemon.tuxepedia.reporter import TuxepediaReporter
 
 MenuGameObj = Callable[[], object]
 lookup_cache: dict[str, MonsterModel] = {}

--- a/tuxemon/trade_manager.py
+++ b/tuxemon/trade_manager.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
-from tuxemon.db import Acquisition, SeenStatus
+from tuxemon.db import Acquisition
 from tuxemon.event import get_event_bus
 from tuxemon.monster import Monster
 from tuxemon.time_handler import today_ordinal
@@ -132,8 +132,8 @@ class TradeManager:
         monster_a: Monster,
         monster_b: Monster,
     ) -> None:
-        player_a.tuxepedia.add_entry(monster_b.slug, SeenStatus.caught)
-        player_b.tuxepedia.add_entry(monster_a.slug, SeenStatus.caught)
+        player_a.tuxepedia.register_caught(monster_b.slug)
+        player_b.tuxepedia.register_caught(monster_a.slug)
 
     def _create_trade_record(
         self,
@@ -217,7 +217,7 @@ class TradeManager:
         if not owner.party.replace_monster(player_monster, new_monster):
             return TradeResult.NOT_FOUND
 
-        owner.tuxepedia.add_entry(new_monster.slug, SeenStatus.caught)
+        owner.tuxepedia.register_caught(new_monster.slug)
 
         record = TradeRecord(
             from_player=owner.name,

--- a/tuxemon/tuxepedia/data.py
+++ b/tuxemon/tuxepedia/data.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tuxemon.db import SeenStatus
+
+if TYPE_CHECKING:
+    from tuxemon.tuxepedia.manager import MonsterEntry
+
+
+class TuxepediaData:
+    """
+    The core, read-only data structure containing all monster entries.
+    Provides safe reading and basic count queries.
+    """
+
+    def __init__(self, entries: dict[str, MonsterEntry] | None = None) -> None:
+        self._entries: dict[str, MonsterEntry] = (
+            entries if entries is not None else {}
+        )
+
+    def _set_entries(self, new_entries: dict[str, MonsterEntry]) -> None:
+        """
+        Allows the trusted Manager to replace the entry set (e.g., during reset).
+        """
+        self._entries = new_entries
+
+    def get_entry_for_mutation(self, monster_slug: str) -> MonsterEntry | None:
+        """
+        Returns the actual entry object (not a copy) for in-place modification
+        by the Manager.
+        """
+        return self._entries.get(monster_slug)
+
+    def set_entry(self, monster_slug: str, entry: MonsterEntry) -> None:
+        """Adds or replaces a single entry (used for initial add)."""
+        self._entries[monster_slug] = entry
+
+    def delete_entry(self, monster_slug: str) -> None:
+        """Deletes a single entry (used for remove)."""
+        if monster_slug in self._entries:
+            del self._entries[monster_slug]
+        else:
+            raise KeyError(f"Entry {monster_slug} not found.")
+
+    @property
+    def entries(self) -> dict[str, MonsterEntry]:
+        """Returns a copy of the entries for safe reading."""
+        return dict(self._entries)
+
+    def get_total_monsters(self) -> int:
+        return len(self._entries)
+
+    def get_caught_count(self) -> int:
+        return sum(
+            1
+            for entry in self._entries.values()
+            if entry.status == SeenStatus.CAUGHT
+        )
+
+    def get_seen_count(self) -> int:
+        return sum(
+            1
+            for entry in self._entries.values()
+            if entry.status == SeenStatus.SEEN
+        )
+
+    def get_status(self, monster_slug: str) -> SeenStatus | None:
+        entry = self._entries.get(monster_slug)
+        return entry.status if entry else None
+
+    def get_appearance(self, monster_slug: str) -> int:
+        entry = self._entries.get(monster_slug)
+        return entry.appearance_count if entry else 0
+
+    def get_caught(self, monster_slug: str) -> int:
+        entry = self._entries.get(monster_slug)
+        return entry.caught_count if entry else 0
+
+    def is_registered(self, monster_slug: str) -> bool:
+        return monster_slug in self._entries
+
+    def is_seen(self, monster_slug: str) -> bool:
+        entry = self._entries.get(monster_slug)
+        return bool(entry and entry.status == SeenStatus.SEEN)
+
+    def is_caught(self, monster_slug: str) -> bool:
+        entry = self._entries.get(monster_slug)
+        return bool(entry and entry.status == SeenStatus.CAUGHT)
+
+    def get_monsters(self) -> list[str]:
+        return list(self._entries.keys())

--- a/tuxemon/tuxepedia/manager.py
+++ b/tuxemon/tuxepedia/manager.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 from tuxemon.db import SeenStatus
+from tuxemon.tuxepedia.data import TuxepediaData
 
 if TYPE_CHECKING:
     from tuxemon.event.eventbus import EventBus
@@ -27,7 +28,7 @@ class MonsterEntry:
     count.
     """
 
-    status: SeenStatus = SeenStatus.seen
+    status: SeenStatus = SeenStatus.SEEN
     appearance_count: int = 1
     caught_count: int = 0
 
@@ -36,28 +37,31 @@ class MonsterEntry:
             try:
                 self.status = SeenStatus(self.status)
             except ValueError:
-                self.status = SeenStatus.seen
+                self.status = SeenStatus.SEEN
+        self._validate()
 
     def update_status(self, status: SeenStatus) -> None:
         """Prevents status downgrade from caught to seen."""
-        if self.status == SeenStatus.caught and status == SeenStatus.seen:
+        if self.status == SeenStatus.CAUGHT and status == SeenStatus.SEEN:
             return
 
         self.appearance_count += 1
 
-        if status == SeenStatus.caught and self.status != SeenStatus.caught:
+        if status == SeenStatus.CAUGHT and self.status != SeenStatus.CAUGHT:
             self.caught_count += 1
 
         self.status = status
+        self._validate()
 
     def reset_entry(self) -> None:
         """
         Resets the monster entry to its initial state, with the status set
-        to SeenStatus.seen and the appearance count set to 1.
+        to SeenStatus.SEEN and the appearance count set to 1.
         """
-        self.status = SeenStatus.seen
+        self.status = SeenStatus.SEEN
         self.appearance_count = 1
         self.caught_count = 0
+        self._validate()
 
     def get_state(self) -> dict[str, Any]:
         """Returns state for serialization."""
@@ -67,100 +71,21 @@ class MonsterEntry:
             "caught_count": self.caught_count,
         }
 
+    def _validate(self) -> None:
+        assert self.appearance_count >= 1
+        assert self.caught_count >= 0
+        assert self.caught_count <= self.appearance_count
+
+    def register_appearance(self) -> None:
+        self.appearance_count += 1
+        self._validate()
+
     def __str__(self) -> str:
         return (
             f"MonsterEntry(status={self.status.name}, "
             f"appearance_count={self.appearance_count}, "
             f"caught_count={self.caught_count})"
         )
-
-
-class TuxepediaData:
-    """
-    The core, read-only data structure containing all monster entries.
-    Provides safe reading and basic count queries.
-    """
-
-    def __init__(
-        self, entries: Optional[dict[str, MonsterEntry]] = None
-    ) -> None:
-        self._entries: dict[str, MonsterEntry] = (
-            entries if entries is not None else {}
-        )
-
-    def _set_entries(self, new_entries: dict[str, MonsterEntry]) -> None:
-        """
-        Allows the trusted Manager to replace the entry set (e.g., during reset).
-        """
-        self._entries = new_entries
-
-    def get_entry_for_mutation(
-        self, monster_slug: str
-    ) -> Optional[MonsterEntry]:
-        """
-        Returns the actual entry object (not a copy) for in-place modification
-        by the Manager.
-        """
-        return self._entries.get(monster_slug)
-
-    def set_entry(self, monster_slug: str, entry: MonsterEntry) -> None:
-        """Adds or replaces a single entry (used for initial add)."""
-        self._entries[monster_slug] = entry
-
-    def delete_entry(self, monster_slug: str) -> None:
-        """Deletes a single entry (used for remove)."""
-        if monster_slug in self._entries:
-            del self._entries[monster_slug]
-        else:
-            raise KeyError(f"Entry {monster_slug} not found.")
-
-    @property
-    def entries(self) -> dict[str, MonsterEntry]:
-        """Returns a copy of the entries for safe reading."""
-        return dict(self._entries)
-
-    def get_total_monsters(self) -> int:
-        return len(self._entries)
-
-    def get_caught_count(self) -> int:
-        return sum(
-            1
-            for entry in self._entries.values()
-            if entry.status == SeenStatus.caught
-        )
-
-    def get_seen_count(self) -> int:
-        return sum(
-            1
-            for entry in self._entries.values()
-            if entry.status == SeenStatus.seen
-        )
-
-    def get_status(self, monster_slug: str) -> Optional[SeenStatus]:
-        entry = self._entries.get(monster_slug)
-        return entry.status if entry else None
-
-    def get_appearance(self, monster_slug: str) -> int:
-        entry = self._entries.get(monster_slug)
-        return entry.appearance_count if entry else 0
-
-    def get_caught(self, monster_slug: str) -> int:
-        entry = self._entries.get(monster_slug)
-        return entry.caught_count if entry else 0
-
-    def is_registered(self, monster_slug: str) -> bool:
-        return monster_slug in self._entries
-
-    def is_seen(self, monster_slug: str) -> bool:
-        entry = self._entries.get(monster_slug)
-        return bool(entry and entry.status == SeenStatus.seen)
-
-    def is_caught(self, monster_slug: str) -> bool:
-        entry = self._entries.get(monster_slug)
-        return bool(entry and entry.status == SeenStatus.caught)
-
-    def get_monsters(self) -> list[str]:
-        return list(self._entries.keys())
 
 
 class TuxepediaManager:
@@ -201,12 +126,33 @@ class TuxepediaManager:
     def get_monsters(self) -> list[str]:
         return self._data.get_monsters()
 
-    def add_entry(
-        self, monster_slug: str, status: SeenStatus = SeenStatus.seen
-    ) -> None:
-        """Adds a new monster entry or updates an existing one, publishing events."""
+    def register_seen(self, slug: str) -> None:
+        """Record that a monster was seen."""
+        self._apply_status(slug, SeenStatus.SEEN)
 
-        entry = self._data.get_entry_for_mutation(monster_slug)
+    def register_caught(self, slug: str) -> None:
+        """Record that a monster was caught."""
+        self._apply_status(slug, SeenStatus.CAUGHT)
+
+    def register_appearance(self, slug: str) -> None:
+        """Record an appearance without changing status."""
+        entry = self._data.get_entry_for_mutation(slug)
+        if entry:
+            entry.register_appearance()
+            self._event_bus.publish(
+                EVENT_MONSTER_STATUS_UPDATED,
+                monster_slug=slug,
+                status=entry.status,
+                appearance_count=entry.appearance_count,
+                caught_count=entry.caught_count,
+                status_changed=False,
+            )
+        else:
+            # First appearance = seen
+            self.register_seen(slug)
+
+    def _apply_status(self, slug: str, status: SeenStatus) -> None:
+        entry = self._data.get_entry_for_mutation(slug)
 
         if entry:
             old_status = entry.status
@@ -214,27 +160,23 @@ class TuxepediaManager:
 
             self._event_bus.publish(
                 EVENT_MONSTER_STATUS_UPDATED,
-                monster_slug=monster_slug,
+                monster_slug=slug,
                 status=entry.status,
                 appearance_count=entry.appearance_count,
                 caught_count=entry.caught_count,
                 status_changed=(entry.status != old_status),
             )
-            logger.debug(
-                f"Updated monster {monster_slug}: entry={entry}",
-            )
         else:
             new_entry = MonsterEntry(status)
-            self._data.set_entry(monster_slug, new_entry)
+            self._data.set_entry(slug, new_entry)
 
             self._event_bus.publish(
                 EVENT_MONSTER_ADDED,
-                monster_slug=monster_slug,
-                status=status,
+                monster_slug=slug,
+                status=new_entry.status,
                 appearance_count=new_entry.appearance_count,
                 caught_count=new_entry.caught_count,
             )
-            logger.debug(f"Added monster {monster_slug} with status={status}")
 
     def remove_entry(self, monster_slug: str) -> None:
         """Removes a monster entry and publishes the relevant event."""
@@ -270,12 +212,12 @@ class TuxepediaManager:
             removed_entries = {
                 slug: entry
                 for slug, entry in current_entries.items()
-                if entry.status == SeenStatus.seen
+                if entry.status == SeenStatus.SEEN
             }
             new_entries = {
                 slug: entry
                 for slug, entry in current_entries.items()
-                if entry.status != SeenStatus.seen
+                if entry.status != SeenStatus.SEEN
             }
             self._data._set_entries(new_entries)
         else:
@@ -301,76 +243,6 @@ class TuxepediaManager:
         logger.debug(
             f"Tuxepedia reset: removed={initial_count - final_count}, remaining={final_count}, remove_seen_only={remove_seen_only}",
         )
-
-
-class TuxepediaReporter:
-    """
-    Provides analytical functions and generates complex reports based on
-    TuxepediaData.
-    """
-
-    def __init__(self, data: TuxepediaData) -> None:
-        self._data = data
-
-    def get_most_frequent_monsters(self, n: int = 5) -> list[tuple[str, int]]:
-        """
-        Returns a list of the n most frequently appearing monsters,
-        along with their appearance counts.
-        """
-        if not self._data.entries:
-            return []
-
-        return [
-            (slug, entry.appearance_count)
-            for slug, entry in sorted(
-                self._data.entries.items(),
-                key=lambda item: item[1].appearance_count,
-                reverse=True,
-            )[:n]
-        ]
-
-    def get_completeness_report(self, total_monsters: int) -> dict[str, Any]:
-        """Returns a detailed report on the Tuxepedia's completion status."""
-        if total_monsters <= 0:
-            return {
-                "total_game": 0,
-                "registered_count": 0,
-                "caught_count": 0,
-                "registered_percent": 0.0,
-                "caught_percent": 0.0,
-            }
-
-        registered = self._data.get_total_monsters()
-        caught = self._data.get_caught_count()
-
-        return {
-            "total_game": total_monsters,
-            "registered_count": registered,
-            "caught_count": caught,
-            "registered_percent": registered / total_monsters,
-            "caught_percent": caught / total_monsters,
-        }
-
-    def get_unregistered_monsters(
-        self, all_monster_slugs: set[str]
-    ) -> list[str]:
-        """
-        Returns a list of monster slugs from the complete set that are not
-        yet registered in the Tuxepedia.
-        """
-        current_slugs = set(self._data.entries.keys())
-        return list(all_monster_slugs - current_slugs)
-
-    def get_monster_status_distribution(self) -> dict[SeenStatus, int]:
-        """
-        Returns a dictionary representing the distribution of monster statuses.
-        """
-        distribution = {
-            status: 0 for status in [SeenStatus.seen, SeenStatus.caught]
-        }
-        for entry in self._data.entries.values():
-            distribution[entry.status] += 1
-        return distribution
 
 
 def decode_tuxepedia(

--- a/tuxemon/tuxepedia/reporter.py
+++ b/tuxemon/tuxepedia/reporter.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from tuxemon.db import SeenStatus
+
+if TYPE_CHECKING:
+    from tuxemon.tuxepedia.data import TuxepediaData
+
+
+class TuxepediaReporter:
+    """
+    Provides analytical functions and generates complex reports based on
+    TuxepediaData.
+    """
+
+    def __init__(self, data: TuxepediaData) -> None:
+        self._data = data
+
+    def get_most_frequent_monsters(self, n: int = 5) -> list[tuple[str, int]]:
+        """
+        Returns a list of the n most frequently appearing monsters,
+        along with their appearance counts.
+        """
+        if not self._data.entries:
+            return []
+
+        return [
+            (slug, entry.appearance_count)
+            for slug, entry in sorted(
+                self._data.entries.items(),
+                key=lambda item: item[1].appearance_count,
+                reverse=True,
+            )[:n]
+        ]
+
+    def get_completeness_report(self, total_monsters: int) -> dict[str, Any]:
+        """Returns a detailed report on the Tuxepedia's completion status."""
+        if total_monsters <= 0:
+            return {
+                "total_game": 0,
+                "registered_count": 0,
+                "caught_count": 0,
+                "registered_percent": 0.0,
+                "caught_percent": 0.0,
+            }
+
+        registered = self._data.get_total_monsters()
+        caught = self._data.get_caught_count()
+
+        return {
+            "total_game": total_monsters,
+            "registered_count": registered,
+            "caught_count": caught,
+            "registered_percent": registered / total_monsters,
+            "caught_percent": caught / total_monsters,
+        }
+
+    def get_unregistered_monsters(
+        self, all_monster_slugs: set[str]
+    ) -> list[str]:
+        """
+        Returns a list of monster slugs from the complete set that are not
+        yet registered in the Tuxepedia.
+        """
+        current_slugs = set(self._data.entries.keys())
+        return list(all_monster_slugs - current_slugs)
+
+    def get_monster_status_distribution(self) -> dict[SeenStatus, int]:
+        """
+        Returns a dictionary representing the distribution of monster statuses.
+        """
+        distribution = {
+            status: 0 for status in [SeenStatus.SEEN, SeenStatus.CAUGHT]
+        }
+        for entry in self._data.entries.values():
+            distribution[entry.status] += 1
+        return distribution


### PR DESCRIPTION
PR reorganizes `tuxepedia.py` by moving it into its own folder and splitting it into three separate modules: one for the manager, one for the data model, and one for reporting.