### PR TITLE
Fix player being treated as AI during combat

### DIFF
--- a/tuxemon/player.py
+++ b/tuxemon/player.py
@@ -60,6 +60,7 @@ class Player(NPC):
 
     def set_state(self, session: Session, save_data: NPCState) -> None:
         super().set_state(session, save_data)
+        self.is_player = True
 
     def update(self, dt: float) -> None:
         super().update(dt)

--- a/tuxemon/session.py
+++ b/tuxemon/session.py
@@ -70,6 +70,7 @@ class AbstractSession(ABC, Generic[ClientType]):
     def set_player(self, player: Player) -> None:
         """Sets the player. Can be overridden, but is provided for local convenience."""
         self._player = player
+        player.is_player = True
         logger.debug("Player initialized successfully.")
 
     def has_player(self) -> bool:


### PR DESCRIPTION
fixes #3399

Changes:
- force `Player.set_state()` to restore `is_player=True` after loading save data