### PR TITLE
Centralize variable condition logic and modernize faction tests

### DIFF
--- a/mods/tuxemon/db/economy/cotton_scoop.yaml
+++ b/mods/tuxemon/db/economy/cotton_scoop.yaml
@@ -8,14 +8,14 @@
 #   price: Purchase price of the item (integer, example: 20)
 #   cost: Internal cost value for the item (integer, example: 5)
 #   inventory: Quantity available (default -1 = unlimited)
-#   variables: Optional list of variables affecting the item (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the item (must be non-empty if provided)
 # monsters: List of monsters available in this economy
 #   slug: Slug of the monster (must exist in the monster database)
 #   price: Purchase price of the monster (integer)
 #   cost: Internal cost value for the monster (integer)
 #   inventory: Quantity available (must be > 0, default = 1)
 #   level: Minimum level of the monster (must be > 0)
-#   variables: Optional list of variables affecting the monster (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the monster (must be non-empty if provided)
 
 background: gfx/ui/item/item_menu_bg.png
 items:

--- a/mods/tuxemon/db/economy/leather_scoop.yaml
+++ b/mods/tuxemon/db/economy/leather_scoop.yaml
@@ -8,14 +8,14 @@
 #   price: Purchase price of the item (integer, example: 20)
 #   cost: Internal cost value for the item (integer, example: 5)
 #   inventory: Quantity available (default -1 = unlimited)
-#   variables: Optional list of variables affecting the item (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the item (must be non-empty if provided)
 # monsters: List of monsters available in this economy
 #   slug: Slug of the monster (must exist in the monster database)
 #   price: Purchase price of the monster (integer)
 #   cost: Internal cost value for the monster (integer)
 #   inventory: Quantity available (must be > 0, default = 1)
 #   level: Minimum level of the monster (must be > 0)
-#   variables: Optional list of variables affecting the monster (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the monster (must be non-empty if provided)
 
 background: gfx/ui/item/item_menu_bg.png
 items:

--- a/mods/tuxemon/db/economy/spyder_scoops.yaml
+++ b/mods/tuxemon/db/economy/spyder_scoops.yaml
@@ -8,14 +8,14 @@
 #   price: Purchase price of the item (integer, example: 20)
 #   cost: Internal cost value for the item (integer, example: 5)
 #   inventory: Quantity available (default -1 = unlimited)
-#   variables: Optional list of variables affecting the item (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the item (must be non-empty if provided)
 # monsters: List of monsters available in this economy
 #   slug: Slug of the monster (must exist in the monster database)
 #   price: Purchase price of the monster (integer)
 #   cost: Internal cost value for the monster (integer)
 #   inventory: Quantity available (must be > 0, default = 1)
 #   level: Minimum level of the monster (must be > 0)
-#   variables: Optional list of variables affecting the monster (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the monster (must be non-empty if provided)
 
 - background: gfx/ui/item/item_menu_bg.png
   items:
@@ -159,12 +159,14 @@
     slug: tuxeball_diurnal
     price: 300
     variables:
-    - daytime: 'true'
+      - key: daytime
+        value: "true"
   - cost: 60
     slug: tuxeball_nocturnal
     price: 300
     variables:
-    - daytime: 'false'
+      - key: daytime
+        value: "false"
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_timber_scoop
@@ -189,12 +191,14 @@
     slug: tuxeball_diurnal
     price: 300
     variables:
-    - daytime: 'true'
+      - key: daytime
+        value: "true"
   - cost: 60
     slug: tuxeball_nocturnal
     price: 300
     variables:
-    - daytime: 'false'
+      - key: daytime
+        value: "false"
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_candy_scoop

--- a/mods/tuxemon/db/economy/tuxe_mart_taba.yaml
+++ b/mods/tuxemon/db/economy/tuxe_mart_taba.yaml
@@ -8,14 +8,14 @@
 #   price: Purchase price of the item (integer, example: 20)
 #   cost: Internal cost value for the item (integer, example: 5)
 #   inventory: Quantity available (default -1 = unlimited)
-#   variables: Optional list of variables affecting the item (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the item (must be non-empty if provided)
 # monsters: List of monsters available in this economy
 #   slug: Slug of the monster (must exist in the monster database)
 #   price: Purchase price of the monster (integer)
 #   cost: Internal cost value for the monster (integer)
 #   inventory: Quantity available (must be > 0, default = 1)
 #   level: Minimum level of the monster (must be > 0)
-#   variables: Optional list of variables affecting the monster (must be non-empty if provided)
+# variables: Optional list of GameCondition entries affecting the monster (must be non-empty if provided)
 
 background: gfx/ui/item/item_menu_bg.png
 items:

--- a/mods/tuxemon/db/encounter/eclipse_lion_mountain.yaml
+++ b/mods/tuxemon/db/encounter/eclipse_lion_mountain.yaml
@@ -7,7 +7,8 @@ monsters:
   - 65
   monster: snowrilla
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 75
   monster: snowrilla
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 65
   monster: tadcool
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 75
   monster: bumbulus
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 65
   monster: chillimp
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 75
   monster: bumbulus
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 65
   monster: tux
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 75
   monster: tux
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: eclipse_lion_mountain

--- a/mods/tuxemon/db/encounter/eclipse_route7.yaml
+++ b/mods/tuxemon/db/encounter/eclipse_route7.yaml
@@ -7,7 +7,8 @@ monsters:
   - 20
   monster: pairagrim
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 20
   monster: aardart
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 20
   monster: weavifly
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 20
   monster: pantherafira
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 20
   monster: flacono
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 1
   held_items: []
@@ -52,5 +57,6 @@ monsters:
   - 20
   monster: slichen
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: eclipse_route7

--- a/mods/tuxemon/db/encounter/example_horde.yaml
+++ b/mods/tuxemon/db/encounter/example_horde.yaml
@@ -14,7 +14,8 @@ horde:
           probability: 0.4
       level_range: [2, 4]
       variables:
-        - { stage_of_day: "night" }
+        - key: stage_of_day
+          value: "night"
       exp_req_mod: 1.0
 
     - monster: "nut"      # Second monster in the horde
@@ -24,7 +25,8 @@ horde:
           probability: 0.2
       level_range: [3, 5]
       variables:
-        - { stage_of_day: "night" }
+        - key: stage_of_day
+          value: "night"
       exp_req_mod: 1.5
 
     - monster: "rockitten"       # Third monster in the horde
@@ -34,7 +36,8 @@ horde:
           probability: 0.1
       level_range: [5, 7]
       variables:
-        - { stage_of_day: "night" }
+        - key: stage_of_day
+          value: "night"
       exp_req_mod: 2.0
 
   horde_level_range: [3, 6]         # Base level range for the entire horde

--- a/mods/tuxemon/db/encounter/example_single.yaml
+++ b/mods/tuxemon/db/encounter/example_single.yaml
@@ -13,7 +13,8 @@ monsters:
         probability: 0.25           # 25% chance the Pairagrin holds this item
     level_range: [3, 5]             # Pairagrin appears between level 3 and 5
     variables:                      # Variables affecting encounter
-      - { stage_of_day: "night" }   # Example: only appears at night
+      - key: stage_of_day
+        value: "night"              # Example: only appears at night
     exp_req_mod: 1.2                # 20% more XP required to defeat
     level_offset: 1                 # Pairagrin level is shifted +1
     min_player_level: 2             # Player must be at least level 2

--- a/mods/tuxemon/db/encounter/spyder_citypark.yaml
+++ b/mods/tuxemon/db/encounter/spyder_citypark.yaml
@@ -7,7 +7,8 @@ monsters:
   - 8
   monster: cardiling
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 11
   monster: cardiwing
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 9
   monster: cataspike
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 8
   monster: eyenemy
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 12
   monster: axolightl
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 12
   monster: tourbidi
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 12
   monster: squabbit
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 14
   monster: puparmor
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_citypark

--- a/mods/tuxemon/db/encounter/spyder_cotton_tunnel.yaml
+++ b/mods/tuxemon/db/encounter/spyder_cotton_tunnel.yaml
@@ -7,7 +7,8 @@ monsters:
   - 40
   monster: dinoflop
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 35
   monster: furnursus
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 35
   monster: boltnu
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -34,5 +37,6 @@ monsters:
   - 35
   monster: metesaur
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 slug: spyder_cotton_tunnel

--- a/mods/tuxemon/db/encounter/spyder_datacenter.yaml
+++ b/mods/tuxemon/db/encounter/spyder_datacenter.yaml
@@ -7,7 +7,8 @@ monsters:
   - 50
   monster: pythwire
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 0.5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 50
   monster: ouroboutlet
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 0.5
   exp_req_mod: 3
   held_items: []
@@ -25,5 +27,6 @@ monsters:
   - 45
   monster: sockeserp
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 slug: spyder_datacenter

--- a/mods/tuxemon/db/encounter/spyder_dragonscave.yaml
+++ b/mods/tuxemon/db/encounter/spyder_dragonscave.yaml
@@ -7,7 +7,8 @@ monsters:
   - 28
   monster: agnite
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 25
   monster: agnidon
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 28
   monster: embra
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 25
   monster: ruption
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 30
   monster: agnite
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 28
   monster: agnidon
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 30
   monster: embra
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 28
   monster: ruption
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_dragonscave

--- a/mods/tuxemon/db/encounter/spyder_dryadsgrove.yaml
+++ b/mods/tuxemon/db/encounter/spyder_dryadsgrove.yaml
@@ -7,7 +7,8 @@ monsters:
   - 28
   monster: coleorus
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 25
   monster: tourbidi
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 28
   monster: shybulb
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 28
   monster: narcileaf
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 30
   monster: sapsnap
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -52,5 +57,6 @@ monsters:
   - 28
   monster: lambert
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_dryadsgrove

--- a/mods/tuxemon/db/encounter/spyder_greenwash.yaml
+++ b/mods/tuxemon/db/encounter/spyder_greenwash.yaml
@@ -7,7 +7,8 @@ monsters:
   - 25
   monster: cochini
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 25
   monster: cateye
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 5
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 25
   monster: sclairus
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 5
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 25
   monster: bursa
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 5
   exp_req_mod: 3
   held_items: []
@@ -43,5 +47,6 @@ monsters:
   - 25
   monster: nut
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_greenwash

--- a/mods/tuxemon/db/encounter/spyder_mansion.yaml
+++ b/mods/tuxemon/db/encounter/spyder_mansion.yaml
@@ -7,7 +7,8 @@ monsters:
   - 16
   monster: cairfrey
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 16
   monster: polyrock
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 17
   monster: djinnbo
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 16
   monster: pigabyte
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 18
   monster: cairfrey
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 18
   monster: polyrock
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 18
   monster: djinnbo
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 18
   monster: pigabyte
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_mansion

--- a/mods/tuxemon/db/encounter/spyder_route1.yaml
+++ b/mods/tuxemon/db/encounter/spyder_route1.yaml
@@ -7,7 +7,8 @@ monsters:
   - 4
   monster: pairagrin
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 4
   monster: aardorn
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 4
   monster: cataspike
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 5
   monster: pairagrin
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 5
   monster: aardorn
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -52,5 +57,6 @@ monsters:
   - 5
   monster: cataspike
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_route1

--- a/mods/tuxemon/db/encounter/spyder_route2.yaml
+++ b/mods/tuxemon/db/encounter/spyder_route2.yaml
@@ -7,7 +7,8 @@ monsters:
   - 6
   monster: cardiling
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 6
   monster: aardorn
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 6
   monster: eyenemy
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 7
   monster: axolightl
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 6
   monster: cataspike
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 6
   monster: cardiling
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 8
   monster: aardorn
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -70,7 +77,8 @@ monsters:
   - 8
   monster: eyenemy
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -79,7 +87,8 @@ monsters:
   - 8
   monster: axolightl
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 2.5
   exp_req_mod: 3
   held_items: []
@@ -88,5 +97,6 @@ monsters:
   - 8
   monster: cataspike
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_route2

--- a/mods/tuxemon/db/encounter/spyder_route3.yaml
+++ b/mods/tuxemon/db/encounter/spyder_route3.yaml
@@ -7,7 +7,8 @@ monsters:
   - 10
   monster: cardiling
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 10
   monster: elofly
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 11
   monster: squabbit
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 10
   monster: shybulb
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 12
   monster: cardiling
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 12
   monster: elofly
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 12
   monster: squabbit
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 12
   monster: shybulb
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_route3

--- a/mods/tuxemon/db/encounter/spyder_route4.yaml
+++ b/mods/tuxemon/db/encounter/spyder_route4.yaml
@@ -7,7 +7,8 @@ monsters:
   - 14
   monster: elofly
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 15
   monster: sapsnap
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 14
   monster: aardorn
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 14
   monster: katapill
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 16
   monster: elofly
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 16
   monster: sapsnap
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 16
   monster: aardorn
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 16
   monster: katapill
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_route4

--- a/mods/tuxemon/db/encounter/spyder_route5.yaml
+++ b/mods/tuxemon/db/encounter/spyder_route5.yaml
@@ -7,7 +7,8 @@ monsters:
   - 23
   monster: foofle
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 20
   monster: vamporm
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 22
   monster: dracune
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 22
   monster: anoleaf
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -43,5 +47,6 @@ monsters:
   - 26
   monster: gectile
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_route5

--- a/mods/tuxemon/db/encounter/spyder_route6.yaml
+++ b/mods/tuxemon/db/encounter/spyder_route6.yaml
@@ -7,7 +7,8 @@ monsters:
   - 20
   monster: dandicub
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 23
   monster: dandylion
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 10
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 22
   monster: capiti
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 10
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 24
   monster: dandicub
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 5
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 24
   monster: dandylion
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 10
   exp_req_mod: 3
   held_items: []
@@ -52,5 +57,6 @@ monsters:
   - 24
   monster: capiti
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_route6

--- a/mods/tuxemon/db/encounter/spyder_routea.yaml
+++ b/mods/tuxemon/db/encounter/spyder_routea.yaml
@@ -7,7 +7,8 @@ monsters:
   - 15
   monster: shybulb
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 15
   monster: katapill
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1.5
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 15
   monster: anoleaf
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 18
   monster: katapill
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1.5
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 18
   monster: vamporm
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1.5
   exp_req_mod: 3
   held_items: []
@@ -52,5 +57,6 @@ monsters:
   - 18
   monster: anoleaf
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_routea

--- a/mods/tuxemon/db/encounter/spyder_routeb.yaml
+++ b/mods/tuxemon/db/encounter/spyder_routeb.yaml
@@ -7,7 +7,8 @@ monsters:
   - 28
   monster: toufigel
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 25
   monster: pipis
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 28
   monster: strella
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 25
   monster: noctula
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 30
   monster: noctalo
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 30
   monster: cairfrey
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 30
   monster: possessun
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 1
   exp_req_mod: 3
   held_items: []
@@ -70,5 +77,6 @@ monsters:
   - 30
   monster: rockat
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_routeb

--- a/mods/tuxemon/db/encounter/spyder_routec.yaml
+++ b/mods/tuxemon/db/encounter/spyder_routec.yaml
@@ -7,7 +7,8 @@ monsters:
   - 26
   monster: nudiflot_male
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -16,7 +17,8 @@ monsters:
   - 26
   monster: nudiflot_female
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -25,7 +27,8 @@ monsters:
   - 26
   monster: nudimind
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -34,7 +37,8 @@ monsters:
   - 26
   monster: nudikill
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -43,7 +47,8 @@ monsters:
   - 26
   monster: manosting
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -52,7 +57,8 @@ monsters:
   - 26
   monster: tweesher
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -61,7 +67,8 @@ monsters:
   - 26
   monster: nostray
   variables:
-  - daytime: 'true'
+    - key: daytime
+      value: "true"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -70,7 +77,8 @@ monsters:
   - 29
   monster: nudiflot_male
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -79,7 +87,8 @@ monsters:
   - 29
   monster: nudiflot_female
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -88,7 +97,8 @@ monsters:
   - 29
   monster: nudimind
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -97,7 +107,8 @@ monsters:
   - 29
   monster: nudikill
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -106,7 +117,8 @@ monsters:
   - 29
   monster: manosting
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -115,7 +127,8 @@ monsters:
   - 29
   monster: tweesher
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 - encounter_rate: 3.5
   exp_req_mod: 3
   held_items: []
@@ -124,5 +137,6 @@ monsters:
   - 29
   monster: nostray
   variables:
-  - daytime: 'false'
+    - key: daytime
+      value: "false"
 slug: spyder_routec

--- a/mods/tuxemon/db/mission/spyder.yaml
+++ b/mods/tuxemon/db/mission/spyder.yaml
@@ -29,7 +29,8 @@
 - slug: spyder_maniac_achievement1
   description: spyder_maniac_achievement2
   prerequisites:
-  - maniac_achievements: 'yes'
+    - key: maniac_achievements
+      value: "yes"
   failure_conditions: []
   connected_missions: []
   required_items: {}
@@ -42,37 +43,43 @@
       order: 0
       description: Verify maniac achievements unlocked.
       conditions:
-        maniac_achievements: 'yes'
+        key: maniac_achievements
+        value: "yes"
       next_steps:
-      - fossil_check
-      - shammer_check
+        - fossil_check
+        - shammer_check
       optional: false
     fossil_check:
       slug: fossil_check
       order: 1
       description: Confirm player has both fossils.
       conditions:
-        got_both_fossils: 'yes'
+        key: got_both_fossils
+        value: "yes"
       next_steps:
-      - candy_trade
+        - candy_trade
       optional: false
     shammer_check:
       slug: shammer_check
       order: 1
       description: Verify possession of Shammer monster.
       conditions:
-        got_shammer: 'yes'
+        key: got_shammer
+        value: "yes"
       next_steps:
-      - candy_trade
+        - candy_trade
       optional: false
     candy_trade:
       slug: candy_trade
       order: 2
       description: Confirm candy trade with catgirl was completed.
       conditions:
-        any_of:
-        - got_both_fossils: 'yes'
-        - got_shammer: 'yes'
-        catgirl_candy_hastraded: 'yes'
+        key: catgirl_candy_hastraded
+        value: "yes"
+      any_of:
+        - key: got_both_fossils
+          value: "yes"
+        - key: got_shammer
+          value: "yes"
       next_steps: []
       optional: false

--- a/mods/tuxemon/db/monster/brumi.json
+++ b/mods/tuxemon/db/monster/brumi.json
@@ -54,7 +54,8 @@
       "monster_slug": "bewhich",
       "variables": [
         {
-          "daytime": "false"
+          "key": "daytime",
+          "value": "false"
         }
       ]
     }

--- a/mods/tuxemon/db/monster/cackleen.json
+++ b/mods/tuxemon/db/monster/cackleen.json
@@ -42,7 +42,8 @@
       "monster_slug": "brumi",
       "variables": [
         {
-          "daytime": "false"
+          "key": "daytime",
+          "value": "false"
         }
       ]
     }

--- a/mods/tuxemon/db/monster/chromeye.json
+++ b/mods/tuxemon/db/monster/chromeye.json
@@ -34,7 +34,8 @@
       "monster_slug": "angrito",
       "variables": [
         {
-          "season": "winter"
+          "key": "season",
+          "value": "winter"
         }
       ]
     },
@@ -43,7 +44,8 @@
       "monster_slug": "happito",
       "variables": [
         {
-          "season": "summer"
+          "key": "season",
+          "value": "summer"
         }
       ]
     },
@@ -52,7 +54,8 @@
       "monster_slug": "neutrito",
       "variables": [
         {
-          "season": "spring"
+          "key": "season",
+          "value": "spring"
         }
       ]
     },
@@ -61,7 +64,8 @@
       "monster_slug": "sadito",
       "variables": [
         {
-          "season": "autumn"
+          "key": "season",
+          "value": "autumn"
         }
       ]
     }

--- a/mods/tuxemon/db/monster/shull.json
+++ b/mods/tuxemon/db/monster/shull.json
@@ -38,7 +38,8 @@
       "monster_slug": "myrmison",
       "variables": [
         {
-          "daytime": "false"
+          "key": "daytime",
+          "value": "false"
         }
       ]
     }

--- a/mods/tuxemon/db/monster/waysprite.json
+++ b/mods/tuxemon/db/monster/waysprite.json
@@ -34,7 +34,8 @@
       "monster_slug": "angesnow",
       "variables": [
         {
-          "daytime": "true"
+          "key": "daytime",
+          "value": "true"
         }
       ]
     },
@@ -43,7 +44,8 @@
       "monster_slug": "demosnow",
       "variables": [
         {
-          "daytime": "false"
+          "key": "daytime",
+          "value": "false"
         }
       ]
     }

--- a/tests/tuxemon/test_economy.py
+++ b/tests/tuxemon/test_economy.py
@@ -40,26 +40,6 @@ def economy():
     return econ
 
 
-def test_update_item_field_with_valid_item(economy):
-    economy.update_entity_field("potion", "item", "price", 30)
-    assert economy.get_item("potion").price == 30
-
-
-def test_update_item_field_with_unknown_item(economy):
-    with pytest.raises(RuntimeError):
-        economy.update_entity_field("unknown_item", "item", "price", 30)
-
-
-def test_update_item_quantity_with_valid_item(economy):
-    economy.update_item_quantity("potion", 20)
-    assert economy.get_item("potion").inventory == 20
-
-
-def test_update_item_quantity_with_unknown_item(economy):
-    with pytest.raises(RuntimeError):
-        economy.update_item_quantity("unknown_item", 20)
-
-
 @pytest.mark.parametrize(
     "slug,expected_level,expected_inventory",
     [
@@ -84,28 +64,6 @@ def test_refresh_maps_after_modification(economy):
     assert economy.get_item("tea") is None
     economy.refresh_maps()
     assert economy.get_item("tea").price == 200
-
-
-@pytest.mark.parametrize(
-    "npc_vars,conditions,expected",
-    [
-        (
-            {"quest_stage": "start", "alignment": "good"},
-            [{"quest_stage": "start"}, {"alignment": "good"}],
-            True,
-        ),
-        (
-            {"quest_stage": "start", "alignment": "evil"},
-            [{"quest_stage": "start"}, {"alignment": "good"}],
-            False,
-        ),
-        ({"quest_stage": "middle"}, [{"quest_stage": "start"}], False),
-        ({"quest_stage": "start"}, [], True),
-    ],
-)
-def test_variable_conditions(economy, npc_vars, conditions, expected):
-    npc = DummyNPC(npc_vars)
-    assert economy.variable(conditions, npc) is expected
 
 
 @pytest.mark.parametrize(
@@ -147,8 +105,65 @@ def test_calculate_price(
     for k, v in kwargs.items():
         setattr(mock_entity, k, v)
 
-    price, discount = economy.calculate_price(
+    price = economy.calculate_price(
         mock_entity, quantity=quantity, seller_mode=seller_mode
     )
-    assert price == expected_price
-    assert discount == 0
+    assert price.final_price == expected_price
+    assert price.modifier_percent == 0
+
+
+def test_get_model_for_item(economy):
+    mock_item = MagicMock(spec=Item)
+    mock_item.slug = "potion"
+    model = economy.get_model_for(mock_item)
+    assert isinstance(model, EconomyItemModel)
+    assert model.slug == "potion"
+
+
+def test_get_model_for_monster(economy):
+    mock_monster = MagicMock(spec=Monster)
+    mock_monster.slug = "rockitten"
+    model = economy.get_model_for(mock_monster)
+    assert isinstance(model, EconomyMonsterModel)
+    assert model.slug == "rockitten"
+
+
+def test_get_model_for_unknown(economy):
+    mock_item = MagicMock(spec=Item)
+    mock_item.slug = "does_not_exist"
+    assert economy.get_model_for(mock_item) is None
+
+
+def test_calculate_price_missing_monster_price_raises(economy):
+    mock_monster = MagicMock(spec=Monster)
+    mock_monster.slug = "ghost"
+    mock_monster.hp = 10
+    with pytest.raises(ValueError):
+        economy.calculate_price(mock_monster, quantity=1, seller_mode=False)
+
+
+def test_calculate_price_missing_item_cost_resale(economy):
+    mock_item = MagicMock(spec=Item)
+    mock_item.slug = "revive"  # cost=0 in model
+    mock_item.cost = 0
+    price = economy.calculate_price(mock_item, quantity=1, seller_mode=True)
+    assert price.final_price == 0
+    assert price.modifier_percent == 0
+
+
+def test_calculate_price_item_without_model_resale(economy):
+    mock_item = MagicMock(spec=Item)
+    mock_item.slug = "unknown_item"
+    mock_item.cost = 12
+    price = economy.calculate_price(mock_item, quantity=1, seller_mode=True)
+    assert price.final_price == round(12 * economy.model.resale_multiplier)
+    assert price.modifier_percent == 0
+
+
+def test_calculate_price_item_without_model_purchase(economy):
+    mock_item = MagicMock(spec=Item)
+    mock_item.slug = "unknown_item"
+    mock_item.cost = 20
+    price = economy.calculate_price(mock_item, quantity=1, seller_mode=False)
+    assert price.final_price == round(20 * economy.model.resale_multiplier)
+    assert price.modifier_percent == 0

--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -8,6 +8,7 @@ from tuxemon.db import (
     Acquisition,
     BondComparison,
     Comparison,
+    GameCondition,
     GenderType,
     LearningMethod,
     MonsterEvolutionItemModel,
@@ -254,29 +255,39 @@ def test_stats_conditions(
 
 
 @pytest.mark.parametrize(
-    "variables,player_values,expected",
+    "variables, player_values, expected",
     [
-        ([{"var": "val"}], {"var": "val"}, True),  # single match
-        ([{"var": "val"}], {"var": "other_val"}, False),  # single mismatch
+        ([{"var": "val"}], {"var": "val"}, True),
+        ([{"var": "val"}], {"var": "other_val"}, False),
         (
             [{"var1": "val"}, {"var2": "val"}],
             {"var1": "val", "var2": "val"},
             True,
-        ),  # double match
+        ),
         (
             [{"var1": "val"}, {"var2": "other_val"}],
             {"var1": "val", "var2": "val"},
             False,
-        ),  # double mismatch
+        ),
     ],
 )
 def test_variables_conditions(
     setup_evolution, variables, player_values, expected
 ):
     mon, player, _ = setup_evolution
+
     for k, v in player_values.items():
         player.game_variables.set(k, v)
-    evo = MonsterEvolutionItemModel(monster_slug="rockat", variables=variables)
+
+    game_conditions = [
+        GameCondition(key=k, value=v)
+        for cond in variables
+        for k, v in cond.items()
+    ]
+    evo = MonsterEvolutionItemModel(
+        monster_slug="rockat",
+        variables=game_conditions,
+    )
     context = {"map_inside": True}
     assert mon.evolution_handler.can_evolve(evo, context) == expected
 

--- a/tests/tuxemon/test_faction.py
+++ b/tests/tuxemon/test_faction.py
@@ -1,234 +1,226 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
+import pytest
 
 from tuxemon.db import FactionRelationStatus, RankStep
-from tuxemon.faction.faction import Faction, satisfies_all_requirements
+from tuxemon.faction.faction import Faction
+from tuxemon.game_variables import GameVariablesManager
 
 
-class TestFaction(unittest.TestCase):
+@pytest.fixture
+def faction():
+    return Faction()
 
-    def setUp(self):
-        self.faction = Faction()
 
-    @patch("tuxemon.locale.T.translate", return_value="")
-    def test_init(self, mock_translate):
-        self.assertEqual(self.faction.slug, "")
-        self.assertEqual(self.faction.name, "")
-        self.assertEqual(self.faction.description, "")
-        self.assertIsNone(self.faction.kind)
-        self.assertIsNone(self.faction.alignment)
-        self.assertIsNone(self.faction.badge_id)
-        self.assertIsNone(self.faction.leader_char)
-        self.assertEqual(self.faction.ranks, [])
-        self.assertEqual(self.faction.members, [])
-        self.assertEqual(self.faction.reputation, {})
-        self.assertEqual(self.faction.relations, {})
+def test_init(faction, mocker):
+    mocker.patch("tuxemon.locale.T.translate", return_value="")
+    assert faction.slug == ""
+    assert faction.name == ""
+    assert faction.description == ""
+    assert faction.kind is None
+    assert faction.alignment is None
+    assert faction.badge_id is None
+    assert faction.leader_char is None
+    assert faction.ranks == []
+    assert faction.members == []
+    assert faction.reputation == {}
+    assert faction.relations == {}
 
-    def test_get_rank_for_reputation(self):
-        self.faction.ranks = [
-            RankStep(threshold=100, title="test_rank1"),
-            RankStep(threshold=200, title="test_rank2"),
-        ]
-        self.assertEqual(self.faction.get_rank_for_reputation(50), None)
-        self.assertEqual(
-            self.faction.get_rank_for_reputation(150), "test_rank1"
+
+@pytest.mark.parametrize(
+    "rep,expected",
+    [
+        (50, None),
+        (150, "test_rank1"),
+        (250, "test_rank2"),
+    ],
+)
+def test_get_rank_for_reputation(faction, rep, expected):
+    faction.ranks = [
+        RankStep(threshold=100, title="test_rank1"),
+        RankStep(threshold=200, title="test_rank2"),
+    ]
+    assert faction.get_rank_for_reputation(rep) == expected
+
+
+def test_get_current_rank(faction):
+    faction.ranks = [
+        RankStep(threshold=100, title="test_rank1"),
+        RankStep(threshold=200, title="test_rank2"),
+    ]
+    faction.reputation = {"test_npc": 150}
+    assert faction.get_current_rank("test_npc") == "test_rank1"
+
+
+def test_get_relation(faction):
+    faction.relations = {"test_faction": FactionRelationStatus.ALLY}
+    assert faction.get_relation("test_faction") == FactionRelationStatus.ALLY
+    assert (
+        faction.get_relation("other_faction") == FactionRelationStatus.UNKNOWN
+    )
+
+
+def test_is_ally(faction):
+    faction.relations = {"test_faction": FactionRelationStatus.ALLY}
+    assert faction.is_ally("test_faction")
+    assert not faction.is_ally("other_faction")
+
+
+def test_set_relation(faction):
+    faction.set_relation("test_faction", FactionRelationStatus.ALLY)
+    assert faction.relations == {"test_faction": FactionRelationStatus.ALLY}
+
+
+def test_modify_reputation(faction):
+    faction.reputation = {"test_npc": 100}
+    faction.modify_reputation("test_npc", 50)
+    assert faction.reputation == {"test_npc": 150}
+
+
+def test_get_reputation(faction):
+    faction.reputation = {"test_npc": 100}
+    assert faction.get_reputation("test_npc") == 100
+
+
+def test_add_member(faction):
+    faction.add_member("test_npc")
+    assert faction.members == ["test_npc"]
+
+
+def test_remove_member(faction):
+    faction.members = ["test_npc"]
+    faction.remove_member("test_npc")
+    assert faction.members == []
+
+
+def test_has_member(faction):
+    faction.members = ["test_npc"]
+    assert faction.has_member("test_npc")
+    assert not faction.has_member("other_npc")
+
+
+@pytest.mark.parametrize(
+    "initial,new_rep,expected",
+    [
+        ("test_rank1", 250, "test_rank2"),  # promotion
+        ("test_rank2", 150, "test_rank1"),  # degradation
+        ("test_rank2", 50, None),  # degradation to none
+    ],
+)
+def test_evaluate_rank_change(faction, initial, new_rep, expected):
+    faction.ranks = [
+        RankStep(threshold=100, title="test_rank1"),
+        RankStep(threshold=200, title="test_rank2"),
+    ]
+    faction.reputation = {"test_npc": new_rep}
+    faction._rank_cache = {"test_npc": initial}
+
+    new_rank = faction.evaluate_rank_change("test_npc", MagicMock())
+    assert new_rank == expected
+
+    if expected is not None:
+        assert faction.get_current_rank("test_npc") == expected
+    else:
+        assert faction.get_current_rank("test_npc") == initial
+
+
+def test_can_be_promoted(faction):
+    faction.ranks = [RankStep(threshold=100, title="test_rank")]
+    faction.reputation = {"test_npc": 150}
+    assert faction.can_be_promoted(
+        "test_npc", GameVariablesManager(initial_player={})
+    )
+
+
+def test_update_decay_towards_baseline(faction):
+    faction._public_reputation = 30
+    faction._neutral_baseline = 50
+    faction.update(10.0)
+    assert faction._public_reputation > 30
+
+
+def test_update_removes_member_below_threshold(faction):
+    faction.ranks = [RankStep(threshold=100, title="Novice")]
+    faction.add_member("npc1")
+    faction.reputation["npc1"] = 10
+    faction._decay_timer = 600.0
+    faction.update(1.0)
+    assert "npc1" not in faction.members
+
+
+def test_power_level_calculation(faction):
+    faction.add_member("npc1")
+    faction.reputation["npc1"] = 20
+    assert faction.power_level == 20 + 10
+
+
+def test_power_level_empty(faction):
+    assert faction.power_level == 0
+
+
+def test_from_save_data_and_to_save_data_roundtrip(faction):
+    data = {"npc1": {"reputation": 10, "is_member": True}}
+    relations = {"faction2": "ALLY"}
+
+    faction.from_save_data(data, public_reputation=5, relations=relations)
+    save = faction.to_save_data(["npc1"])
+
+    assert save["members"]["npc1"]["reputation"] == 10
+    assert save["public_reputation"] == 5
+    assert save["relations"]["faction2"] == "ALLY"
+
+
+def test_to_save_data_returns_none_for_empty_faction(faction):
+    assert faction.to_save_data(["npc1"]) is None
+
+
+def test_set_relation_publishes_event(faction, mocker):
+    mock_bus = mocker.Mock()
+    faction._event_bus = mock_bus
+    faction.set_relation("factionX", FactionRelationStatus.ALLY)
+    mock_bus.publish.assert_called()
+
+
+def test_add_member_publishes_event(faction, mocker):
+    mock_bus = mocker.Mock()
+    faction._event_bus = mock_bus
+    faction.add_member("npc1")
+    mock_bus.publish.assert_called()
+
+
+def test_remove_member_publishes_event(faction, mocker):
+    mock_bus = mocker.Mock()
+    faction._event_bus = mock_bus
+    faction.members = ["npc1"]
+    faction.remove_member("npc1")
+    mock_bus.publish.assert_called()
+
+
+def test_rank_cache_invalidation_on_reputation_change(faction):
+    faction._rank_cache["npc1"] = "OldRank"
+    faction.modify_reputation("npc1", 5)
+    assert "npc1" not in faction._rank_cache
+
+
+def test_promotion_with_unsatisfied_requirements(faction):
+    faction.ranks = [
+        RankStep(
+            threshold=100,
+            title="Champion",
+            requirement={"variables": [{"key": "badge", "value": "fire"}]},
         )
-        self.assertEqual(
-            self.faction.get_rank_for_reputation(250), "test_rank2"
-        )
+    ]
+    faction.reputation["npc1"] = 150
 
-    def test_get_current_rank(self):
-        self.faction.ranks = [
-            RankStep(threshold=100, title="test_rank1"),
-            RankStep(threshold=200, title="test_rank2"),
-        ]
-        self.faction.reputation = {"test_npc": 150}
-        self.assertEqual(
-            self.faction.get_current_rank("test_npc"), "test_rank1"
-        )
+    game_vars = GameVariablesManager(initial_player={"badge": "water"})
+    assert not faction.can_be_promoted("npc1", game_vars)
 
-    def test_get_relation(self):
-        self.faction.relations = {"test_faction": FactionRelationStatus.ALLY}
-        self.assertEqual(
-            self.faction.get_relation("test_faction"),
-            FactionRelationStatus.ALLY,
-        )
-        self.assertEqual(
-            self.faction.get_relation("other_faction"),
-            FactionRelationStatus.UNKNOWN,
-        )
 
-    def test_is_ally(self):
-        self.faction.relations = {"test_faction": FactionRelationStatus.ALLY}
-        self.assertTrue(self.faction.is_ally("test_faction"))
-        self.assertFalse(self.faction.is_ally("other_faction"))
+def test_set_public_reputation_bounds(faction):
+    faction.set_public_reputation(-10)
+    assert faction.public_reputation == 0
 
-    def test_set_relation(self):
-        self.faction.relations = {}
-        self.faction.set_relation("test_faction", FactionRelationStatus.ALLY)
-        self.assertEqual(
-            self.faction.relations,
-            {"test_faction": FactionRelationStatus.ALLY},
-        )
-
-    def test_modify_reputation(self):
-        self.faction.reputation = {"test_npc": 100}
-        self.faction.modify_reputation("test_npc", 50)
-        self.assertEqual(self.faction.reputation, {"test_npc": 150})
-
-    def test_get_reputation(self):
-        self.faction.reputation = {"test_npc": 100}
-        self.assertEqual(self.faction.get_reputation("test_npc"), 100)
-
-    def test_add_member(self):
-        self.faction.members = []
-        self.faction.add_member("test_npc")
-        self.assertEqual(self.faction.members, ["test_npc"])
-
-    def test_remove_member(self):
-        self.faction.members = ["test_npc"]
-        self.faction.remove_member("test_npc")
-        self.assertEqual(self.faction.members, [])
-
-    def test_has_member(self):
-        self.faction.members = ["test_npc"]
-        self.assertTrue(self.faction.has_member("test_npc"))
-        self.assertFalse(self.faction.has_member("other_npc"))
-
-    def test_evaluate_rank_change_promotion(self):
-        self.faction.ranks = [
-            RankStep(threshold=100, title="test_rank1"),
-            RankStep(threshold=200, title="test_rank2"),
-        ]
-        self.faction.reputation = {"test_npc": 150}
-        self.faction._rank_cache = {"test_npc": "test_rank1"}
-        self.faction.reputation["test_npc"] = 250
-        new_rank = self.faction.evaluate_rank_change("test_npc", {})
-        self.assertEqual(new_rank, "test_rank2")
-        self.assertEqual(
-            self.faction.get_current_rank("test_npc"), "test_rank2"
-        )
-
-    def test_evaluate_rank_change_degradation_valid(self):
-        self.faction.ranks = [
-            RankStep(threshold=100, title="test_rank1"),
-            RankStep(threshold=200, title="test_rank2"),
-        ]
-        self.faction.reputation = {"test_npc": 150}
-        self.faction._rank_cache = {"test_npc": "test_rank2"}
-        new_rank = self.faction.evaluate_rank_change("test_npc", {})
-        self.assertEqual(new_rank, "test_rank1")
-        self.assertEqual(
-            self.faction.get_current_rank("test_npc"), "test_rank1"
-        )
-
-    def test_evaluate_rank_change_degradation_to_none(self):
-        self.faction.ranks = [
-            RankStep(threshold=100, title="test_rank1"),
-            RankStep(threshold=200, title="test_rank2"),
-        ]
-        self.faction.reputation = {"test_npc": 50}
-        self.faction._rank_cache = {"test_npc": "test_rank2"}
-        new_rank = self.faction.evaluate_rank_change("test_npc", {})
-        self.assertIsNone(new_rank)
-        self.assertEqual(
-            self.faction.get_current_rank("test_npc"), "test_rank2"
-        )
-
-    def test_can_be_promoted(self):
-        self.faction.ranks = [
-            RankStep(threshold=100, title="test_rank", requirement=None)
-        ]
-        self.faction.reputation = {"test_npc": 150}
-        self.assertTrue(self.faction.can_be_promoted("test_npc", {}))
-
-    def test_update_decay_towards_baseline(self):
-        self.faction._public_reputation = 30
-        self.faction._neutral_baseline = 50
-        self.faction.update(10.0)
-        self.assertGreater(self.faction._public_reputation, 30)
-
-    def test_update_removes_member_below_threshold(self):
-        self.faction.ranks = [RankStep(threshold=100, title="Novice")]
-        self.faction.add_member("npc1")
-        self.faction.reputation["npc1"] = 10
-        self.faction._decay_timer = 600.0
-        self.faction.update(1.0)
-        self.assertNotIn("npc1", self.faction.members)
-
-    def test_power_level_calculation(self):
-        self.faction.add_member("npc1")
-        self.faction.reputation["npc1"] = 20
-        self.assertEqual(self.faction.power_level, 20 + 1 * 10)
-
-    def test_power_level_empty(self):
-        self.assertEqual(self.faction.power_level, 0)
-
-    def test_from_save_data_and_to_save_data_roundtrip(self):
-        data = {"npc1": {"reputation": 10, "is_member": True}}
-        relations = {"faction2": "ALLY"}
-        self.faction.from_save_data(
-            data, public_reputation=5, relations=relations
-        )
-        save = self.faction.to_save_data(["npc1"])
-        self.assertEqual(save["members"]["npc1"]["reputation"], 10)
-        self.assertEqual(save["public_reputation"], 5)
-        self.assertEqual(save["relations"]["faction2"], "ALLY")
-
-    def test_to_save_data_returns_none_for_empty_faction(self):
-        self.assertIsNone(self.faction.to_save_data(["npc1"]))
-
-    def test_set_relation_publishes_event(self):
-        mock_bus = MagicMock()
-        self.faction._event_bus = mock_bus
-        self.faction.set_relation("factionX", FactionRelationStatus.ALLY)
-        mock_bus.publish.assert_called()
-
-    def test_add_member_publishes_event(self):
-        mock_bus = MagicMock()
-        self.faction._event_bus = mock_bus
-        self.faction.add_member("npc1")
-        mock_bus.publish.assert_called()
-
-    def test_remove_member_publishes_event(self):
-        mock_bus = MagicMock()
-        self.faction._event_bus = mock_bus
-        self.faction.members = ["npc1"]
-        self.faction.remove_member("npc1")
-        mock_bus.publish.assert_called()
-
-    def test_rank_cache_invalidation_on_reputation_change(self):
-        self.faction._rank_cache["npc1"] = "OldRank"
-        self.faction.modify_reputation("npc1", 5)
-        self.assertNotIn("npc1", self.faction._rank_cache)
-
-    def test_promotion_with_unsatisfied_requirements(self):
-        req = MagicMock()
-        req.variables = [{"badge": "fire"}]
-        self.faction.ranks = [
-            RankStep(
-                threshold=100,
-                title="Champion",
-                requirement={"variables": [{"badge": "fire"}]},
-            )
-        ]
-        self.faction.reputation["npc1"] = 150
-        game_vars = {"badge": "water"}
-        self.assertFalse(self.faction.can_be_promoted("npc1", game_vars))
-
-    def test_set_public_reputation_bounds(self):
-        self.faction.set_public_reputation(-10)
-        self.assertEqual(self.faction.public_reputation, 0)
-        self.faction.set_public_reputation(999)
-        self.assertEqual(
-            self.faction.public_reputation, self.faction.MAX_PUBLIC_REPUTATION
-        )
-
-    def test_satisfies_all_requirements_true_and_false(self):
-        game_vars = {"level": 10, "badge": "fire"}
-        reqs = [{"level": 10}, {"badge": "fire"}]
-        self.assertTrue(satisfies_all_requirements(reqs, game_vars))
-        bad_reqs = [{"level": 20}]
-        self.assertFalse(satisfies_all_requirements(bad_reqs, game_vars))
+    faction.set_public_reputation(999)
+    assert faction.public_reputation == faction.MAX_PUBLIC_REPUTATION

--- a/tests/tuxemon/test_faction_manager.py
+++ b/tests/tuxemon/test_faction_manager.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+
+import pytest
 
 from tuxemon.db import FactionAlignment, FactionRelationStatus
 from tuxemon.event.eventbus import EventBus
@@ -9,251 +10,264 @@ from tuxemon.faction.faction import Faction
 from tuxemon.faction.manager import FactionManager
 
 
-class TestFactionManager(unittest.TestCase):
+@pytest.fixture
+def faction_manager():
+    return FactionManager(EventBus())
 
-    def setUp(self):
-        self.event_bus = EventBus()
-        self.faction_manager = FactionManager(self.event_bus)
 
-    def test_init(self):
-        self.assertEqual(self.faction_manager._factions, {})
-        self.assertEqual(self.faction_manager._membership_cache, {})
+@pytest.fixture
+def faction():
+    return Faction()
 
-    def test_load_core_factions(self):
-        faction_slugs = ["faction1", "faction2"]
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction2 = Faction()
-        faction2.slug = "faction2"
 
-        with patch.object(Faction, "load_from_db") as mock_load:
-            with patch.object(
-                self.faction_manager, "register"
-            ) as mock_register:
-                self.faction_manager.load_core_factions(faction_slugs)
+def test_init(faction_manager):
+    assert faction_manager._factions == {}
+    assert faction_manager._membership_cache == {}
 
-        self.assertEqual(mock_load.call_count, 2)
-        self.assertEqual(mock_register.call_count, 2)
 
-    def test_register(self):
-        faction = Faction()
-        faction.slug = "faction1"
-        self.faction_manager.register(faction)
-        self.assertIn(faction.slug, self.faction_manager._factions)
+def test_load_core_factions(faction_manager, mocker):
+    mock_load = mocker.patch.object(Faction, "load_from_db")
+    mock_register = mocker.patch.object(faction_manager, "register")
 
-    def test_get(self):
-        faction = Faction()
-        faction.slug = "faction1"
-        self.faction_manager.register(faction)
-        self.assertEqual(self.faction_manager.get("faction1"), faction)
+    faction_manager.load_core_factions(["f1", "f2"])
 
-    def test_all_factions(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction2 = Faction()
-        faction2.slug = "faction2"
-        self.faction_manager.register(faction1)
-        self.faction_manager.register(faction2)
-        self.assertEqual(len(self.faction_manager.all_factions()), 2)
+    assert mock_load.call_count == 2
+    assert mock_register.call_count == 2
 
-    def test_is_loaded(self):
-        faction = Faction()
-        faction.slug = "faction1"
-        self.faction_manager.register(faction)
-        self.assertTrue(self.faction_manager.is_loaded("faction1"))
 
-    def test_get_factions_by_member(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.add_member("npc1")
-        faction2 = Faction()
-        faction2.slug = "faction2"
-        self.faction_manager.register(faction1)
-        self.faction_manager.register(faction2)
-        self.assertEqual(
-            len(self.faction_manager.get_factions_by_member("npc1")), 1
-        )
+def test_register(faction_manager, faction):
+    faction.slug = "faction1"
+    faction_manager.register(faction)
+    assert "faction1" in faction_manager._factions
 
-    def test_clear_membership_cache(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.add_member("npc1")
-        self.faction_manager.register(faction1)
-        self.faction_manager.get_factions_by_member("npc1")
-        self.faction_manager.clear_membership_cache("npc1")
-        self.assertNotIn("npc1", self.faction_manager._membership_cache)
 
-    def test_resolve_diplomacy(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.alignment = FactionAlignment.LAWFUL
-        faction2 = Faction()
-        faction2.slug = "faction2"
-        faction2.alignment = FactionAlignment.LAWFUL
-        self.faction_manager.register(faction1)
-        self.faction_manager.register(faction2)
-        self.faction_manager.resolve_diplomacy("faction1", "faction2")
-        self.assertEqual(
-            faction1.get_relation("faction2"), FactionRelationStatus.ALLY
-        )
+def test_get(faction_manager, faction):
+    faction.slug = "faction1"
+    faction_manager.register(faction)
+    assert faction_manager.get("faction1") is faction
 
-    def test_find_factions_by_alignment(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.alignment = FactionAlignment.LAWFUL
-        faction2 = Faction()
-        faction2.slug = "faction2"
-        faction2.alignment = FactionAlignment.CHAOTIC
-        self.faction_manager.register(faction1)
-        self.faction_manager.register(faction2)
-        self.assertEqual(
-            len(
-                self.faction_manager.find_factions_by_alignment(
-                    FactionAlignment.LAWFUL
-                )
-            ),
-            1,
-        )
 
-    def test_rank_npc_globally(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.add_member("npc1")
-        self.faction_manager.register(faction1)
-        self.assertIsNotNone(self.faction_manager.rank_npc_globally("npc1"))
+def test_all_factions(faction_manager):
+    f1, f2 = Faction(), Faction()
+    f1.slug, f2.slug = "f1", "f2"
+    faction_manager.register(f1)
+    faction_manager.register(f2)
+    assert len(faction_manager.all_factions()) == 2
 
-    def test_get_state(self):
-        save_data = {
-            "factions_manager": {
-                "faction1": {
-                    "members": {"npc1": {"reputation": 10, "is_member": True}},
-                    "public_reputation": 5,
-                    "relations": {"faction2": "ALLY"},
-                }
+
+def test_is_loaded(faction_manager, faction):
+    faction.slug = "faction1"
+    faction_manager.register(faction)
+    assert faction_manager.is_loaded("faction1")
+
+
+def test_get_factions_by_member(faction_manager):
+    f1, f2 = Faction(), Faction()
+    f1.slug, f2.slug = "f1", "f2"
+    f1.add_member("npc1")
+    faction_manager.register(f1)
+    faction_manager.register(f2)
+
+    assert len(faction_manager.get_factions_by_member("npc1")) == 1
+
+
+def test_clear_membership_cache(faction_manager):
+    f1 = Faction()
+    f1.slug = "f1"
+    f1.add_member("npc1")
+    faction_manager.register(f1)
+
+    faction_manager.get_factions_by_member("npc1")
+    faction_manager.clear_membership_cache("npc1")
+
+    assert "npc1" not in faction_manager._membership_cache
+
+
+def test_resolve_diplomacy_allies(faction_manager):
+    f1, f2 = Faction(), Faction()
+    f1.slug, f2.slug = "f1", "f2"
+    f1.alignment = FactionAlignment.LAWFUL
+    f2.alignment = FactionAlignment.LAWFUL
+
+    faction_manager.register(f1)
+    faction_manager.register(f2)
+
+    faction_manager.resolve_diplomacy("f1", "f2")
+    assert f1.get_relation("f2") == FactionRelationStatus.ALLY
+
+
+def test_find_factions_by_alignment(faction_manager):
+    f1, f2 = Faction(), Faction()
+    f1.slug, f2.slug = "f1", "f2"
+    f1.alignment = FactionAlignment.LAWFUL
+    f2.alignment = FactionAlignment.CHAOTIC
+
+    faction_manager.register(f1)
+    faction_manager.register(f2)
+
+    lawful = faction_manager.find_factions_by_alignment(
+        FactionAlignment.LAWFUL
+    )
+    assert len(lawful) == 1
+
+
+def test_rank_npc_globally(faction_manager):
+    f1 = Faction()
+    f1.slug = "f1"
+    f1.add_member("npc1")
+    faction_manager.register(f1)
+
+    assert faction_manager.rank_npc_globally("npc1") is not None
+
+
+def test_get_state(faction_manager):
+    save_data = {
+        "factions_manager": {
+            "f1": {
+                "members": {"npc1": {"reputation": 10, "is_member": True}},
+                "public_reputation": 5,
+                "relations": {"f2": "ALLY"},
             }
         }
+    }
 
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        self.faction_manager.register(faction1)
-        self.faction_manager.get_state(save_data)
-        self.assertEqual(faction1.get_reputation("npc1"), 10)
-        self.assertIn("npc1", faction1.members)
-        self.assertEqual(faction1.public_reputation, 5)
-        self.assertEqual(
-            faction1.get_relation("faction2"), FactionRelationStatus.ALLY
-        )
+    f1 = Faction()
+    f1.slug = "f1"
+    faction_manager.register(f1)
 
-    def test_set_state(self):
-        npc_manager = Mock()
-        npc_manager.get_all_slugs.return_value = ["npc1"]
+    faction_manager.get_state(save_data)
 
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.add_member("npc1")
-        faction1.reputation["npc1"] = 10
-        faction1.set_public_reputation(5)
-        faction1.set_relation("faction2", FactionRelationStatus.ALLY)
-        self.faction_manager.register(faction1)
-        state = self.faction_manager.set_state(npc_manager)
-        self.assertIn("factions_manager", state)
-        faction_data = state["factions_manager"].get("faction1")
-        self.assertIsNotNone(faction_data)
-        member_data = faction_data.get("members", {}).get("npc1")
-        self.assertEqual(member_data["reputation"], 10)
-        self.assertTrue(member_data["is_member"])
-        self.assertEqual(faction_data.get("public_reputation"), 5)
-        self.assertIn("relations", faction_data)
-        self.assertEqual(faction_data["relations"].get("faction2"), "ALLY")
+    assert f1.get_reputation("npc1") == 10
+    assert "npc1" in f1.members
+    assert f1.public_reputation == 5
+    assert f1.get_relation("f2") == FactionRelationStatus.ALLY
 
-    def test_load_core_factions_empty_list(self):
-        self.faction_manager.load_core_factions([])
-        self.assertEqual(self.faction_manager.all_factions(), [])
 
-    def test_register_duplicate_faction(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        self.faction_manager.register(faction1)
-        self.faction_manager.register(faction1)
-        self.assertEqual(len(self.faction_manager.all_factions()), 1)
+def test_set_state(faction_manager):
+    npc_manager = Mock()
+    npc_manager.get_all_slugs.return_value = ["npc1"]
 
-    def test_get_non_existent_faction(self):
-        self.assertIsNone(self.faction_manager.get("faction1"))
+    f1 = Faction()
+    f1.slug = "f1"
+    f1.add_member("npc1")
+    f1.reputation["npc1"] = 10
+    f1.set_public_reputation(5)
+    f1.set_relation("f2", FactionRelationStatus.ALLY)
 
-    def test_all_factions_empty(self):
-        self.assertEqual(self.faction_manager.all_factions(), [])
+    faction_manager.register(f1)
 
-    def test_is_loaded_non_existent_faction(self):
-        self.assertFalse(self.faction_manager.is_loaded("faction1"))
+    state = faction_manager.set_state(npc_manager)
 
-    def test_get_factions_by_member_empty(self):
-        self.assertEqual(
-            self.faction_manager.get_factions_by_member("npc1"), []
-        )
+    assert "factions_manager" in state
+    fdata = state["factions_manager"]["f1"]
 
-    def test_clear_membership_cache_all(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.add_member("npc1")
-        self.faction_manager.register(faction1)
-        self.faction_manager.get_factions_by_member("npc1")
-        self.faction_manager.clear_membership_cache()
-        self.assertEqual(self.faction_manager._membership_cache, {})
+    assert fdata["members"]["npc1"]["reputation"] == 10
+    assert fdata["members"]["npc1"]["is_member"]
+    assert fdata["public_reputation"] == 5
+    assert fdata["relations"]["f2"] == "ALLY"
 
-    def test_update_triggers_maintenance(self):
-        faction = Faction()
-        faction.slug = "faction1"
-        faction.add_member("npc1")
-        faction.update = Mock()
-        faction.evaluate_rank_change = Mock()
-        self.faction_manager.register(faction)
-        session = Mock()
-        session.player = Mock()
-        session.player.game_variables = Mock()
-        session.player.game_variables.get_state.return_value = {}
-        self.faction_manager.update(601.0, session)
-        faction.update.assert_called_once_with(601.0)
-        faction.evaluate_rank_change.assert_called_with("npc1", {})
 
-    def test_resolve_diplomacy_rivals(self):
-        faction1 = Faction()
-        faction1.slug = "faction1"
-        faction1.alignment = FactionAlignment.LAWFUL
-        faction2 = Faction()
-        faction2.slug = "faction2"
-        faction2.alignment = FactionAlignment.CHAOTIC
-        self.faction_manager.register(faction1)
-        self.faction_manager.register(faction2)
-        self.faction_manager.resolve_diplomacy("faction1", "faction2")
-        self.assertEqual(
-            faction1.get_relation("faction2"), FactionRelationStatus.RIVAL
-        )
+def test_load_core_factions_empty_list(faction_manager):
+    faction_manager.load_core_factions([])
+    assert faction_manager.all_factions() == []
 
-    def test_get_factions_by_member_cache_reuse(self):
-        faction = Faction()
-        faction.slug = "faction1"
-        faction.add_member("npc1")
-        self.faction_manager.register(faction)
-        result1 = self.faction_manager.get_factions_by_member("npc1")
-        with patch.object(
-            Faction, "has_member", return_value=False
-        ) as mock_has_member:
-            result2 = self.faction_manager.get_factions_by_member("npc1")
-            mock_has_member.assert_not_called()
-        self.assertEqual(result1, result2)
 
-    def test_on_faction_loaded_logs(self):
-        faction = Faction()
-        faction.slug = "faction1"
-        with self.assertLogs("tuxemon.faction.manager", level="INFO") as cm:
-            self.faction_manager.on_faction_loaded(faction)
-        self.assertTrue(
-            any("detected faction loaded" in msg for msg in cm.output)
-        )
+def test_register_duplicate_faction(faction_manager):
+    f1 = Faction()
+    f1.slug = "f1"
+    faction_manager.register(f1)
+    faction_manager.register(f1)
+    assert len(faction_manager.all_factions()) == 1
 
-    def test_load_core_factions_failure(self):
-        with patch.object(
-            Faction, "load_from_db", side_effect=Exception("DB error")
-        ):
-            self.faction_manager.load_core_factions(["bad_faction"])
-        self.assertEqual(self.faction_manager.all_factions(), [])
+
+def test_get_non_existent_faction(faction_manager):
+    assert faction_manager.get("missing") is None
+
+
+def test_all_factions_empty(faction_manager):
+    assert faction_manager.all_factions() == []
+
+
+def test_is_loaded_non_existent(faction_manager):
+    assert not faction_manager.is_loaded("missing")
+
+
+def test_get_factions_by_member_empty(faction_manager):
+    assert faction_manager.get_factions_by_member("npc1") == []
+
+
+def test_clear_membership_cache_all(faction_manager):
+    f1 = Faction()
+    f1.slug = "f1"
+    f1.add_member("npc1")
+    faction_manager.register(f1)
+
+    faction_manager.get_factions_by_member("npc1")
+    faction_manager.clear_membership_cache()
+
+    assert faction_manager._membership_cache == {}
+
+
+def test_update_triggers_maintenance(faction_manager):
+    f = Faction()
+    f.slug = "f1"
+    f.add_member("npc1")
+    f.update = Mock()
+    f.evaluate_rank_change = Mock()
+
+    faction_manager.register(f)
+
+    session = Mock()
+    session.player = Mock()
+    session.player.variable_manager = Mock()
+    session.player.variable_manager.get_state.return_value = {}
+
+    faction_manager.update(601.0, session)
+
+    f.update.assert_called_once_with(601.0)
+    f.evaluate_rank_change.assert_called_with(
+        "npc1", session.player.variable_manager
+    )
+
+
+def test_resolve_diplomacy_rivals(faction_manager):
+    f1, f2 = Faction(), Faction()
+    f1.slug, f2.slug = "f1", "f2"
+    f1.alignment = FactionAlignment.LAWFUL
+    f2.alignment = FactionAlignment.CHAOTIC
+
+    faction_manager.register(f1)
+    faction_manager.register(f2)
+
+    faction_manager.resolve_diplomacy("f1", "f2")
+    assert f1.get_relation("f2") == FactionRelationStatus.RIVAL
+
+
+def test_get_factions_by_member_cache_reuse(faction_manager, mocker):
+    f = Faction()
+    f.slug = "f1"
+    f.add_member("npc1")
+    faction_manager.register(f)
+    result1 = faction_manager.get_factions_by_member("npc1")
+    mock_has = mocker.patch.object(Faction, "has_member", return_value=False)
+    result2 = faction_manager.get_factions_by_member("npc1")
+    mock_has.assert_not_called()
+    assert result1 == result2
+
+
+def test_on_faction_loaded_logs(faction_manager, caplog):
+    f = Faction()
+    f.slug = "f1"
+
+    with caplog.at_level("INFO", logger="tuxemon.faction.manager"):
+        faction_manager.on_faction_loaded(f)
+
+    assert any("detected faction loaded" in msg for msg in caplog.messages)
+
+
+def test_load_core_factions_failure(faction_manager, mocker):
+    mocker.patch.object(
+        Faction, "load_from_db", side_effect=Exception("DB error")
+    )
+    faction_manager.load_core_factions(["bad"])
+    assert faction_manager.all_factions() == []

--- a/tests/tuxemon/test_game_variables.py
+++ b/tests/tuxemon/test_game_variables.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.db import GameCondition
+from tuxemon.game_variables import GameVariablesManager
+
+
+@pytest.fixture
+def manager():
+    return GameVariablesManager(
+        initial_player={"hp": 10, "daytime": True},
+        initial_world={"weather": "rain", "difficulty": 2},
+    )
+
+
+def test_scope_basic_operations(manager):
+    assert manager.player.get("hp") == 10
+    assert manager.world.get("weather") == "rain"
+
+    manager.player.set("hp", 20)
+    assert manager.player.get("hp") == 20
+
+    assert manager.player.has("hp")
+    assert not manager.player.has("missing")
+
+    assert manager.world.remove("weather")
+    assert not manager.world.has("weather")
+
+
+def test_dirty_flags(manager):
+    assert not manager.is_any_dirty()
+
+    manager.player.set("hp", 99)
+    assert manager.is_any_dirty()
+
+    manager.clear_all_dirty()
+    assert not manager.is_any_dirty()
+
+    manager.world.set("difficulty", 5)
+    assert manager.is_any_dirty()
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        ("hp", 10),  # player
+        ("daytime", True),  # player
+        ("weather", "rain"),  # world
+        ("difficulty", 2),  # world
+        ("missing", None),  # not found anywhere
+    ],
+)
+def test_resolve_value(manager, key, expected):
+    assert manager._resolve_value(key) == expected
+
+
+@pytest.mark.parametrize(
+    "conditions, expected",
+    [
+        ([{"hp": 10}], True),
+        ([{"hp": 5}], False),
+        ([{"weather": "rain"}], True),
+        ([{"weather": "sun"}], False),
+        ([{"hp": 10}, {"weather": "rain"}], True),
+        ([{"hp": 10}, {"weather": "sun"}], False),
+        ([], True),  # empty = always true
+    ],
+)
+def test_check_logic_dict(manager, conditions, expected):
+    assert manager.check_logic(conditions) is expected
+
+
+@pytest.mark.parametrize(
+    "conditions, expected",
+    [
+        ([GameCondition(key="hp", value=10)], True),
+        ([GameCondition(key="hp", value=5)], False),
+        ([GameCondition(key="weather", value="rain")], True),
+        ([GameCondition(key="weather", value="sun")], False),
+        (
+            [
+                GameCondition(key="hp", value=10),
+                GameCondition(key="weather", value="rain"),
+            ],
+            True,
+        ),
+        (
+            [
+                GameCondition(key="hp", value=10),
+                GameCondition(key="weather", value="sun"),
+            ],
+            False,
+        ),
+        ([], True),
+    ],
+)
+def test_check_conditions(manager, conditions, expected):
+    assert manager.check_conditions(conditions) is expected
+
+
+@pytest.mark.parametrize(
+    "cond, expected",
+    [
+        (GameCondition(key="hp", value=10, scope="player"), True),
+        (GameCondition(key="hp", value=10, scope="world"), False),
+        (GameCondition(key="weather", value="rain", scope="world"), True),
+        (GameCondition(key="weather", value="rain", scope="player"), False),
+    ],
+)
+def test_check_conditions_scope(manager, cond, expected):
+    assert manager.check_conditions([cond]) is expected
+
+
+def test_missing_requirements(manager):
+    conditions = [
+        GameCondition(key="hp", value=10, description="HP must be 10"),
+        GameCondition(key="weather", value="sun", description="Sunny weather"),
+        GameCondition(key="difficulty", value=2),
+    ]
+
+    missing = manager.get_missing_requirements(conditions)
+
+    assert "Sunny weather" in missing
+    assert "Missing requirement: difficulty" not in missing
+    assert len(missing) == 1
+
+
+def test_missing_requirements_empty(manager):
+    assert manager.get_missing_requirements([]) == []
+
+
+def test_check_logic_unknown_key(manager):
+    assert not manager.check_logic([{"unknown": 5}])
+
+
+def test_check_conditions_unknown_key(manager):
+    cond = GameCondition(key="unknown", value=123)
+    assert not manager.check_conditions([cond])
+
+
+def test_numeric_comparison(manager):
+    manager.player.set("score", 100)
+    cond = GameCondition(key="score", value=100)
+    assert manager.check_conditions([cond])
+
+
+def test_none_values(manager):
+    manager.player.set("flag", None)
+    cond = GameCondition(key="flag", value=None)
+    assert manager.check_conditions([cond])

--- a/tests/tuxemon/test_mission.py
+++ b/tests/tuxemon/test_mission.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from unittest import TestCase
 from unittest.mock import MagicMock
 
-from tuxemon.db import MissionStatus
+import pytest
+
+from tuxemon.db import (
+    GameCondition,
+    MissionModel,
+    MissionStatus,
+    MissionStepModel,
+)
 from tuxemon.entity_dir.bag import BagHandler
 from tuxemon.entity_dir.party import PartyHandler
 from tuxemon.game_variables import GameVariablesManager
@@ -13,183 +19,511 @@ from tuxemon.mission.mission import Mission, check_items, check_monsters
 from tuxemon.npc import NPC
 
 
-class TestMissionManager(TestCase):
-    def setUp(self):
-        self.character = MagicMock(spec=NPC)
-        self.character.slug = "test_character"
-        self.character._variables = GameVariablesManager()
-        self.mission = Mission()
-        self.manager = MissionManager()
-        self.mission_controller = MissionController(
-            self.character, self.manager
+@pytest.fixture
+def character(mission_manager):
+    c = MagicMock(spec=NPC)
+    c.slug = "test_character"
+    c.variable_manager = GameVariablesManager()
+    c.mission_controller = MissionController(c, mission_manager)
+    return c
+
+
+@pytest.fixture
+def mission():
+    model = MissionModel(
+        slug="empty",
+        description="empty",
+        prerequisites=[],
+        connected_missions=[],
+        failure_conditions=[],
+        required_items={},
+        required_monsters={},
+        required_missions=[],
+        steps={},
+        repeatable=False,
+    )
+    return Mission(db_data=model)
+
+
+@pytest.fixture
+def mission_manager():
+    return MissionManager()
+
+
+@pytest.fixture
+def controller(character, mission_manager):
+    return MissionController(character, mission_manager)
+
+
+def test_add_mission(mission_manager, mission):
+    mission_manager.add_mission(mission)
+    assert mission_manager.missions == {mission.slug: mission}
+
+
+def test_remove_mission(mission_manager, mission):
+    mission_manager.add_mission(mission)
+    mission_manager.remove_mission(mission)
+    assert mission_manager.missions == {}
+
+
+def test_remove_mission_not_found(mission_manager, mission):
+    mission_manager.remove_mission(mission)
+    assert mission_manager.get_mission_count() == 0
+
+
+def test_find_mission(mission_manager, mission):
+    mission.slug = "test_mission"
+    mission_manager.add_mission(mission)
+    assert mission_manager.find_mission("test_mission") is mission
+
+
+def test_find_mission_not_found(mission_manager):
+    assert mission_manager.find_mission("missing") is None
+
+
+def test_get_mission_count(mission_manager, mission):
+    assert mission_manager.get_mission_count() == 0
+    mission_manager.add_mission(mission)
+    assert mission_manager.get_mission_count() == 1
+
+
+def test_add_duplicate_mission(mission_manager, mission):
+    mission_manager.add_mission(mission)
+    mission_manager.add_mission(mission)
+    assert mission_manager.get_mission_count() == 1
+
+
+def test_large_mission_list(mission_manager):
+    for i in range(1000):
+        m = MagicMock()
+        m.slug = f"mission_{i}"
+        mission_manager.add_mission(m)
+    assert mission_manager.get_mission_count() == 1000
+
+
+@pytest.mark.parametrize(
+    "initial, new, expected",
+    [
+        (
+            MissionStatus.PENDING,
+            MissionStatus.COMPLETED,
+            MissionStatus.COMPLETED,
+        ),
+        (MissionStatus.PENDING, MissionStatus.PENDING, MissionStatus.PENDING),
+    ],
+)
+def test_update_status(mission, initial, new, expected):
+    mission.status = initial
+    mission.update_status(new)
+    assert mission.status == expected
+
+
+def test_check_all_prerequisites(
+    character, controller, mission_manager, mission
+):
+    mission.prerequisites = [GameCondition(key="key", value="value")]
+    mission_manager.add_mission(mission)
+
+    character.game_variables = character.variable_manager.player
+    character.game_variables.set("key", "value")
+    assert controller.check_all_prerequisites()
+
+    character.game_variables.set("key", "wrong_value")
+    assert not controller.check_all_prerequisites()
+
+
+def test_check_all_prerequisites_with_no_missions(controller):
+    assert controller.check_all_prerequisites()
+
+
+def test_check_all_prerequisites_with_unmet_conditions(
+    character, controller, mission_manager, mission
+):
+    mission.prerequisites = [GameCondition(key="key", value="required_value")]
+    mission_manager.add_mission(mission)
+
+    character.game_variables = character.variable_manager.player
+    character.game_variables.set("key", "incorrect_value")
+    assert not controller.check_all_prerequisites()
+
+
+@pytest.mark.parametrize(
+    "potion_qty, lotion_state, expected",
+    [
+        (1, 2, True),
+        (1, 1, False),
+        (1, "missing", False),
+    ],
+)
+def test_check_required_items(
+    character, mission, potion_qty, lotion_state, expected
+):
+    mission.required_items = {"potion": None, "lotion": 2}
+
+    item1 = MagicMock(slug="potion", quantity=potion_qty)
+    item2 = (
+        None
+        if lotion_state == "missing"
+        else MagicMock(slug="lotion", quantity=lotion_state)
+    )
+
+    character.bag = MagicMock(spec=BagHandler)
+    character.bag.find_item.side_effect = lambda slug: (
+        item1 if slug == "potion" else item2
+    )
+
+    assert check_items(character, mission.required_items) is expected
+
+
+@pytest.mark.parametrize(
+    "lvl1, lvl2, expected",
+    [
+        (3, 5, True),
+        (3, 4, False),
+        (3, None, False),
+    ],
+)
+def test_check_required_monsters(character, mission, lvl1, lvl2, expected):
+    mission.required_monsters = {"monster1": None, "monster2": 5}
+
+    monster1 = MagicMock(slug="monster1", level=lvl1)
+    monster2 = (
+        MagicMock(slug="monster2", level=lvl2) if lvl2 is not None else None
+    )
+
+    character.party = MagicMock(spec=PartyHandler)
+    character.party.find_monster.side_effect = lambda slug: (
+        monster1 if slug == "monster1" else monster2
+    )
+
+    assert check_monsters(character, mission.required_monsters) is expected
+
+
+def test_encode_missions(mission_manager, controller, mission):
+    mission.slug = "mission1"
+    mission.status = MissionStatus.PENDING
+    mission_manager.add_mission(mission)
+
+    encoded = controller.encode_missions()
+    assert isinstance(encoded, list)
+    assert len(encoded) == 1
+    assert encoded[0]["slug"] == "mission1"
+    assert encoded[0]["status"] == MissionStatus.PENDING
+
+
+@pytest.mark.parametrize("result", [True, False])
+def test_check_connected_missions(
+    mission_manager, controller, mission, result
+):
+    mission.check_connected_missions = MagicMock(return_value=result)
+    mission_manager.add_mission(mission)
+    assert controller.check_connected_missions() is result
+
+
+@pytest.fixture
+def mission_with_steps():
+    steps = {
+        "start": MissionStepModel(
+            slug="start",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=1,
+            next_steps=["mid"],
+            optional=False,
+        ),
+        "mid": MissionStepModel(
+            slug="mid",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=2,
+            next_steps=["end"],
+            optional=False,
+        ),
+        "end": MissionStepModel(
+            slug="end",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=3,
+            next_steps=[],
+            optional=False,
+        ),
+    }
+    model = MissionModel(
+        slug="agnite",
+        description="agnite",
+        prerequisites=[],
+        connected_missions=[],
+        failure_conditions=[],
+        required_items={},
+        required_monsters={},
+        required_missions=[],
+        steps=steps,
+        repeatable=False,
+    )
+    return Mission(db_data=model)
+
+
+def test_root_step_unlocked(mission_with_steps):
+    assert mission_with_steps.is_step_unlocked("start")
+
+
+def test_child_locked_initially(mission_with_steps):
+    assert not mission_with_steps.is_step_unlocked("mid")
+
+
+def test_child_unlocked_after_parent(mission_with_steps):
+    mission_with_steps.mark_step_completed("start")
+    assert mission_with_steps.is_step_unlocked("mid")
+
+
+def test_auto_complete_step(character):
+    step = MissionStepModel(
+        slug="rockitten",
+        conditions=GameCondition(key="x", value="1"),
+        description="",
+        order=1,
+        next_steps=[],
+        optional=False,
+        auto_complete=True,
+        any_of=[],
+        all_of=[],
+    )
+
+    model = MissionModel(
+        slug="agnite",
+        description="agnite",
+        prerequisites=[],
+        connected_missions=[],
+        failure_conditions=[],
+        required_items={},
+        required_monsters={},
+        required_missions=[],
+        steps={"rockitten": step},
+        repeatable=False,
+    )
+
+    mission = Mission(db_data=model)
+
+    character.game_variables = character.variable_manager.player
+    character.game_variables.set("x", "1")
+
+    mission.check_step_conditions(character)
+
+    assert "rockitten" in mission.completed_steps
+
+
+def test_progress_ignores_optional_steps():
+    steps = {
+        "rockitten": MissionStepModel(
+            slug="rockitten",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=1,
+            next_steps=[],
+            optional=False,
+        ),
+        "pairagrin": MissionStepModel(
+            slug="pairagrin",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=2,
+            next_steps=[],
+            optional=True,
+        ),
+    }
+    model = MissionModel(
+        slug="agnite",
+        description="agnite",
+        prerequisites=[],
+        connected_missions=[],
+        failure_conditions=[],
+        required_items={},
+        required_monsters={},
+        required_missions=[],
+        steps=steps,
+        repeatable=False,
+    )
+    mission = Mission(db_data=model)
+
+    mission.mark_step_completed("rockitten")
+
+    assert mission.get_progress() == 100.0
+
+
+def test_repeatable_mission_resets(character):
+    steps = {
+        "rockitten": MissionStepModel(
+            slug="rockitten",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=1,
+            next_steps=[],
+            optional=False,
+        ),
+    }
+
+    model = MissionModel(
+        slug="agnite",
+        description="agnite",
+        prerequisites=[],
+        connected_missions=[],
+        failure_conditions=[],
+        required_items={},
+        required_monsters={},
+        required_missions=[],
+        steps=steps,
+        repeatable=True,
+    )
+
+    mission = Mission(db_data=model)
+
+    mission.mark_step_completed("rockitten")
+    mission.update_progress(character)
+
+    assert mission.status == MissionStatus.PENDING
+    assert mission.completed_steps == set()
+
+
+def test_graph_valid():
+    steps = {
+        "rockitten": MissionStepModel(
+            slug="rockitten",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=1,
+            next_steps=["pairagrin"],
+        ),
+        "pairagrin": MissionStepModel(
+            slug="pairagrin",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=2,
+            next_steps=[],
+        ),
+    }
+    mission = Mission(
+        db_data=MissionModel(
+            slug="agnite",
+            description="agnite",
+            prerequisites=[],
+            connected_missions=[],
+            failure_conditions=[],
+            required_items={},
+            required_monsters={},
+            required_missions=[],
+            steps=steps,
+            repeatable=False,
         )
-        self.mission_manager = self.mission_controller.mission_manager
+    )
+    mission.validate_graph()  # should not raise
 
-    def test_add_mission(self):
-        self.mission_manager.add_mission(self.mission)
-        output = {self.mission.slug: self.mission}
-        self.assertEqual(self.mission_manager.missions, output)
 
-    def test_remove_mission(self):
-        self.mission_manager.add_mission(self.mission)
-        self.mission_manager.remove_mission(self.mission)
-        self.assertEqual(self.mission_manager.missions, {})
-
-    def test_remove_mission_not_found(self):
-        self.mission_manager.remove_mission(self.mission)
-        self.assertEqual(self.mission_manager.get_mission_count(), 0)
-
-    def test_find_mission(self):
-        self.mission.slug = "test_mission"
-        self.mission_manager.add_mission(self.mission)
-        found_mission = self.mission_manager.find_mission("test_mission")
-        self.assertEqual(found_mission, self.mission)
-
-    def test_find_mission_not_found(self):
-        found_mission = self.mission_manager.find_mission("test_mission")
-        self.assertIsNone(found_mission)
-
-    def test_update_status(self):
-        self.mission.status = MissionStatus.pending
-        self.mission.update_status(MissionStatus.completed)
-        self.assertEqual(self.mission.status, MissionStatus.completed)
-
-    def test_update_status_no_change(self):
-        self.mission.status = MissionStatus.pending
-        self.mission.update_status(MissionStatus.pending)
-        self.assertEqual(self.mission.status, MissionStatus.pending)
-
-    def test_get_mission_count(self):
-        self.assertEqual(self.mission_manager.get_mission_count(), 0)
-        self.mission_manager.add_mission(Mission())
-        self.assertEqual(self.mission_manager.get_mission_count(), 1)
-
-    def test_check_all_prerequisites(self):
-        self.mission.prerequisites = [{"key": "value"}]
-        self.mission_manager.add_mission(self.mission)
-        self.character.game_variables = self.character._variables.player
-
-        self.character.game_variables.set("key", "value")
-        self.assertTrue(self.mission_controller.check_all_prerequisites())
-
-        self.character.game_variables.set("key", "wrong_value")
-        self.assertFalse(self.mission_controller.check_all_prerequisites())
-
-    def test_check_required_items(self):
-        self.mission.required_items = {"potion": None, "lotion": 2}
-
-        item1 = MagicMock()
-        item1.slug = "potion"
-        item1.quantity = 1
-
-        item2 = MagicMock()
-        item2.slug = "lotion"
-        item2.quantity = 2
-
-        self.character.bag = MagicMock(spec=BagHandler)
-        self.character.bag.find_item.side_effect = lambda slug: (
-            item1 if slug == "potion" else item2 if slug == "lotion" else None
+def test_graph_cycle():
+    steps = {
+        "rockitten": MissionStepModel(
+            slug="rockitten",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=1,
+            next_steps=["pairagrin"],
+        ),
+        "pairagrin": MissionStepModel(
+            slug="pairagrin",
+            conditions=GameCondition(key="x", value=1),
+            description="",
+            order=2,
+            next_steps=["rockitten"],
+        ),
+    }
+    mission = Mission(
+        db_data=MissionModel(
+            slug="agnite",
+            description="agnite",
+            prerequisites=[],
+            connected_missions=[],
+            failure_conditions=[],
+            required_items={},
+            required_monsters={},
+            required_missions=[],
+            steps=steps,
+            repeatable=False,
         )
+    )
+    with pytest.raises(ValueError):
+        mission.validate_graph()
 
-        self.assertTrue(
-            check_items(self.character, self.mission.required_items)
+
+def test_required_missions(character, mission_manager):
+    m1 = Mission(
+        db_data=MissionModel(
+            slug="pairagrin",
+            description="pairagrin",
+            prerequisites=[],
+            connected_missions=[],
+            failure_conditions=[],
+            required_items={},
+            required_monsters={},
+            required_missions=[],
+            steps={},
+            repeatable=False,
         )
-
-        item2.quantity = 1
-        self.assertFalse(
-            check_items(self.character, self.mission.required_items)
+    )
+    m2 = Mission(
+        db_data=MissionModel(
+            slug="rockitten",
+            description="rockitten",
+            prerequisites=[],
+            connected_missions=[],
+            failure_conditions=[],
+            required_items={},
+            required_monsters={},
+            required_missions=["pairagrin"],
+            steps={},
+            repeatable=False,
         )
+    )
 
-        self.character.bag.find_item.side_effect = lambda slug: (
-            item1 if slug == "potion" else None
+    mission_manager.add_mission(m1)
+    mission_manager.add_mission(m2)
+
+    character.mission_controller.mission_manager = mission_manager
+
+    assert m2.check_required_missions(character)
+
+
+def test_connected_missions_logic(character, mission_manager):
+    m1 = Mission(
+        db_data=MissionModel(
+            slug="rockitten",
+            description="rockitten",
+            prerequisites=[],
+            connected_missions=[],
+            failure_conditions=[],
+            required_items={},
+            required_monsters={},
+            required_missions=[],
+            steps={},
+            repeatable=False,
         )
-        self.assertFalse(
-            check_items(self.character, self.mission.required_items)
+    )
+    m2 = Mission(
+        db_data=MissionModel(
+            slug="pairagrin",
+            description="pairagrin",
+            prerequisites=[],
+            connected_missions=[{"slug": "rockitten"}],
+            failure_conditions=[],
+            required_items={},
+            required_monsters={},
+            required_missions=[],
+            steps={},
+            repeatable=False,
         )
+    )
 
-    def test_check_required_monsters(self):
-        self.mission.required_monsters = {"monster1": None, "monster2": 5}
+    mission_manager.add_mission(m1)
+    mission_manager.add_mission(m2)
 
-        monster1 = MagicMock()
-        monster1.slug = "monster1"
-        monster1.level = 3
+    character.mission_controller.mission_manager = mission_manager
 
-        monster2 = MagicMock()
-        monster2.slug = "monster2"
-        monster2.level = 5
-
-        self.character.party = MagicMock(spec=PartyHandler)
-        self.character.party.find_monster.side_effect = lambda slug: (
-            monster1
-            if slug == "monster1"
-            else monster2 if slug == "monster2" else None
-        )
-
-        self.assertTrue(
-            check_monsters(self.character, self.mission.required_monsters)
-        )
-
-        monster2.level = 4
-        self.assertFalse(
-            check_monsters(self.character, self.mission.required_monsters)
-        )
-
-        self.character.party.find_monster.side_effect = lambda slug: (
-            monster1 if slug == "monster1" else None
-        )
-        self.assertFalse(
-            check_monsters(self.character, self.mission.required_monsters)
-        )
-
-    def test_check_all_prerequisites_with_no_missions(self):
-        self.assertTrue(self.mission_controller.check_all_prerequisites())
-
-    def test_check_all_prerequisites_with_unmet_conditions(self):
-        self.mission.prerequisites = [{"key": "required_value"}]
-        self.mission_manager.add_mission(self.mission)
-
-        self.character.game_variables.set("key", "incorrect_value")
-        self.assertFalse(self.mission_controller.check_all_prerequisites())
-
-    def test_encode_missions(self):
-        self.mission.slug = "mission1"
-        self.mission.status = MissionStatus.pending
-        self.mission_manager.add_mission(self.mission)
-
-        encoded_missions = self.mission_controller.encode_missions()
-        self.assertIsInstance(encoded_missions, list)
-        self.assertEqual(len(encoded_missions), 1)
-        self.assertEqual(encoded_missions[0]["slug"], "mission1")
-        self.assertEqual(encoded_missions[0]["status"], MissionStatus.pending)
-
-    def test_check_connected_missions(self):
-        self.mission.check_connected_missions = MagicMock(return_value=True)
-        self.mission_manager.add_mission(self.mission)
-
-        self.assertTrue(self.mission_controller.check_connected_missions())
-
-        self.mission.check_connected_missions.return_value = False
-        self.assertFalse(self.mission_controller.check_connected_missions())
-
-    def test_large_mission_list(self):
-        for i in range(1000):
-            mock_mission = MagicMock()
-            mock_mission.slug = f"mission_{i}"
-            self.mission_manager.add_mission(mock_mission)
-
-        self.assertEqual(self.mission_manager.get_mission_count(), 1000)
-
-    def test_remove_duplicate_mission(self):
-        self.mission_manager.add_mission(self.mission)
-        self.mission_manager.remove_mission(self.mission)
-        self.assertEqual(self.mission_manager.get_mission_count(), 0)
-
-    def test_add_and_remove_mission(self):
-        self.mission_manager.add_mission(self.mission)
-        self.mission_manager.remove_mission(self.mission)
-        self.assertEqual(self.mission_manager.get_mission_count(), 0)
-
-    def test_add_duplicate_mission(self):
-        self.mission_manager.add_mission(self.mission)
-        self.mission_manager.add_mission(self.mission)
-        self.assertEqual(self.mission_manager.get_mission_count(), 1)
+    assert m2.check_connected_missions(character)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -131,10 +131,10 @@ class EvolutionStage(str, Enum):
 
 
 class MissionStatus(str, Enum):
-    pending = "pending"
-    completed = "completed"
-    failed = "failed"
-    removed = "removed"
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    REMOVED = "removed"
 
 
 class MusicStatus(str, Enum):
@@ -382,6 +382,25 @@ class BondComparison(BaseComparison):
         description="The bond value to compare against.",
         ge=config_monster.bond_range[0],
         le=config_monster.bond_range[1],
+    )
+
+
+class GameCondition(BaseModel):
+    """
+    A generic condition requirement used across Economy, Quests, and NPCs.
+    """
+
+    key: str = Field(..., description="The internal variable name to check.")
+    value: Any = Field(
+        ..., description="The value required to pass the check."
+    )
+    scope: str | None = Field(
+        default=None,
+        description="Optional scope: 'player' or 'world'. Checks both if None.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="A human-readable explanation of the requirement for debugging.",
     )
 
 
@@ -865,20 +884,20 @@ class MonsterEvolutionItemModel(BaseModel):
             "Each item must exist in the database and have a non-negative weight."
         ),
     )
-    inside: Optional[bool] = Field(
+    inside: bool | None = Field(
         None,
         description="Whether the monster must be inside to evolve.",
     )
-    acquisition: Optional[Acquisition] = Field(
+    acquisition: Acquisition | None = Field(
         None,
         description="How the monster was obtained (e.g. caught, bred, traded, gifted).",
     )
-    variables: Sequence[dict[str, str]] = Field(
+    variables: Sequence[GameCondition] = Field(
         default_factory=list,
         description="The game variables that must exist and match a specific value for the monster to evolve.",
         min_length=1,
     )
-    stats: Optional[StatsComparison] = Field(
+    stats: StatsComparison | None = Field(
         None,
         description=(
             "Defines a condition where one monster stat must compare to another stat or value "
@@ -1724,7 +1743,7 @@ class PartyMemberModel(BaseModel):
         ..., description="Experience required modifier", gt=0
     )
     gender: GenderType = Field(..., description="Gender of the monster")
-    variables: Sequence[dict[str, str]] = Field(
+    variables: Sequence[GameCondition] = Field(
         default_factory=list,
         description="Sequence of variables that affect the presence of the monster.",
         min_length=1,
@@ -1740,7 +1759,7 @@ class PartyMemberModel(BaseModel):
 class BagItemModel(BaseModel):
     slug: str = Field(..., description="Slug of the item")
     quantity: int = Field(..., description="Quantity of the item")
-    variables: Sequence[dict[str, str]] = Field(
+    variables: Sequence[GameCondition] = Field(
         default_factory=list,
         description="List of variables that affect the item.",
         min_length=1,
@@ -2170,7 +2189,7 @@ class EncounterItemModel(BaseModel):
         ...,
         description="Minimum and maximum levels at which this encounter can occur.",
     )
-    variables: Sequence[dict[str, str]] = Field(
+    variables: Sequence[GameCondition] = Field(
         ...,
         description="List of variables that affect the encounter.",
     )
@@ -2581,37 +2600,41 @@ class TasteModel(BaseModel, BaseLookupModel):
 
 
 class EconomyEntityModel(BaseModel):
-    price: int = Field(..., description="Price of the entity")
-    cost: int = Field(..., description="Cost of the entity")
-    inventory: int = Field(-1, description="Quantity of the entity")
-    variables: Sequence[dict[str, str]] = Field(
+    """Base class. Do not instantiate directly."""
+
+    price: int = Field(..., description="Price of the entity", ge=0)
+    cost: int = Field(..., description="Cost of the entity", ge=0)
+    variables: Sequence[GameCondition] = Field(
         default_factory=list,
         description="List of variables that affect the entity in the economy.",
-        min_length=1,
     )
 
 
 class EconomyItemModel(EconomyEntityModel):
     slug: str = Field(..., description="Slug of the Item")
-    inventory: int = Field(-1, description="Quantity of the entity")
+    inventory: int = Field(
+        -1, description="Quantity of the item. -1 means infinite stock."
+    )
 
     @field_validator("slug")
     def item_exists(cls, v: str) -> str:
         if has.db_entry("item", v):
             return v
-        raise ValueError(f"the item {v} doesn't exist in the db")
+        raise ValueError(f"Item '{v}' referenced in economy is not in the DB")
 
 
 class EconomyMonsterModel(EconomyEntityModel):
     slug: str = Field(..., description="Slug of the Monster")
-    inventory: int = Field(1, description="Quantity of the entity", gt=0)
-    level: int = Field(..., description="Level of the entity", gt=0)
+    inventory: int = Field(1, description="Quantity of the monster", gt=0)
+    level: int = Field(..., description="Level of the monster", gt=0)
 
     @field_validator("slug")
     def monster_exists(cls, v: str) -> str:
         if has.db_entry("monster", v):
             return v
-        raise ValueError(f"the monster {v} doesn't exist in the db")
+        raise ValueError(
+            f"Monster '{v}' referenced in economy is not in the DB"
+        )
 
 
 class EconomyModel(BaseModel, BaseLookupModel):
@@ -2619,8 +2642,8 @@ class EconomyModel(BaseModel, BaseLookupModel):
     slug: str = Field(..., description="Slug uniquely identifying the economy")
     resale_multiplier: float = Field(..., description="Resale multiplier")
     background: str = Field(..., description="Sprite used for background")
-    items: Sequence[EconomyItemModel]
-    monsters: Sequence[EconomyMonsterModel]
+    items: list[EconomyItemModel]
+    monsters: list[EconomyMonsterModel]
 
     @classmethod
     def lookup(cls, slug: str, db: ModData) -> EconomyModel:
@@ -2632,9 +2655,11 @@ class EconomyModel(BaseModel, BaseLookupModel):
 
     @field_validator("background")
     def background_exists(cls, v: str) -> str:
-        if has.file(v) and has.size(v, sizes.NATIVE_RESOLUTION):
-            return v
-        raise ValueError(f"no resource exists with path: {v}")
+        if not has.file(v):
+            raise ValueError(f"Background file not found: {v}")
+        if not has.size(v, sizes.NATIVE_RESOLUTION):
+            raise ValueError(f"Background file {v} has incorrect resolution")
+        return v
 
 
 class FactionKind(str, Enum):
@@ -2667,7 +2692,7 @@ class FactionRelationStatus(str, Enum):
 
 class RankRequirement(BaseModel):
     min_reputation: int = 0
-    variables: Sequence[dict[str, Any]] = Field(
+    variables: Sequence[GameCondition] = Field(
         default_factory=list,
         description="List of variables that affect the requirement.",
         min_length=1,
@@ -2794,15 +2819,14 @@ class MissionStepModel(BaseModel):
     description: str = Field(
         ..., description="Describes what the step requires or represents"
     )
-    conditions: dict[str, Any] = Field(
-        default_factory=dict,
+    conditions: GameCondition = Field(
         description="Simple conditions on game_variables (all must be true)",
     )
-    any_of: list[dict[str, Any]] = Field(
+    any_of: list[GameCondition] = Field(
         default_factory=list,
         description="Alternative condition sets; step completes if any are satisfied",
     )
-    all_of: list[dict[str, Any]] = Field(
+    all_of: list[GameCondition] = Field(
         default_factory=list,
         description="Additional condition sets; all must be satisfied",
     )
@@ -2819,6 +2843,17 @@ class MissionStepModel(BaseModel):
         description="Monsters required to complete this step. Level is optional; None means any level.",
     )
     optional: bool = Field(False, description="Whether the step is optional")
+    auto_complete: bool = Field(
+        True,
+        description=(
+            "If true, the step is automatically marked as completed as soon as its "
+            "conditions (conditions, any_of, all_of, item and monster requirements) "
+            "are satisfied. If false, the step only becomes unlocked when conditions "
+            "are met, but must be completed manually through an explicit game event "
+            "such as interacting with an NPC, triggering a script, or performing a "
+            "player action."
+        ),
+    )
 
 
 class MissionModel(BaseModel, BaseLookupModel):
@@ -2828,7 +2863,7 @@ class MissionModel(BaseModel, BaseLookupModel):
     description: str = Field(
         ..., description="Detailed description of the mission objectives"
     )
-    prerequisites: Sequence[dict[str, Any]] = Field(
+    prerequisites: Sequence[GameCondition] = Field(
         default_factory=list,
         description="List of game variables required to unlock the mission",
     )
@@ -2855,7 +2890,7 @@ class MissionModel(BaseModel, BaseLookupModel):
     repeatable: bool = Field(
         False, description="Whether the mission can be repeated"
     )
-    failure_conditions: Sequence[dict[str, Any]] = Field(
+    failure_conditions: Sequence[GameCondition] = Field(
         default_factory=list,
         description="List of game variables that, if met, cause the mission to fail",
     )

--- a/tuxemon/economy/applier.py
+++ b/tuxemon/economy/applier.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from tuxemon.db import Acquisition, EconomyItemModel, EconomyMonsterModel
 from tuxemon.economy.economy import Economy
@@ -44,7 +44,7 @@ class EconomyApplier:
         entity: NPC,
         eco_model: EconomyItemModel | EconomyMonsterModel,
         shop_manager: ShopManager,
-    ) -> Optional[Item | Monster]:
+    ) -> Item | Monster | None:
         """Process a single item or monster model and return the created entity, or None."""
 
         entity_name = eco_model.slug
@@ -57,8 +57,11 @@ class EconomyApplier:
         )
         quantity = shop_manager.get_or_set_default(label, default_quantity)
 
-        if eco_model.variables and not economy.variable(
-            eco_model.variables, entity
+        if (
+            eco_model.variables
+            and not entity.variable_manager.check_conditions(
+                eco_model.variables
+            )
         ):
             logger.debug(
                 f"Skipping {entity_type} '{entity_name}' (variables mismatch)"

--- a/tuxemon/economy/economy.py
+++ b/tuxemon/economy/economy.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from dataclasses import dataclass
 
 from tuxemon.database.runtime import db
 from tuxemon.db import EconomyItemModel, EconomyModel, EconomyMonsterModel
@@ -13,10 +12,13 @@ from tuxemon.item.item import Item
 from tuxemon.monster import Monster
 from tuxemon.platform.const.graphics import GRAD_BLUE
 
-if TYPE_CHECKING:
-    from tuxemon.npc import NPC
-
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PriceResult:
+    final_price: int
+    modifier_percent: int
 
 
 class Economy:
@@ -27,12 +29,12 @@ class Economy:
     """
 
     def __init__(
-        self, slug: Optional[str] = None, policy: Optional[PricePolicy] = None
+        self, slug: str | None = None, policy: PricePolicy | None = None
     ) -> None:
         self.policy = policy or PricePolicy()
         self.model: EconomyModel
-        self._items_map: dict[str, EconomyItemModel] = {}  # New
-        self._monsters_map: dict[str, EconomyMonsterModel] = {}  # New
+        self._items_map: dict[str, EconomyItemModel] = {}
+        self._monsters_map: dict[str, EconomyMonsterModel] = {}
 
         if slug:
             self.load(slug)
@@ -75,29 +77,17 @@ class Economy:
     def set_policy(self, policy: PricePolicy) -> None:
         self.policy = policy
 
-    def get_item(self, item_slug: str) -> Optional[EconomyItemModel]:
+    def get_item(self, item_slug: str) -> EconomyItemModel | None:
         """
         Gets an EconomyItemModel definition from the economy by its slug (O(1) lookup).
         """
         return self._items_map.get(item_slug)
 
-    def get_monster(self, monster_slug: str) -> Optional[EconomyMonsterModel]:
+    def get_monster(self, monster_slug: str) -> EconomyMonsterModel | None:
         """
         Gets an EconomyMonsterModel definition from the economy by its name (O(1) lookup).
         """
         return self._monsters_map.get(monster_slug)
-
-    def _get_entity_model(
-        self, entity: Item | Monster
-    ) -> Optional[EconomyItemModel | EconomyMonsterModel]:
-        """
-        Internal method to safely retrieve the associated economy model (Item or Monster).
-        """
-        if isinstance(entity, Item):
-            return self.get_item(entity.slug)
-        elif isinstance(entity, Monster):
-            return self.get_monster(entity.slug)
-        return None
 
     def refresh_maps(self) -> None:
         """
@@ -109,71 +99,47 @@ class Economy:
             monster.slug: monster for monster in self.model.monsters
         }
 
-    def update_entity_field(
-        self, entity_slug: str, entity_kind: str, field: str, value: int
-    ) -> None:
+    def get_model_for(
+        self, entity: Item | Monster
+    ) -> EconomyItemModel | EconomyMonsterModel | None:
+        slug = entity.slug
+        if isinstance(entity, Item):
+            return self._items_map.get(slug)
+        return self._monsters_map.get(slug)
+
+    def _resolve_resale_base(
+        self,
+        entity: Item | Monster,
+        model: EconomyItemModel | EconomyMonsterModel | None,
+    ) -> float:
         """
-        Updates the value of a specific field for an entity definition in the economy.
-        entity_kind should be "item" or "monster".
+        Determine the base resale value (shop buys from player).
         """
-        entity_model: EconomyItemModel | EconomyMonsterModel | None
+        if model:
+            return float(model.cost)
 
-        if entity_kind == "item":
-            entity_model = self.get_item(entity_slug)
-        elif entity_kind == "monster":
-            entity_model = self.get_monster(entity_slug)
-        else:
-            raise ValueError(
-                "Invalid entity kind provided. Use 'item' or 'monster'."
-            )
+        intrinsic = entity.cost if isinstance(entity, Item) else entity.hp
+        return intrinsic * self.model.resale_multiplier
 
-        if entity_model is None:
-            raise RuntimeError(
-                f"Entity definition '{entity_slug}' not found in economy '{self.model.slug}'"
-            )
-
-        if hasattr(entity_model, field):
-            setattr(entity_model, field, value)
-        else:
-            raise AttributeError(
-                f"Entity definition '{entity_slug}' has no field '{field}'"
-            )
-
-    def update_item_quantity(self, item_slug: str, quantity: int) -> None:
-        self.update_entity_field(item_slug, "item", "inventory", quantity)
-
-    def update_monster_quantity(
-        self, monster_slug: str, quantity: int
-    ) -> None:
-        self.update_entity_field(
-            monster_slug, "monster", "inventory", quantity
-        )
-
-    def variable(
-        self, variables: Sequence[dict[str, str]], character: NPC
-    ) -> bool:
+    def _resolve_purchase_base(
+        self,
+        entity: Item | Monster,
+        model: EconomyItemModel | EconomyMonsterModel | None,
+    ) -> float:
         """
-        Checks if the given variables (conditions from economy data) match
-        the character's game variables.
-
-        Parameters:
-            variables: A sequence of dictionaries, each representing a set of
-                variable-value pairs to check.
-            character: The character (NPC or player) whose game variables are
-                checked.
-
-        Returns:
-            True if all specified variable conditions match the character's
-            game variables, otherwise False.
+        Determine the base purchase value (shop sells to player).
         """
-        if not variables:
-            return True
-        return all(
-            all(
-                character.game_variables.get(key) == value
-                for key, value in variable.items()
+        if model:
+            return float(model.price)
+
+        if isinstance(entity, Item):
+            logger.warning(
+                f"Missing price for Item '{entity.slug}'. Falling back to resale calculation."
             )
-            for variable in variables
+            return round(entity.cost * self.model.resale_multiplier)
+
+        raise ValueError(
+            f"Missing mandatory price for monster: {entity.slug} in economy '{self.model.slug}'"
         )
 
     def calculate_price(
@@ -181,7 +147,7 @@ class Economy:
         entity: Item | Monster,
         quantity: int,
         seller_mode: bool = False,
-    ) -> tuple[int, int]:
+    ) -> PriceResult:
         """
         Calculate the final transaction price for an Item or Monster.
 
@@ -191,49 +157,18 @@ class Economy:
             seller_mode: True if the entity is being resold *to* the shop
                 (cost for buyer), False if it is being sold *by* the shop
                 (price for buyer).
-
-        Returns:
-            (final_price, discount_percent)
         """
-        entity_model = self._get_entity_model(entity)
-        base_value: float
+        model = self.get_model_for(entity)
 
         if seller_mode:
-            # --- Calculating Resale Cost (Price to Buyer) ---
-            lookup_cost = entity_model.cost if entity_model else None
-
-            if lookup_cost is not None:
-                base_value = float(lookup_cost)
-            else:
-                intrinsic_cost = (
-                    entity.cost if isinstance(entity, Item) else entity.hp
-                )
-                base_value = intrinsic_cost * self.model.resale_multiplier
-
-            return self.policy.apply_resell_modifiers(
-                round(base_value), quantity, entity.slug
+            base = self._resolve_resale_base(entity, model)
+            final_price, discount = self.policy.apply_resell_modifiers(
+                round(base), quantity, entity.slug
             )
+            return PriceResult(final_price, discount)
 
-        else:
-            # --- Calculating Purchase Price (Price from Shop) ---
-            lookup_price = entity_model.price if entity_model else None
-
-            if lookup_price is not None:
-                base_value = lookup_price
-            else:
-                if isinstance(entity, Item):
-                    intrinsic_cost = entity.cost
-                    base_value = round(
-                        intrinsic_cost * self.model.resale_multiplier
-                    )
-                    logger.warning(
-                        f"Missing price for Item '{entity.slug}'. Falling back to resale calculation."
-                    )
-                else:
-                    raise ValueError(
-                        f"Missing mandatory price for monster: {entity.slug} in economy '{self.model.slug}'"
-                    )
-
-            return self.policy.apply_modifiers(
-                base_value, quantity, entity.slug
-            )
+        base = self._resolve_purchase_base(entity, model)
+        final_price, discount = self.policy.apply_modifiers(
+            round(base), quantity, entity.slug
+        )
+        return PriceResult(final_price, discount)

--- a/tuxemon/encounter.py
+++ b/tuxemon/encounter.py
@@ -113,10 +113,6 @@ class Encounter:
         self._cache: list[EncounterItemModel] = list(zone.get_encounters())
 
     def _is_valid(self, enc: EncounterItemModel, character: NPC) -> bool:
-        """
-        Unified validation for single and horde monsters.
-        Checks levels and game-state variables.
-        """
         avg_lvl = character.party.level_average
         if avg_lvl is None:
             return False
@@ -126,12 +122,8 @@ class Encounter:
         if enc.max_player_level and avg_lvl > enc.max_player_level:
             return False
 
-        if enc.variables and not any(
-            all(
-                character.game_variables.get(k) == v
-                for k, v in var_set.items()
-            )
-            for var_set in enc.variables
+        if enc.variables and not character.variable_manager.check_conditions(
+            enc.variables
         ):
             return False
 

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -20,6 +20,7 @@ from tuxemon.npc import NPC
 
 if TYPE_CHECKING:
     from tuxemon.db import PartyMemberModel
+    from tuxemon.game_variables import GameVariablesManager
     from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
@@ -65,11 +66,14 @@ class CreateNpcAction(EventAction):
         npc.template = npc_details.template
         npc.combat = npc_details.combat
         npc.audio = npc_details.audio
-        game_variables = session.player.game_variables.get_state()
+        variable_manager = session.player.variable_manager
+
         if npc_details.monsters:
-            load_party_monsters(npc, npc_details, game_variables)
+            load_party_monsters(npc, npc_details, variable_manager)
+
         if npc_details.items:
-            load_party_items(npc, npc_details, game_variables)
+            load_party_items(npc, npc_details, variable_manager)
+
         npc.sprite_controller.update_template(npc.template)
         npc.dialogue = merge_dialogue(npc_details.speech.profile, None)
 
@@ -87,13 +91,13 @@ def load_party(slug: str) -> NpcModel:
 
 
 def load_party_monsters(
-    npc: NPC, party: NpcModel, game_variables: dict[str, Any]
+    npc: NPC, party: NpcModel, variable_manager: GameVariablesManager
 ) -> None:
     """Loads the NPC's party monsters from the database."""
     npc.party.clear_party()
     for npc_monster in party.monsters:
-        if npc_monster.variables and check_variables(
-            npc_monster.variables, game_variables
+        if npc_monster.variables and variable_manager.check_conditions(
+            npc_monster.variables
         ):
             monster = party_monster(npc_monster)
             npc.party.insert_monster_to_party(monster, len(npc.monsters))
@@ -109,13 +113,13 @@ def party_monster(npc_monster: PartyMemberModel) -> Monster:
 
 
 def load_party_items(
-    npc: NPC, bag: NpcModel, game_variables: dict[str, Any]
+    npc: NPC, bag: NpcModel, variable_manager: GameVariablesManager
 ) -> None:
     """Loads the NPC's items from the database."""
     npc.bag.clear_items()
     for npc_item in bag.items:
-        if npc_item.variables and check_variables(
-            npc_item.variables, game_variables
+        if npc_item.variables and variable_manager.check_conditions(
+            npc_item.variables
         ):
             item = Item.create(npc_item.slug, npc_item.model_dump())
             npc.bag.add_item(item, npc_item.quantity)

--- a/tuxemon/event/actions/modify_faction_reputation.py
+++ b/tuxemon/event/actions/modify_faction_reputation.py
@@ -54,7 +54,5 @@ class ModifyFactionReputationAction(EventAction):
             f"[Reputation] {char.slug}'s rep in {self.faction_slug} changed by {self.amount}. "
             f"New rep: {faction.get_reputation(char.slug)}"
         )
-        faction.evaluate_rank_change(
-            char.slug, char.game_variables.get_state()
-        )
+        faction.evaluate_rank_change(char.slug, char.variable_manager)
         faction_manager.clear_membership_cache(char.slug)

--- a/tuxemon/event/actions/set_mission.py
+++ b/tuxemon/event/actions/set_mission.py
@@ -55,7 +55,7 @@ class SetMissionAction(EventAction):
 
             progress = mission.get_progress()
             if progress >= 100.0:
-                mission.update_status(MissionStatus.completed)
+                mission.update_status(MissionStatus.COMPLETED)
                 if mission.repeatable:
                     mission.completed_steps.clear()
-                    mission.update_status(MissionStatus.pending)
+                    mission.update_status(MissionStatus.PENDING)

--- a/tuxemon/faction/faction.py
+++ b/tuxemon/faction/faction.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from tuxemon.database.runtime import db
 from tuxemon.db import (
@@ -19,6 +19,7 @@ from tuxemon.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.event.eventbus import EventBus
+    from tuxemon.game_variables import GameVariablesManager
 
 logger = logging.getLogger(__name__)
 
@@ -43,16 +44,16 @@ class Faction:
 
     MAX_PUBLIC_REPUTATION: int = 100
 
-    def __init__(self, event_bus: Optional[EventBus] = None) -> None:
+    def __init__(self, event_bus: EventBus | None = None) -> None:
         self._event_bus = event_bus
         self._rank_cache: dict[str, str] = {}
         self.slug: str = ""
-        self._custom_name: Optional[str] = None
-        self._custom_description: Optional[str] = None
-        self.kind: Optional[FactionKind] = None
-        self.alignment: Optional[FactionAlignment] = None
-        self.badge_id: Optional[str] = None
-        self.leader_char: Optional[str] = None
+        self._custom_name: str | None = None
+        self._custom_description: str | None = None
+        self.kind: FactionKind | None = None
+        self.alignment: FactionAlignment | None = None
+        self.badge_id: str | None = None
+        self.leader_char: str | None = None
         self.ranks: list[RankStep] = []
         self.members: list[str] = []
         self.reputation: dict[str, int] = {}
@@ -133,13 +134,13 @@ class Faction:
             f"[Faction] {npc_id} assigned rank '{rank_title}' in faction '{self.slug}'"
         )
 
-    def get_rank_for_reputation(self, rep: int) -> Optional[str]:
+    def get_rank_for_reputation(self, rep: int) -> str | None:
         for rank in reversed(self.ranks):
             if rep >= rank.threshold:
                 return rank.title
         return None
 
-    def get_current_rank(self, npc_id: str) -> Optional[str]:
+    def get_current_rank(self, npc_id: str) -> str | None:
         if npc_id in self._rank_cache:
             return self._rank_cache[npc_id]
         rep = self.get_reputation(npc_id)
@@ -165,7 +166,7 @@ class Faction:
     def on_relation_changed(
         self,
         other_id: str,
-        old_status: Optional[FactionRelationStatus],
+        old_status: FactionRelationStatus | None,
         new_status: FactionRelationStatus,
     ) -> None:
         logger.info(
@@ -220,8 +221,8 @@ class Faction:
         return npc_id in self.members
 
     def evaluate_rank_change(
-        self, npc_id: str, game_variables: dict[str, Any]
-    ) -> Optional[str]:
+        self, npc_id: str, game_variables: GameVariablesManager
+    ) -> str | None:
         rep = self.get_reputation(npc_id)
         desired_rank = self.get_rank_for_reputation(rep)
         current_rank = self.get_current_rank(npc_id)
@@ -268,19 +269,19 @@ class Faction:
     def can_be_promoted(
         self,
         npc_id: str,
-        game_variables: dict[str, Any],
+        variable_manager: GameVariablesManager,
     ) -> bool:
         rep = self.get_reputation(npc_id)
+
         for rank in self.ranks:
             req = rank.requirement
+
             if rep >= rank.threshold:
-                if req:
-                    if req.variables:
-                        if not satisfies_all_requirements(
-                            req.variables, game_variables
-                        ):
-                            continue
+                if req and req.variables:
+                    if not variable_manager.check_conditions(req.variables):
+                        continue
                 return True
+
         return False
 
     def calculate_power_level(self, multiplier: int = 10) -> int:
@@ -319,7 +320,7 @@ class Faction:
         self,
         members_data: Mapping[str, Any],
         public_reputation: int = 0,
-        relations: Optional[Mapping[str, str]] = None,
+        relations: Mapping[str, str] | None = None,
     ) -> None:
         self._public_reputation = public_reputation
 
@@ -349,7 +350,7 @@ class Faction:
                         f"[Faction] Unknown relation status '{status_str}' for faction '{slug}'"
                     )
 
-    def to_save_data(self, npc_slugs: list[str]) -> Optional[dict[str, Any]]:
+    def to_save_data(self, npc_slugs: list[str]) -> dict[str, Any] | None:
         members_data: dict[str, Any] = {}
 
         for npc_slug in npc_slugs:
@@ -376,14 +377,3 @@ class Faction:
                 slug: status.name for slug, status in self.relations.items()
             },
         }
-
-
-def satisfies_all_requirements(
-    req_variables: Sequence[dict[str, Any]], game_variables: dict[str, Any]
-) -> bool:
-    return all(
-        all(
-            game_variables.get(key) == value for key, value in variable.items()
-        )
-        for variable in req_variables
-    )

--- a/tuxemon/faction/manager.py
+++ b/tuxemon/faction/manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from tuxemon.db import (
     FactionAlignment,
@@ -45,7 +45,7 @@ class FactionManager:
             for faction in self._factions.values():
                 for npc_id in faction.members:
                     faction.evaluate_rank_change(
-                        npc_id, session.player.game_variables.get_state()
+                        npc_id, session.player.variable_manager
                     )
             self.clear_membership_cache()
 
@@ -80,7 +80,7 @@ class FactionManager:
     def on_faction_loaded(self, faction: Faction) -> None:
         logger.info(f"FactionManager detected faction loaded: {faction.slug}")
 
-    def get(self, slug: str) -> Optional[Faction]:
+    def get(self, slug: str) -> Faction | None:
         return self._factions.get(slug)
 
     def all_factions(self) -> list[Faction]:
@@ -105,7 +105,7 @@ class FactionManager:
         self._membership_cache[npc_id] = member_factions
         return member_factions
 
-    def clear_membership_cache(self, npc_id: Optional[str] = None) -> None:
+    def clear_membership_cache(self, npc_id: str | None = None) -> None:
         """Clears membership cache for one or all NPCs."""
         if npc_id:
             self._membership_cache.pop(npc_id, None)
@@ -134,7 +134,7 @@ class FactionManager:
     ) -> list[Faction]:
         return [f for f in self._factions.values() if f.alignment == alignment]
 
-    def rank_npc_globally(self, npc_id: str) -> dict[str, Optional[str]]:
+    def rank_npc_globally(self, npc_id: str) -> dict[str, str | None]:
         """Returns a map of faction slugs to NPC ranks based on reputation."""
         return {
             slug: faction.get_rank_for_reputation(

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -510,11 +510,16 @@ def calculate_capdev_modifier(
             ):
                 logger.warning(f"Invalid variables structure: {variables}")
                 continue
-            if (
-                character.game_variables.get(variables["key"])
-                == variables["value"]
+
+            if character.variable_manager.check_logic(
+                [{variables["key"]: variables["value"]}]
             ):
+                logger.debug(
+                    f"Variable match for key '{variables['key']}' == {variables['value']}. "
+                    f"Applying fallback_variables_bonus"
+                )
                 capdev_modifier *= config.fallback_variables_bonus
+
         logger.debug(
             "No matching variable found. Applying fallback_variables_malus"
         )

--- a/tuxemon/game_variables.py
+++ b/tuxemon/game_variables.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
-from typing import Any, Optional
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from tuxemon.db import GameCondition
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +17,11 @@ class ScopeVariablesManager:
     Tracks whether the internal state has changed since last check.
     """
 
-    def __init__(self, initial: Optional[dict[str, Any]] = None) -> None:
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
         self._variables: dict[str, Any] = initial.copy() if initial else {}
         self._dirty: bool = False
 
-    def get(self, key: str, default: Optional[Any] = None) -> Any:
+    def get(self, key: str, default: Any | None = None) -> Any:
         return self._variables.get(key, default)
 
     def set(self, key: str, value: Any) -> None:
@@ -127,8 +129,8 @@ class GameVariablesManager:
 
     def __init__(
         self,
-        initial_player: Optional[dict[str, Any]] = None,
-        initial_world: Optional[dict[str, Any]] = None,
+        initial_player: dict[str, Any] | None = None,
+        initial_world: dict[str, Any] | None = None,
     ) -> None:
         self._player = PlayerVariablesManager(initial_player)
         self._world = WorldVariablesManager(initial_world)
@@ -152,3 +154,100 @@ class GameVariablesManager:
 
     def set_world_state(self, state: dict[str, Any]) -> None:
         self._world.set_state(state)
+
+    def is_any_dirty(self) -> bool:
+        return self.player.is_dirty() or self.world.is_dirty()
+
+    def clear_all_dirty(self) -> None:
+        self.player.clear_dirty()
+        self.world.clear_dirty()
+
+    def _resolve_value(self, key: str) -> Any:
+        if self.player.has(key):
+            return self.player.get(key)
+        return self.world.get(key)
+
+    def _evaluate_conditions(
+        self,
+        entries: Sequence[tuple[str, Any, str | None, str | None]],
+    ) -> bool:
+        for key, expected, description, scope in entries:
+
+            # Scope-aware resolution
+            if scope == "player":
+                current = self.player.get(key)
+            elif scope == "world":
+                current = self.world.get(key)
+            else:
+                current = self._resolve_value(key)
+
+            if current != expected:
+                reason = description or f"Variable '{key}' check"
+                logger.debug(
+                    f"Condition Failed: {reason} "
+                    f"(Expected {expected}, Got {current})"
+                )
+                return False
+
+        return True
+
+    def _collect_missing(
+        self,
+        entries: Sequence[tuple[str, Any, str | None, str | None]],
+    ) -> list[str]:
+        missing: list[str] = []
+
+        for key, expected, description, scope in entries:
+
+            # Scope-aware resolution
+            if scope == "player":
+                current = self.player.get(key)
+            elif scope == "world":
+                current = self.world.get(key)
+            else:
+                current = self._resolve_value(key)
+
+            if current != expected:
+                msg = description or f"Missing requirement: {key}"
+                missing.append(msg)
+
+        return missing
+
+    def check_logic(self, conditions: Sequence[dict[str, Any]]) -> bool:
+        """
+        Evaluate simple dict-based variable checks using the unified condition engine.
+        Each dict maps keys to expected values. All entries must match for success.
+        """
+        entries = []
+        for cond in conditions:
+            for key, value in cond.items():
+                entries.append((key, value, None, None))
+        return self._evaluate_conditions(entries)
+
+    def check_conditions(self, conditions: Sequence[GameCondition]) -> bool:
+        """
+        Evaluate typed GameCondition entries using the unified condition engine.
+        Supports per-condition scope and optional human-readable descriptions.
+        """
+        entries = [
+            (cond.key, cond.value, cond.description, cond.scope)
+            for cond in conditions
+        ]
+        return self._evaluate_conditions(entries)
+
+    def get_missing_requirements(
+        self, conditions: Sequence[GameCondition]
+    ) -> list[str]:
+        """
+        Return descriptions for all GameCondition entries that fail their checks.
+        Uses the unified condition engine to collect every mismatch.
+        """
+        if not conditions:
+            return []
+
+        entries = [
+            (cond.key, cond.value, cond.description, cond.scope)
+            for cond in conditions
+        ]
+
+        return self._collect_missing(entries)

--- a/tuxemon/item/shop_utils.py
+++ b/tuxemon/item/shop_utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from pygame.rect import Rect
 
@@ -49,9 +49,9 @@ def get_monster_label(monster: Monster, price_tag: str) -> str:
 
 
 def generate_label(
-    entity: Union[Item, Monster],
+    entity: Item | Monster,
     economy: Economy,
-    qty: Optional[int] = None,
+    qty: int | None = None,
     seller_mode: bool = False,
 ) -> tuple[str, str, int]:
     """
@@ -64,15 +64,17 @@ def generate_label(
     qty = qty or 1
     safe_qty = qty if qty > 0 else 1
 
-    total_price, discount_percent = economy.calculate_price(
-        entity, qty, seller_mode
-    )
+    price = economy.calculate_price(entity, qty, seller_mode)
     unit_price = (
-        round(total_price / safe_qty) if qty != -1 else round(total_price)
+        round(price.final_price / safe_qty)
+        if qty != -1
+        else round(price.final_price)
     )
     price_tag = formatter.format(unit_price)
     discount_label = (
-        f" ({discount_percent}% off)" if discount_percent > 0 else ""
+        f" ({price.modifier_percent}% off)"
+        if price.modifier_percent > 0
+        else ""
     )
 
     if isinstance(entity, Item):

--- a/tuxemon/mission/controller.py
+++ b/tuxemon/mission/controller.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
-from tuxemon.db import MissionStatus
 from tuxemon.mission.manager import MissionManager
-from tuxemon.mission.mission import Mission, check_items, check_monsters
+from tuxemon.mission.mission import Mission
 
 if TYPE_CHECKING:
     from tuxemon.npc import NPC
@@ -32,7 +31,7 @@ class MissionController:
         return encode_mission(self.get_missions())
 
     def decode_missions(
-        self, save_data: Optional[Sequence[Mapping[str, Any]]]
+        self, save_data: Sequence[Mapping[str, Any]] | None
     ) -> None:
         """
         Recreates missions from saved data.
@@ -62,36 +61,7 @@ class MissionController:
         Updates the progress of all missions for the given character.
         """
         for mission in self.get_missions():
-            if not mission.is_active():
-                continue
-
-            if mission.check_failure_conditions(self.character):
-                mission.update_status(MissionStatus.failed)
-                continue
-
-            if not mission.check_all_prerequisites(self.character):
-                continue
-
-            mission.check_step_conditions(self.character)
-
-            for step_slug, step in mission.steps.items():
-                if step_slug in mission.completed_steps:
-                    continue
-
-                # Check step-specific requirements
-                if not check_items(self.character, step.step_items_needed):
-                    continue
-                if not check_monsters(
-                    self.character, step.step_monsters_needed
-                ):
-                    continue
-
-                if mission.get_progress() >= 100.0:
-                    mission.update_status(MissionStatus.completed)
-
-                    if mission.repeatable:
-                        mission.completed_steps.clear()
-                        mission.update_status(MissionStatus.pending)
+            mission.update_progress(self.character)
 
     def get_missions_with_met_prerequisites(self) -> list[Mission]:
         """
@@ -146,17 +116,25 @@ class MissionController:
 
 
 def decode_mission(
-    json_data: Optional[Sequence[Mapping[str, Any]]],
+    json_data: Sequence[Mapping[str, Any]] | None,
 ) -> list[Mission]:
-    missions = []
-    for mission_data in json_data or []:
-        mission = Mission.from_db(mission_data["slug"])
-        if mission:
-            mission.set_state(mission_data)
+    if not json_data:
+        return []
+
+    missions: list[Mission] = []
+
+    for mission_data in json_data:
+        slug = mission_data.get("slug")
+        if not slug:
+            logger.warning("Skipping mission entry without slug.")
+            continue
+
+        try:
+            mission = Mission.from_save(mission_data)
             missions.append(mission)
-        else:
+        except Exception as exc:
             logger.warning(
-                f"Mission with slug '{mission_data['slug']}' not found in database."
+                f"Failed to load mission '{slug}' from save data: {exc}"
             )
     return missions
 

--- a/tuxemon/mission/manager.py
+++ b/tuxemon/mission/manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from tuxemon.db import MissionStatus
 
@@ -31,7 +31,7 @@ class MissionManager:
     def remove_by_slug(self, slug: str) -> None:
         self.missions.pop(slug, None)
 
-    def find_mission(self, slug: str) -> Optional[Mission]:
+    def find_mission(self, slug: str) -> Mission | None:
         return self.missions.get(slug)
 
     def get_mission_count(self) -> int:
@@ -51,5 +51,5 @@ class MissionManager:
             m
             for m in self.missions.values()
             if m.assigned_to in (None, npc_slug)
-            and m.status != MissionStatus.removed
+            and m.status != MissionStatus.REMOVED
         ]

--- a/tuxemon/mission/mission.py
+++ b/tuxemon/mission/mission.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from tuxemon.database.runtime import db
-from tuxemon.db import MissionModel, MissionStatus, MissionStepModel
+from tuxemon.db import (
+    GameCondition,
+    MissionModel,
+    MissionStatus,
+    MissionStepModel,
+)
 from tuxemon.locale import T
 
 if TYPE_CHECKING:
@@ -16,33 +21,37 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SIMPLE_PERSISTANCE_ATTRIBUTES = (
-    "slug",
-    "status",
-)
-
 
 class Mission:
     """Tuxemon mission."""
 
-    def __init__(self) -> None:
-        self.slug: str = ""
-        self._custom_name: Optional[str] = None
-        self._description_slug: str = ""
-        self._custom_description: Optional[str] = None
+    def __init__(
+        self,
+        db_data: MissionModel,
+        instance_id: UUID | None = None,
+        completed_steps: set[str] | None = None,
+        status: MissionStatus = MissionStatus.PENDING,
+        assigned_to: str | None = None,
+    ):
+        self.slug = db_data.slug
+        self._description_slug = db_data.description
+        self.prerequisites = db_data.prerequisites
+        self.connected_missions = db_data.connected_missions
+        self.failure_conditions = db_data.failure_conditions
+        self.required_items = db_data.required_items
+        self.required_monsters = db_data.required_monsters
+        self.required_missions = db_data.required_missions
+        self.steps = {s.slug: s for s in db_data.steps.values()}
+        self.repeatable = db_data.repeatable
+
+        self.instance_id = instance_id or uuid4()
+        self.completed_steps = completed_steps or set()
+        self.status = status
+        self.assigned_to = assigned_to
+
         self.generated: bool = False
-        self.prerequisites: Sequence[dict[str, Any]] = []
-        self.connected_missions: Sequence[dict[str, Any]] = []
-        self.failure_conditions: Sequence[dict[str, Any]] = []
-        self.required_items: dict[str, Optional[int]] = {}
-        self.required_monsters: dict[str, Optional[int]] = {}
-        self.required_missions: Sequence[str] = []
-        self.steps: dict[str, MissionStepModel] = {}
-        self.completed_steps: set[str] = set()
-        self.assigned_to: Optional[str] = None
-        self.repeatable: bool = False
-        self.status: MissionStatus = MissionStatus.pending
-        self.instance_id: UUID = uuid4()
+        self._custom_name: str | None = None
+        self._custom_description: str | None = None
 
     @property
     def name(self) -> str:
@@ -69,82 +78,35 @@ class Mission:
         self._custom_description = value
 
     @classmethod
-    def from_db(cls, slug: str) -> Mission:
-        results = MissionModel.lookup(slug, db)
-        mission = cls()
-        mission.slug = results.slug
-        mission._description_slug = results.description
-        mission.prerequisites = results.prerequisites
-        mission.connected_missions = results.connected_missions
-        mission.required_items = results.required_items
-        mission.required_monsters = results.required_monsters
-        mission.required_missions = results.required_missions
-        mission.steps = {s.slug: s for s in results.steps.values()}
-        mission.repeatable = results.repeatable
-        mission.failure_conditions = results.failure_conditions
-        return mission
+    def create(cls, slug: str) -> Mission:
+        db_data = MissionModel.lookup(slug, db)
+        return cls(db_data=db_data)
 
-    def load(self, slug: str) -> None:
-        """
-        Loads and sets mission from the db.
-        """
-        results = MissionModel.lookup(slug, db)
-        self.slug = results.slug
-        self._description_slug = results.description
-        self.prerequisites = results.prerequisites
-        self.connected_missions = results.connected_missions
-        self.required_items = results.required_items
-        self.required_monsters = results.required_monsters
-        self.required_missions = results.required_missions
-        self.steps = {s.slug: s for s in results.steps.values()}
+    @classmethod
+    def from_save(cls, save_data: Mapping[str, Any]) -> Mission:
+        slug = save_data["slug"]
+        db_data = MissionModel.lookup(slug, db)
+
+        return cls(
+            db_data=db_data,
+            instance_id=UUID(save_data["instance_id"]),
+            completed_steps=set(save_data.get("completed_steps", [])),
+            status=save_data.get("status", MissionStatus.PENDING),
+            assigned_to=save_data.get("assigned_to"),
+        )
 
     def update_status(self, new_status: MissionStatus) -> None:
-        """
-        Updates the mission's status.
-        """
+        """Updates the mission's status."""
         self.status = new_status
 
     def get_state(self) -> Mapping[str, Any]:
-        """
-        Prepares a dictionary of the mission to be saved to a file.
-        """
-        save_data = {
-            attr: getattr(self, attr)
-            for attr in SIMPLE_PERSISTANCE_ATTRIBUTES
-            if getattr(self, attr)
+        return {
+            "slug": self.slug,
+            "instance_id": self.instance_id.hex,
+            "completed_steps": list(self.completed_steps),
+            "status": self.status,
+            "assigned_to": self.assigned_to,
         }
-        save_data["instance_id"] = self.instance_id.hex
-        save_data["completed_steps"] = list(self.completed_steps)
-        save_data["assigned_to"] = self.assigned_to
-
-        if self.generated and self.steps:
-            save_data["steps"] = {
-                slug: step.model_dump() for slug, step in self.steps.items()
-            }
-
-        return save_data
-
-    def set_state(self, save_data: Mapping[str, Any]) -> None:
-        """
-        Loads information from saved data.
-        """
-        if not save_data:
-            return
-
-        self.instance_id = UUID(save_data.get("instance_id", uuid4().hex))
-        self.completed_steps = set(save_data.get("completed_steps", []))
-        self.assigned_to = save_data.get("assigned_to", None)
-        self.generated = save_data.get("generated", False)
-
-        for key in SIMPLE_PERSISTANCE_ATTRIBUTES:
-            if key in save_data:
-                setattr(self, key, save_data[key])
-
-        if self.generated and "steps" in save_data:
-            self.steps = {
-                slug: MissionStepModel.model_validate(step_data)
-                for slug, step_data in save_data["steps"].items()
-            }
 
     def mark_step_completed(self, slug: str) -> None:
         if slug in self.steps:
@@ -170,27 +132,19 @@ class Mission:
 
     def check_prerequisites(self, character: NPC) -> bool:
         if not self.prerequisites:
-            return True  # No prerequisites means it's allowed
+            return True
 
         return all(
-            all(
-                character.game_variables.has(key)
-                and character.game_variables.get(key) == value
-                for key, value in prerequisite.items()
-            )
+            character.variable_manager.check_conditions([prerequisite])
             for prerequisite in self.prerequisites
         )
 
     def check_failure_conditions(self, character: NPC) -> bool:
         if not self.failure_conditions:
-            return False  # No failure conditions means nothing can fail
+            return False
 
         return all(
-            all(
-                character.game_variables.has(key)
-                and character.game_variables.get(key) == value
-                for key, value in condition.items()
-            )
+            character.variable_manager.check_conditions([condition])
             for condition in self.failure_conditions
         )
 
@@ -246,15 +200,13 @@ class Mission:
         )
 
     def _check_conditions_list(
-        self, conditions_list: Sequence[dict[str, Any]], character: NPC
+        self, conditions_list: Sequence[GameCondition], character: NPC
     ) -> bool:
         if not conditions_list:
             return True
+
         return all(
-            all(
-                character.game_variables.get(k) == v
-                for k, v in condition.items()
-            )
+            character.variable_manager.check_conditions([condition])
             for condition in conditions_list
         )
 
@@ -269,7 +221,12 @@ class Mission:
             any_of_met = self._check_conditions_list(step.any_of, character)
             all_of_met = self._check_conditions_list(step.all_of, character)
 
-            if base_conditions_met and any_of_met and all_of_met:
+            if (
+                step.auto_complete
+                and base_conditions_met
+                and any_of_met
+                and all_of_met
+            ):
                 self.mark_step_completed(slug)
 
     def check_all_prerequisites(self, character: NPC) -> bool:
@@ -281,13 +238,68 @@ class Mission:
         )
 
     def is_active(self) -> bool:
-        return self.status == MissionStatus.pending
+        return self.status == MissionStatus.PENDING
 
     def is_completed(self) -> bool:
-        return self.status == MissionStatus.completed
+        return self.status == MissionStatus.COMPLETED
+
+    def update_progress(self, character: NPC) -> None:
+        if not self.is_active():
+            return
+
+        if self.check_failure_conditions(character):
+            self.update_status(MissionStatus.FAILED)
+            return
+
+        if not self.check_all_prerequisites(character):
+            return
+
+        self.check_step_conditions(character)
+
+        for step in self.get_active_steps():
+            if step.slug in self.completed_steps:
+                continue
+
+            if not check_items(character, step.step_items_needed):
+                continue
+
+            if not check_monsters(character, step.step_monsters_needed):
+                continue
+
+        if self.get_progress() >= 100.0:
+            self.update_status(MissionStatus.COMPLETED)
+
+            if self.repeatable:
+                self.completed_steps.clear()
+                self.update_status(MissionStatus.PENDING)
+
+    def validate_graph(self) -> None:
+        visited = set()
+
+        def dfs(slug: str) -> None:
+            if slug in visited:
+                raise ValueError(
+                    f"Circular dependency detected at step {slug}"
+                )
+            visited.add(slug)
+            for nxt in self.steps[slug].next_steps:
+                if nxt not in self.steps:
+                    continue
+                dfs(nxt)
+            visited.remove(slug)
+
+        roots = self.get_root_steps()
+
+        if not roots and self.steps:
+            raise ValueError(
+                "Circular dependency detected: no root steps found"
+            )
+
+        for root in roots:
+            dfs(root)
 
 
-def check_items(character: NPC, step_items: dict[str, Optional[int]]) -> bool:
+def check_items(character: NPC, step_items: dict[str, int | None]) -> bool:
     for item_slug, required_quantity in step_items.items():
         item = character.bag.find_item(item_slug)
         if not item:
@@ -298,7 +310,7 @@ def check_items(character: NPC, step_items: dict[str, Optional[int]]) -> bool:
 
 
 def check_monsters(
-    character: NPC, step_monsters: dict[str, Optional[int]]
+    character: NPC, step_monsters: dict[str, int | None]
 ) -> bool:
     for monster_slug, required_level in step_monsters.items():
         monster = character.party.find_monster(monster_slug)

--- a/tuxemon/monster_dir/evolution_conditions.py
+++ b/tuxemon/monster_dir/evolution_conditions.py
@@ -173,13 +173,10 @@ def check_variables(
     """Append checks for required game variable values from the owner."""
     if not evolution_item.variables:
         return
-
-    for variable in evolution_item.variables:
-        for key, value in variable.items():
-            conditions.append(
-                monster.get_owner().game_variables.has(key)
-                and monster.get_owner().game_variables.get(key) == value
-            )
+    owner = monster.get_owner()
+    conditions.append(
+        owner.variable_manager.check_conditions(evolution_item.variables)
+    )
 
 
 def check_steps(

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -148,6 +148,10 @@ class NPC(Entity):
         return self._variables.player
 
     @property
+    def variable_manager(self) -> GameVariablesManager:
+        return self._variables
+
+    @property
     def monsters(self) -> list[Monster]:
         """Returns the list of monsters in the party."""
         return self.party.monsters

--- a/tuxemon/states/mission.py
+++ b/tuxemon/states/mission.py
@@ -109,7 +109,7 @@ class SingleMissionState(PygameMenuState):
             open_choice_dialog(self.client, menu)
 
         def confirm_deletion() -> None:
-            self.mission.update_status(MissionStatus.removed)
+            self.mission.update_status(MissionStatus.REMOVED)
             self.character.mission_controller.mission_manager.remove_by_slug(
                 self.mission.slug
             )

--- a/tuxemon/states/shop_item.py
+++ b/tuxemon/states/shop_item.py
@@ -66,9 +66,9 @@ class ShopItemMenuState(ShopMenuState[Item]):
             )
 
             def buy_item(quantity: int) -> None:
-                total_price, _ = self.economy.calculate_price(item, quantity)
+                price = self.economy.calculate_price(item, quantity)
                 self.transaction_manager.buy_item(
-                    self.buyer, item, quantity, label, total_price
+                    self.buyer, item, quantity, label, price.final_price
                 )
                 self.reload_shop()
 
@@ -97,11 +97,11 @@ class ShopItemMenuState(ShopMenuState[Item]):
                 label = self.client.shop_manager.get_full_label(
                     self.economy.model.slug, item.slug
                 )
-                total_price, _ = self.economy.calculate_price(
+                price = self.economy.calculate_price(
                     item, quantity, seller_mode=True
                 )
                 self.transaction_manager.sell_item(
-                    self.seller, item, quantity, total_price, label
+                    self.seller, item, quantity, price.final_price, label
                 )
                 self.reload_shop()
 
@@ -126,9 +126,9 @@ class ShopItemBuyMenuState(ShopItemMenuState):
         )
 
         def buy_item(quantity: int) -> None:
-            total_price, _ = self.economy.calculate_price(item, quantity)
+            price = self.economy.calculate_price(item, quantity)
             self.transaction_manager.buy_item(
-                self.buyer, item, quantity, label, total_price
+                self.buyer, item, quantity, label, price.final_price
             )
             self.reload_items()
             if (
@@ -174,11 +174,11 @@ class ShopItemSellMenuState(ShopItemMenuState):
             label = self.client.shop_manager.get_full_label(
                 self.economy.model.slug, item.slug
             )
-            total_price, _ = self.economy.calculate_price(
+            price = self.economy.calculate_price(
                 item, quantity, seller_mode=True
             )
             self.transaction_manager.sell_item(
-                self.seller, item, quantity, total_price, label
+                self.seller, item, quantity, price.final_price, label
             )
             self.reload_items()
             if not self.seller.bag.has_item(item.slug):

--- a/tuxemon/states/shop_monster.py
+++ b/tuxemon/states/shop_monster.py
@@ -68,11 +68,9 @@ class ShopMonsterMenuState(ShopMenuState[Monster]):
             )
 
             def buy_monster(quantity: int) -> None:
-                total_price, _ = self.economy.calculate_price(
-                    monster, quantity
-                )
+                price = self.economy.calculate_price(monster, quantity)
                 self.transaction_manager.buy_monster(
-                    self.buyer, monster, quantity, label, total_price
+                    self.buyer, monster, quantity, label, price.final_price
                 )
                 self.reload_shop()
 
@@ -101,11 +99,11 @@ class ShopMonsterMenuState(ShopMenuState[Monster]):
                 label = self.client.shop_manager.get_full_label(
                     self.economy.model.slug, monster.slug
                 )
-                total_price, _ = self.economy.calculate_price(
+                price = self.economy.calculate_price(
                     monster, quantity, seller_mode=True
                 )
                 self.transaction_manager.sell_monster(
-                    self.seller, monster, total_price, label
+                    self.seller, monster, price.final_price, label
                 )
                 self.reload_shop()
 
@@ -130,9 +128,9 @@ class ShopMonsterBuyMenuState(ShopMonsterMenuState):
         )
 
         def buy_monster(quantity: int) -> None:
-            total_price, _ = self.economy.calculate_price(monster, quantity)
+            price = self.economy.calculate_price(monster, quantity)
             self.transaction_manager.buy_monster(
-                self.buyer, monster, quantity, label, total_price
+                self.buyer, monster, quantity, label, price.final_price
             )
             self.reload_items()
             if (
@@ -178,11 +176,11 @@ class ShopMonsterSellMenuState(ShopMonsterMenuState):
             label = self.client.shop_manager.get_full_label(
                 self.economy.model.slug, monster.slug
             )
-            total_price, _ = self.economy.calculate_price(
+            price = self.economy.calculate_price(
                 monster, quantity, seller_mode=True
             )
             self.transaction_manager.sell_monster(
-                self.seller, monster, total_price, label
+                self.seller, monster, price.final_price, label
             )
             self.reload_items()
             if not self.seller.party.has_monster(monster):


### PR DESCRIPTION
This change consolidates all variable‑based condition checks across the engine into a single, unified `check_logic` implementation provided by `GameVariablesManager`. Several subsystems duplicated their own ad‑hoc variable checks, leading to inconsistent behavior and maintenance overhead. This PR removes those scattered implementations and routes all variable evaluation through the new `variables_manager` property.

Changes:
- introduced `variables_manager` on player/NPC objects as the standard entry point for variable evaluation
- replaced local variable‑checking code in: Economy, Encounter validation, NPC creation (`create_npc`) and Faction promotion logic
- removed legacy helper functions that manually compared dicts
- updated `CreateNpcAction` to pass the full variable manager instead of raw dicts
- modernized the faction and faction‑manager test suites
- cleaned up unused code paths and improved consistency across systems.