### PR TITLE
Add `set_char_birthday` EventAction and new `DatePickerState` UI

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -125,6 +125,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.set_bill.SetBillAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_bubble.SetBubbleAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_char_attribute.SetCharAttributeAction
+.. autoscriptinfoclass:: tuxemon.event.actions.set_char_birthday.SetPlayerBirthdayAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_cipher.SetCipherAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_economy.SetEconomyAction
 .. autoscriptinfoclass:: tuxemon.event.actions.set_environment.SetEnvironmentAction

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4343,8 +4343,8 @@ msgstr "From ${{map_name}} to ${{east}}"
 msgid "menu_alphabet"
 msgstr "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-!"
 
-msgid "dont_care"
-msgstr "RANDOM"
+msgid "random"
+msgstr "Random"
 
 # Monster Menu notifications
 msgid "monster_menu_info"
@@ -9157,6 +9157,53 @@ msgstr "Woodland"
 
 msgid "terrain_other"
 msgstr "Other"
+
+# Date Picker
+msgid "select_month"
+msgstr "Select Month"
+
+msgid "select_day"
+msgstr "Select Day"
+
+msgid "back_months"
+msgstr "Back Months"
+
+# Months
+msgid "month_jan"
+msgstr "January"
+
+msgid "month_feb"
+msgstr "February"
+
+msgid "month_mar"
+msgstr "March"
+
+msgid "month_apr"
+msgstr "April"
+
+msgid "month_may"
+msgstr "May"
+
+msgid "month_jun"
+msgstr "June"
+
+msgid "month_jul"
+msgstr "July"
+
+msgid "month_aug"
+msgstr "August"
+
+msgid "month_sep"
+msgstr "September"
+
+msgid "month_oct"
+msgstr "October"
+
+msgid "month_nov"
+msgstr "November"
+
+msgid "month_dec"
+msgstr "December"
 
 # Weathers
 msgid "weather_misty"

--- a/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/zh_CN/LC_MESSAGES/base.po
@@ -7014,7 +7014,7 @@ msgstr "白人男性"
 msgid "black_male"
 msgstr "黑人男性"
 
-msgid "dont_care"
+msgid "random"
 msgstr "随机"
 
 msgid "spyder_papertown_rival"

--- a/tuxemon/event/actions/set_char_birthday.py
+++ b/tuxemon/event/actions/set_char_birthday.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from functools import partial
+from random import randint
+from typing import TYPE_CHECKING, final
+
+from tuxemon.event.eventaction import EventAction
+
+if TYPE_CHECKING:
+    from tuxemon.npc import NPC
+    from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class SetPlayerBirthdayAction(EventAction):
+    """
+    Open the date picker to set the player's birthday.
+
+    Script usage:
+        .. code-block::
+
+            set_char_birthday <character> [random]
+
+    Script parameters:
+        character: Either "player" or an NPC slug (e.g. "npc_maple")
+        random: If provided, assigns a random birthday instead of
+            opening the date picker.
+    """
+
+    name = "set_char_birthday"
+    character: str
+    random: str | None = None
+
+    def set_birthday(self, character: NPC, date: tuple[int, int]) -> None:
+        character.birthdate = date
+        logger.debug(f"Assigned birthday {date} to {character.slug}")
+
+    def start(self, session: Session) -> None:
+        character = session.get_npc(self.character)
+
+        if character is None:
+            logger.error(f"{self.character} not found")
+            return
+
+        if self.random is not None:
+            birthdate = self._generate_random_date()
+            self.set_birthday(character, birthdate)
+            self.stop()
+            return
+
+        session.client.push_state(
+            "DatePickerState",
+            callback=partial(self.set_birthday, character),
+            escape_key_exits=False,
+        )
+
+    def _generate_random_date(self) -> tuple[int, int]:
+        month = randint(1, 12)
+
+        if month in (4, 6, 9, 11):
+            max_days = 30
+        elif month == 2:
+            max_days = 29
+        else:
+            max_days = 31
+
+        day = randint(1, max_days)
+        return month, day
+
+    def update(self, session: Session, dt: float) -> None:
+        try:
+            session.client.get_state_by_name("DatePickerState")
+        except ValueError:
+            self.stop()

--- a/tuxemon/menu/input.py
+++ b/tuxemon/menu/input.py
@@ -351,7 +351,7 @@ class InputMenu(Menu[InputMenuObj]):
 
         if self.random:
             yield MenuItem(
-                self.shadow_text(T.translate("dont_care")),
+                self.shadow_text(T.translate("random").upper()),
                 None,
                 None,
                 InputMenuObj(self.dont_care),

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -112,6 +112,7 @@ class NPC(Entity):
         self.steps: float = 0.0
         self.dialogue: Optional[DialogueProfile] = None
         self.sprite_controller = SpriteController(self)
+        self.birthdate: tuple[int, int] | None = None
 
         # PathController manages all path/pathfinding state & logic.
         self.path_controller = PathController(

--- a/tuxemon/states/date_picker.py
+++ b/tuxemon/states/date_picker.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+
+from tuxemon.locale import T
+from tuxemon.menu.menu import PygameMenuState
+from tuxemon.platform.const.graphics import BG_MISSIONS
+from tuxemon.prepare import SCREEN_SIZE
+
+
+class DatePickerState(PygameMenuState):
+    name = "DatePickerState"
+
+    def __init__(
+        self, callback: Callable[[tuple[int, int]], None], **kwargs: Any
+    ):
+        self.callback = callback
+        self.selected_month: int | None = None
+        width, height = SCREEN_SIZE
+        escape_key_exits = kwargs.pop("escape_key_exits", None)
+
+        theme = self._setup_theme(BG_MISSIONS)
+        theme.widget_alignment = ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.title = True
+
+        super().__init__(width=width, height=height, **kwargs)
+
+        if escape_key_exits is not None:
+            self.escape_key_exits = escape_key_exits
+        self._build_month_menu()
+        self.reset_theme()
+
+    def _build_month_menu(self) -> None:
+        self.menu.clear()
+        self.menu.set_title(T.translate("select_month")).center_content()
+
+        months = [
+            ("month_jan", 1),
+            ("month_feb", 2),
+            ("month_mar", 3),
+            ("month_apr", 4),
+            ("month_may", 5),
+            ("month_jun", 6),
+            ("month_jul", 7),
+            ("month_aug", 8),
+            ("month_sep", 9),
+            ("month_oct", 10),
+            ("month_nov", 11),
+            ("month_dec", 12),
+        ]
+
+        for key, num in months:
+            self.menu.add.button(
+                T.translate(key), lambda m=num: self._pick_month(m)
+            )
+
+    def _pick_month(self, month: int) -> None:
+        self.selected_month = month
+        self._build_day_menu()
+
+    def _build_day_menu(self) -> None:
+        self.menu.clear()
+        self.menu.set_title(T.translate("select_day"))
+
+        if self.selected_month in [4, 6, 9, 11]:
+            max_days = 30
+        elif self.selected_month == 2:
+            max_days = 29
+        else:
+            max_days = 31
+
+        for day in range(1, max_days + 1):
+            self.menu.add.button(
+                str(day), lambda d=day: self._pick_day(d), align=ALIGN_CENTER
+            )
+
+        self.menu.add.button(
+            T.translate("select_month"), self._build_month_menu
+        )
+
+    def _pick_day(self, day: int) -> None:
+        assert self.selected_month is not None
+        self.callback((self.selected_month, day))
+        self.client.pop_state()


### PR DESCRIPTION
PR introduces a new birthday‑selection flow for player and NPC characters. It adds a dedicated `set_char_birthday` event action and a reusable `DatePickerState` built on `pygame-menu`. The new state provides a clean month/day picker with proper callback integration and prevents accidental closure via Back/B. This enables scripts to request a birthday from the player in a consistent, UI‑friendly way.