### PR TITLE
Make Difficulty Selection a Reusable Callback‑Based State

### DIFF
--- a/tuxemon/states/difficulty_pick.py
+++ b/tuxemon/states/difficulty_pick.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 from typing import ClassVar
 
@@ -10,32 +11,30 @@ from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.platform.const.sizes import PLAYER_NPC
-from tuxemon.player import Player
 from tuxemon.prepare import SCREEN_SIZE
-from tuxemon.session import local_session
 
 DIFFICULTIES = ["beginner", "easy", "normal", "hard", "expert"]
 
 
-class DifficultyBattleState(PygameMenuState):
-    """
-    A state that allows players to choose the difficulty level before entering the battle.
-    """
+class DifficultyPickState(PygameMenuState):
+    """Generic difficulty selection state."""
 
-    name: ClassVar[str] = "DifficultyBattleState"
+    name: ClassVar[str] = "DifficultyPickState"
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        on_pick: Callable[[str], None],
+        difficulties: list[str] = DIFFICULTIES,
+    ) -> None:
         width, height = SCREEN_SIZE
         super().__init__(height=height, width=width)
 
+        self.on_pick = on_pick
+        self.difficulties = difficulties
         self._build_menu()
         self.reset_theme()
 
     def _build_menu(self) -> None:
-        """
-        Constructs the difficulty selection menu with a title label and difficulty buttons.
-        """
         title = T.translate("choose_difficulty")
         self.menu.add.label(
             title=title,
@@ -44,22 +43,15 @@ class DifficultyBattleState(PygameMenuState):
             underline=True,
         )
 
-        for level in DIFFICULTIES:
+        for level in self.difficulties:
             self.menu.add.button(
                 title=T.translate(f"level_{level}"),
-                action=partial(self.start_battle, level),
+                action=partial(self._handle_pick, level),
                 button_id=f"diff_{level}",
                 font_size=self.font_type.medium,
                 selection_effect=HighlightSelection(),
                 align=locals.ALIGN_CENTER,
             )
 
-    def start_battle(self, difficulty: str) -> None:
-        Player.create(local_session, slug=PLAYER_NPC)
-        self.client.push_state(
-            "WorldState", session=local_session, map_name=None
-        )
-        self.client.event_engine.execute_action(
-            "set_variable", [f"difficulty:{difficulty}"]
-        )
-        self.client.event_engine.execute_action("load_yaml", ["battle_menu"])
+    def _handle_pick(self, difficulty: str) -> None:
+        self.on_pick(difficulty)

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -31,52 +31,6 @@ def _lookup_monsters() -> None:
     }
 
 
-DIFFICULTIES = ["easy", "normal", "hard"]
-
-
-class DifficultySelectState(PygameMenuState):
-    """
-    A state that allows players to choose the difficulty level before entering the minigame.
-    """
-
-    name: ClassVar[str] = "DifficultySelectState"
-
-    def __init__(self) -> None:
-        width, height = SCREEN_SIZE
-        super().__init__(height=height, width=width)
-
-        self._build_menu()
-        self.reset_theme()
-
-    def _build_menu(self) -> None:
-        """
-        Constructs the difficulty selection menu with a title label and difficulty buttons.
-        """
-        title = T.translate("choose_difficulty")
-        self.menu.add.label(
-            title=title,
-            font_size=self.font_type.big,
-            align=locals.ALIGN_CENTER,
-            underline=True,
-        )
-
-        for level in DIFFICULTIES:
-            self.menu.add.button(
-                title=T.translate(f"level_{level}"),
-                action=partial(self.start_minigame, level),
-                button_id=f"diff_{level}",
-                font_size=self.font_type.medium,
-                selection_effect=HighlightSelection(),
-                align=locals.ALIGN_CENTER,
-            )
-
-    def start_minigame(self, difficulty: str) -> None:
-        """
-        Transitions to the minigame with the selected difficulty.
-        """
-        self.client.replace_state("MinigameState", difficulty=difficulty)
-
-
 class MinigameState(PygameMenuState):
     """Minigame where player guesses a monster using image or description."""
 

--- a/tuxemon/states/start.py
+++ b/tuxemon/states/start.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from functools import partial
-from typing import Any, ClassVar, Optional, Union
+from typing import Any, ClassVar
 
 import pygame_menu
 from pygame.surface import Surface
@@ -19,7 +19,9 @@ from tuxemon.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import BG_START_SCREEN, BLACK_COLOR
+from tuxemon.platform.const.sizes import PLAYER_NPC
 from tuxemon.platform.events import PlayerInput
+from tuxemon.player import Player
 from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.save import get_index_of_latest_save
 from tuxemon.session import local_session
@@ -69,7 +71,7 @@ class StartState(PygameMenuState):
             )
 
         def change_state(
-            state: Union[State, str], **kwargs: Any
+            state: State | str, **kwargs: Any
         ) -> Callable[[], None]:
             def _change() -> None:
                 self.unsubscribe(
@@ -107,13 +109,19 @@ class StartState(PygameMenuState):
             )
         menu.add.button(
             title=T.translate("menu_battle"),
-            action=change_state("DifficultyBattleState"),
+            action=change_state(
+                "DifficultyPickState", on_pick=self.start_battle
+            ),
             font_size=self.font_type.big,
             button_id="menu_battle",
         )
         menu.add.button(
             title=T.translate("menu_minigame"),
-            action=change_state("DifficultySelectState"),
+            action=change_state(
+                "DifficultyPickState",
+                on_pick=self.start_minigame,
+                difficulties=["easy", "normal", "hard"],
+            ),
             font_size=self.font_type.big,
             button_id="menu_minigame",
         )
@@ -153,7 +161,7 @@ class StartState(PygameMenuState):
         self.unsubscribe("afk.threshold_reached", self._on_afk_threshold)
         super().shutdown()
 
-    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+    def process_event(self, event: PlayerInput) -> PlayerInput | None:
         if (
             event.button in (buttons.HOME, buttons.BACK, buttons.B)
             and event.pressed
@@ -161,6 +169,24 @@ class StartState(PygameMenuState):
             return None
         else:
             return super().process_event(event)
+
+    def start_battle(self, difficulty: str) -> None:
+        Player.create(local_session, slug=PLAYER_NPC)
+        self.client.push_state(
+            "WorldState", session=local_session, map_name=None
+        )
+        self.client.event_engine.execute_action(
+            "set_variable", [f"difficulty:{difficulty}"]
+        )
+        self.client.event_engine.execute_action("load_yaml", ["battle_menu"])
+
+    def start_minigame(self, difficulty: str) -> None:
+        self.client.push_state(
+            "MinigameState",
+            difficulty=difficulty,
+            streak=0,
+            score=0,
+        )
 
 
 class ModsChoice(PygameMenuState):


### PR DESCRIPTION
PR replaces the hard‑coded battle start logic with a generic `DifficultyPickState` that calls a user‑provided function when a difficulty is chosen.

Changes:
- added `DifficultyPickState(on_pick=..., difficulties=...)` as a reusable difficulty selector
- removed direct gameplay logic from the picker and deleted the redundant `DifficultySelectState`
- updated battle and minigame menu entries to use the shared picker
- added `start_minigame(difficulty)` to mirror the existing battle flow