### PR TITLE
Fix incorrect version reporting and modernize version handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tuxemon"
+version = "0.4.35"
 description = "Open source monster-fighting RPG"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -25,7 +26,7 @@ classifiers = [
         "Topic :: Games/Entertainment :: Role-Playing"
 ]
 requires-python = ">=3.10"
-dynamic = ["version", "dependencies"]
+dynamic = ["dependencies"]
 
 [project.urls]
 homepage = "https://www.tuxemon.org"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ babel
 cbor
 websockets
 pillow
+packaging
 pygame-ce==2.5.6
 pyscroll>=2.31
 pytmx==3.32

--- a/tests/tuxemon/test_version.py
+++ b/tests/tuxemon/test_version.py
@@ -1,126 +1,82 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
+import pytest
 
-from tuxemon.version import Version, VersionComparator
-
-
-class TestVersion(unittest.TestCase):
-
-    def test_initialization(self):
-        version = Version(1, 2, 3)
-        self.assertEqual(version.major, 1)
-        self.assertEqual(version.minor, 2)
-        self.assertEqual(version.patch, 3)
-        self.assertEqual(version.pre_release, "")
-        self.assertEqual(version.build_metadata, "")
-
-    def test_string_representation(self):
-        version = Version(1, 2, 3, "alpha", "001")
-        self.assertEqual(str(version), "1.2.3-alpha+001")
-
-    def test_from_string(self):
-        version = Version.from_string("1.2.3-alpha+001")
-        self.assertEqual(version.major, 1)
-        self.assertEqual(version.minor, 2)
-        self.assertEqual(version.patch, 3)
-        self.assertEqual(version.pre_release, "alpha")
-        self.assertEqual(version.build_metadata, "001")
-
-    def test_from_string_invalid(self):
-        with self.assertRaises(ValueError):
-            Version.from_string("invalid.version.string")
-
-    def test_equality(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 3)
-        version3 = Version(1, 2, 4)
-        self.assertTrue(version1 == version2)
-        self.assertFalse(version1 == version3)
-
-    def test_inequality(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 4)
-        self.assertTrue(version1 != version2)
-
-    def test_less_than(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 4)
-        self.assertTrue(version1 < version2)
-
-    def test_less_than_equal(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 3)
-        version3 = Version(1, 2, 4)
-        self.assertTrue(version1 <= version2)
-        self.assertTrue(version1 <= version3)
-
-    def test_greater_than(self):
-        version1 = Version(1, 2, 4)
-        version2 = Version(1, 2, 3)
-        self.assertTrue(version1 > version2)
-
-    def test_greater_than_equal(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 3)
-        version3 = Version(1, 2, 2)
-        self.assertTrue(version1 >= version2)
-        self.assertTrue(version1 >= version3)
-
-    def test_validate_version(self):
-        Version.validate_version("1.2.3")
-        Version.validate_version("1.2.3-alpha")
-        Version.validate_version("1.2.3-alpha+001")
-        Version.validate_version("1.2.3+001")
-
-        with self.assertRaises(ValueError):
-            Version.validate_version("1.2")
-        with self.assertRaises(ValueError):
-            Version.validate_version("1.2.3.4")
-        with self.assertRaises(ValueError):
-            Version.validate_version("invalid.version")
+from tuxemon.version import (
+    Version,
+    VersionComparator,
+    __version__,
+    version_info,
+)
 
 
-class TestVersionComparator(unittest.TestCase):
+def test_string_roundtrip():
+    v = Version("1.2.3")
+    assert str(v) == "1.2.3"
 
-    def test_compare_equal(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 3)
-        self.assertEqual(VersionComparator.compare(version1, version2), 0)
 
-    def test_compare_greater(self):
-        version1 = Version(1, 2, 4)
-        version2 = Version(1, 2, 3)
-        self.assertEqual(VersionComparator.compare(version1, version2), 1)
+@pytest.mark.parametrize(
+    "input_str",
+    [
+        "1.2.3",
+        "1.2.3a1",
+        "1.2.3b2",
+        "1.2.3rc3",
+        "1.2.3.post1",
+        "1.2.3.dev4",
+        "1!1.2.3",  # epoch
+        "1.2.3+local",  # local version
+    ],
+)
+def test_valid_pep440_versions(input_str):
+    Version(input_str)  # should not raise
 
-    def test_compare_less(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 4)
-        self.assertEqual(VersionComparator.compare(version1, version2), -1)
 
-    def test_compare_major_difference(self):
-        version1 = Version(2, 0, 0)
-        version2 = Version(1, 9, 9)
-        self.assertEqual(VersionComparator.compare(version1, version2), 1)
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "1.2.x",  # invalid character
+        "1..3",  # empty segment
+        "1.2.3-foo",  # invalid prerelease (SemVer style)
+        "1.2.3+foo+bar",  # invalid local version (only one + allowed)
+    ],
+)
+def test_invalid_pep440_versions(invalid):
+    with pytest.raises(ValueError):
+        Version(invalid)
 
-        version1 = Version(1, 0, 0)
-        version2 = Version(2, 0, 0)
-        self.assertEqual(VersionComparator.compare(version1, version2), -1)
 
-    def test_compare_minor_difference(self):
-        version1 = Version(1, 1, 0)
-        version2 = Version(1, 2, 0)
-        self.assertEqual(VersionComparator.compare(version1, version2), -1)
+def test_equality():
+    assert Version("1.2.3") == Version("1.2.3")
+    assert Version("1.2.3") != Version("1.2.4")
 
-        version1 = Version(1, 2, 0)
-        version2 = Version(1, 1, 0)
-        self.assertEqual(VersionComparator.compare(version1, version2), 1)
 
-    def test_compare_patch_difference(self):
-        version1 = Version(1, 2, 3)
-        version2 = Version(1, 2, 4)
-        self.assertEqual(VersionComparator.compare(version1, version2), -1)
+def test_comparison():
+    assert Version("1.2.3") < Version("1.2.4")
+    assert Version("1.2.3a1") < Version("1.2.3b1")
+    assert Version("1.2.3b1") < Version("1.2.3rc1")
+    assert Version("1.2.3rc1") < Version("1.2.3")
+    assert Version("1.2.3") < Version("1.2.3.post1")
+    assert Version("1.2.3.dev1") < Version("1.2.3")
 
-        version1 = Version(1, 2, 4)
-        version2 = Version(1, 2, 3)
-        self.assertEqual(VersionComparator.compare(version1, version2), 1)
+
+@pytest.mark.parametrize(
+    "v1,v2,expected",
+    [
+        (Version("1.2.3"), Version("1.2.3"), 0),
+        (Version("1.2.4"), Version("1.2.3"), 1),
+        (Version("1.2.3"), Version("1.2.4"), -1),
+        (Version("2.0.0"), Version("1.9.9"), 1),
+        (Version("1.0.0"), Version("2.0.0"), -1),
+    ],
+)
+def test_version_comparator(v1, v2, expected):
+    assert VersionComparator.compare(v1, v2) == expected
+
+
+def test_dunder_version_is_string():
+    assert isinstance(__version__, str)
+
+
+def test_version_info_contains_dunder_version():
+    assert __version__ in version_info()

--- a/tuxemon/__init__.py
+++ b/tuxemon/__init__.py
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from tuxemon.version import __version__
+from tuxemon.version import __version__, version_info
+
+__all__ = ["__version__", "version_info"]

--- a/tuxemon/version.py
+++ b/tuxemon/version.py
@@ -2,114 +2,70 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import re
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = "0.4.35"
+from packaging.version import InvalidVersion
+from packaging.version import Version as PEP440Version
+
+try:
+    __version__ = version("tuxemon")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
+
+
+def version_info() -> str:
+    """Returns a human-readable version string for display or debugging."""
+    return f"Tuxemon version {__version__}"
 
 
 class Version:
-    """Represents the version of a plugin, following semantic versioning."""
+    """
+    A strict PEP 440 version wrapper.
 
-    def __init__(
-        self,
-        major: int,
-        minor: int,
-        patch: int,
-        pre_release: str = "",
-        build_metadata: str = "",
-    ):
-        self.major = major
-        self.minor = minor
-        self.patch = patch
-        self.pre_release = pre_release
-        self.build_metadata = build_metadata
+    This class delegates all parsing, normalization, and comparison
+    to packaging.version.Version to ensure full PEP 440 compliance.
+    """
+
+    def __init__(self, version_str: str):
+        try:
+            self._v = PEP440Version(version_str)
+        except InvalidVersion as e:
+            raise ValueError(f"Invalid PEP 440 version: {version_str}") from e
 
     def __str__(self) -> str:
-        """Returns the string representation of the version."""
-        version_str = f"{self.major}.{self.minor}.{self.patch}"
-        if self.pre_release:
-            version_str += f"-{self.pre_release}"
-        if self.build_metadata:
-            version_str += f"+{self.build_metadata}"
-        return version_str
+        return str(self._v)
+
+    def __repr__(self) -> str:
+        return f"Version('{self._v}')"
 
     @classmethod
     def from_string(cls, version_str: str) -> Version:
-        """Creates a Version from a string, supporting pre-release and build metadata."""
-        Version.validate_version(version_str)
+        return cls(version_str)
 
-        try:
-            main_part, *rest = version_str.split("-")
-            major, minor, patch = map(int, main_part.split("."))
-            pre_release = ""
-            build_metadata = ""
-
-            if rest:
-                pre_release = rest[0]
-                if "+" in pre_release:
-                    pre_release, build_metadata = pre_release.split("+", 1)
-
-            return cls(major, minor, patch, pre_release, build_metadata)
-        except ValueError:
-            raise ValueError(
-                f"Invalid version string: {version_str}. Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
-            )
-
+    # Comparison operators simply delegate to packaging.version.Version
     def __eq__(self, other: object) -> bool:
-        """Checks if two Version instances are equal."""
         if not isinstance(other, Version):
             return NotImplemented
-        return (
-            self.major == other.major
-            and self.minor == other.minor
-            and self.patch == other.patch
-            and self.pre_release == other.pre_release
-            and self.build_metadata == other.build_metadata
-        )
+        return self._v == other._v
 
     def __lt__(self, other: Version) -> bool:
-        """Compares two Version instances for less than."""
-        if self.major != other.major:
-            return self.major < other.major
-        if self.minor != other.minor:
-            return self.minor < other.minor
-        if self.patch != other.patch:
-            return self.patch < other.patch
-        return self.pre_release < other.pre_release
+        return self._v < other._v
+
+    def __le__(self, other: Version) -> bool:
+        return self._v <= other._v
 
     def __gt__(self, other: Version) -> bool:
-        """Compares two Version instances for greater than."""
-        return not (self < other or self == other)
+        return self._v > other._v
 
     def __ge__(self, other: Version) -> bool:
-        """Compares two Version instances for greater than or equal to."""
-        return self > other or self == other
-
-    @staticmethod
-    def validate_version(version_str: str) -> None:
-        """Validates the version string format."""
-        if not re.match(
-            r"^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$",
-            version_str,
-        ):
-            raise ValueError(
-                f"Invalid version format: {version_str}. Expected format: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]"
-            )
+        return self._v >= other._v
 
 
 class VersionComparator:
     @staticmethod
     def compare(version1: Version, version2: Version) -> int:
-        """
-        Compares two Version objects.
-
-        Returns:
-            -1 if version1 < version2
-             0 if version1 == version2
-             1 if version1 > version2
-        """
-        if version1.major != version2.major:
-            return version1.major - version2.major
-        if version1.minor != version2.minor:
-            return version1.minor - version2.minor
-        return version1.patch - version2.patch
+        if version1 < version2:
+            return -1
+        if version1 > version2:
+            return 1
+        return 0


### PR DESCRIPTION
PR fixes the issue where the installed package reported version `0.0.0` and introduces a clearer, more reliable version management approach.

Changes: 
- Fixed an issue where the installed package incorrectly reported version `0.0.0`
- Added a static `version = "X.Y.Z"` field to `pyproject.toml` for reliable build‑time versioning
- Removed dynamic versioning from the `dynamic` section
- Implemented a runtime version loader using `importlib.metadata` with a safe fallback
- Added a `version_info()` helper for human‑readable version output
- Updated `tuxemon/__init__.py` to expose `__version__` and `version_info`
- Modernized the test suite to use pytest
- Added parametrized tests for version parsing, comparison, validation, and metadata handling
- Added tests for the runtime `__version__` loader and `version_info()`