### PR TITLE
Fix incorrect combat sheet field when loading NPC templates from save data

### DIFF
--- a/docs/handcrafted/condition_list.rst
+++ b/docs/handcrafted/condition_list.rst
@@ -16,8 +16,8 @@
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_facing.CharFacingCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_facing_char.CharFacingCharCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_facing_tile.CharFacingTileCondition
-.. autoscriptinfoclass:: tuxemon.event.conditions.char_healed.CharHealedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_gender.CharGenderCondition
+.. autoscriptinfoclass:: tuxemon.event.conditions.char_healed.CharHealedCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_in.CharInCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_in_boundary.CharInBoundaryCondition
 .. autoscriptinfoclass:: tuxemon.event.conditions.char_moved.CharMovedCondition

--- a/tuxemon/event/actions/camera_position.py
+++ b/tuxemon/event/actions/camera_position.py
@@ -26,7 +26,6 @@ class CameraPositionAction(EventAction):
 
     Script parameters:
         x,y: the coordinates where the camera needs to be centered.
-
     """
 
     name = "camera_position"

--- a/tuxemon/event/actions/char_stop.py
+++ b/tuxemon/event/actions/char_stop.py
@@ -25,7 +25,6 @@ class CharStopAction(EventAction):
 
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple").
-
     """
 
     name = "char_stop"

--- a/tuxemon/event/actions/clear_tuxepedia.py
+++ b/tuxemon/event/actions/clear_tuxepedia.py
@@ -27,7 +27,6 @@ class ClearTuxepediaAction(EventAction):
 
     Script parameters:
         monster_slug: Monster slug name (e.g. "rockitten").
-
     """
 
     name = "clear_tuxepedia"

--- a/tuxemon/event/actions/copy_variable.py
+++ b/tuxemon/event/actions/copy_variable.py
@@ -27,7 +27,6 @@ class CopyVariableAction(EventAction):
     Script parameters:
         var1: The variable to copy to.
         var2: The variable to copy from.
-
     """
 
     name = "copy_variable"

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -46,7 +46,6 @@ class DojoMethodAction(EventAction):
             - "technique": Learn any move the monster hasn't acquired from its base
               moveset, without restrictions based on level or evolution stage.
             - "monster": Devolve the monster.
-
     """
 
     name = "dojo_method"

--- a/tuxemon/event/actions/fadeout_music.py
+++ b/tuxemon/event/actions/fadeout_music.py
@@ -26,7 +26,6 @@ class FadeoutMusicAction(EventAction):
 
     Script parameters:
         duration: Number of milliseconds to fade out the music over.
-
     """
 
     name = "fadeout_music"

--- a/tuxemon/event/actions/format_variable.py
+++ b/tuxemon/event/actions/format_variable.py
@@ -30,7 +30,6 @@ class FormatVariableAction(EventAction):
         type_format: Kind of format (float or int).
 
     eg. "format_variable name_variable,int"
-
     """
 
     name = "format_variable"

--- a/tuxemon/event/actions/info.py
+++ b/tuxemon/event/actions/info.py
@@ -43,7 +43,6 @@ class InfoAction(EventAction):
         "info name_variable,owner_steps"
         -> if the owner walked 69 steps, then it'll create a variable called:
         "info_owner_steps:69"
-
     """
 
     name = "info"

--- a/tuxemon/event/actions/modify_char_attribute.py
+++ b/tuxemon/event/actions/modify_char_attribute.py
@@ -31,7 +31,6 @@ class ModifyCharAttributeAction(EventAction):
         character: Either "player" or character slug name (e.g. "npc_maple").
         attribute: Name of the attribute to modify.
         value: Value of the attribute modifier.
-
     """
 
     name = "modify_char_attribute"

--- a/tuxemon/event/actions/modify_money.py
+++ b/tuxemon/event/actions/modify_money.py
@@ -30,7 +30,6 @@ class ModifyMoneyAction(EventAction):
 
     eg. "modify_money player,-50"
     eg. "modify_money player,,name_variable"
-
     """
 
     name = "modify_money"

--- a/tuxemon/event/actions/pause_music.py
+++ b/tuxemon/event/actions/pause_music.py
@@ -22,7 +22,6 @@ class PauseMusicAction(EventAction):
         .. code-block::
 
             pause_music
-
     """
 
     name = "pause_music"

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -37,7 +37,6 @@ class PlayMusicAction(EventAction):
         The volume will be based on the main value in the options menu.
         e.g. if you set volume = 0.5 here, but the player has 0.5 among
         its options, then it'll result into 0.25 (0.5*0.5)
-
     """
 
     name = "play_music"

--- a/tuxemon/event/actions/save_game.py
+++ b/tuxemon/event/actions/save_game.py
@@ -37,7 +37,6 @@ class SaveGameAction(EventAction):
 
     eg: "save_game" (slot4.save)
     eg: "save_game 1"
-
     """
 
     name = "save_game"

--- a/tuxemon/event/actions/set_char_attribute.py
+++ b/tuxemon/event/actions/set_char_attribute.py
@@ -25,7 +25,6 @@ class SetCharAttributeAction(EventAction):
         character: Either "player" or character slug name (e.g. "npc_maple").
         attribute: Name of the attribute.
         value: Value of the attribute.
-
     """
 
     name = "set_char_attribute"

--- a/tuxemon/event/actions/set_layer.py
+++ b/tuxemon/event/actions/set_layer.py
@@ -28,7 +28,6 @@ class SetLayerAction(EventAction):
     Note: this is not a separate state, so it's advisable
         to add a 4th value to the rgb, if not you're not
         going to see the character, ideally 128.
-
     """
 
     name = "set_layer"

--- a/tuxemon/event/actions/set_party_attribute.py
+++ b/tuxemon/event/actions/set_party_attribute.py
@@ -28,7 +28,6 @@ class SetPartyAttributeAction(EventAction):
         character: Either "player" or character slug name (e.g. "npc_maple").
         attribute: Name of the attribute.
         value: Value of the attribute.
-
     """
 
     name = "set_party_attribute"

--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -30,7 +30,6 @@ class SetTuxepediaAction(EventAction):
         character: Either "player" or npc slug name (e.g. "npc_maple").
         monster_slug: Monster slug name (e.g. "rockitten").
         label: seen / caught
-
     """
 
     name = "set_tuxepedia"

--- a/tuxemon/event/actions/stop_cinema_mode.py
+++ b/tuxemon/event/actions/stop_cinema_mode.py
@@ -19,7 +19,6 @@ class StopCinemaModeAction(EventAction):
         .. code-block::
 
             stop_cinema_mode
-
     """
 
     name = "stop_cinema_mode"

--- a/tuxemon/event/actions/unpause_music.py
+++ b/tuxemon/event/actions/unpause_music.py
@@ -22,7 +22,6 @@ class UnpauseMusicAction(EventAction):
         .. code-block::
 
             unpause_music
-
     """
 
     name = "unpause_music"

--- a/tuxemon/event/actions/variable_math.py
+++ b/tuxemon/event/actions/variable_math.py
@@ -34,7 +34,6 @@ class VariableMathAction(EventAction):
         var2: Second operand.
         result: Variable where to store the result. If missing, it will be
             ``var1``.
-
     """
 
     name = "variable_math"

--- a/tuxemon/event/conditions/char_exists.py
+++ b/tuxemon/event/conditions/char_exists.py
@@ -21,7 +21,6 @@ class CharExistsCondition(EventCondition):
 
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple").
-
     """
 
     name = "char_exists"

--- a/tuxemon/event/conditions/char_facing.py
+++ b/tuxemon/event/conditions/char_facing.py
@@ -25,7 +25,6 @@ class CharFacingCondition(EventCondition):
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple").
         direction: One of "up", "down", "left" or "right".
-
     """
 
     name = "char_facing"

--- a/tuxemon/event/conditions/char_facing_char.py
+++ b/tuxemon/event/conditions/char_facing_char.py
@@ -26,7 +26,6 @@ class CharFacingCharCondition(EventCondition):
     Script parameters:
         character1: Either "player" or character slug name (e.g. "npc_maple").
         character2: Either "player" or character slug name (e.g. "npc_maple").
-
     """
 
     name = "char_facing_char"

--- a/tuxemon/event/conditions/char_sprite.py
+++ b/tuxemon/event/conditions/char_sprite.py
@@ -25,7 +25,6 @@ class CharSpriteCondition(EventCondition):
     Script parameters:
         character: Either "player" or character slug name (e.g. "npc_maple")
         sprite: NPC's sprite (eg maniac, florist, etc.)
-
     """
 
     name = "char_sprite"

--- a/tuxemon/event/conditions/check_char_parameter.py
+++ b/tuxemon/event/conditions/check_char_parameter.py
@@ -29,7 +29,6 @@ class CheckCharParameterCondition(EventCondition):
         value: Given value to check.
 
     eg. "player,name,alpha" -> is the player named alpha? true/false
-
     """
 
     name = "check_char_parameter"

--- a/tuxemon/event/conditions/check_party_parameter.py
+++ b/tuxemon/event/conditions/check_party_parameter.py
@@ -35,7 +35,6 @@ class CheckPartyParameterCondition(EventCondition):
 
     eg. "check_party_parameter player,level,5,equals,1"
     translated: "is there 1 monster in the party at level 5? True/False"
-
     """
 
     name = "check_party_parameter"

--- a/tuxemon/event/conditions/current_state.py
+++ b/tuxemon/event/conditions/current_state.py
@@ -25,7 +25,6 @@ class CurrentStateCondition(EventCondition):
 
     eg: "is current_state CombatState"
     eg: "is current_state CombatState:DialogState"
-
     """
 
     name = "current_state"

--- a/tuxemon/event/conditions/has_bag.py
+++ b/tuxemon/event/conditions/has_bag.py
@@ -29,7 +29,6 @@ class HasBagCondition(EventCondition):
             "less_or_equal", "greater_than", "greater_or_equal", "equals"
             and "not_equals".
         value: The value to compare the bag with.
-
     """
 
     name = "has_bag"

--- a/tuxemon/event/conditions/has_item.py
+++ b/tuxemon/event/conditions/has_item.py
@@ -30,7 +30,6 @@ class HasItemCondition(EventCondition):
             "less_or_equal", "greater_than", "greater_or_equal", "equals"
             and "not_equals".
         quantity: Quantity to compare with.
-
     """
 
     name = "has_item"

--- a/tuxemon/event/conditions/has_kennel.py
+++ b/tuxemon/event/conditions/has_kennel.py
@@ -30,7 +30,6 @@ class HasKennelCondition(EventCondition):
             "less_or_equal", "greater_than", "greater_or_equal", "equals"
             and "not_equals".
         value: The value to compare the party with.
-
     """
 
     name = "has_kennel"

--- a/tuxemon/event/conditions/has_monster.py
+++ b/tuxemon/event/conditions/has_monster.py
@@ -25,7 +25,6 @@ class HasMonsterCondition(EventCondition):
     Script parameters:
         character: Either "player" or npc slug name (e.g. "npc_maple").
         monster: Monster slug name (e.g. "rockitten").
-
     """
 
     name = "has_monster"

--- a/tuxemon/event/conditions/has_party_breeder.py
+++ b/tuxemon/event/conditions/has_party_breeder.py
@@ -25,7 +25,6 @@ class HasPartyBreederCondition(EventCondition):
 
     Script parameters:
         character: Either "player" or npc slug name (e.g. "npc_maple").
-
     """
 
     name = "has_party_breeder"

--- a/tuxemon/event/conditions/has_tech.py
+++ b/tuxemon/event/conditions/has_tech.py
@@ -21,7 +21,6 @@ class HasTechCondition(EventCondition):
 
     Script parameters:
         technique: Technique slug name (e.g. "bullet").
-
     """
 
     name = "has_tech"

--- a/tuxemon/event/conditions/location_inside.py
+++ b/tuxemon/event/conditions/location_inside.py
@@ -20,7 +20,6 @@ class LocationInsideCondition(EventCondition):
             is location_inside
 
     eg. "is location_inside"
-
     """
 
     name = "location_inside"

--- a/tuxemon/event/conditions/location_name.py
+++ b/tuxemon/event/conditions/location_name.py
@@ -26,7 +26,6 @@ class LocationNameCondition(EventCondition):
 
     eg. "is location_name routeb"
     eg. "is location_name routeb:routea"
-
     """
 
     name = "location_name"

--- a/tuxemon/fusion.py
+++ b/tuxemon/fusion.py
@@ -279,7 +279,6 @@ def fuse(
         >>> # Fuse the sprites.
         >>> fuse(body=sapsnap, face=vivitron)
         >>> fuse(body=vivitron, face=sapsnap)
-
     """
     logger.info(
         f"Starting fusion for body '{body.name}' and face '{face.name}'."

--- a/tuxemon/map/map_loader.py
+++ b/tuxemon/map/map_loader.py
@@ -350,7 +350,6 @@ class TMXMapLoader:
     understand.
 
     **Tiled:** http://www.mapeditor.org/
-
     """
 
     def __init__(self) -> None:

--- a/tuxemon/npc.py
+++ b/tuxemon/npc.py
@@ -267,7 +267,7 @@ class NPC(Entity):
                 "sprite_name", ""
             )
             self.template.combat_sheet = save_data.template.get(
-                "combat_front", ""
+                "combat_sheet", ""
             )
             self.sprite_controller.update_template(self.template)
 

--- a/tuxemon/script/parser.py
+++ b/tuxemon/script/parser.py
@@ -17,7 +17,6 @@ def split_escaped(
 
     Returns:
         A list of the split string.
-
     """
     # Split by "," unless it is escaped by a "\"
     split_list = re.split(r"(?<!\\)" + delimeter, string_to_split)

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar
 
 import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, ALIGN_LEFT, POSITION_EAST
 
 from tuxemon import formula
 from tuxemon.database.runtime import db
@@ -44,7 +44,6 @@ class CharacterState(PygameMenuState):
 
     Shows details of the character (e.g. monster captured, seen,
     battles, wallet, etc.).
-
     """
 
     name: ClassVar[str] = "CharacterState"
@@ -121,7 +120,7 @@ class CharacterState(PygameMenuState):
             title=name.upper(),
             label_id="name",
             font_size=self.font_type.big,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             underline=True,
             float=True,
         )
@@ -133,7 +132,7 @@ class CharacterState(PygameMenuState):
             title=f"{T.translate('wallet')}: {money.format(amount)}",
             label_id="money",
             font_size=self.font_type.smaller,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab2.translate(fxw(0.45), fxh(0.25))
@@ -142,7 +141,7 @@ class CharacterState(PygameMenuState):
             title=msg_seen,
             label_id="seen",
             font_size=self.font_type.smaller,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab3.translate(fxw(0.45), fxh(0.30))
@@ -151,7 +150,7 @@ class CharacterState(PygameMenuState):
             title=msg_caught,
             label_id="caught",
             font_size=self.font_type.smaller,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab4.translate(fxw(0.45), fxh(0.35))
@@ -160,7 +159,7 @@ class CharacterState(PygameMenuState):
             title=msg_begin,
             label_id="begin",
             font_size=self.font_type.smaller,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab5.translate(fxw(0.45), fxh(0.40))
@@ -170,7 +169,7 @@ class CharacterState(PygameMenuState):
                 title=msg_walked,
                 label_id="walked",
                 font_size=self.font_type.smaller,
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
                 float=True,
             )
             lab6.translate(fxw(0.45), fxh(0.45))
@@ -179,7 +178,7 @@ class CharacterState(PygameMenuState):
             title=msg_battles,
             label_id="battle",
             font_size=self.font_type.smaller,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab7.translate(fxw(0.45), fxh(0.50))
@@ -188,7 +187,7 @@ class CharacterState(PygameMenuState):
             title=msg_progress,
             label_id="progress",
             font_size=self.font_type.smaller,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab8.translate(fxw(0.45), fxh(0.10))
@@ -203,7 +202,7 @@ class CharacterState(PygameMenuState):
     def __init__(self, **kwargs: Any) -> None:
         if not lookup_cache:
             _lookup_monsters()
-        character: Optional[NPC] = None
+        character: NPC | None = None
         for element in kwargs.values():
             character = element["character"]
         if character is None:
@@ -219,15 +218,15 @@ class CharacterState(PygameMenuState):
         )
 
         theme = self._setup_theme(bg)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         super().__init__(height=height, width=width)
 
         self.add_menu_items(self.menu)
         self.reset_theme()
 
-    def process_event(self, event: PlayerInput) -> Optional[PlayerInput]:
+    def process_event(self, event: PlayerInput) -> PlayerInput | None:
         if (
             event.button == buttons.RIGHT
             and event.pressed


### PR DESCRIPTION
`[2026-02-01 08:43:14,257] tuxemon.menu.input_handler - ERROR - Unexpected error in menu event processing: [Fetch] Asset not found: gfx/sprites/player/.png`

Fixes #3405

Changes:
- NPC templates were loaded using the key `combat_front` instead of `combat_sheet`
- Saved templates use the correct field name `combat_sheet`, so loading always produced an empty value
- This resulted in invalid paths such as `gfx/sprites/player/.png` and a crash when opening the character menu
- The fix replaces `combat_front` with `combat_sheet` and keeps an optional fallback for very old saves
- NPC combat sheets now load correctly in both new and existing save files

Removed also a bunch of empty lines.