### PR TITLE
Centralize Monster Leveling and Evolution Logic (with Held Item Support)

### DIFF
--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -158,7 +158,7 @@ def test_no_owner(setup_evolution):
 )
 def test_level_requirement(setup_evolution, level, at_level, expected):
     mon, _, _ = setup_evolution
-    mon.set_level(level)
+    mon.set_level(level, level)
     evo = MonsterEvolutionItemModel(monster_slug="rockat", at_level=at_level)
     context = {"map_inside": True}
     assert mon.evolution_handler.can_evolve(evo, context) == expected
@@ -441,7 +441,7 @@ def test_probability_conditions(
 ):
     mon, _, _ = setup_evolution
     if level is not None:
-        mon.set_level(level)
+        mon.set_level(level, level)
     evo_kwargs = {"monster_slug": "rockat"}
     if at_level is not None:
         evo_kwargs["at_level"] = at_level
@@ -670,9 +670,86 @@ def test_deny_pending_evolution_calls_registry_and_resets_flags(
     mon, _, evo = setup_evolution
     registry = MagicMock()
     mon.instance_id = "iid123"
-    mon.set_level(10)
+    mon.set_level(10, 10)
     mon.experience_handler.reset_status_flags = MagicMock()
     evo.deny_pending_evolution(registry, "slug123")
     registry.log_missed.assert_called_once_with("iid123", "slug123", 10)
     registry.clear_pending.assert_called_once_with("iid123")
     mon.experience_handler.reset_status_flags.assert_called_once()
+
+
+def test_get_eligible_evolution_slug_requires_item_but_not_used(
+    setup_evolution,
+):
+    mon, player, evo = setup_evolution
+
+    evolution_item = MonsterEvolutionItemModel.model_construct(
+        monster_slug="rockat", item={"stone": 1}
+    )
+
+    mon.evolutions = [evolution_item]
+    evo.is_eligible_for_evolution = lambda: True
+    evo.can_evolve = lambda item, ctx: False
+    registry = MagicMock()
+    registry.get_blocked.return_value = []
+    player.evolution_registry = registry
+
+    type(mon).held_item = PropertyMock(return_value=None)
+    slug = evo.get_eligible_evolution_slug(context={"use_item": False})
+    assert slug is None
+
+
+def test_get_eligible_evolution_slug_held_item_blocks(setup_evolution):
+    mon, player, evo = setup_evolution
+
+    evolution_item = MonsterEvolutionItemModel(monster_slug="rockat")
+    mon.evolutions = [evolution_item]
+
+    evo.is_eligible_for_evolution = lambda: True
+    evo.can_evolve = lambda item, ctx: True
+
+    registry = MagicMock()
+    registry.get_blocked.return_value = []
+    player.evolution_registry = registry
+
+    blocker = MagicMock()
+    blocker.behaviors.block_evolution = True
+    type(mon).held_item = PropertyMock(return_value=blocker)
+    slug = evo.get_eligible_evolution_slug()
+    assert slug is None
+
+
+def test_get_eligible_evolution_slug_blocked(setup_evolution):
+    mon, player, evo = setup_evolution
+
+    evolution_item = MonsterEvolutionItemModel(monster_slug="rockat")
+    mon.evolutions = [evolution_item]
+
+    evo.is_eligible_for_evolution = lambda: True
+    evo.can_evolve = lambda item, ctx: True
+
+    registry = MagicMock()
+    registry.get_blocked.return_value = ["rockat"]
+    player.evolution_registry = registry
+
+    type(mon).held_item = PropertyMock(return_value=None)
+    slug = evo.get_eligible_evolution_slug()
+    assert slug is None
+
+
+def test_get_eligible_evolution_slug(setup_evolution):
+    mon, player, evo = setup_evolution
+
+    evolution_item = MonsterEvolutionItemModel(monster_slug="rockat")
+    mon.evolutions = [evolution_item]
+
+    evo.is_eligible_for_evolution = lambda: True
+    evo.can_evolve = lambda item, ctx: True
+
+    registry = MagicMock()
+    registry.get_blocked.return_value = []
+    player.evolution_registry = registry
+
+    type(mon).held_item = PropertyMock(return_value=None)
+    slug = evo.get_eligible_evolution_slug()
+    assert slug == "rockat"

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -63,7 +63,7 @@ def monster(monkeypatch):
     ],
 )
 def test_set_level(monster, input_level, expected):
-    monster.set_level(input_level)
+    monster.set_level(input_level, input_level)
     assert monster.level == expected
 
 
@@ -102,7 +102,7 @@ def tastes(monkeypatch):
 
 
 def test_set_stats_basic(monster):
-    monster.set_level(5)
+    monster.set_level(5, 5)
     value = monster.level + config_monster.coeff_stats
     monster.set_stats()
 
@@ -115,7 +115,7 @@ def test_set_stats_basic(monster):
 
 
 def test_set_stats_shape(monster, shape_model):
-    monster.set_level(5)
+    monster.set_level(5, 5)
     value = monster.level + config_monster.coeff_stats
 
     monster.shape = ShapeHandler("dragon")
@@ -131,7 +131,7 @@ def test_set_stats_shape(monster, shape_model):
 
 
 def test_set_stats_taste_warm(monster, tastes):
-    monster.set_level(5)
+    monster.set_level(5, 5)
     value = monster.level + config_monster.coeff_stats
 
     monster.taste_warm = "peppy"
@@ -141,7 +141,7 @@ def test_set_stats_taste_warm(monster, tastes):
 
 
 def test_set_stats_taste_cold(monster, tastes):
-    monster.set_level(5)
+    monster.set_level(5, 5)
     value = monster.level + config_monster.coeff_stats
 
     monster.taste_cold = "mild"
@@ -151,7 +151,7 @@ def test_set_stats_taste_cold(monster, tastes):
 
 
 def test_set_stats_tastes(monster, tastes):
-    monster.set_level(5)
+    monster.set_level(5, 5)
     value = monster.level + config_monster.coeff_stats
 
     monster.taste_cold = "flakey"

--- a/tests/tuxemon/test_reward.py
+++ b/tests/tuxemon/test_reward.py
@@ -214,10 +214,10 @@ def test_award_rewards_moves_updates(setup_combat):
         combat_type,
     ) = setup_combat
 
-    winner.moves.update_moves.return_value = ["Fireball"]
+    winner.moves.preview_moves_learned.return_value = ["Fireball"]
 
     second_winner = monster_mock(level=5, hp=50)
-    second_winner.moves.update_moves.return_value = ["Ram"]
+    second_winner.moves.preview_moves_learned.return_value = ["Ram"]
     second_winner.owner = winner.owner
 
     damage_tracker.log_damage(second_winner, loser, 5, 1)

--- a/tuxemon/combat/reward_system.py
+++ b/tuxemon/combat/reward_system.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from tuxemon.combat.damage_tracker import DamageTracker
     from tuxemon.monster.monster import Monster
     from tuxemon.session import Session
-    from tuxemon.technique.technique import Technique
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ class RewardDataEntry:
 class RewardData:
     winners: list[RewardDataEntry]
     messages: list[str]
-    moves: list[Technique]
+    moves: list[str]
     update: bool
     prize: int
 
@@ -112,8 +111,7 @@ class RewardCalculator:
             all_monsters = set(owner.party.alive)
             non_participants = all_monsters - winners
             for non_participant in non_participants:
-                levels = non_participant.give_experience(awarded_exp)
-                non_participant.moves.update_moves(non_participant, levels)
+                non_participant.give_experience(awarded_exp)
 
     def calculate_winner_entry(
         self, loser: Monster, winner: Monster
@@ -138,7 +136,9 @@ class RewardCalculator:
         self, winner: Monster, entry: RewardDataEntry, rewards_data: RewardData
     ) -> None:
         """Update moves and add messages for a winner."""
-        new_moves = winner.moves.update_moves(winner, entry.levels_gained)
+        new_moves = winner.moves.preview_moves_learned(
+            winner, entry.levels_gained
+        )
         if new_moves:
             rewards_data.moves.extend(new_moves)
 

--- a/tuxemon/core/conditions/can_evolve.py
+++ b/tuxemon/core/conditions/can_evolve.py
@@ -37,11 +37,6 @@ class CanEvolveCondition(CoreCondition):
             "map_inside": session.client.map_manager.map_inside,
             "use_item": True,
         }
-        if not target.evolutions:
-            return False
-        for evolution in target.evolutions:
-            if target.evolution_handler.can_evolve(
-                evolution_item=evolution, context=context
-            ):
-                return True
-        return False
+        return bool(
+            target.evolution_handler.get_eligible_evolution_slug(context)
+        )

--- a/tuxemon/core/effects/evolve.py
+++ b/tuxemon/core/effects/evolve.py
@@ -36,33 +36,16 @@ class EvolveEffect(CoreEffect):
     def apply_item_target(
         self, session: Session, item: Item, target: Monster
     ) -> ItemEffectResult:
-        if not target.evolutions:
-            return ItemEffectResult(name=item.name)
-
         context = {"use_item": True}
-        possible_evolutions = (
-            target.evolution_handler.get_possible_item_evolutions(
-                item, context
-            )
+        possible = target.evolution_handler.get_possible_item_evolutions(
+            item, context
         )
+        if not possible:
+            return ItemEffectResult(name=item.name, success=False)
 
-        if not possible_evolutions:
-            return ItemEffectResult(name=item.name)
+        model = target.evolution_handler.choose_evolution_model(possible)
+        registry = target.get_owner().evolution_registry
+        registry.add_pending(target.instance_id, model.monster_slug)
 
-        selected_evolution_model = (
-            target.evolution_handler.choose_evolution_model(
-                possible_evolutions
-            )
-        )
-        new_monster = Monster.spawn_base(
-            selected_evolution_model.monster_slug, target.level
-        )
-        target.evolution_handler.evolve_monster(new_monster)
-
-        session.client.push_state(
-            "EvolutionTransition",
-            original=target.slug,
-            evolved=new_monster.slug,
-        )
-
+        target.waiting_to_evolve = True
         return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -526,6 +526,10 @@ class ItemBehaviors(Behaviors):
     wear_on_use: bool = Field(
         False, description="Whether using this item increases its wear."
     )
+    block_evolution: bool = Field(
+        False,
+        description="Whether or not this item prevents the holder from evolving.",
+    )
 
 
 class TechBehaviors(Behaviors):

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -95,55 +95,25 @@ class EvolutionAction(EventAction):
 
     def process_pending_evolutions(self) -> None:
         """Process pending evolutions for the character"""
+        candidates = [m for m in self.char.monsters if m.waiting_to_evolve]
+        if not candidates:
+            return
+
+        monster = candidates[0]
+        context = {"use_item": monster.waiting_to_evolve}
+        slug = monster.evolution_handler.get_eligible_evolution_slug(context)
+
+        if not slug:
+            monster.waiting_to_evolve = False
+            return
+
         registry = self.char.evolution_registry
-        logger.debug(
-            f"Checking pending evolutions for character: {self.char.name}"
-        )
+        if slug not in registry.get_pending(monster.instance_id):
+            registry.add_pending(monster.instance_id, slug)
 
-        evolve_candidates: list[Monster] = []
-        for monster in self.char.monsters:
-            logger.debug(
-                f"Evaluating monster: {monster.name} (ID: {monster.instance_id})"
-            )
-            logger.debug(
-                f"  got_experience={monster.got_experience}, levelling_up={monster.levelling_up}"
-            )
-
-            pending = registry.get_pending(monster.instance_id)
-            logger.debug(f"  Pending evolutions: {pending}")
-
-            if monster.got_experience and monster.levelling_up and pending:
-                evolve_candidates.append(monster)
-                logger.debug(f"  -> Added to evolve_candidates")
-
-        if not evolve_candidates:
-            logger.debug("No evolve candidates found. Returning from action.")
-            return
-
-        monster_to_evolve = evolve_candidates[0]
-        logger.debug(
-            f"Selected monster for evolution: {monster_to_evolve.name}"
-        )
-
-        pending_evolutions = registry.get_pending(
-            monster_to_evolve.instance_id
-        )
-        logger.debug(
-            f"Pending evolutions for selected monster: {pending_evolutions}"
-        )
-
-        if not pending_evolutions:
-            logger.debug("No pending evolutions found for selected monster.")
-            return
-
-        slug = pending_evolutions[0]
-        evolved = Monster.spawn_base(slug, monster_to_evolve.level)
-        logger.debug(f"Created evolved monster: {evolved.name} (slug: {slug})")
-
-        self._pending_map[monster_to_evolve.instance_id] = slug
-        logger.debug(f"Stored pending evolution slug for denial logic")
-
-        self.question_evolution(monster_to_evolve, evolved)
+        evolved = Monster.spawn_base(slug, monster.level)
+        self._pending_map[monster.instance_id] = slug
+        self.question_evolution(monster, evolved)
 
     def question_evolution(self, monster: Monster, evolved: Monster) -> None:
         """Ask the user to confirm the evolution"""
@@ -162,32 +132,27 @@ class EvolutionAction(EventAction):
         open_choice_dialog(self.session.client, MenuOptions(options))
 
     def confirm_evolution(self, monster: Monster, evolved: Monster) -> None:
-        """Confirm the evolution"""
         self.client.pop_state()
         self.client.pop_state()
-        logger.info(f"{monster.name} evolves into {evolved.name}!")
 
         registry = self.char.evolution_registry
         monster.evolution_handler.confirm_pending_evolution(
             registry, evolved.slug
         )
-        self._pending_map.pop(monster.instance_id, None)
-
         monster.evolution_handler.evolve_monster(evolved)
+        monster.waiting_to_evolve = False
+
         self.client.push_state(
             "EvolutionTransition", original=monster.slug, evolved=evolved.slug
         )
 
     def deny_evolution(self, monster: Monster) -> None:
-        """Deny the evolution"""
-        monster.experience_handler.reset_status_flags()
-        logger.info(f"{monster.name}'s evolution refused!")
-
+        monster.waiting_to_evolve = False
         slug = self._pending_map.get(monster.instance_id)
         if slug:
             registry = self.char.evolution_registry
-            monster.evolution_handler.deny_pending_evolution(registry, slug)
-            self._pending_map.pop(monster.instance_id, None)
+            registry.log_missed(monster.instance_id, slug, monster.level)
+            registry.clear_pending_slug(monster.instance_id, slug)
 
         self.client.pop_state()
         self.client.pop_state()

--- a/tuxemon/event/actions/give_experience.py
+++ b/tuxemon/event/actions/give_experience.py
@@ -69,8 +69,5 @@ class GiveExperienceAction(EventAction):
 
         if monsters:
             for mon in monsters:
-                level = mon.give_experience(exp)
+                mon.give_experience(exp)
                 logger.info(f"{mon.name} +{exp} exp")
-                if level > 0:
-                    mon.moves.update_moves(mon, level)
-                    logger.info(f"{mon.name} +{level} levels")

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -54,10 +54,8 @@ class SetMonsterLevelAction(EventAction):
                 logger.error("Monster not found")
                 return
             new_level = monster.level + self.levels_added
-            monster.set_level(new_level)
-            monster.moves.update_moves(monster, self.levels_added)
+            monster.set_level(new_level, monster.level)
         else:
             for monster in player.monsters:
                 new_level = monster.level + self.levels_added
-                monster.set_level(new_level)
-                monster.moves.update_moves(monster, self.levels_added)
+                monster.set_level(new_level, monster.level)

--- a/tuxemon/event/conditions/check_evolution.py
+++ b/tuxemon/event/conditions/check_evolution.py
@@ -34,69 +34,8 @@ class CheckEvolutionCondition(EventCondition):
 
     def test(self, session: Session, condition: SpatialCondition) -> bool:
         target_name = condition.parameters[0]
-        logger.debug(
-            f"EvolutionCondition.test() called with target_name='{target_name}'"
-        )
-
         target_character = session.get_npc(target_name)
-        if target_character is None:
-            logger.error(f"Character '{target_name}' not found.")
+        if not target_character:
             return False
 
-        logger.debug(f"Found character: {target_character.name}")
-        context = {"map_inside": session.client.map_manager.map_inside}
-        new_evolutions_found = False
-        has_pending_evolutions = False
-
-        for monster in target_character.monsters:
-            logger.debug(
-                f"Checking monster: {monster.name} (ID: {monster.instance_id})"
-            )
-
-            if not monster.evolutions:
-                logger.debug(f"  No evolutions available for {monster.name}")
-                continue
-
-            registry = target_character.evolution_registry
-            pending_evolutions = registry.get_pending(monster.instance_id)
-            blocked_evolutions = registry.get_blocked(monster.instance_id)
-
-            if pending_evolutions:
-                logger.debug(
-                    f"  Already has pending evolutions: {pending_evolutions}"
-                )
-                has_pending_evolutions = True
-
-            for evolution_data in monster.evolutions:
-                evolution_slug = evolution_data.monster_slug
-                logger.debug(
-                    f"  Evaluating evolution option: {evolution_slug}"
-                )
-
-                if evolution_slug in blocked_evolutions:
-                    logger.debug(
-                        f"  Skipping '{evolution_slug}' — permanently blocked"
-                    )
-                    continue
-
-                if evolution_slug in pending_evolutions:
-                    logger.debug(
-                        f"  Skipping '{evolution_slug}' — already pending"
-                    )
-                    continue
-
-                if monster.evolution_handler.can_evolve(
-                    evolution_item=evolution_data, context=context
-                ):
-                    logger.debug(f"  Adding '{evolution_slug}' to pending")
-                    registry.add_pending(monster.instance_id, evolution_slug)
-                    new_evolutions_found = True
-                    has_pending_evolutions = True
-                else:
-                    logger.debug(
-                        f"  '{evolution_slug}' not valid in current context"
-                    )
-
-        logger.debug(f"New evolutions found: {new_evolutions_found}")
-        logger.debug(f"Has any pending evolutions: {has_pending_evolutions}")
-        return has_pending_evolutions
+        return any(m.waiting_to_evolve for m in target_character.monsters)

--- a/tuxemon/monster/evolution.py
+++ b/tuxemon/monster/evolution.py
@@ -33,6 +33,37 @@ class Evolution:
     def __init__(self, monster: Monster):
         self.monster = monster
 
+    def get_eligible_evolution_slug(
+        self, context: dict[str, bool] | None = None
+    ) -> str | None:
+        """Checks all paths. Returns target slug or None."""
+        if not self.is_eligible_for_evolution():
+            return None
+
+        ctx = context or {"use_item": False}
+        registry = self.monster.get_owner().evolution_registry
+        monster_id = self.monster.instance_id
+
+        # Check Held Item (Everstone) - Bypass if using an evolution item
+        if not ctx.get("use_item"):
+            held = self.monster.held_item
+            if held and held.behaviors.block_evolution:
+                return None
+
+        # Check Registry (Blocked list)
+        blocked = registry.get_blocked(monster_id)
+
+        # Scan evolution paths
+        for evolution_item in self.monster.evolutions:
+            slug = evolution_item.monster_slug
+            if slug in blocked:
+                continue
+
+            if self.can_evolve(evolution_item, ctx):
+                return slug
+
+        return None
+
     def has_evolution_to(self, slug: str) -> bool:
         return any(
             evolution.monster_slug == slug

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -119,6 +119,7 @@ class Monster:
         self.state: str = ""
         self.out_of_range: bool = False
         self.wild: bool = False
+        self.waiting_to_evolve: bool = False
 
         self.is_charging: bool = False
         self.charged_technique: str | None = None
@@ -504,14 +505,13 @@ class Monster:
         return self.types.has_type(type_slug)
 
     def give_experience(self, amount: int = 1) -> int:
-        """Increase experience."""
+        """Adds experience and triggers synchronization if level changes."""
+        old_level = self.level
         levels_earned = self.experience_handler.give_experience(amount)
 
         if levels_earned > 0:
-            self.set_stats()
-            logger.info(
-                f"Leveling {self.name} from {self.level -1} to {self.level}!"
-            )
+            new_level = self.level  # XP handler already updated it
+            self.set_level(new_level, old_level)
 
         return levels_earned
 
@@ -604,10 +604,22 @@ class Monster:
         if self.item_handler.held_item:
             self.item_handler.held_item.temporary_stat_boosts = BasicStats()
 
-    def set_level(self, level: int) -> None:
-        """Set monster level."""
-        self.experience_handler.set_level(level)
+    def set_level(self, new_level: int, old_level: int) -> int:
+        self.experience_handler.set_level(new_level)
         self.set_stats()
+        level_delta = new_level - old_level
+
+        if level_delta > 0:
+            self.moves.update_moves(self, level_delta)
+            slug = self.evolution_handler.get_eligible_evolution_slug()
+
+            if slug:
+                self.waiting_to_evolve = True
+                logger.debug(f"{self.name} is ready to evolve into {slug}!")
+            else:
+                logger.debug("No evolution flagged at level-up")
+
+        return level_delta
 
     def set_experience_modifier(self, modifier: float) -> None:
         """Sets the experience modifier for this monster."""
@@ -635,7 +647,7 @@ class Monster:
 
     def transfer_properties_from(self, old_monster: Monster) -> None:
         """Copies essential state and identity properties from the pre-evolved monster."""
-        self.set_level(old_monster.level)
+        self.set_level(old_monster.level, old_monster.level)
         self.current_hp = min(old_monster.current_hp, self.hp)
         self.moves = old_monster.moves
         self.status = old_monster.status

--- a/tuxemon/monster/moves.py
+++ b/tuxemon/monster/moves.py
@@ -85,8 +85,8 @@ class MonsterMovesHandler:
         if max_moves is None:
             max_moves = monster.max_moves
 
-        if not ignore_eligibility and not self.is_technique_eligible(
-            monster, technique, method
+        if not ignore_eligibility and not self.can_learn(
+            monster, technique, max_moves, method
         ):
             return False
 
@@ -97,8 +97,19 @@ class MonsterMovesHandler:
             self.moves.append(technique)
         else:
             self.moves.append(technique)
+        return True
 
-        logger.debug(f"Monster learned technique: {technique.slug}")
+    def can_learn(
+        self,
+        monster: Monster,
+        technique: Technique,
+        max_moves: int | None = None,
+        method: LearningMethod | None = None,
+    ) -> bool:
+        if max_moves is None:
+            max_moves = monster.max_moves
+        if not self.is_technique_eligible(monster, technique, method):
+            return False
         return True
 
     def forget(self, technique: Technique) -> bool:
@@ -247,6 +258,35 @@ class MonsterMovesHandler:
                     f"Monster '{monster.slug}' learned technique: {technique.slug} at level {monster.level} and stage {monster.stage}"
                 )
 
+    def techniques_learned_between(
+        self, start_level: int, end_level: int
+    ) -> list[str]:
+        return [
+            move.technique
+            for move in self.moveset
+            if start_level < move.level_learned <= end_level
+        ]
+
+    def preview_moves_learned(
+        self,
+        monster: Monster,
+        levels_earned: int,
+        method: LearningMethod = LearningMethod.LEVEL_UP,
+    ) -> list[str]:
+        start_level = monster.level - levels_earned
+        techniques = self.techniques_learned_between(
+            start_level, monster.level
+        )
+
+        learnable = []
+        for tech in techniques:
+            technique = Technique.create(tech)
+
+            if self.can_learn(monster, technique, method=method):
+                learnable.append(tech)
+
+        return learnable
+
     def update_moves(
         self,
         monster: Monster,
@@ -254,16 +294,17 @@ class MonsterMovesHandler:
         method: LearningMethod = LearningMethod.LEVEL_UP,
     ) -> list[Technique]:
         start_level = monster.level - levels_earned
-        newly_learned_techniques = []
+        techniques = self.techniques_learned_between(
+            start_level, monster.level
+        )
 
-        for move in self.moveset:
-            if start_level < move.level_learned <= monster.level:
-                technique = Technique.create(move.technique)
+        newly_learned = []
+        for tech in techniques:
+            technique = Technique.create(tech)
+            if self.learn(monster, technique, method=method):
+                newly_learned.append(technique)
 
-                if self.learn(monster, technique, method=method):
-                    newly_learned_techniques.append(technique)
-
-        return newly_learned_techniques
+        return newly_learned
 
     def learn_by_method(
         self,

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -831,7 +831,7 @@ class CombatState(CombatAnimations):
             )
 
     def update_hud_and_level_up(
-        self, winner: Monster, techniques: list[Technique]
+        self, winner: Monster, techniques: list[str]
     ) -> None:
         """
         Update the HUD and handle level ups for the winner.
@@ -842,7 +842,9 @@ class CombatState(CombatAnimations):
         """
         if winner in self.combat_session.monsters_in_play_right:
             if techniques:
-                tech_list = ", ".join(tech.name.upper() for tech in techniques)
+                tech_list = ", ".join(
+                    T.translate(tech).upper() for tech in techniques
+                )
                 params = {"name": winner.name.upper(), "tech": tech_list}
                 mex = T.format("tuxemon_new_tech", params)
                 self.text_anim.add_xp_message(mex)

--- a/tuxemon/states/shop_training.py
+++ b/tuxemon/states/shop_training.py
@@ -137,8 +137,7 @@ class ShopTrainingMenuState(ShopMenuState[Monster]):
             cost = self._calculate_total_training_cost(monster, quantity)
             if quantity > 0 and cost <= available_money:
                 self.seller_manager.remove_money(cost)
-                monster.set_level(monster.level + quantity)
-                monster.moves.update_moves(monster, quantity)
+                monster.set_level(monster.level + quantity, monster.level)
                 self.reload_shop()
 
         base_cost = self._calculate_training_cost(monster)


### PR DESCRIPTION
PR improves how monsters level up and evolve by moving all growth‑related logic into one place.

Changes:
- unified Leveling Logic: the monster’s `set_level` method is now the single place where stat updates, move learning, and evolution checks happen and it now receives both the old level and the new level, so the game can correctly detect how many levels were gained and react accordingly
- monsters now use a `waiting_to_evolve` flag, this separates “the monster is eligible to evolve” from “the evolution scene should start,” which makes the evolution flow more stable and easier to control
- items can now include a `block_evolution` behavior, if a monster is holding such an item, it will skip evolution checks during level‑ups unless the evolution is triggered by using an item
- the evolution system now works with the `EvolutionRegistry`, if a player cancels an evolution, the game remembers and won’t immediately prompt again until the next valid trigger
- event conditions, item effects, and other systems now rely on the centralized leveling and evolution helpers, this reduces duplicated logic