### PR TITLE
Simplify PC menu system and replace over‑engineered provider injection with a clear registry‑based design

### DIFF
--- a/mods/email.yaml
+++ b/mods/email.yaml
@@ -1,0 +1,16 @@
+emails:
+  # Each entry represents a single email the player can receive.
+  # Fields:
+  #   id:        Unique identifier for the email (used internally)
+  #   sender:    Who the email appears to come from
+  #   subject:   Title shown in the email list
+  #   body:      Full text shown when the email is opened
+  #   pc_tags:   Which PC types can display this email
+  #              (matches the tags passed to AccessPCAction)
+  #   maps:      Optional list of map slugs where this email is visible.
+  #              If omitted or null, the email appears on ALL maps.
+  - id: "example_id"
+    sender: "example_welcome_sender"
+    subject: "example_welcome_subject"
+    body: "example_welcome_body"
+    pc_tags: ["example"]

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4622,6 +4622,21 @@ msgstr "Pick Up Item"
 msgid "menu_item_dropoff"
 msgstr "Drop Off Item"
 
+msgid "menu_calendar"
+msgstr "Calendar"
+
+msgid "menu_email"
+msgstr "Emails"
+
+msgid "menu_email_none"
+msgstr "No emails"
+
+msgid "menu_email_from"
+msgstr "From"
+
+msgid "menu_back"
+msgstr "Back"
+
 msgid "menu_multiplayer"
 msgstr "Multiplayer"
 

--- a/tuxemon/computer.py
+++ b/tuxemon/computer.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from typing import TYPE_CHECKING, ClassVar
+
+from tuxemon.locale.locale import T
+from tuxemon.platform.const.sizes import MAX_LOCKER
+from tuxemon.tools import open_dialog
+
+if TYPE_CHECKING:
+    from tuxemon.base_client import BaseClient
+    from tuxemon.entity.npc import NPC
+
+MenuGameObj = Callable[[], object]
+
+
+class PCMenuRegistry:
+    """Global registry to manage PC feature expansion."""
+
+    _providers: list[MenuProvider] = []
+
+    @classmethod
+    def register(cls, provider: MenuProvider) -> None:
+        """Register a new feature provider."""
+        cls._providers.append(provider)
+
+    @classmethod
+    def get_for_tag(cls, tag: str) -> list[MenuProvider]:
+        """Return providers matching a specific PC type/tag."""
+        return [p for p in cls._providers if tag in p.target_tags]
+
+
+class MenuProvider:
+    """Base class for adding dynamic content to the PC menu."""
+
+    target_tags: list[str] = ["standard"]
+
+    def get_menu_items(
+        self,
+        client: BaseClient,
+        character: NPC,
+        tag_list: list[str],
+    ) -> list[tuple[str, MenuGameObj]]:
+        raise NotImplementedError
+
+
+class CalendarProvider(MenuProvider):
+
+    name: ClassVar[str] = "menu_calendar"
+    target_tags = ["calendar"]
+
+    def get_menu_items(
+        self,
+        client: BaseClient,
+        character: NPC,
+        tag_list: list[str],
+    ) -> list[tuple[str, MenuGameObj]]:
+        return [
+            (
+                "menu_calendar",
+                partial(
+                    client.push_state,
+                    "CalendarState",
+                    session=character.session,
+                ),
+            )
+        ]
+
+
+class EmailProvider(MenuProvider):
+
+    name: ClassVar[str] = "menu_email"
+    target_tags = ["email"]
+
+    def get_menu_items(
+        self,
+        client: BaseClient,
+        character: NPC,
+        tag_list: list[str],
+    ) -> list[tuple[str, MenuGameObj]]:
+        return [
+            (
+                "menu_email",
+                partial(
+                    client.push_state,
+                    "EmailState",
+                    character=character,
+                    tag_list=tag_list,
+                ),
+            )
+        ]
+
+
+PCMenuRegistry.register(CalendarProvider())
+PCMenuRegistry.register(EmailProvider())
+
+
+class PCMenuBuilder:
+    def __init__(
+        self,
+        client: BaseClient,
+        character: NPC,
+        menu_providers: list[MenuProvider] | None = None,
+        tag_list: list[str] | None = None,
+    ) -> None:
+        self.client = client
+        self.character = character
+        self.menu_providers = menu_providers or []
+        self.tag_list = tag_list or []
+
+    def build_menu_items(self) -> list[tuple[str, MenuGameObj]]:
+        char = self.character
+        menu: list[tuple[str, MenuGameObj]] = []
+
+        monster_callback = partial(
+            self.client.replace_state, "MonsterStorageState", character=char
+        )
+        if char.monster_boxes.get_all_monsters_visible():
+            menu.append(("menu_storage", monster_callback))
+
+        # Monster drop-off
+        if len(char.monsters) > 1:
+            menu.append(
+                (
+                    "menu_dropoff",
+                    partial(
+                        self.client.replace_state,
+                        "MonsterDropOffState",
+                        character=char,
+                    ),
+                )
+            )
+
+        # --- Item Storage ---
+        if len(char.items) == MAX_LOCKER:
+            item_callback = partial(
+                open_dialog,
+                self.client,
+                [T.translate("menu_storage_items_full")],
+            )
+        else:
+            item_callback = partial(
+                self.client.replace_state, "ItemStorageState", character=char
+            )
+
+        if char.item_boxes.get_all_items_visible():
+            menu.append(("menu_item_storage", item_callback))
+
+        # Item drop-off
+        if len(char.items) > 1:
+            menu.append(
+                (
+                    "menu_item_dropoff",
+                    partial(
+                        self.client.replace_state,
+                        "ItemDropOffState",
+                        character=char,
+                    ),
+                )
+            )
+
+        # --- Dynamic Providers ---
+        for provider in self.menu_providers:
+            menu.extend(
+                provider.get_menu_items(self.client, char, self.tag_list)
+            )
+
+        # --- Multiplayer placeholder ---
+        menu.append(
+            (
+                "menu_multiplayer",
+                partial(
+                    open_dialog, self.client, [T.translate("not_implemented")]
+                ),
+            )
+        )
+
+        # --- Log Off ---
+        menu.append(("log_off", self.client.pop_state))
+
+        return menu

--- a/tuxemon/event/actions/access_pc.py
+++ b/tuxemon/event/actions/access_pc.py
@@ -6,9 +6,9 @@ import logging
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon.computer import PCMenuBuilder, PCMenuRegistry
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
-from tuxemon.states.pc import PCMenuBuilder
 
 logger = logging.getLogger()
 
@@ -17,48 +17,71 @@ logger = logging.getLogger()
 @dataclass
 class AccessPCAction(EventAction):
     """
-    Change to PCState.
+    Open a PC interface for a specific character.
 
-    This action transitions to the PCState, typically used for viewing
-    player character details or an NPC as if it were a PC.
+    This action transitions the game into ``PCState`` and displays a
+    context-appropriate PC menu. The menu contents are determined by:
+
+      • The target character (NPC) being viewed
+      • The ``pc_tags`` string provided in the script
+      • Any registered ``MenuProvider`` objects whose tags match
+
+    ``pc_tags`` is a colon-separated list of tag identifiers.
+    Example:
+        ``standard:email:league``
+
+    This allows maps, story events, and mods to define complex PC
+    terminals that combine multiple feature sets—for example:
+    a standard PC with email access, a league PC with storage, or
+    any custom combination added by extensions.
 
     Script usage:
         .. code-block::
 
-            access_pc <character_slug>
+            access_pc <character_slug> [pc_tags]
 
     Script parameters:
-        character_slug: The slug of the character (NPC) to view in PCState.
+        character_slug:
+            The slug of the NPC whose PC interface should be opened.
+        pc_tags (optional):
+            A colon-separated string of PC tags.
+            Defaults to ``"standard"`` if omitted.
+            Each tag enables additional menu providers from
+            ``PCMenuRegistry``.
     """
 
     name = "access_pc"
     character_slug: str
+    pc_tags: str = "standard"
 
     def start(self, session: Session) -> None:
         self.session = session
         self.client = session.client
 
-        if self.client.current_state is None:
-            raise RuntimeError("No current state active. This is unexpected.")
-
-        if self.client.current_state.name == "PCState":
-            logger.error(
-                f"The state 'PCState' is already active. No action taken."
-            )
-            return
-
         character = self.session.get_npc(self.character_slug)
-        if character is None:
-            logger.error(
-                f"Character '{self.character_slug}' not found for PCState."
-            )
+        if not character:
             return
+
+        tag_list = [
+            tag.strip() for tag in self.pc_tags.split(":") if tag.strip()
+        ]
+
+        providers = []
+        for tag in tag_list:
+            providers.extend(PCMenuRegistry.get_for_tag(tag))
 
         menu_builder = PCMenuBuilder(
-            client=self.client, character=character, menu_providers=None
+            client=self.client,
+            character=character,
+            menu_providers=providers,
+            tag_list=tag_list,
         )
+
         self.client.push_state(
-            "PCState", character=character, menu_builder=menu_builder
+            "PCState",
+            character=character,
+            tag_list=tag_list,
+            menu_builder=menu_builder,
         )
 
     def update(self, session: Session, dt: float) -> None:

--- a/tuxemon/states/email_provider.py
+++ b/tuxemon/states/email_provider.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
+
+from tuxemon.constants import paths
+from tuxemon.database.yaml_utils import load_yaml
+from tuxemon.entity.npc import NPC
+from tuxemon.locale.locale import T
+from tuxemon.menu.menu import PygameMenuState
+from tuxemon.platform.const.graphics import BG_MISSIONS
+from tuxemon.platform.const.sizes import UNKNOWN_MAP_SLUG
+from tuxemon.prepare import SCREEN_SIZE
+
+
+@dataclass
+class EmailData:
+    id: str
+    sender: str
+    subject: str
+    body: str
+    date: Sequence[int]
+    pc_tags: list[str]
+    maps: list[str] | None = None
+
+
+class EmailManager:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.emails: list[EmailData] = []
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            return
+
+        data = load_yaml(self.path) or {}
+
+        for entry in data.get("emails", []):
+            self.emails.append(EmailData(**entry))
+
+    def get_all(self) -> Sequence[EmailData]:
+        return self.emails
+
+
+class EmailState(PygameMenuState):
+    """
+    Displays a list of emails loaded from YAML and allows the player
+    to read them in a simple menu interface.
+    """
+
+    name: ClassVar[str] = "EmailState"
+
+    def __init__(self, character: NPC, tag_list: list[str]) -> None:
+        self.char = character
+        self.session = character.session
+        self.tag_list = tag_list
+
+        yaml_path = paths.mods_folder / "email.yaml"
+        self.email_manager = EmailManager(yaml_path)
+
+        if self.char.current_map:
+            self.current_map = self.char.current_map.split(".")[0]
+        else:
+            self.current_map = UNKNOWN_MAP_SLUG
+
+        width, height = SCREEN_SIZE
+        width = int(width * 0.8)
+        height = int(height * 0.8)
+
+        theme = self._setup_theme(BG_MISSIONS)
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
+
+        super().__init__(height=height, width=width)
+        self.initialize_items(self.menu)
+        self.reset_theme()
+
+    def initialize_items(self, menu: Menu) -> None:
+        menu.add.label(
+            T.translate("menu_email"),
+            selectable=True,
+            font_size=self.font_type.medium,
+        )
+        menu.add.vertical_margin(10)
+
+        emails = [
+            e
+            for e in self.email_manager.get_all()
+            if any(tag in e.pc_tags for tag in self.tag_list)
+            and (e.maps is None or self.current_map in e.maps)
+        ]
+
+        if not emails:
+            menu.add.label(
+                T.translate("menu_email_none"),
+                font_size=self.font_type.small,
+            )
+            return
+
+        # Sort by date (month, day)
+        emails = sorted(emails, key=lambda e: tuple(e.date))
+
+        for email in emails:
+            menu.add.button(
+                T.translate(email.subject),
+                lambda e=email: self.open_email(e),
+                font_size=self.font_type.small,
+            )
+            menu.add.vertical_margin(5)
+
+    def open_email(self, email: EmailData) -> None:
+        """Open a dedicated state to read a single email."""
+        self.client.push_state("EmailReadState", email=email)
+
+
+class EmailReadState(PygameMenuState):
+    """
+    Displays a single email in a clean, focused view.
+    """
+
+    name: ClassVar[str] = "EmailReadState"
+
+    def __init__(self, email: EmailData) -> None:
+        self.email = email
+
+        width, height = SCREEN_SIZE
+        width = int(width * 0.7)
+        height = int(height * 0.7)
+
+        theme = self._setup_theme(BG_MISSIONS)
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
+
+        super().__init__(height=height, width=width)
+        self.initialize_items(self.menu)
+        self.reset_theme()
+
+    def initialize_items(self, menu: Menu) -> None:
+        menu.add.label(
+            T.translate(self.email.subject),
+            font_size=self.font_type.big,
+            selectable=True,
+        )
+        menu.add.vertical_margin(10)
+
+        menu.add.label(
+            f"{T.translate('menu_email_from')}: {T.translate(self.email.sender)}",
+            font_size=self.font_type.medium,
+        )
+        menu.add.vertical_margin(10)
+
+        menu.add.label(
+            T.translate(self.email.body),
+            font_size=self.font_type.small,
+            wordwrap=True,
+        )
+
+        menu.add.vertical_margin(20)
+        menu.add.button(T.translate("menu_back"), self.client.pop_state)

--- a/tuxemon/states/pc.py
+++ b/tuxemon/states/pc.py
@@ -1,143 +1,69 @@
 # SPDX-License-Identifier: GPL-3.0
-# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+# Copyright (c) 2014-2026
+# William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+
 from __future__ import annotations
 
 from collections.abc import Callable
-from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
-import pygame_menu
+from pygame_menu.menu import Menu
 
 from tuxemon.animation import Animation, ScheduleType
+from tuxemon.computer import PCMenuBuilder
 from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
-from tuxemon.platform.const.sizes import KENNEL, LOCKER, MAX_LOCKER
-from tuxemon.state.state import State
-from tuxemon.tools import open_dialog
+from tuxemon.platform.const.sizes import KENNEL, LOCKER
 
 if TYPE_CHECKING:
-    from tuxemon.base_client import BaseClient
     from tuxemon.entity.npc import NPC
+
 
 MenuGameObj = Callable[[], object]
 
 
-def add_menu_items(
-    menu: pygame_menu.Menu,
-    items: list[tuple[str, MenuGameObj]],
-) -> None:
+def add_menu_items(menu: Menu, items: list[tuple[str, MenuGameObj]]) -> None:
+    """Add translated menu entries to a pygame_menu.Menu."""
     for key, callback in items:
         label = T.translate(key).upper()
         menu.add.button(label, callback)
 
 
-class MenuProvider:
-    def get_menu_items(
-        self, client: BaseClient, character: NPC
-    ) -> list[tuple[str, MenuGameObj]]:
-        raise NotImplementedError
-
-
-class PCMenuBuilder:
-    """Builds the menu items for the PCState."""
-
-    def __init__(
-        self,
-        client: BaseClient,
-        character: NPC,
-        menu_providers: list[MenuProvider] | None = None,
-    ) -> None:
-        self.client = client
-        self.character = character
-        self.menu_providers = (
-            menu_providers if menu_providers is not None else []
-        )
-
-    def _change_state(self, state: str, **kwargs: Any) -> partial[State]:
-        return partial(self.client.replace_state, state, **kwargs)
-
-    def _not_implemented_dialog(self) -> None:
-        open_dialog(
-            self.client, [T.translate("not_implemented")], dialog_speed="max"
-        )
-
-    def build_menu_items(self) -> list[tuple[str, MenuGameObj]]:
-        char = self.character
-        menu: list[tuple[str, MenuGameObj]] = []
-
-        # Monster box logic
-        monster_storage_callback = self._change_state(
-            "MonsterStorageState", character=char
-        )
-
-        if char.monster_boxes.get_all_monsters_visible():
-            menu.append(("menu_storage", monster_storage_callback))
-
-        if len(char.monsters) > 1:
-            menu.append(
-                (
-                    "menu_dropoff",
-                    self._change_state("MonsterDropOffState", character=char),
-                )
-            )
-
-        # Item box logic
-        if len(char.items) == MAX_LOCKER:
-            item_storage_callback = partial(
-                open_dialog,
-                self.client,
-                [T.translate("menu_storage_items_full")],
-            )
-        else:
-            item_storage_callback = self._change_state(
-                "ItemStorageState", character=char
-            )
-
-        if char.item_boxes.get_all_items_visible():
-            menu.append(("menu_item_storage", item_storage_callback))
-
-        if len(char.items) > 1:
-            menu.append(
-                (
-                    "menu_item_dropoff",
-                    self._change_state("ItemDropOffState", character=char),
-                )
-            )
-
-        # Other menu items
-        menu.append(("menu_multiplayer", self._not_implemented_dialog))
-        menu.append(("log_off", self.client.pop_state))
-
-        # Collect items from all injected providers
-        for provider in self.menu_providers:
-            menu.extend(provider.get_menu_items(self.client, self.character))
-
-        return menu
-
-
 class PCState(PygameMenuState):
-    """The PC State: deposit monster, deposit item, etc."""
+    """
+    The PC State: deposit monsters, deposit items, and any dynamic
+    menu entries provided by registered PC menu providers.
+
+    This state receives a PCMenuBuilder instance (injected by
+    AccessPCAction) and uses it to populate the menu.
+    """
 
     name: ClassVar[str] = "PCState"
 
     def __init__(
-        self, character: NPC, menu_builder: PCMenuBuilder | None = None
+        self,
+        character: NPC,
+        tag_list: list[str],
+        menu_builder: PCMenuBuilder | None = None,
     ) -> None:
+        self.tag_list = tag_list
         super().__init__()
-        kennel = KENNEL
-        locker = LOCKER
+        self.escape_key_exits = False
+
         char = character
 
-        # it creates the kennel and locker (new players)
-        if not char.monster_boxes.has_box(kennel, "monster"):
-            char.monster_boxes.create_box(kennel)
-        if not char.item_boxes.has_box(locker, "item"):
-            char.item_boxes.create_box(locker)
+        if not char.monster_boxes.has_box(KENNEL, "monster"):
+            char.monster_boxes.create_box(KENNEL)
+
+        if not char.item_boxes.has_box(LOCKER, "item"):
+            char.item_boxes.create_box(LOCKER)
 
         if menu_builder is None:
-            self.menu_builder = PCMenuBuilder(self.client, char)
-        else:
-            self.menu_builder = menu_builder
+            menu_builder = PCMenuBuilder(
+                self.client, char, menu_providers=[], tag_list=self.tag_list
+            )
+
+        self.menu_builder = menu_builder
 
         menu_items = self.menu_builder.build_menu_items()
         add_menu_items(self.menu, menu_items)


### PR DESCRIPTION
This change restructures how the PC menu is extended and customized. The previous approach relied on passing provider lists through multiple layers of state construction, which made the system more complicated than necessary and harder to follow. The new design introduces a small registry that keeps track of all available PC menu providers and selects the appropriate ones based on a simple tag. The event action now decides which providers apply and hands them directly to the menu builder. This keeps the builder focused on assembling the menu rather than discovering providers on its own.

In addition to the architectural cleanup, this update also introduces two new modular PC features: `menu_calendar` and `menu_email`. Each feature is implemented as a standalone provider, registered once and automatically activated on any PC whose tag list includes the corresponding capability. This makes it easy to add new PC functions without touching the core menu logic and ensures that different PC types can expose different features simply by declaring their tags.