### PR TITLE
Replace `pygame_menu` references with direct `Menu`, etc import for consistency

### DIFF
--- a/tuxemon/states/control_state.py
+++ b/tuxemon/states/control_state.py
@@ -6,8 +6,8 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any, ClassVar
 
-import pygame_menu
 from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.sound import SOUND_TYPE_WIDGET_SELECTION
 
 from tuxemon.animation import Animation, ScheduleType
@@ -37,10 +37,7 @@ class ControlState(PygameMenuState):
         self.reload_controls()
         self.reset_theme()
 
-    def initialize_items(
-        self,
-        menu: pygame_menu.Menu,
-    ) -> None:
+    def initialize_items(self, menu: Menu) -> None:
         def change_state(
             state: State | str, **change_state_kwargs: Any
         ) -> Callable[[], State]:

--- a/tuxemon/states/craft_menu.py
+++ b/tuxemon/states/craft_menu.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.constants import paths
 from tuxemon.item.crafting_system import CraftingSystem
@@ -37,7 +37,7 @@ class CraftMenuState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_MISSIONS)
-        theme.scrollarea_position = locals.POSITION_EAST
+        theme.scrollarea_position = POSITION_EAST
 
         width = int(0.8 * width)
         height = int(0.8 * height)
@@ -47,7 +47,7 @@ class CraftMenuState(PygameMenuState):
         self.initialize_items(self.menu)
         self.reset_theme()
 
-    def initialize_items(self, menu: pygame_menu.Menu) -> None:
+    def initialize_items(self, menu: Menu) -> None:
 
         def up() -> None:
             menu._scrollarea._scrollbars[0].bump_to_top()
@@ -75,9 +75,7 @@ class CraftMenuState(PygameMenuState):
                 self.add_ingredient_label(menu, recipe)
             menu.add.button(T.translate("menu_to_the_top"), action=up)
 
-    def add_craft_button(
-        self, menu: pygame_menu.Menu, slug: str, recipe: Recipe
-    ) -> None:
+    def add_craft_button(self, menu: Menu, slug: str, recipe: Recipe) -> None:
 
         def craft(recipe_slug: str) -> None:
             self.client.remove_state_by_name("CraftMenuState")
@@ -105,7 +103,7 @@ class CraftMenuState(PygameMenuState):
                 wordwrap=True,
             )
 
-    def add_tool_label(self, menu: pygame_menu.Menu, recipe: Recipe) -> None:
+    def add_tool_label(self, menu: Menu, recipe: Recipe) -> None:
         for tool in recipe.required_tools:
             tool_name = T.translate(tool.get("slug", ""))
             consumed_text = (
@@ -120,9 +118,7 @@ class CraftMenuState(PygameMenuState):
                 wordwrap=True,
             )
 
-    def add_ingredient_label(
-        self, menu: pygame_menu.Menu, recipe: Recipe
-    ) -> None:
+    def add_ingredient_label(self, menu: Menu, recipe: Recipe) -> None:
         items = f"{T.translate('menu_items')}: {T.translate(recipe.get_ingredients_str())}"
         menu.add.label(
             title=items,

--- a/tuxemon/states/difficulty_pick.py
+++ b/tuxemon/states/difficulty_pick.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import ClassVar
 
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.locale.locale import T
@@ -39,7 +39,7 @@ class DifficultyPickState(PygameMenuState):
         self.menu.add.label(
             title=title,
             font_size=self.font_type.big,
-            align=locals.ALIGN_CENTER,
+            align=ALIGN_CENTER,
             underline=True,
         )
 
@@ -50,7 +50,7 @@ class DifficultyPickState(PygameMenuState):
                 button_id=f"diff_{level}",
                 font_size=self.font_type.medium,
                 selection_effect=HighlightSelection(),
-                align=locals.ALIGN_CENTER,
+                align=ALIGN_CENTER,
             )
 
     def _handle_pick(self, difficulty: str) -> None:

--- a/tuxemon/states/journal_choice.py
+++ b/tuxemon/states/journal_choice.py
@@ -7,8 +7,8 @@ from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_LEFT, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.database.runtime import db
 from tuxemon.db import MonsterModel
@@ -44,7 +44,7 @@ class JournalChoice(PygameMenuState):
 
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
         monsters: list[MonsterModel],
     ) -> None:
 
@@ -97,8 +97,8 @@ class JournalChoice(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_JOURNAL_CHOICE)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_LEFT
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_LEFT
 
         self.char = character
 

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, ALIGN_LEFT, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon import formula
 from tuxemon.database.runtime import db
@@ -41,11 +41,7 @@ class JournalInfoState(PygameMenuState):
 
     name: ClassVar[str] = "JournalInfoState"
 
-    def add_menu_items(
-        self,
-        menu: pygame_menu.Menu,
-        monster: MonsterModel,
-    ) -> None:
+    def add_menu_items(self, menu: Menu, monster: MonsterModel) -> None:
         fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
         fxh: Callable[[float], int] = lambda r: fix_measure(menu._height, r)
         menu._width = fxw(248 / 256)
@@ -79,7 +75,7 @@ class JournalInfoState(PygameMenuState):
             title=name,
             label_id="name",
             font_size=self.font_type.biggest,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab1.translate(fxw(126 / 256), fxh(19.8 / 144))
@@ -89,7 +85,7 @@ class JournalInfoState(PygameMenuState):
             title=_weight,
             label_id="weight",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab2.translate(fxw(158 / 256), fxh(39 / 144))
@@ -99,7 +95,7 @@ class JournalInfoState(PygameMenuState):
             title=_height,
             label_id="height",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab3.translate(fxw(126 / 256), fxh(39 / 144))
@@ -130,7 +126,7 @@ class JournalInfoState(PygameMenuState):
             title=types,
             label_id="type_loaded",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab5.translate(fxw((141.4 / 256) + type_shift), fxh(56 / 144))
@@ -140,7 +136,7 @@ class JournalInfoState(PygameMenuState):
             title=_type,
             label_id="type_label",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab4.translate(fxw((141 / 256) + type_shift), fxh(49 / 144))
@@ -152,7 +148,7 @@ class JournalInfoState(PygameMenuState):
             title=shape,
             label_id="shape",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab6.translate(fxw(126 / 256), fxh(66 / 144))
@@ -164,7 +160,7 @@ class JournalInfoState(PygameMenuState):
             title=species,
             label_id="species",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab7.translate(fxw(126 / 256), fxh(29 / 144))
@@ -174,7 +170,7 @@ class JournalInfoState(PygameMenuState):
             title=_txmn_id,
             label_id="txmn_id",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab8.translate(fxw(124.6 / 256), fxh(10 / 144))
@@ -188,7 +184,7 @@ class JournalInfoState(PygameMenuState):
             font_size=self.font_type.small,
             wordwrap=True,
             leading=35,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
 
@@ -201,7 +197,7 @@ class JournalInfoState(PygameMenuState):
             label_id="evolution",
             font_size=self.font_type.small,
             wordwrap=True,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab10.translate(fxw(2 / 256), fxh(109 / 144))
@@ -221,7 +217,7 @@ class JournalInfoState(PygameMenuState):
             labels = [
                 menu.add.label(
                     title=f"{T.translate(ele).upper()}",
-                    align=locals.ALIGN_LEFT,
+                    align=ALIGN_LEFT,
                     font_size=self.font_type.smaller,
                 )
                 for ele in elements
@@ -262,8 +258,8 @@ class JournalInfoState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_JOURNAL_INFO)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         super().__init__(height=height, width=width)
 

--- a/tuxemon/states/journal_state.py
+++ b/tuxemon/states/journal_state.py
@@ -6,8 +6,8 @@ from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_LEFT, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.database.runtime import db
 from tuxemon.db import MonsterModel
@@ -42,11 +42,7 @@ class JournalState(PygameMenuState):
 
     name: ClassVar[str] = "JournalState"
 
-    def add_menu_items(
-        self,
-        menu: pygame_menu.Menu,
-        monsters: list[MonsterModel],
-    ) -> None:
+    def add_menu_items(self, menu: Menu, monsters: list[MonsterModel]) -> None:
         column_width = fix_measure(menu._width, 0.35)
         btn_x_offset = fix_measure(menu._width, 0.25)
         btn_y_offset = fix_measure(menu._height, 0.01)
@@ -104,8 +100,8 @@ class JournalState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_JOURNAL)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_LEFT
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_LEFT
 
         columns = 2
 

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -6,8 +6,8 @@ import random
 from functools import partial
 from typing import ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.database.runtime import db
@@ -48,20 +48,20 @@ class MinigameState(PygameMenuState):
         self.score = score
 
         theme = self._setup_theme(BG_MINIGAME)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         super().__init__(height=height, width=width)
         self.add_menu_items(self.menu)
         self.reset_theme()
 
-    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+    def add_menu_items(self, menu: Menu) -> None:
         name = T.translate("who_is_that")
         menu.add.label(
             title=name,
             label_id="question",
             font_size=self.font_type.big,
-            align=locals.ALIGN_CENTER,
+            align=ALIGN_CENTER,
             underline=True,
         )
 
@@ -99,7 +99,7 @@ class MinigameState(PygameMenuState):
                 title=description,
                 font_size=self.font_type.small,
                 label_id="description_label",
-                align=locals.ALIGN_CENTER,
+                align=ALIGN_CENTER,
                 max_char=-1,
                 wordwrap=True,
             )
@@ -115,7 +115,7 @@ class MinigameState(PygameMenuState):
             width=fix_measure(menu._width, 0.95),
             height=fix_measure(menu._width, 0.05),
             frame_id="options",
-            align=locals.ALIGN_CENTER,
+            align=ALIGN_CENTER,
         )
         frame._relax = True
 
@@ -127,20 +127,20 @@ class MinigameState(PygameMenuState):
                 button_id=mon.slug,
                 selection_effect=HighlightSelection(),
             )
-            frame.pack(label, align=locals.ALIGN_CENTER)
+            frame.pack(label, align=ALIGN_CENTER)
 
         # Score and Streak
         menu.add.label(
             title=f"{T.translate('score_label')}: {self.score}",
             label_id="score_label",
             font_size=self.font_type.medium,
-            align=locals.ALIGN_CENTER,
+            align=ALIGN_CENTER,
         )
         menu.add.label(
             title=f"{T.translate('streak_label')}: {self.streak}",
             label_id="streak_label",
             font_size=self.font_type.medium,
-            align=locals.ALIGN_CENTER,
+            align=ALIGN_CENTER,
         )
 
         if self.streak >= 10:
@@ -149,7 +149,7 @@ class MinigameState(PygameMenuState):
                 font_size=self.font_type.medium,
                 font_color=(255, 215, 0),
                 label_id="streak_bonus_label",
-                align=locals.ALIGN_CENTER,
+                align=ALIGN_CENTER,
             )
 
     def check_answer(self, mon: MonsterModel) -> None:

--- a/tuxemon/states/mission.py
+++ b/tuxemon/states/mission.py
@@ -6,8 +6,8 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, ALIGN_LEFT, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.db import MissionStatus
 from tuxemon.entity.npc import NPC
@@ -36,8 +36,8 @@ class MissionState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_MISSIONS)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         width = int(0.8 * width)
         height = int(0.8 * height)
@@ -46,10 +46,7 @@ class MissionState(PygameMenuState):
         self.initialize_items(self.menu)
         self.reset_theme()
 
-    def initialize_items(
-        self,
-        menu: pygame_menu.Menu,
-    ) -> None:
+    def initialize_items(self, menu: Menu) -> None:
         def change_state(state: str, **kwargs: Any) -> MenuGameObj:
             return partial(self.client.push_state, state, **kwargs)
 
@@ -84,18 +81,15 @@ class SingleMissionState(PygameMenuState):
         self.character = character
         width, height = SCREEN_SIZE
         theme = self._setup_theme(BG_MISSIONS)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         width = int(0.8 * width)
         height = int(0.8 * height)
         super().__init__(height=height, width=width)
         self.initialize_items(self.menu)
         self.reset_theme()
 
-    def initialize_items(
-        self,
-        menu: pygame_menu.Menu,
-    ) -> None:
+    def initialize_items(self, menu: Menu) -> None:
         def delete_mission() -> None:
             msg = T.translate("mission_deletion")
             open_dialog(self.client, [msg], dialog_speed="max")
@@ -127,7 +121,7 @@ class SingleMissionState(PygameMenuState):
             title=f"{self.mission.name}",
             label_id="name",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=False,
         )
 
@@ -135,7 +129,7 @@ class SingleMissionState(PygameMenuState):
             title=self.mission.description,
             label_id="description",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=False,
         )
 
@@ -143,7 +137,7 @@ class SingleMissionState(PygameMenuState):
             menu.add.label(
                 title=T.translate("mission_repeatable"),
                 font_size=self.font_type.small,
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
             )
 
         next_missions = (
@@ -155,7 +149,7 @@ class SingleMissionState(PygameMenuState):
             title=f"{T.translate('mission_next')}: {next_missions}",
             label_id="next_missions",
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=False,
         )
 
@@ -164,7 +158,7 @@ class SingleMissionState(PygameMenuState):
             title=T.translate("mission_progress"),
             default=progress,
             font_size=self.font_type.small,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=False,
         )
 

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, ALIGN_LEFT, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.widgets.widget.label import Label
 from pygame_menu.widgets.widget.progressbar import ProgressBar
 
@@ -58,7 +58,7 @@ class MonsterMovesState(PygameMenuState):
     # -------------------------
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
         monster: Monster,
     ) -> None:
         fxw: Callable[[float], int] = lambda r: fix_measure(menu._width, r)
@@ -72,7 +72,7 @@ class MonsterMovesState(PygameMenuState):
             label_id=monster.slug,
             font_color=(255, 255, 255),  # white
             font_size=self.font_type.biggest,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         lab1.translate(fxw(79.4 / 256), fxh(-0.2 / 144))
@@ -89,7 +89,7 @@ class MonsterMovesState(PygameMenuState):
                 action=None,
                 button_id=tech.slug,
                 font_size=self.font_type.biggest,
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
                 float=True,
             ).translate(fxw(83.6 / 256), fxh(_height))
 
@@ -103,7 +103,7 @@ class MonsterMovesState(PygameMenuState):
     # -------------------------
     # Per-tech UI updates
     # -------------------------
-    def add_menu_technique(self, menu: pygame_menu.Menu, slug: str) -> None:
+    def add_menu_technique(self, menu: Menu, slug: str) -> None:
         # keep width stable across updates
         menu._width = fix_measure(SCREEN_SIZE[0], 248 / 256)
 
@@ -120,9 +120,7 @@ class MonsterMovesState(PygameMenuState):
         )  # power % label (manual placement)
 
     # -------- description ----------
-    def _add_description_label(
-        self, menu: pygame_menu.Menu, technique: Technique
-    ) -> None:
+    def _add_description_label(self, menu: Menu, technique: Technique) -> None:
         width, height = SCREEN_SIZE
         description_label: Label | None = None
         for widget in menu.get_widgets():
@@ -136,7 +134,7 @@ class MonsterMovesState(PygameMenuState):
                 label_id="description",
                 font_size=self.font_type.bigger,
                 wordwrap=True,
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
                 float=True,
             )
             assert not isinstance(self.description_label, list)
@@ -147,9 +145,7 @@ class MonsterMovesState(PygameMenuState):
             description_label.set_title(technique.description)
 
     # -------- info line (id/types/recharge) ----------
-    def _add_info_label(
-        self, menu: pygame_menu.Menu, technique: Technique
-    ) -> None:
+    def _add_info_label(self, menu: Menu, technique: Technique) -> None:
         width, height = SCREEN_SIZE
         info_label: Label | None = None
         for widget in menu.get_widgets():
@@ -175,7 +171,7 @@ class MonsterMovesState(PygameMenuState):
                 label_id="label",
                 font_size=self.font_type.small,
                 wordwrap=True,
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
                 float=True,
             )
             # place it just above the description block
@@ -187,9 +183,7 @@ class MonsterMovesState(PygameMenuState):
             info_label.set_title(label_text)
 
     # -------- bars ----------
-    def _add_progress_bars(
-        self, menu: pygame_menu.Menu, technique: Technique
-    ) -> None:
+    def _add_progress_bars(self, menu: Menu, technique: Technique) -> None:
         width, height = SCREEN_SIZE
 
         diff_accuracy = round((technique.accuracy / ACCURACY_RANGE[1]) * 100)
@@ -212,7 +206,7 @@ class MonsterMovesState(PygameMenuState):
                 default=diff_accuracy,
                 font_size=self.font_type.biggest,
                 width=fix_measure(width, 80 / 256),
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
                 float=True,
             )
             self.bar_accuracy.translate(
@@ -228,7 +222,7 @@ class MonsterMovesState(PygameMenuState):
                 default=diff_potency,
                 font_size=self.font_type.biggest,
                 width=fix_measure(width, 80 / 256),
-                align=locals.ALIGN_LEFT,
+                align=ALIGN_LEFT,
                 float=True,
             )
             self.bar_potency.translate(
@@ -238,7 +232,7 @@ class MonsterMovesState(PygameMenuState):
             bar_potency.set_value(diff_potency)
 
     # -------- icons (types, range, speed) ----------
-    def _add_icons(self, menu: pygame_menu.Menu, technique: Technique) -> None:
+    def _add_icons(self, menu: Menu, technique: Technique) -> None:
         # Ensure attributes exist
         if not hasattr(self, "type_icon_widgets"):
             self.type_icon_widgets: list[Any] = []
@@ -306,9 +300,7 @@ class MonsterMovesState(PygameMenuState):
         self.speed_icon_widget.translate(fxw(222 / 256), fxh(51.8 / 144))
 
     # -------- power label ----------
-    def _add_power_label(
-        self, menu: pygame_menu.Menu, technique: Technique
-    ) -> None:
+    def _add_power_label(self, menu: Menu, technique: Technique) -> None:
         width, height = SCREEN_SIZE
         power_percent = round(technique.power * 100)
         power_text = f"{T.translate('technique_power')} {power_percent}%"
@@ -324,7 +316,7 @@ class MonsterMovesState(PygameMenuState):
         self.power_label = menu.add.label(
             title=power_text,
             font_size=self.font_type.biggest,
-            align=locals.ALIGN_LEFT,
+            align=ALIGN_LEFT,
             float=True,
         )
         assert not isinstance(self.power_label, list)
@@ -349,8 +341,8 @@ class MonsterMovesState(PygameMenuState):
 
         width, height = SCREEN_SIZE
         theme = self._setup_theme(TECH_INFO)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         super().__init__(height=height, width=width)
         self._source = source

--- a/tuxemon/states/multiplayer.py
+++ b/tuxemon/states/multiplayer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Generator
 from typing import ClassVar
 
-import pygame_menu
+from pygame_menu.menu import Menu
 
 from tuxemon.animation import Animation, ScheduleType
 from tuxemon.locale.locale import T
@@ -16,10 +16,7 @@ from tuxemon.tools import open_dialog
 MenuGameObj = Callable[[], object]
 
 
-def add_menu_items(
-    menu: pygame_menu.Menu,
-    items: list[tuple[str, MenuGameObj]],
-) -> None:
+def add_menu_items(menu: Menu, items: list[tuple[str, MenuGameObj]]) -> None:
     for key, callback in items:
         label = T.translate(key).upper()
         menu.add.button(label, callback)

--- a/tuxemon/states/park.py
+++ b/tuxemon/states/park.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
@@ -27,8 +27,8 @@ class ParkState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_MISSIONS)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         width = int(0.8 * width)
         height = int(0.8 * height)
@@ -36,7 +36,7 @@ class ParkState(PygameMenuState):
         self.initialize_items(self.menu)
         self.reset_theme()
 
-    def initialize_items(self, menu: pygame_menu.Menu) -> None:
+    def initialize_items(self, menu: Menu) -> None:
         tracker = self.park_session.tracker
         history = self.park_session.encounter_history
 

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -9,8 +9,8 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.animation import ScheduleType
@@ -195,8 +195,8 @@ class MonsterTakeState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_PC_KENNEL)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         # menu
         theme.title = True
@@ -276,9 +276,7 @@ class MonsterTakeState(PygameMenuState):
             escape_key_exits=True,
         )
 
-    def add_menu_items(
-        self, menu: pygame_menu.Menu, items: Sequence[Monster]
-    ) -> None:
+    def add_menu_items(self, menu: Menu, items: Sequence[Monster]) -> None:
         self.monster_boxes = self.char.monster_boxes
         self.box = self.monster_boxes.get_monsters(self.box_name)
         handler = MonsterActionHandler(
@@ -303,13 +301,13 @@ class MonsterTakeState(PygameMenuState):
                 level,
                 default=diff,
                 font_size=self.font_type.small,
-                align=locals.ALIGN_CENTER,
+                align=ALIGN_CENTER,
             )
             menu.add.button(
                 label,
                 partial(handler.description_dialog, monster),
                 font_size=self.font_type.small,
-                align=locals.ALIGN_CENTER,
+                align=ALIGN_CENTER,
                 selection_effect=HighlightSelection(),
             )
 
@@ -337,7 +335,7 @@ class MonsterBoxState(PygameMenuState):
 
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
         items: Sequence[tuple[str, MenuGameObj]],
     ) -> None:
         menu.add.vertical_fill()

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -9,8 +9,8 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.animation import ScheduleType
@@ -126,8 +126,8 @@ class ItemTakeState(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_PC_LOCKER)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         # menu
         theme.title = True
@@ -228,9 +228,7 @@ class ItemTakeState(PygameMenuState):
             escape_key_exits=True,
         )
 
-    def add_menu_items(
-        self, menu: pygame_menu.Menu, items: Sequence[Item]
-    ) -> None:
+    def add_menu_items(self, menu: Menu, items: Sequence[Item]) -> None:
         self.item_boxes = self.char.item_boxes
         self.box = self.item_boxes.get_items(self.box_name)
         handler = ItemActionHandler(
@@ -254,7 +252,7 @@ class ItemTakeState(PygameMenuState):
                 label,
                 selectable=True,
                 font_size=self.font_type.small,
-                align=locals.ALIGN_CENTER,
+                align=ALIGN_CENTER,
                 selection_effect=HighlightSelection(),
             )
 
@@ -281,7 +279,7 @@ class ItemBoxState(PygameMenuState):
 
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
         items: Sequence[tuple[str, MenuGameObj]],
     ) -> None:
         menu.add.vertical_fill()

--- a/tuxemon/states/phone.py
+++ b/tuxemon/states/phone.py
@@ -7,8 +7,8 @@ from collections.abc import Callable, Sequence
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.item.item import Item
@@ -33,8 +33,8 @@ class NuPhone(PygameMenuState):
         self.char = character
 
         theme = self._setup_theme(BG_PHONE)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         theme.title = True
 
         self.menu_apps: list[Item] = []
@@ -90,7 +90,7 @@ class NuPhone(PygameMenuState):
 
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
         items: Sequence[Item],
     ) -> None:
         """Dynamically adds app items to the phone menu."""

--- a/tuxemon/states/phone_contacts.py
+++ b/tuxemon/states/phone_contacts.py
@@ -6,8 +6,8 @@ import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.constants import paths
@@ -107,7 +107,7 @@ class NuPhoneContacts(PygameMenuState):
 
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
     ) -> None:
 
         T_RELATIONSHIP = T.translate("relation_relationship")
@@ -150,8 +150,8 @@ class NuPhoneContacts(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_PHONE_CONTACTS)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         theme.title = True
 
         self.char = character

--- a/tuxemon/states/phone_map.py
+++ b/tuxemon/states/phone_map.py
@@ -6,8 +6,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.constants import paths
 from tuxemon.database.yaml_utils import load_yaml
@@ -75,7 +75,7 @@ class NuPhoneMap(PygameMenuState):
 
     def add_menu_items(
         self,
-        menu: pygame_menu.Menu,
+        menu: Menu,
     ) -> None:
         new_image = self._create_image(data.map_path)
         new_image.scale(SCALE, SCALE)
@@ -111,8 +111,8 @@ class NuPhoneMap(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_PHONE_MAP)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
 
         theme.title = True
 

--- a/tuxemon/states/phone_radio.py
+++ b/tuxemon/states/phone_radio.py
@@ -7,8 +7,8 @@ from abc import ABC, abstractmethod
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame_menu
 from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.constants import paths
 from tuxemon.database.yaml_utils import load_yaml
@@ -160,7 +160,7 @@ class NuPhoneRadioBase(PygameMenuState, ABC):
         )
 
     @abstractmethod
-    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+    def add_menu_items(self, menu: Menu) -> None:
         pass
 
 
@@ -175,7 +175,7 @@ class NuPhoneRadioMenu(NuPhoneRadioBase):
         """Starts the broadcast when a button is clicked."""
         self._start_broadcast(station_slug)
 
-    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+    def add_menu_items(self, menu: Menu) -> None:
         """Builds the menu with clickable station buttons based on map location."""
         available_stations = RADIO_MAP_LISTS.get(
             self.current_map, RADIO_MAP_LISTS.get("all_maps", [])
@@ -320,7 +320,7 @@ class NuPhoneRadioTuner(NuPhoneRadioBase):
 
         return best_match_slug
 
-    def add_menu_items(self, menu: pygame_menu.Menu) -> None:
+    def add_menu_items(self, menu: Menu) -> None:
         """Builds the menu with the frequency tuner slider."""
 
         menu.add.label(

--- a/tuxemon/states/phone_renaming.py
+++ b/tuxemon/states/phone_renaming.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
@@ -22,16 +22,13 @@ if TYPE_CHECKING:
 class NuPhoneRenaming(PygameMenuState):
     name: ClassVar[str] = "NuPhoneRenaming"
 
-    def add_menu_items(
-        self,
-        menu: pygame_menu.Menu,
-    ) -> None:
+    def add_menu_items(self, menu: Menu) -> None:
         def rename_callback(new_name: str, monster: Monster) -> None:
             monster.name = new_name
             self.menu.clear()
             theme = self._setup_theme(BG_PHONE_RENAMING)
-            theme.scrollarea_position = locals.POSITION_EAST
-            theme.widget_alignment = locals.ALIGN_CENTER
+            theme.scrollarea_position = POSITION_EAST
+            theme.widget_alignment = ALIGN_CENTER
             self.add_menu_items(self.menu)
 
         def rename(monster: Monster) -> None:
@@ -60,8 +57,8 @@ class NuPhoneRenaming(PygameMenuState):
         width, height = SCREEN_SIZE
 
         theme = self._setup_theme(BG_PHONE_RENAMING)
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         theme.title = True
 
         self.char = character

--- a/tuxemon/states/set_key_state.py
+++ b/tuxemon/states/set_key_state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar
 
 import pygame
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
 
 from tuxemon.animation import Animation, ScheduleType
 from tuxemon.locale.locale import T
@@ -27,8 +27,8 @@ class SetKeyState(PygameMenuState):
         Used when initializing the state
         """
         theme = get_theme()
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         super().__init__(**kwargs)
         self.menu.add.label(
             T.translate("options_new_input_key0").upper(),

--- a/tuxemon/states/set_language.py
+++ b/tuxemon/states/set_language.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from functools import partial
 from typing import Any, ClassVar
 
-import pygame_menu
-from pygame_menu import locals
+from pygame_menu.locals import ALIGN_CENTER, POSITION_EAST
+from pygame_menu.menu import Menu
 
 from tuxemon.animation import Animation, ScheduleType
 from tuxemon.locale.locale import T
@@ -29,8 +29,8 @@ class SetLanguage(PygameMenuState):
         """
         self.main_menu = main_menu
         theme = get_theme()
-        theme.scrollarea_position = locals.POSITION_EAST
-        theme.widget_alignment = locals.ALIGN_CENTER
+        theme.scrollarea_position = POSITION_EAST
+        theme.widget_alignment = ALIGN_CENTER
         super().__init__(**kwargs)
         self.initialize_items(self.menu)
         self.reset_theme()
@@ -50,10 +50,7 @@ class SetLanguage(PygameMenuState):
                 character=local_session.player,
             )
 
-    def initialize_items(
-        self,
-        menu: pygame_menu.Menu,
-    ) -> None:
+    def initialize_items(self, menu: Menu) -> None:
         used = self.client.config.locale.slug
         languages = T.get_available_languages()
         for language in languages:

--- a/tuxemon/states/world_menus.py
+++ b/tuxemon/states/world_menus.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar
 
-import pygame_menu
+from pygame_menu.menu import Menu
 
 from tuxemon.animation import ScheduleType
 from tuxemon.menu.menu import PygameMenuState
@@ -27,10 +27,7 @@ logger = logging.getLogger(__name__)
 WorldMenuGameObj = Callable[[], object]
 
 
-def add_menu_items_to_pygame_menu(
-    menu: pygame_menu.Menu,
-    items: list[MenuItem],
-) -> None:
+def add_menu_items_to_pygame_menu(menu: Menu, items: list[MenuItem]) -> None:
     """Helper function to add items to a pygame_menu.Menu instance."""
     menu.clear()
     menu.add.vertical_fill()


### PR DESCRIPTION
waiting
- [x] #3423

This update standardizes how the `Menu` class is referenced across the codebase. Several files were still using `pygame_menu.Menu` even though `Menu` is already imported directly from `pygame_menu.menu`. This created unnecessary duplication and made type hints harder to read.