### PR TITLE
Fix: Register items with ActiveEffectManager so multi‑frame item effects (e.g. fishing) update correctly

### DIFF
--- a/tuxemon/item/item.py
+++ b/tuxemon/item/item.py
@@ -214,6 +214,9 @@ class Item:
             session=session, source=self, target=target
         )
 
+        if session.client:
+            session.client.active_effect_manager.add_item(self)
+
         if self.durability.has_wear and self.behaviors.wear_on_use:
             just_broke = self.increase_wear()
 


### PR DESCRIPTION
PR restores the missing lifecycle step for item‑based effects that require per‑frame updates. During the previous refactor of `Item.use()`, the call to register the item with `ActiveEffectManager` was unintentionally removed. As a result, items with time‑based or staged effects (notably the `FishingEffect`) never received update ticks, causing fishing to stall after `apply_item()` and never progress through its CAST → WAIT → BITE → ENCOUNTER stages. With this fix, item effects once again participate in the engine’s update loop, and fishing works as intended.