### PR TITLE
Add environment override lock to prevent map logic from overwriting scripted environments

### DIFF
--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -159,12 +159,14 @@ class FishingEffect(CoreEffect):
             if self._trigger_next_frame and self._pending_encounter:
                 mon_slug, level = self._pending_encounter
                 exp_req_mod = self._fish.exp_req_mod
-                environment = (
+                env = (
                     self._fish.environment.get("night")
                     if session.time.get_time_variables().stage_of_day
                     == "night"
                     else self._fish.environment.get("default")
                 )
+                session.client.environment_manager.load_environment(env)
+                session.client.environment_manager.lock_environment()
                 rgb = ":".join(map(str, self._fish.animation_color))
                 held_item = None
                 if self._fish.held_items:
@@ -178,7 +180,6 @@ class FishingEffect(CoreEffect):
                         level,
                         exp_req_mod,
                         None,
-                        environment,
                         rgb,
                         held_item,
                     ],

--- a/tuxemon/core/effects/trap.py
+++ b/tuxemon/core/effects/trap.py
@@ -189,7 +189,7 @@ class TrapEffect(CoreEffect):
                 mon_slug, level = self._pending_encounter
                 session.client.event_engine.execute_action(
                     "wild_encounter",
-                    [mon_slug, level, None, None, None, None, None],
+                    [mon_slug, level, None, None, None, None],
                     True,
                 )
                 session.client.event_engine.execute_action(

--- a/tuxemon/environment.py
+++ b/tuxemon/environment.py
@@ -125,6 +125,7 @@ class EnvironmentManager:
 
     def __init__(self) -> None:
         self._active_handler: Environment | None = None
+        self._override_lock: bool = False
         logger.debug("EnvironmentManager initialized.")
 
     def update(self, dt: float) -> None:
@@ -136,6 +137,10 @@ class EnvironmentManager:
         Loads a new environment by creating an EnvironmentData and Environment object.
         Returns True on success, False on failure.
         """
+        if self._override_lock:
+            logger.debug(f"Environment override active, ignoring load: {slug}")
+            return False
+
         self._active_handler = None
         try:
             env_data = EnvironmentData(slug)
@@ -154,6 +159,15 @@ class EnvironmentManager:
     def get_active_environment(self) -> Environment | None:
         """Returns the currently active Environment, or None if none is loaded."""
         return self._active_handler
+
+    def lock_environment(self):
+        self._override_lock = True
+
+    def unlock_environment(self):
+        self._override_lock = False
+
+    def is_locked(self) -> bool:
+        return self._override_lock
 
 
 class EnvironmentData:

--- a/tuxemon/event/actions/set_environment.py
+++ b/tuxemon/event/actions/set_environment.py
@@ -49,4 +49,6 @@ class SetEnvironmentAction(EventAction):
         if success:
             logger.info(f"Environment '{self.slug}' successfully loaded.")
         else:
+            if session.client.environment_manager.is_locked():
+                return
             logger.error(f"Failed to load environment '{self.slug}'.")

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -32,14 +32,13 @@ class WildEncounterAction(EventAction):
         .. code-block::
 
             wild_encounter <monster_slug>,<monster_level>[,exp_mod]
-                            [,mon_mod][,env][,rgb][,held_item]
+                            [,mon_mod][,rgb][,held_item]
 
     Script parameters:
         monster_slug: Monster slug.
         monster_level: Level of monster.
         exp_mod: Experience modifier.
         mon_mod: Money modifier.
-        env: Environment (grass default)
         rgb: color (eg red > 255,0,0 > 255:0:0) - default rgb(255,255,255)
         held_item: item held by the monster
     """

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -959,6 +959,7 @@ class CombatState(CombatAnimations):
         self.combat_session.reset()
         self.unregister_event_handlers()
         self.client.current_music.stop()
+        self.client.environment_manager.unlock_environment()
         self.clear_combat_states()
         self.phase = None
 


### PR DESCRIPTION
While testing the fishing encounter, I found that the environment set during `WildEncounterAction` was immediately overwritten by the map’s automatic `set_environment` logic. This caused the fishing environment to disappear instantly and produced repeated “Failed to load environment” errors.

PR introduces a simple override mechanism in `EnvironmentManager`:
- added `_override_lock` flag  
- added `lock_environment()`, `unlock_environment()`, and `is_locked()`  
- modified `load_environment()` to ignore loads while locked  
- updated `SetEnvironmentAction` to suppress errors when the lock is active  

Fishing now locks the environment through the manager, and the lock is released at the end of `CombatState`. The old `env` attribute in `WildEncounterAction` was removed in favor of using the centralized manager.