### PR TITLE
Replace `CharFacePlayerAction` with generalized `CharFaceCharAction` to support NPC‑to‑NPC facing logic

### DIFF
--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -27,7 +27,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.change_state.ChangeStateAction
 .. autoscriptinfoclass:: tuxemon.event.actions.change_taste.ChangeTasteAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_face.CharFaceAction
-.. autoscriptinfoclass:: tuxemon.event.actions.char_face_player.CharFacePlayerAction
+.. autoscriptinfoclass:: tuxemon.event.actions.char_face_char.CharFaceCharAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_look.CharLookAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_move.CharMoveAction
 .. autoscriptinfoclass:: tuxemon.event.actions.char_patrol.CharPatrolAction

--- a/tuxemon/event/actions/char_face_char.py
+++ b/tuxemon/event/actions/char_face_char.py
@@ -13,40 +13,39 @@ from tuxemon.session import Session
 
 @final
 @dataclass
-class CharFacePlayerAction(EventAction):
+class CharFaceCharAction(EventAction):
     """
-    Make an NPC face the player when they come within a specified distance.
+    Make an NPC face another character when they come within a specified distance.
 
     Script usage:
         .. code-block::
 
-            char_face_player <npc_slug>,<trigger_dist>,<persistent>
-
     Script parameters:
-        npc_slug: Slug of the NPC that will face the player.
-        trigger_dist: Maximum tile distance at which the NPC will begin
-            facing the player. Defaults to 3.
-        persistent: Whether the NPC should continue tracking the player
-            after the first trigger. Defaults to True.
+        npc_slug: Slug of the NPC that will do the turning.
+        target_slug: Slug of the character (NPC or player) to look at.
+        trigger_dist: Maximum tile distance for the trigger. Defaults to 3.
+        persistent: Whether to continue tracking. Defaults to True.
     """
 
-    name = "char_face_player"
+    name = "char_face_char"
     character: str
+    target: str
     trigger_dist: int = 3
     persistent: bool = True
 
     def start(self, session: Session) -> None:
         self.npc = session.get_npc(self.character)
+        self.target_char = session.get_npc(self.target)
 
     def update(self, session: Session, dt: float) -> None:
-        if not self.npc:
+        if not self.npc or not self.target_char:
             return
 
-        dist = tile_distance(self.npc.tile_pos, session.player.tile_pos)
+        dist = tile_distance(self.npc.tile_pos, self.target_char.tile_pos)
 
         if dist <= self.trigger_dist:
             direction = get_direction(
-                self.npc.tile_pos, session.player.tile_pos
+                self.npc.tile_pos, self.target_char.tile_pos
             )
             self.npc.set_facing(direction)
 


### PR DESCRIPTION
PR replaces the old `char_face_player` event action with a more flexible `char_face_char` action. The previous implementation only allowed an NPC to react to the player’s position, which was too limiting for scenarios where two NPCs need to interact with each other. The new action accepts both an acting NPC and a target character (NPC or player), enabling broader event scripting and more dynamic scene behavior.