### PR TITLE
Refactor display initialization to use `DisplayContext` and pass it through game entry points

### DIFF
--- a/run_tuxemon.py
+++ b/run_tuxemon.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from argparse import ArgumentParser, Namespace
 import sys
-from tuxemon import prepare
+from tuxemon.prepare import pygame_init,headless_init, DisplayContext
 from tuxemon.user_config import CONFIG
 
 
@@ -27,11 +27,11 @@ def parse_args() -> Namespace:
     )
     return parser.parse_args()
 
-def init(platform: str = "pygame") -> None:
+def init(platform: str = "pygame") -> DisplayContext:
     if platform == "pygame":
-        prepare.pygame_init()
+        return pygame_init()
     elif platform == "headless":
-        prepare.headless_init()
+        return headless_init()
     else:
         raise ValueError(f"Unsupported platform: {platform}")
 
@@ -39,9 +39,9 @@ def launch_game() -> None:
     args = parse_args()
 
     if args.headless:
-        init(platform="headless")
+        context = init(platform="headless")
     else:
-        init(platform="pygame")
+        context = init(platform="pygame")
 
     from tuxemon import main
     config = CONFIG
@@ -54,9 +54,9 @@ def launch_game() -> None:
             config.splash = False
 
         if args.headless:
-            main.headless(config=config)
+            main.headless(config=config, context=context)
         else:
-            main.main(config=config, load_slot=args.slot)
+            main.main(config=config, context=context, load_slot=args.slot)
 
     except Exception as e:
         import traceback

--- a/tests/tuxemon/test_bubble_manager.py
+++ b/tests/tuxemon/test_bubble_manager.py
@@ -1,47 +1,101 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
 from unittest.mock import MagicMock
 
-from pygame.surface import Surface
+import pytest
+from pygame import Rect, Surface
 
 from tuxemon.entity.npc import NPC
+from tuxemon.map.tuxemon import AbstractMap
 from tuxemon.map.view import BubbleManager
+from tuxemon.prepare import DisplayContext
 
 
-class TestBubbleManager(unittest.TestCase):
+@pytest.fixture
+def context():
+    ctx = MagicMock(spec=DisplayContext)
+    ctx.rect = Rect(0, 0, 800, 600)
+    ctx.tile_size = (32, 32)
 
-    def setUp(self):
-        self.manager = BubbleManager()
-        self.entity = MagicMock(spec=NPC)
-        self.surface = MagicMock(spec=Surface)
+    return ctx
 
-    def test_init(self):
-        self.assertEqual(self.manager.layer, 100)
-        self.assertEqual(self.manager.offset_divisor, 10)
-        self.assertEqual(self.manager._bubbles, {})
 
-    def test_add_bubble(self):
-        self.manager.add_bubble(self.entity, self.surface)
-        self.assertIn(self.entity, self.manager._bubbles)
-        self.assertEqual(self.manager._bubbles[self.entity], self.surface)
+@pytest.fixture
+def manager(context):
+    return BubbleManager(context=context)
 
-    def test_remove_bubble(self):
-        self.manager.add_bubble(self.entity, self.surface)
-        self.manager.remove_bubble(self.entity)
-        self.assertNotIn(self.entity, self.manager._bubbles)
 
-    def test_has_bubble(self):
-        self.assertFalse(self.manager.has_bubble(self.entity))
-        self.manager.add_bubble(self.entity, self.surface)
-        self.assertTrue(self.manager.has_bubble(self.entity))
+@pytest.fixture
+def npc():
+    npc = MagicMock(spec=NPC)
+    npc.sprite_controller = MagicMock()
+    npc.tile_pos = (5, 5)
+    sprite_renderer = MagicMock()
+    sprite_renderer.rect = Rect(0, 0, 32, 48)
+    npc.sprite_controller.get_sprite_renderer.return_value = sprite_renderer
+    return npc
 
-    def test_clear_all_bubbles(self):
-        entity1 = MagicMock(spec=NPC)
-        entity2 = MagicMock(spec=NPC)
-        surface1 = MagicMock(spec=Surface)
-        surface2 = MagicMock(spec=Surface)
-        self.manager.add_bubble(entity1, surface1)
-        self.manager.add_bubble(entity2, surface2)
-        self.manager.clear_all_bubbles()
-        self.assertEqual(self.manager._bubbles, {})
+
+@pytest.fixture
+def surface():
+    return Surface((64, 32))
+
+
+def test_init(manager, context):
+    assert manager.layer == 100
+    assert manager.offset_divisor == 10
+    assert manager.context is context
+    assert manager._bubbles == {}
+
+
+def test_add_bubble(manager, npc, surface):
+    manager.add_bubble(npc, surface)
+    assert npc in manager._bubbles
+    assert manager._bubbles[npc] is surface
+
+
+def test_remove_bubble(manager, npc, surface):
+    manager.add_bubble(npc, surface)
+    manager.remove_bubble(npc)
+    assert npc not in manager._bubbles
+
+
+@pytest.mark.parametrize("present", [False, True])
+def test_has_bubble(manager, npc, surface, present):
+    if present:
+        manager.add_bubble(npc, surface)
+    assert manager.has_bubble(npc) is present
+
+
+def test_clear_all_bubbles(manager, npc, surface):
+    npc2 = MagicMock(spec=NPC)
+    surface2 = MagicMock(spec=Surface)
+
+    manager.add_bubble(npc, surface)
+    manager.add_bubble(npc2, surface2)
+
+    manager.clear_all_bubbles()
+    assert manager._bubbles == {}
+
+
+def test_get_rendered_bubbles(manager, npc, surface, context, monkeypatch):
+    current_map = MagicMock(spec=AbstractMap)
+
+    monkeypatch.setattr(
+        "tuxemon.map.view.get_pos_from_tilepos", lambda m, c, v: (100, 200)
+    )
+
+    manager.add_bubble(npc, surface)
+    rendered = manager.get_rendered_bubbles(current_map)
+
+    assert len(rendered) == 1
+
+    surf, rect, layer = rendered[0]
+
+    assert surf is surface
+    assert isinstance(rect, Rect)
+    assert layer == manager.layer
+
+    sprite_renderer = npc.sprite_controller.get_sprite_renderer()
+    assert rect.centerx == 100 + sprite_renderer.rect.width // 2
+    assert rect.bottom < 200

--- a/tests/tuxemon/test_camera.py
+++ b/tests/tuxemon/test_camera.py
@@ -5,24 +5,29 @@ from unittest.mock import Mock
 import pytest
 from pygame.rect import Rect
 
-from tuxemon import prepare
 from tuxemon.camera.camera import Camera, project, unproject
 from tuxemon.math import Vector2
+from tuxemon.prepare import DISPLAY_CONTEXT
 
 
 @pytest.fixture
-def camera_setup():
-    prepare.TILE_SIZE = (16, 16)
+def context():
+    return DISPLAY_CONTEXT
+
+
+@pytest.fixture
+def camera_setup(context):
+    context.tile_size = (16, 16)
     entity = Mock()
     entity.position = Vector2(5.0, 5.0)
     boundary = Mock()
     boundary.get_boundary_validity.return_value = (True, True)
-    camera = Camera(entity, boundary)
+    camera = Camera(entity, boundary, context)
     camera.reset_to_entity_center()
-    projected = project((entity.position.x, entity.position.y))
+    projected = project(context, (entity.position.x, entity.position.y))
     expected_center = Vector2(
-        projected[0] + prepare.TILE_SIZE[0] // 2,
-        projected[1] + prepare.TILE_SIZE[1] // 2,
+        projected[0] + context.tile_size[0] // 2,
+        projected[1] + context.tile_size[1] // 2,
     )
     return camera, entity, boundary, expected_center
 
@@ -208,8 +213,8 @@ def test_viewport_top_left_calculation(camera_setup):
         ((100.0, 200.0), (1600, 3200)),
     ],
 )
-def test_project(coords, expected):
-    assert project(coords) == expected
+def test_project(coords, expected, context):
+    assert project(context, coords) == expected
 
 
 @pytest.mark.parametrize(
@@ -221,12 +226,12 @@ def test_project(coords, expected):
         ((1600, 3200), (100, 200)),
     ],
 )
-def test_unproject(pixels, expected):
-    assert unproject(pixels) == expected
+def test_unproject(pixels, expected, context):
+    assert unproject(context, pixels) == expected
 
 
-def test_project_unproject_round_trip():
+def test_project_unproject_round_trip(context):
     original = (7.5, 3.25)
-    projected = project(original)
-    unprojected = unproject(projected)
+    projected = project(context, original)
+    unprojected = unproject(context, projected)
     assert unprojected == (7, 3)

--- a/tests/tuxemon/test_camera_manager.py
+++ b/tests/tuxemon/test_camera_manager.py
@@ -5,11 +5,17 @@ from unittest.mock import Mock
 import pytest
 
 from tuxemon.camera.camera import Camera, CameraController, CameraManager
+from tuxemon.prepare import DISPLAY_CONTEXT
 
 
 @pytest.fixture
 def manager():
     return CameraManager()
+
+
+@pytest.fixture
+def context():
+    return DISPLAY_CONTEXT
 
 
 @pytest.fixture
@@ -111,11 +117,11 @@ def test_remove_active_camera_with_multiple_then_clear(manager, cameras):
     assert manager.get_active_camera() == camera2
 
 
-def test_integration_add_and_switch_real_cameras():
+def test_integration_add_and_switch_real_cameras(context):
     player = Mock()
     boundary = Mock()
-    camera1 = Camera(player, boundary)
-    camera2 = Camera(player, boundary)
+    camera1 = Camera(player, boundary, context)
+    camera2 = Camera(player, boundary, context)
     manager = CameraManager()
 
     manager.add_camera("cam1", camera1)

--- a/tests/tuxemon/test_camera_view.py
+++ b/tests/tuxemon/test_camera_view.py
@@ -2,16 +2,28 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import pytest
 
-from tuxemon import prepare
 from tuxemon.camera.camera import CameraView, project
 from tuxemon.math import Vector2
+from tuxemon.prepare import DISPLAY_CONTEXT, DisplayContext
 
 
 @pytest.fixture
-def view():
-    tile_size = prepare.TILE_SIZE
-    screen_size = prepare.SCREEN_SIZE
-    return CameraView(tile_size=tile_size, screen_size=screen_size)
+def context():
+    return DISPLAY_CONTEXT
+
+
+@pytest.fixture
+def view(context):
+    return CameraView(context)
+
+
+@pytest.fixture
+def center(context):
+    def compute(position: Vector2, tile_size):
+        px, py = project(context, (position.x, position.y))
+        return Vector2(px + tile_size[0] // 2, py + tile_size[1] // 2)
+
+    return compute
 
 
 def assert_vector_equal(actual: Vector2, expected: Vector2):
@@ -23,13 +35,9 @@ def test_initial_position(view):
     assert_vector_equal(view.position, Vector2(0, 0))
 
 
-def test_set_position(view):
+def test_set_position(view, center):
     target = Vector2(1.0, 1.0)
-    projected = project((target.x, target.y))
-    expected = Vector2(
-        projected[0] + view.tile_size[0] // 2,
-        projected[1] + view.tile_size[1] // 2,
-    )
+    expected = center(target, view.tile_size)
     view.set_position(target.x, target.y)
     assert_vector_equal(view.position, expected)
 
@@ -40,77 +48,64 @@ def test_move_relative(view):
     assert_vector_equal(view.position, Vector2(60, 30))
 
 
-def test_get_center_origin(view):
-    projected = project((0.0, 0.0))
-    expected = Vector2(
-        projected[0] + view.tile_size[0] // 2,
-        projected[1] + view.tile_size[1] // 2,
-    )
+def test_get_center_origin(view, center):
+    expected = center(Vector2(0.0, 0.0), view.tile_size)
     result = view.get_center(Vector2(0.0, 0.0))
     assert_vector_equal(result, expected)
 
 
-def test_get_center_whole_tile(view):
+def test_get_center_whole_tile(view, center):
     position = Vector2(2.0, 3.0)
-    projected = project((position.x, position.y))
-    expected = Vector2(
-        projected[0] + view.tile_size[0] // 2,
-        projected[1] + view.tile_size[1] // 2,
-    )
+    expected = center(position, view.tile_size)
     result = view.get_center(position)
     assert_vector_equal(result, expected)
 
 
-def test_get_center_fractional_tile(view):
+def test_get_center_fractional_tile(view, center):
     position = Vector2(0.5, 0.5)
-    projected = project((position.x, position.y))
-    expected = Vector2(
-        projected[0] + view.tile_size[0] // 2,
-        projected[1] + view.tile_size[1] // 2,
-    )
+    expected = center(position, view.tile_size)
     result = view.get_center(position)
     assert_vector_equal(result, expected)
 
 
-def test_get_center_negative_coordinates(view):
+def test_get_center_negative_coordinates(view, center):
     position = Vector2(-1.0, -1.0)
-    projected = project((position.x, position.y))
-    expected = Vector2(
-        projected[0] + view.tile_size[0] // 2,
-        projected[1] + view.tile_size[1] // 2,
-    )
+    expected = center(position, view.tile_size)
     result = view.get_center(position)
     assert_vector_equal(result, expected)
 
 
-def test_get_center_large_coordinates(view):
+def test_get_center_large_coordinates(view, center):
     position = Vector2(100.0, 200.0)
-    projected = project((position.x, position.y))
-    expected = Vector2(
-        projected[0] + view.tile_size[0] // 2,
-        projected[1] + view.tile_size[1] // 2,
-    )
+    expected = center(position, view.tile_size)
     result = view.get_center(position)
     assert_vector_equal(result, expected)
 
 
-def test_get_center_zero_tile_size():
-    screen_size = prepare.SCREEN_SIZE
-    view = CameraView(tile_size=(0, 0), screen_size=screen_size)
-    projected = project((1.0, 1.0))
-    expected = Vector2(projected[0], projected[1])
+def test_get_center_zero_tile_size(context):
+    fake_context = DisplayContext(
+        screen=context.screen,
+        rect=context.rect,
+        scale=1,
+        tile_size=(0, 0),
+    )
+    view = CameraView(fake_context)
+    px, py = project(fake_context, (1.0, 1.0))
+    expected = Vector2(px, py)
     result = view.get_center(Vector2(1.0, 1.0))
     assert_vector_equal(result, expected)
 
 
-def test_get_center_extreme_tile_size():
-    screen_size = prepare.SCREEN_SIZE
+def test_get_center_extreme_tile_size(context):
     tile_size = (1024, 512)
-    view = CameraView(tile_size=tile_size, screen_size=screen_size)
-    projected = project((1.0, 1.0))
-    expected = Vector2(
-        projected[0] + tile_size[0] // 2,
-        projected[1] + tile_size[1] // 2,
+    fake_context = DisplayContext(
+        screen=context.screen,
+        rect=context.rect,
+        scale=1,
+        tile_size=tile_size,
     )
+    view = CameraView(fake_context)
+    px, py = project(fake_context, (1.0, 1.0))
+    expected = Vector2(px + tile_size[0] // 2, py + tile_size[1] // 2)
     result = view.get_center(Vector2(1.0, 1.0))
     assert_vector_equal(result, expected)

--- a/tests/tuxemon/test_map.py
+++ b/tests/tuxemon/test_map.py
@@ -4,6 +4,7 @@ import unittest
 from math import pi
 from unittest.mock import MagicMock
 
+from tuxemon import prepare
 from tuxemon.compat import Rect
 from tuxemon.db import Direction, Orientation
 from tuxemon.map.map import (
@@ -25,7 +26,6 @@ from tuxemon.map.map import (
     tiles_inside_rect,
 )
 from tuxemon.math import Vector2
-from tuxemon.prepare import TILE_SIZE
 
 
 class TestParsePathParameters(unittest.TestCase):
@@ -781,19 +781,24 @@ class TestGetExplicitTileExits(unittest.TestCase):
 
 
 class TestGetPosFromTilePos(unittest.TestCase):
+    def setUp(self):
+        self.context = MagicMock()
+        self.context.tile_size = prepare.DISPLAY_CONTEXT.tile_size
+
     def test_get_pos_from_tilepos(self):
         mock_map = MagicMock()
         mock_map.renderer.get_center_offset.return_value = (50, 75)
 
         tile_position = Vector2(3, 4)
+        ts = self.context.tile_size
 
-        expected_px = 3 * TILE_SIZE[0]
-        expected_py = 4 * TILE_SIZE[1]
+        expected_px = 3 * ts[0]
+        expected_py = 4 * ts[1]
         expected_x = expected_px + 50
         expected_y = expected_py + 75
         expected_result = (expected_x, expected_y)
 
-        result = get_pos_from_tilepos(mock_map, tile_position)
+        result = get_pos_from_tilepos(mock_map, self.context, tile_position)
         self.assertEqual(result, expected_result)
 
     def test_different_tile_size(self):
@@ -801,12 +806,13 @@ class TestGetPosFromTilePos(unittest.TestCase):
         mock_map.renderer.get_center_offset.return_value = (50, 75)
 
         tile_position = Vector2(2, 3)
+        ts = self.context.tile_size
 
-        expected_px = 2 * TILE_SIZE[0]
-        expected_py = 3 * TILE_SIZE[1]
+        expected_px = 2 * ts[0]
+        expected_py = 3 * ts[1]
         expected_result = (expected_px + 50, expected_py + 75)
 
-        result = get_pos_from_tilepos(mock_map, tile_position)
+        result = get_pos_from_tilepos(mock_map, self.context, tile_position)
         self.assertEqual(result, expected_result)
 
     def test_tile_position_origin(self):
@@ -814,9 +820,9 @@ class TestGetPosFromTilePos(unittest.TestCase):
         mock_map.renderer.get_center_offset.return_value = (50, 75)
 
         tile_position = Vector2(0, 0)
-
         expected_result = (50, 75)
-        result = get_pos_from_tilepos(mock_map, tile_position)
+
+        result = get_pos_from_tilepos(mock_map, self.context, tile_position)
         self.assertEqual(result, expected_result)
 
     def test_negative_tile_position(self):
@@ -824,12 +830,13 @@ class TestGetPosFromTilePos(unittest.TestCase):
         mock_map.renderer.get_center_offset.return_value = (50, 75)
 
         tile_position = Vector2(-1, -2)
+        ts = self.context.tile_size
 
-        expected_px = -1 * TILE_SIZE[0]
-        expected_py = -2 * TILE_SIZE[1]
+        expected_px = -1 * ts[0]
+        expected_py = -2 * ts[1]
         expected_result = (expected_px + 50, expected_py + 75)
 
-        result = get_pos_from_tilepos(mock_map, tile_position)
+        result = get_pos_from_tilepos(mock_map, self.context, tile_position)
         self.assertEqual(result, expected_result)
 
     def test_large_tile_position(self):
@@ -837,12 +844,13 @@ class TestGetPosFromTilePos(unittest.TestCase):
         mock_map.renderer.get_center_offset.return_value = (50, 75)
 
         tile_position = Vector2(1000, 2000)
+        ts = self.context.tile_size
 
-        expected_px = 1000 * TILE_SIZE[0]
-        expected_py = 2000 * TILE_SIZE[1]
+        expected_px = 1000 * ts[0]
+        expected_py = 2000 * ts[1]
         expected_result = (expected_px + 50, expected_py + 75)
 
-        result = get_pos_from_tilepos(mock_map, tile_position)
+        result = get_pos_from_tilepos(mock_map, self.context, tile_position)
         self.assertEqual(result, expected_result)
 
     def test_zero_center_offset(self):
@@ -850,10 +858,11 @@ class TestGetPosFromTilePos(unittest.TestCase):
         mock_map.renderer.get_center_offset.return_value = (0, 0)
 
         tile_position = Vector2(5, 7)
+        ts = self.context.tile_size
 
-        expected_px = 5 * TILE_SIZE[0]
-        expected_py = 7 * TILE_SIZE[1]
+        expected_px = 5 * ts[0]
+        expected_py = 7 * ts[1]
         expected_result = (expected_px, expected_py)
 
-        result = get_pos_from_tilepos(mock_map, tile_position)
+        result = get_pos_from_tilepos(mock_map, self.context, tile_position)
         self.assertEqual(result, expected_result)

--- a/tests/tuxemon/test_map_loader.py
+++ b/tests/tuxemon/test_map_loader.py
@@ -10,6 +10,15 @@ from tuxemon.map.loader import MapLoader
 
 
 @pytest.fixture
+def fake_context():
+    ctx = MagicMock()
+    ctx.tile_size = (16, 16)
+    ctx.rect = MagicMock()
+    ctx.rect.size = (320, 240)
+    return ctx
+
+
+@pytest.fixture
 def mock_tmx_map(mocker):
     m = mocker.MagicMock()
     m.scenario = None
@@ -64,14 +73,14 @@ def mock_mods_folder(mocker):
 
 
 @pytest.fixture
-def loader(mocker, mock_tmx_loader, mock_yaml_loader):
+def loader(mocker, mock_tmx_loader, mock_yaml_loader, fake_context):
     mocker.patch(
         "tuxemon.map.loader.TMXMapLoader", return_value=mock_tmx_loader
     )
     mocker.patch(
         "tuxemon.map.loader.YAMLEventLoader", return_value=mock_yaml_loader
     )
-    return MapLoader(cache_size=2, enable_cache=True)
+    return MapLoader(context=fake_context, cache_size=2, enable_cache=True)
 
 
 def test_load_map_data_cache_miss(loader, mock_fetch_asset, mock_tmx_loader):
@@ -96,11 +105,13 @@ def test_cache_eviction(loader, mock_fetch_asset, mock_tmx_loader):
     assert "/fake/maps/a.tmx" not in loader._cache
 
 
-def test_cache_disabled(mocker, mock_fetch_asset, mock_tmx_loader):
+def test_cache_disabled(
+    mocker, mock_fetch_asset, mock_tmx_loader, fake_context
+):
     mocker.patch(
         "tuxemon.map.loader.TMXMapLoader", return_value=mock_tmx_loader
     )
-    loader = MapLoader(enable_cache=False)
+    loader = MapLoader(context=fake_context, enable_cache=False)
     loader.load_map_data("test")
     loader.load_map_data("test")
     assert mock_tmx_loader.load.call_count == 2
@@ -143,8 +154,8 @@ def test_process_events_missing_yaml(loader, mock_yaml_loader, mocker):
     assert events == defaultdict(list)
 
 
-def test_add_to_cache_disabled(mocker):
-    loader = MapLoader(enable_cache=False)
+def test_add_to_cache_disabled(mocker, fake_context):
+    loader = MapLoader(context=fake_context, enable_cache=False)
     loader.add_to_cache("x", MagicMock())
     assert len(loader._cache) == 0
 

--- a/tests/tuxemon/test_monster_sprite_handler.py
+++ b/tests/tuxemon/test_monster_sprite_handler.py
@@ -3,8 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pygame import SRCALPHA
-from pygame.surface import Surface
+from pygame import Surface
 
 from tuxemon.monster.sprite import MonsterSpriteHandler
 
@@ -58,19 +57,19 @@ def test_sheet_loaded_in_constructor(fake_sheet):
     ],
 )
 def test_slice_sprite(handler, sprite_type, expected):
-    sprite = handler.get_sprite(sprite_type)
+    sprite = handler.get_sprite(sprite_type, scale=1)
     assert sprite.image.get_size() == expected
 
 
 def test_sprite_cache(handler):
-    s1 = handler.get_sprite("front")
-    s2 = handler.get_sprite("front")
+    s1 = handler.get_sprite("front", scale=1)
+    s2 = handler.get_sprite("front", scale=1)
     assert s1.image is s2.image
 
 
 def test_invalid_sprite_name(handler):
     with pytest.raises(ValueError):
-        handler.get_sprite("nope")
+        handler.get_sprite("nope", scale=1)
 
 
 def test_from_model(fake_sheet):

--- a/tests/tuxemon/test_sprite_renderer.py
+++ b/tests/tuxemon/test_sprite_renderer.py
@@ -6,7 +6,7 @@ import pygame
 import pytest
 
 from tuxemon.map.view import EntityFacing, SpriteRenderer
-from tuxemon.prepare import SCREEN_SIZE, TILE_SIZE
+from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.user_config import CONFIG
 
 pygame.display.init()
@@ -146,7 +146,7 @@ def test_tall_sprite_offset(monkeypatch):
     renderer = SpriteRenderer(npc)
     renderer.load_sprites(npc.template)
 
-    expected_offset = 64 - TILE_SIZE[1]
+    expected_offset = 64 - DISPLAY_CONTEXT.tile_size[1]
     assert renderer.rect.y == 200 - expected_offset
 
 

--- a/tests/tuxemon/test_state.py
+++ b/tests/tuxemon/test_state.py
@@ -57,7 +57,9 @@ def test_load_animated_sprite(monkeypatch):
     )
     monkeypatch.setattr("tuxemon.state.state.SpriteGroup", lambda: mock_group)
     s = DummyState()
-    result = s.load_animated_sprite(["a.png", "b.png"], delay=0.1, layer=2)
+    result = s.load_animated_sprite(
+        ["a.png", "b.png"], delay=0.1, scale=1.0, layer=2
+    )
     assert result is mock_sprite
     mock_group.add.assert_called_once_with(mock_sprite, layer=2)
 

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     from tuxemon.entity.npc import NPC
     from tuxemon.monster.monster import Monster
     from tuxemon.platform.events import PlayerInput
+    from tuxemon.prepare import DisplayContext
     from tuxemon.state.queue import QueuedState
     from tuxemon.ui.cipher_processor import CipherProcessor
 
@@ -80,9 +81,11 @@ class BaseClient(ABC):
     Handles shared setup and lifecycle management for both graphical and headless clients.
     """
 
-    def __init__(self, config: TuxemonConfig) -> None:
+    def __init__(self, config: TuxemonConfig, context: DisplayContext) -> None:
         init_assets()
         self.config = config
+        self.context = context
+        self.screen = context.screen
         self.active_effect_manager = ActiveEffectManager()
 
         self.event_bus = get_event_bus()
@@ -128,7 +131,7 @@ class BaseClient(ABC):
         self.event_persist = EventPersist()
 
         self.npc_manager = NPCManager()
-        self.map_loader = MapLoader()
+        self.map_loader = MapLoader(self.context)
         self.map_manager = MapManager()
         self.boundary = BoundaryChecker()
         self.camera_manager = CameraManager()

--- a/tuxemon/camera/camera.py
+++ b/tuxemon/camera/camera.py
@@ -12,7 +12,7 @@ from pygame.rect import Rect
 
 from tuxemon.math import Vector2
 from tuxemon.platform.const import intentions
-from tuxemon.prepare import SCREEN_SIZE, TILE_SIZE
+from tuxemon.prepare import DisplayContext
 
 if TYPE_CHECKING:
     from tuxemon.boundary import BoundaryChecker
@@ -22,17 +22,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def project(position: Sequence[float]) -> tuple[int, int]:
+def project(
+    context: DisplayContext, position: Sequence[float]
+) -> tuple[int, int]:
+    ts = context.tile_size
     return (
-        int(position[0] * TILE_SIZE[0]),
-        int(position[1] * TILE_SIZE[1]),
+        int(position[0] * ts[0]),
+        int(position[1] * ts[1]),
     )
 
 
-def unproject(position: Sequence[float]) -> tuple[int, int]:
+def unproject(
+    context: DisplayContext, position: Sequence[float]
+) -> tuple[int, int]:
+    ts = context.tile_size
     return (
-        int(position[0] / TILE_SIZE[0]),
-        int(position[1] / TILE_SIZE[1]),
+        int(position[0] / ts[0]),
+        int(position[1] / ts[1]),
     )
 
 
@@ -151,12 +157,11 @@ class CameraManager:
 class CameraView:
     """Represents the camera's viewport, position, and zoom level."""
 
-    def __init__(
-        self, tile_size: tuple[int, int], screen_size: tuple[int, int]
-    ):
+    def __init__(self, context: DisplayContext):
         """Initializes the view with a tile size and default position."""
-        self.tile_size = tile_size
-        self.screen_size = screen_size
+        self.context = context
+        self.tile_size = context.tile_size
+        self.screen_size = context.rect.size
         self.position = Vector2(0, 0)
 
     def set_position(self, x: float, y: float) -> None:
@@ -165,7 +170,7 @@ class CameraView:
 
     def get_center(self, position: Vector2) -> Vector2:
         """Calculates the center point of the view based on tile size."""
-        cx, cy = project(position)
+        cx, cy = project(self.context, position)
         return Vector2(
             cx + self.tile_size[0] // 2, cy + self.tile_size[1] // 2
         )
@@ -287,10 +292,16 @@ class CameraEffects:
 
 
 class Camera:
-    def __init__(self, entity: Entity, boundary: BoundaryChecker):
-        self.view = CameraView(TILE_SIZE, SCREEN_SIZE)
+    def __init__(
+        self,
+        entity: Entity,
+        boundary: BoundaryChecker,
+        context: DisplayContext,
+    ):
+        self.view = CameraView(context)
         self.tracker = CameraTracker(self.view, entity)
         self.effects = CameraEffects(self.view)
+        self.context = context
         self.boundary = boundary
         self.free_roaming_enabled: bool = False
 
@@ -318,7 +329,8 @@ class Camera:
     def move(self, dx: int = 0, dy: int = 0) -> None:
         """Moves the camera by a specified offset, constrained by boundary validity."""
         tile_pos = unproject(
-            (self.view.position.x + dx, self.view.position.y + dy)
+            self.context,
+            (self.view.position.x + dx, self.view.position.y + dy),
         )
         is_x_valid, is_y_valid = self.boundary.get_boundary_validity(tile_pos)
         if is_x_valid:

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pygame
-from pygame.surface import Surface
 
 from tuxemon.base_client import BaseClient, ClientState
 from tuxemon.config import TuxemonConfig
 from tuxemon.map.tuxemon import NullMap
 from tuxemon.map.view import DebugRenderer, MapRenderer, NullRenderer
 from tuxemon.state.draw import EventDebugDrawer, Renderer, StateDrawer
+
+if TYPE_CHECKING:
+    from tuxemon.prepare import DisplayContext
 
 logger = logging.getLogger(__name__)
 
@@ -32,13 +35,13 @@ class LocalPygameClient(BaseClient):
 
     @classmethod
     def create(
-        cls, config: TuxemonConfig, screen: Surface
+        cls, config: TuxemonConfig, context: DisplayContext
     ) -> LocalPygameClient:
         """
         Initialize the LocalPygameClient with the given configuration and screen.
         """
         try:
-            client = LocalPygameClient(config, screen)
+            client = LocalPygameClient(config, context)
             logger.info("Client initialized successfully.")
         except (TypeError, ValueError) as e:
             logger.error(f"Failed to initialize client: {e}")
@@ -50,9 +53,8 @@ class LocalPygameClient(BaseClient):
             raise
         return client
 
-    def __init__(self, config: TuxemonConfig, screen: Surface) -> None:
-        super().__init__(config)
-        self.screen = screen
+    def __init__(self, config: TuxemonConfig, context: DisplayContext):
+        super().__init__(config, context)
 
         # movie creation
         self.frame_number = 0
@@ -69,9 +71,14 @@ class LocalPygameClient(BaseClient):
             self.config,
             self.event_debug_drawer,
         )
-        self.debug_renderer = DebugRenderer(self.map_manager, self.npc_manager)
+        self.debug_renderer = DebugRenderer(
+            self.map_manager, self.npc_manager, self.context
+        )
         map_renderer = MapRenderer(
-            self.camera_manager, self.npc_manager, self.debug_renderer
+            self.camera_manager,
+            self.npc_manager,
+            self.debug_renderer,
+            self.context,
         )
         self.set_renderer(map_renderer)
 
@@ -82,10 +89,13 @@ class LocalPygameClient(BaseClient):
             logger.debug("Renderer reset to NullRenderer.")
         else:
             self.debug_renderer = DebugRenderer(
-                self.map_manager, self.npc_manager
+                self.map_manager, self.npc_manager, self.context
             )
             map_renderer = MapRenderer(
-                self.camera_manager, self.npc_manager, self.debug_renderer
+                self.camera_manager,
+                self.npc_manager,
+                self.debug_renderer,
+                self.context,
             )
             self.set_renderer(map_renderer)
             logger.debug("Renderer reset to MapRenderer.")

--- a/tuxemon/environment.py
+++ b/tuxemon/environment.py
@@ -16,7 +16,7 @@ from tuxemon.db import (
     EnvironmentModel,
 )
 from tuxemon.graphics import load_and_scale, load_raw_image, scale_surface
-from tuxemon.prepare import SCALE
+from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.tools import scale
 
 logger = logging.getLogger(__name__)
@@ -243,7 +243,7 @@ class Environment:
     def prepare_background(self, screen_size: tuple[int, int]) -> Surface:
         """Processes the background sprite to fit the screen dimensions."""
         graphics = self.data.get_battle_graphics()
-        surf = load_and_scale(graphics.background, SCALE)
+        surf = load_and_scale(graphics.background, DISPLAY_CONTEXT.scale)
 
         full_width, full_height = screen_size
         full_surf = Surface((full_width, full_height))
@@ -286,8 +286,8 @@ class IslandSheet:
             (self.frame_w, 0, self.frame_w, self.frame_h)
         )
 
-        back_scaled = scale_surface(back_raw, SCALE)
-        front_scaled = scale_surface(front_raw, SCALE)
+        back_scaled = scale_surface(back_raw, DISPLAY_CONTEXT.scale)
+        front_scaled = scale_surface(front_raw, DISPLAY_CONTEXT.scale)
 
         return {
             "back": back_scaled,

--- a/tuxemon/event/actions/camera_manage.py
+++ b/tuxemon/event/actions/camera_manage.py
@@ -49,7 +49,9 @@ class CameraManageAction(EventAction):
                     f"Cannot add camera '{self.camera_name}': NPC '{self.npc_slug}' not found."
                 )
                 return
-            camera = Camera(entity, session.client.boundary)
+            camera = Camera(
+                entity, session.client.boundary, session.client.context
+            )
             manager.add_camera(self.camera_name, camera)
             logger.info(
                 f"Camera '{self.camera_name}' added following entity '{entity.slug}'."

--- a/tuxemon/event/actions/change_bg_char.py
+++ b/tuxemon/event/actions/change_bg_char.py
@@ -10,7 +10,6 @@ from tuxemon.db import NpcModel
 from tuxemon.entity.sheet import get_combat_sheet
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import load_surface, scale_surface
-from tuxemon.prepare import SCALE
 from tuxemon.session import Session
 
 
@@ -70,7 +69,7 @@ class ChangeBgNpcAction(EventAction):
         npc_data = NpcModel.lookup(self.slug, db)
         sheet = get_combat_sheet(npc_data.template)
         surface = sheet.front()
-        scaled = scale_surface(surface, SCALE)
+        scaled = scale_surface(surface, session.client.context.scale)
         sprite = load_surface(scaled)
 
         client.push_state(

--- a/tuxemon/event/actions/change_bg_monster.py
+++ b/tuxemon/event/actions/change_bg_monster.py
@@ -73,7 +73,7 @@ class ChangeBgMonsterAction(EventAction):
             menu2_rect=sprites.menu2_rect,
         )
 
-        sprite = handler.get_sprite("front")
+        sprite = handler.get_sprite("front", session.client.context.scale)
 
         client.push_state(
             "MonsterImageState",

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -90,7 +90,9 @@ class SetMonsterFlairAction(EventAction):
 
         if sprite_types:
             for sprite_type in sprite_types:
-                monster.sprite_handler.get_sprite(sprite_type)
+                monster.sprite_handler.get_sprite(
+                    sprite_type, session.client.context.scale
+                )
 
         if flair_model.slug not in monster.flair_slugs:
             monster.flair_slugs.add(flair_model.slug)

--- a/tuxemon/event/conditions/camera_at.py
+++ b/tuxemon/event/conditions/camera_at.py
@@ -40,7 +40,9 @@ class CameraAtCondition(EventCondition):
             logger.error("No active camera found.")
             return False
         camera_pos = camera.get_position()
-        cx, cy = unproject((camera_pos.x, camera_pos.y))
+        cx, cy = unproject(
+            session.client.context, (camera_pos.x, camera_pos.y)
+        )
         if not session.client.boundary.is_within_boundaries((pos_x, pos_y)):
             logger.error(
                 f"({pos_x, pos_y}) is outside the map bounds {map_size}"

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -26,7 +26,7 @@ from pytmx.util_pygame import handle_transformation, smart_convert
 from tuxemon.database.runtime import db
 from tuxemon.db import MonsterModel, NpcModel
 from tuxemon.platform.const.graphics import FUCHSIA_COLOR
-from tuxemon.prepare import SCALE
+from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.scaling import DefaultScaling, ScalingStrategy
 from tuxemon.session import Session
 from tuxemon.sprite import Sprite
@@ -126,7 +126,7 @@ def slice_spritesheet(
         for x in range(0, sheet_w, frame_width):
             rect = Rect(x, y, frame_width, frame_height)
             frame = full_sheet.subsurface(rect)
-            scaled = scale_surface(frame, SCALE)
+            scaled = scale_surface(frame, DISPLAY_CONTEXT.scale)
             frames.append(scaled)
 
     return frames
@@ -152,7 +152,9 @@ def cursor_from_image(image: Surface) -> Sequence[str]:
     return icon_string
 
 
-def load_and_scale(filename: str, scale: float = SCALE) -> Surface:
+def load_and_scale(
+    filename: str, scale: float = DISPLAY_CONTEXT.scale
+) -> Surface:
     """
     Load an image and scale it according to game settings.
 
@@ -231,7 +233,7 @@ def load_surface(surface: Surface, **rect_kwargs: Any) -> Sprite:
 def load_animated_sprite(
     filenames: Iterable[str],
     delay: float,
-    scale: float = SCALE,
+    scale: float,
     loop: int = -1,
     **rect_kwargs: Any,
 ) -> Sprite:
@@ -476,7 +478,7 @@ def get_avatar(session: Session, avatar: str) -> Sprite | None:
 
     if avatar.isdigit():
         monster = session.player.monsters[int(avatar)]
-        return monster.get_sprite("menu")
+        return monster.get_sprite("menu", scale=session.client.context.scale)
 
     if avatar in db.database.get("monster", {}):
         model = MonsterModel.lookup(avatar, db)
@@ -493,7 +495,7 @@ def get_avatar(session: Session, avatar: str) -> Sprite | None:
         )
         if handler is None:
             return None
-        return handler.get_sprite("menu")
+        return handler.get_sprite("menu", session.client.context.scale)
 
     if avatar in db.database.get("npc", {}):
         from tuxemon.entity.sheet import get_combat_sheet

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from tuxemon.base_client import BaseClient, ClientState
-from tuxemon.config import TuxemonConfig
+
+if TYPE_CHECKING:
+    from tuxemon.config import TuxemonConfig
+    from tuxemon.prepare import DisplayContext
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +26,8 @@ class HeadlessClient(BaseClient):
         config: The configuration for the game.
     """
 
-    def __init__(self, config: TuxemonConfig) -> None:
-        super().__init__(config)
+    def __init__(self, config: TuxemonConfig, context: DisplayContext) -> None:
+        super().__init__(config, context)
 
     def main(self) -> None:
         """

--- a/tuxemon/main.py
+++ b/tuxemon/main.py
@@ -10,18 +10,21 @@ from tuxemon.client import LocalPygameClient
 from tuxemon.database.runtime import db
 from tuxemon.headless_client import HeadlessClient
 from tuxemon.launcher import GameLauncher
-from tuxemon.prepare import SCREEN
 from tuxemon.session import local_session
 
 if TYPE_CHECKING:
-
     from tuxemon.config import TuxemonConfig
+    from tuxemon.prepare import DisplayContext
 
 
 logger = logging.getLogger(__name__)
 
 
-def main(config: TuxemonConfig, load_slot: int | None = None) -> None:
+def main(
+    config: TuxemonConfig,
+    context: DisplayContext,
+    load_slot: int | None = None,
+) -> None:
     """
     Configure and start the game.
 
@@ -34,11 +37,9 @@ def main(config: TuxemonConfig, load_slot: int | None = None) -> None:
     """
     log.configure()
 
-    screen = SCREEN
-
     import pygame
 
-    client = LocalPygameClient.create(config, screen)
+    client = LocalPygameClient.create(config, context)
 
     local_session.set_client(client)
 
@@ -49,6 +50,19 @@ def main(config: TuxemonConfig, load_slot: int | None = None) -> None:
 
     client.main()
     pygame.quit()
+
+
+def headless(config: TuxemonConfig, context: DisplayContext) -> None:
+    """
+    Sets up out headless server and start the game.
+
+    Parameters:
+        config: The Tuxemon configuration object containing game settings.
+    """
+    log.configure()
+    control = HeadlessClient(config, context)
+    control.push_state("HeadlessServerState")
+    control.main()
 
 
 def configure_game_states(
@@ -63,7 +77,7 @@ def configure_game_states(
     if not config.skip_titlescreen:
         client.push_state("IntroState")
 
-    if load_slot:
+    if load_slot is not None:
         client.push_state("LoadMenuState", load_slot=load_slot)
         client.pop_state()
 
@@ -96,16 +110,3 @@ def configure_debug_options(client: LocalPygameClient) -> None:
         action("add_item", ("super_potion",))
     for _ in range(100):
         action("add_item", ("apple",))
-
-
-def headless(config: TuxemonConfig) -> None:
-    """
-    Sets up out headless server and start the game.
-
-    Parameters:
-        config: The Tuxemon configuration object containing game settings.
-    """
-    log.configure()
-    control = HeadlessClient(config)
-    control.push_state("HeadlessServerState")
-    control.main()

--- a/tuxemon/map/loader.py
+++ b/tuxemon/map/loader.py
@@ -34,7 +34,7 @@ from tuxemon.platform.const.sizes import (
     REGION_KEYS,
     SURFACE_KEYS,
 )
-from tuxemon.prepare import TILE_SIZE
+from tuxemon.prepare import DisplayContext
 from tuxemon.tools import copy_dict_with_keys
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,10 @@ class MapLoader:
     """
 
     def __init__(
-        self, cache_size: int | None = None, enable_cache: bool = True
+        self,
+        context: DisplayContext,
+        cache_size: int | None = None,
+        enable_cache: bool = True,
     ) -> None:
         """
         Initializes the MapLoader with optional cache configuration.
@@ -62,6 +65,7 @@ class MapLoader:
             enable_cache: Flag to enable or disable caching behavior.
                         If False, maps are always loaded fresh from disk.
         """
+        self.context = context
         self.tmx_loader = TMXMapLoader()
         self.yaml_loader = YAMLEventLoader()
         self.cache_size = cache_size or MAP_CACHE_SIZE
@@ -118,7 +122,7 @@ class MapLoader:
         logger.info(
             f"Cache miss for map '{normalized_path}'. Loading from disk."
         )
-        return self.tmx_loader.load(normalized_path)
+        return self.tmx_loader.load(normalized_path, self.context)
 
     def resolve_yaml_files(
         self, txmn_map: AbstractMap, normalized_path: str
@@ -353,10 +357,9 @@ class TMXMapLoader:
     """
 
     def __init__(self) -> None:
-        # Makes mocking easier during tests
         self.image_loader = scaled_image_loader
 
-    def load(self, filename: str) -> TuxemonMap:
+    def load(self, filename: str, context: DisplayContext) -> TuxemonMap:
         """Load map data from a tmx map file.
 
         Loading the map data is done using the pytmx library.
@@ -387,7 +390,7 @@ class TMXMapLoader:
         """
         data = self.load_tiled_map(filename)
         tile_size = (data.tilewidth, data.tileheight)
-        data.tilewidth, data.tileheight = TILE_SIZE
+        data.tilewidth, data.tileheight = context.tile_size
 
         collision_map, collision_lines_map = self.load_collision_data(
             data, tile_size

--- a/tuxemon/map/map.py
+++ b/tuxemon/map/map.py
@@ -12,6 +12,7 @@ from tuxemon.camera.camera import project
 from tuxemon.compat.rect import ReadOnlyRect
 from tuxemon.db import Direction, Orientation
 from tuxemon.math import Vector2, Vector3
+from tuxemon.prepare import DisplayContext
 from tuxemon.tools import round_to_divisible
 
 if TYPE_CHECKING:
@@ -502,27 +503,34 @@ def get_explicit_tile_exits(
 
 
 def get_pos_from_tilepos(
-    current_map: AbstractMap, tile_position: Vector2
+    current_map: AbstractMap, context: DisplayContext, tile_position: Vector2
 ) -> tuple[int, int]:
     """
-    Returns the map pixel coordinates based on the tile position.
+    Convert a tile-space position into on-screen pixel coordinates.
 
-    This method calculates the pixel coordinates on the map corresponding
-    to the specified tile position, accounting for the map's center offset.
-    Use this method for drawing elements on the screen.
+    This function projects a tile position (in map tile units) into pixel
+    coordinates using the provided DisplayContext, then applies the map
+    renderer's center offset so that the returned coordinates correspond to
+    the correct on-screen location for drawing.
 
     Parameters:
-        current_map: The map object (`AbstractMap`) containing the renderer
-            and relevant positional data.
-        tile_position: A [x, y] tile position represented as a `Vector2`.
+        current_map:
+            The map whose renderer provides the center offset used to align
+            the projected coordinates on screen.
+        context:
+            The DisplayContext containing tile size and projection settings.
+        tile_position:
+            A Vector2 representing the tile-space position to convert.
 
     Returns:
-        A tuple representing the pixel coordinates (x, y) to draw at the
-        given tile position, adjusted for the map's center offset.
+        (x, y):
+            The pixel coordinates on screen where an element at the given
+            tile position should be drawn, after applying projection and
+            the map renderer's center offset.
     """
     assert current_map.renderer
     cx, cy = current_map.renderer.get_center_offset()
-    px, py = project(tile_position)
+    px, py = project(context, tile_position)
     x = px + cx
     y = py + cy
     return x, y

--- a/tuxemon/map/view.py
+++ b/tuxemon/map/view.py
@@ -27,7 +27,7 @@ from tuxemon.graphics import (
 from tuxemon.map.map import get_pos_from_tilepos
 from tuxemon.math import Vector2
 from tuxemon.platform.const.graphics import BLACK_COLOR
-from tuxemon.prepare import SCREEN_SIZE, TILE_SIZE
+from tuxemon.prepare import DISPLAY_CONTEXT, DisplayContext
 from tuxemon.surfanim import SurfaceAnimation, SurfaceAnimationCollection
 from tuxemon.user_config import CONFIG
 
@@ -278,7 +278,7 @@ class SpriteRenderer:
             EntityFacing.front
         ].get_size()
 
-        y_offset = max(0, self.player_height - TILE_SIZE[1])
+        y_offset = max(0, self.player_height - DISPLAY_CONTEXT.tile_size[1])
 
         self.rect = Rect(
             tile_pos[0],
@@ -395,17 +395,19 @@ class MapRenderer(AbstractRenderer):
         camera_manager: CameraManager,
         npc_manager: NPCManager,
         debug_renderer: DebugRenderer,
+        context: DisplayContext,
     ):
         """Initializes the MapRenderer."""
         self.camera_manager = camera_manager
         self.npc_manager = npc_manager
         self.debug_renderer = debug_renderer
-        self.layer = Surface(SCREEN_SIZE, SRCALPHA)
+        self.context = context
+        self.layer = Surface(context.rect.size, SRCALPHA)
         self.layer_color: ColorLike | None = None
         self.cinema_x_ratio: float | None = None
         self.cinema_y_ratio: float | None = None
         self.map_animations = AnimationManager()
-        self.bubble_manager = BubbleManager()
+        self.bubble_manager = BubbleManager(context=context)
 
     @property
     def label(self) -> str:
@@ -474,9 +476,11 @@ class MapRenderer(AbstractRenderer):
     def _apply_cinema_bars(self, surface: Surface) -> None:
         """Applies cinema bars (letterboxing) to the surface."""
         if self.cinema_x_ratio is not None:
-            apply_bars("horizontal", self.cinema_x_ratio, surface)
+            apply_bars(
+                self.context, "horizontal", self.cinema_x_ratio, surface
+            )
         if self.cinema_y_ratio is not None:
-            apply_bars("vertical", self.cinema_y_ratio, surface)
+            apply_bars(self.context, "vertical", self.cinema_y_ratio, surface)
 
     def _get_npc_surfaces(self, sprite_layer: int) -> list[WorldSurfaces]:
         """Retrieves surfaces for NPCs."""
@@ -506,9 +510,11 @@ class MapRenderer(AbstractRenderer):
             surface = frame.surface
             position = frame.position3
             layer = frame.layer
-            screen_position = get_pos_from_tilepos(current_map, position)
+            screen_position = get_pos_from_tilepos(
+                current_map, self.context, position
+            )
             rect = Rect(screen_position, surface.get_size())
-            if surface.get_height() > TILE_SIZE[1]:
+            if surface.get_height() > self.context.tile_size[1]:
                 rect.y -= surface.get_height() // 2
             screen_surfaces.append((surface, rect, layer))
         return screen_surfaces
@@ -537,8 +543,14 @@ class MapRenderer(AbstractRenderer):
 class BubbleManager:
     """Manages the creation, updating, and rendering of speech bubbles."""
 
-    def __init__(self, layer: int = 100, offset_divisor: int = 10):
+    def __init__(
+        self,
+        context: DisplayContext,
+        layer: int = 100,
+        offset_divisor: int = 10,
+    ):
         self._bubbles: dict[NPC, Surface] = {}
+        self.context = context
         self.layer = layer
         self.offset_divisor = offset_divisor
 
@@ -570,7 +582,7 @@ class BubbleManager:
             sprite_renderer = entity.sprite_controller.get_sprite_renderer()
             entity_pos_vector = Vector2(entity.tile_pos)
             center_x, center_y = get_pos_from_tilepos(
-                current_map, entity_pos_vector
+                current_map, self.context, entity_pos_vector
             )
             bubble_rect = surface.get_rect()
 
@@ -588,12 +600,14 @@ class DebugRenderer:
         self,
         map_manager: MapManager,
         npc_manager: NPCManager,
+        context: DisplayContext,
         event_color: ColorLike = (0, 255, 0, 128),
         collision_color: ColorLike = (255, 0, 0, 128),
         center_line_color: ColorLike = (255, 50, 50),
     ) -> None:
         self.map_manager = map_manager
         self.npc_manager = npc_manager
+        self.context = context
         self.event_color = event_color
         self.collision_color = collision_color
         self.center_line_color = center_line_color
@@ -610,8 +624,8 @@ class DebugRenderer:
         """Draws event-related debug information on the surface."""
         for event in self.map_manager.events:
             vector = Vector2(event.box.x, event.box.y)
-            topleft = get_pos_from_tilepos(current_map, vector)
-            size = project((event.box.width, event.box.height))
+            topleft = get_pos_from_tilepos(current_map, self.context, vector)
+            size = project(self.context, (event.box.width, event.box.height))
             rect = topleft, size
             box(surface, rect, self.event_color)
 
@@ -620,13 +634,15 @@ class DebugRenderer:
     ) -> None:
         # We need to iterate over all collidable objects. Start with walls/collision boxes.
         box_iter = map(
-            lambda box: collision_box_to_pgrect(current_map, box),
+            lambda box: collision_box_to_pgrect(
+                current_map, self.context, box
+            ),
             self.map_manager.collision_map,
         )
 
         # Next, deal with solid NPCs.
         npc_iter = map(
-            lambda npc: npc_to_pgrect(current_map, npc),
+            lambda npc: npc_to_pgrect(current_map, self.context, npc),
             self.npc_manager.npcs.values(),
         )
         for item in chain(box_iter, npc_iter):
@@ -639,28 +655,35 @@ class DebugRenderer:
         line(surface, self.center_line_color, (0, cy), (w, cy))
 
 
-def apply_bars(orientation: str, aspect_ratio: float, screen: Surface) -> None:
+def apply_bars(
+    context: DisplayContext,
+    orientation: str,
+    aspect_ratio: float,
+    screen: Surface,
+) -> None:
     apply_cinema_bars(
         aspect_ratio,
         screen,
         orientation,
-        SCREEN_SIZE,
+        context.rect.size,
         BLACK_COLOR,
     )
 
 
 def collision_box_to_pgrect(
-    current_map: AbstractMap, box: tuple[int, int]
+    current_map: AbstractMap, context: DisplayContext, box: tuple[int, int]
 ) -> Rect:
     """
     Returns a Rect (in screen-coords) version of a collision box (in world-coords).
     """
-    x, y = get_pos_from_tilepos(current_map, Vector2(box))
-    tw, th = TILE_SIZE
+    x, y = get_pos_from_tilepos(current_map, context, Vector2(box))
+    tw, th = context.tile_size
     return Rect(x, y, tw, th)
 
 
-def npc_to_pgrect(current_map: AbstractMap, npc: NPC) -> Rect:
+def npc_to_pgrect(
+    current_map: AbstractMap, context: DisplayContext, npc: NPC
+) -> Rect:
     """Returns a Rect (in screen-coords) version of an NPC's bounding box."""
-    pos = get_pos_from_tilepos(current_map, npc.position)
-    return Rect(pos, TILE_SIZE)
+    pos = get_pos_from_tilepos(current_map, context, npc.position)
+    return Rect(pos, context.tile_size)

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -53,7 +53,6 @@ from tuxemon.platform.const.graphics import (
     UNAVAILABLE_COLOR,
     UNAVAILABLE_COLOR_SHOP,
 )
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.sprite import (
     RelativeGroup,
     SpriteGroup,
@@ -979,7 +978,7 @@ class PopUpMenu(Menu[T]):
     def animate_open(self) -> Animation:
         # anchor the center of the popup
         final_rect = self.calc_final_rect()
-        self.anchor("center", SCREEN_RECT.center)
+        self.anchor("center", self.client.context.rect.center)
 
         # set rect to a small size for the initial values of the animation
         self.rect = self._calculate_initial_rect(final_rect)

--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -21,7 +21,7 @@ from tuxemon.platform.const.graphics import (
     SCROLLBAR_SLIDER_COLOR,
     TRANSPARENT_COLOR,
 )
-from tuxemon.prepare import SCALE
+from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.tools import scale, transform_resource_filename
 from tuxemon.user_config import CONFIG
 
@@ -41,7 +41,7 @@ class TuxemonArrowSelection(Selection):
         #  --------------------------
         #
 
-        scale_factor = max(SCALE, 1)
+        scale_factor = max(DISPLAY_CONTEXT.scale, 1)
         arrow = BaseImage(
             image_path=transform_resource_filename(CONFIG.menu_cursor),
         ).scale(scale_factor, scale_factor, smooth=False)
@@ -81,7 +81,7 @@ def get_theme() -> Theme:
     if _theme is not None:
         return _theme
 
-    scale_factor = max(SCALE, 1)
+    scale_factor = max(DISPLAY_CONTEXT.scale, 1)
     tuxemon_border = BaseImage(
         image_path=transform_resource_filename(CONFIG.menu_border),
     ).scale(scale_factor, scale_factor, smooth=False)

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -46,7 +46,7 @@ from tuxemon.monster.stats import (
 )
 from tuxemon.monster.status import MonsterStatusHandler
 from tuxemon.platform.const.sizes import MONTH_KEYS
-from tuxemon.prepare import SCALE
+from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.shape import ShapeHandler
 from tuxemon.sprite import Sprite
 from tuxemon.taste import Taste
@@ -399,13 +399,13 @@ class Monster:
             {"doc": self.capture_string},
         )
 
-    def load_sprites(self, scale: float = SCALE) -> None:
+    def load_sprites(self, scale: float = DISPLAY_CONTEXT.scale) -> None:
         """
         Delegates the task of loading sprites to the sprite handler.
 
         Parameters:
             scale: The scaling factor to resize the sprite images.
-                Defaults to the predefined scale value in 'SCALE'.
+                Defaults to the predefined scale value in 'DISPLAY_CONTEXT.scale'.
         """
         self.sprite_handler.load_sprites(scale)
 
@@ -472,7 +472,7 @@ class Monster:
         self,
         sprite_type: str,
         frame_duration: float = 0.25,
-        scale: float = SCALE,
+        scale: float = DISPLAY_CONTEXT.scale,
         **kwargs: Any,
     ) -> Sprite:
         """

--- a/tuxemon/monster/sprite.py
+++ b/tuxemon/monster/sprite.py
@@ -14,7 +14,6 @@ from tuxemon import graphics, tools
 from tuxemon.database.runtime import db
 from tuxemon.db import ColorModel, FlairModel
 from tuxemon.platform.const.graphics import MISSING_IMAGE
-from tuxemon.prepare import SCALE
 from tuxemon.sprite import Sprite
 
 if TYPE_CHECKING:
@@ -323,7 +322,7 @@ class MonsterSpriteHandler:
     def get_sprite(
         self,
         sprite_type: str,
-        scale: float = SCALE,
+        scale: float,
         frame_duration: float = 0.25,
         **kwargs: Any,
     ) -> Sprite:
@@ -374,7 +373,7 @@ class MonsterSpriteHandler:
         self._flair_cache[cache_key] = image
         return Sprite(image=image)
 
-    def load_sprites(self, scale: float = SCALE) -> dict[str, Surface]:
+    def load_sprites(self, scale: float) -> dict[str, Surface]:
         return {
             key: graphics.scale_surface(self._slice(key), scale)
             for key in self.rects

--- a/tuxemon/network/networking.py
+++ b/tuxemon/network/networking.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 from tuxemon.db import Direction
 from tuxemon.item.item import decode_items, encode_items
 from tuxemon.monster.monster import decode_monsters, encode_monsters
-from tuxemon.prepare import TILE_SIZE
 from tuxemon.session import local_session
 from tuxemon.states import world_state as world
 
@@ -225,7 +224,7 @@ def update_client(
 
         # Handle tile position updates
         if item == "tile_pos":
-            tile_size = TILE_SIZE
+            tile_size = game.context.tile_size
             position = [
                 value[0] * tile_size[0],
                 value[1] * tile_size[1],

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 
-import pygame
+import pygame as pg
 
 from tuxemon.platform.const.sizes import NATIVE_RESOLUTION
 from tuxemon.platform.const.sizes import TILE_SIZE as NATIVE_TILE_SIZE
@@ -15,73 +16,107 @@ from tuxemon.user_config import CONFIG
 
 logger = logging.getLogger(__name__)
 
-# Config-driven defaults
+
+@dataclass
+class DisplayContext:
+    screen: pg.Surface
+    rect: pg.Rect
+    scale: int
+    tile_size: tuple[int, int]
+
+
+_default_surface = pg.Surface((1, 1))
+_default_rect = _default_surface.get_rect()
+
+DISPLAY_CONTEXT: DisplayContext = DisplayContext(
+    screen=_default_surface,
+    rect=_default_rect,
+    scale=1,
+    tile_size=(1, 1),
+)
+
+
 SCREEN_SIZE = CONFIG.resolution
-TILE_SIZE = NATIVE_TILE_SIZE
-SCALE = 1
 DEV_TOOLS = CONFIG.dev_tools
 
-Surface = pygame.Surface
-Rect = pygame.Rect
-SCREEN: Surface = Surface(CONFIG.resolution)
-SCREEN_RECT: Rect = SCREEN.get_rect()
 
-
-def pygame_init() -> None:
+def pygame_init() -> DisplayContext:
     """Initializes Pygame, display, translations, and databases."""
+    global DISPLAY_CONTEXT
+
     core_init()
+
     from tuxemon import platform
 
     platform.init()
-
-    global SCREEN, SCREEN_RECT, SCALE, TILE_SIZE
-
-    import pygame as pg
 
     logger.debug("pygame init")
     pg.init()
     pg.display.set_caption(CONFIG.window_caption)
 
+    # Compute scale
+    scale = 1
     if CONFIG.large_gui:
-        SCALE = 2
+        scale = 2
     elif CONFIG.scaling:
-        SCALE = int(SCREEN_SIZE[0] / NATIVE_RESOLUTION[0])
+        scale = int(SCREEN_SIZE[0] / NATIVE_RESOLUTION[0])
 
-    TILE_SIZE = (NATIVE_TILE_SIZE[0] * SCALE, NATIVE_TILE_SIZE[1] * SCALE)
+    tile_size = (
+        NATIVE_TILE_SIZE[0] * scale,
+        NATIVE_TILE_SIZE[1] * scale,
+    )
 
+    # Fullscreen flags
+    fullscreen = pg.FULLSCREEN if CONFIG.fullscreen else 0
     from tuxemon.platform import is_android
 
-    fullscreen = pg.FULLSCREEN if CONFIG.fullscreen else 0
     if is_android():
         fullscreen = pg.FULLSCREEN
+
     flags = pg.HWSURFACE | pg.DOUBLEBUF | fullscreen
 
     if CONFIG.vsync:
         pg.display.set_allow_screensaver()
 
-    SCREEN = pg.display.set_mode(SCREEN_SIZE, flags, vsync=CONFIG.vsync)
-    SCREEN_RECT = SCREEN.get_rect()
+    screen = pg.display.set_mode(SCREEN_SIZE, flags, vsync=CONFIG.vsync)
+    rect = screen.get_rect()
 
     pg.mouse.set_visible(not CONFIG.controller.hide_mouse)
 
+    DISPLAY_CONTEXT = DisplayContext(
+        screen=screen,
+        rect=rect,
+        scale=scale,
+        tile_size=tile_size,
+    )
 
-def headless_init() -> None:
+    return DISPLAY_CONTEXT
+
+
+def headless_init() -> DisplayContext:
     """Initializes game components for a headless environment."""
+    global DISPLAY_CONTEXT
+
     logger.debug("headless init")
 
     os.environ["SDL_VIDEODRIVER"] = "dummy"
 
-    import pygame as pg
+    core_init()
 
     pg.display.init()
     pg.font.init()
 
-    global SCREEN, SCREEN_RECT
+    screen = pg.Surface(CONFIG.resolution)
+    rect = screen.get_rect()
 
-    SCREEN = pg.Surface(CONFIG.resolution)
-    SCREEN_RECT = SCREEN.get_rect()
+    DISPLAY_CONTEXT = DisplayContext(
+        screen=screen,
+        rect=rect,
+        scale=1,
+        tile_size=NATIVE_TILE_SIZE,
+    )
 
-    core_init()
+    return DISPLAY_CONTEXT
 
 
 def core_init() -> None:

--- a/tuxemon/scaling.py
+++ b/tuxemon/scaling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol, TypeVar, overload
 
-from tuxemon.prepare import SCALE
+from tuxemon.prepare import DISPLAY_CONTEXT
 
 TVarSequence = TypeVar("TVarSequence", bound=tuple[int, ...])
 
@@ -20,10 +20,10 @@ class ScalingStrategy(Protocol):
 
 class DefaultScaling:
     def scale_tuple(self, coords: TVarSequence) -> TVarSequence:
-        return type(coords)(i * SCALE for i in coords)
+        return type(coords)(i * DISPLAY_CONTEXT.scale for i in coords)
 
     def scale_int(self, value: int) -> int:
-        return value * SCALE
+        return value * DISPLAY_CONTEXT.scale
 
 
 class ResolutionScaling:

--- a/tuxemon/state/state.py
+++ b/tuxemon/state/state.py
@@ -90,11 +90,15 @@ class State(AnimationMixin, RenderMixin, ABC):
         return sprite
 
     def load_animated_sprite(
-        self, filenames: Iterable[str], delay: float, **kwargs: Any
+        self,
+        filenames: Iterable[str],
+        delay: float,
+        scale: float,
+        **kwargs: Any,
     ) -> Sprite:
         """Load an animated sprite and add it to this state."""
         layer = kwargs.pop("layer", 0)
-        sprite = load_animated_sprite(filenames, delay, **kwargs)
+        sprite = load_animated_sprite(filenames, delay, scale, **kwargs)
         self.sprites.add(sprite, layer=layer)
         return sprite
 

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -20,7 +20,7 @@ from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import BG_PLAYER1, BG_PLAYER2
 from tuxemon.platform.const.sizes import U_KM, U_MI
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure, format_playtime
 from tuxemon.tuxepedia.reporter import TuxepediaReporter
 
@@ -193,7 +193,7 @@ class CharacterState(PygameMenuState):
         lab8.translate(fxw(0.45), fxh(0.10))
         # image
         surface = self.char.combat_sheet().front()
-        scaled = scale_surface(surface, SCALE)
+        scaled = scale_surface(surface, self.client.context.scale)
         new_image = self._create_image_from_surface(scaled)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/choice_item.py
+++ b/tuxemon/states/choice_item.py
@@ -13,7 +13,7 @@ from tuxemon.database.runtime import db
 from tuxemon.db import ItemModel
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure
 from tuxemon.ui.menu_options import MenuOptions
 
@@ -93,10 +93,8 @@ class ChoiceItem(PygameMenuState):
     ) -> None:
         item = ItemModel.lookup(slug, db)
         new_image = self._create_image(item.sprite)
-        new_image.scale(
-            SCALE * self.config.scale_sprite,
-            SCALE * self.config.scale_sprite,
-        )
+        scaled = self.client.context.scale * self.config.scale_sprite
+        new_image.scale(scaled, scaled)
         self.menu.add.image(new_image)
         self.menu.add.button(
             name,

--- a/tuxemon/states/choice_monster.py
+++ b/tuxemon/states/choice_monster.py
@@ -17,7 +17,7 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 from tuxemon.monster.sprite import MonsterSpriteHandler, SpriteLoader
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.session import local_session
 from tuxemon.ui.menu_options import MenuOptions
 
@@ -91,7 +91,7 @@ class ChoiceMonster(PygameMenuState):
         if handler is None:
             return
         sprite = handler.get_sprite(
-            "front", scale=SCALE * self.config.scale_sprite
+            "front", scale=self.client.context.scale * self.config.scale_sprite
         )
         image = self._create_image_from_surface(sprite.image)
         self.menu.add.image(image, align=ALIGN_CENTER)

--- a/tuxemon/states/choice_npc.py
+++ b/tuxemon/states/choice_npc.py
@@ -17,7 +17,7 @@ from tuxemon.entity.sheet import get_combat_sheet
 from tuxemon.graphics import scale_surface
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.ui.menu_options import MenuOptions
 
 
@@ -79,7 +79,9 @@ class ChoiceNpc(PygameMenuState):
         npc = NpcModel.lookup(slug, db)
         sheet = get_combat_sheet(npc.template)
         surface = sheet.front()
-        scaled = scale_surface(surface, SCALE * self.config.scale_sprite)
+        scaled = scale_surface(
+            surface, self.client.context.scale * self.config.scale_sprite
+        )
         new_image = self._create_image_from_surface(scaled)
         self.menu.add.image(new_image, align=ALIGN_CENTER)
         # replace slug not translated

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -24,7 +24,6 @@ from tuxemon.database.rules import config_combat
 from tuxemon.environment import BattleLayout
 from tuxemon.menu.menu import Menu
 from tuxemon.platform.const.sizes import PARTY_LIMIT
-from tuxemon.prepare import SCALE, SCREEN, SCREEN_RECT
 from tuxemon.sprite import CaptureDeviceSprite, HordeSprite, Sprite
 from tuxemon.tools import scale
 from tuxemon.ui.combat_bars import CombatBars
@@ -79,7 +78,7 @@ class CombatAnimations(Menu[None], ABC):
         _layout = layout_manager.prepare_all(teams)
         self.hud_manager = CombatLayoutManager(_layout)
         self.status_icons = StatusIconManager(self, _layout, self.hud_manager)
-        self.combat_zone = CombatZone(SCREEN_RECT)
+        self.combat_zone = CombatZone(self.client.context.rect)
         self.text_display = CombatTextDisplay(
             get_rect_func=self.hud_manager.get_rect,
             shadow_text_func=self.shadow_text,
@@ -206,7 +205,7 @@ class CombatAnimations(Menu[None], ABC):
         self.sprite_map.add_sprite(monster, monster_sprite)
 
         # Position monster sprite off screen and animate it to final spot
-        monster_sprite.rect.top = SCREEN.get_height()
+        monster_sprite.rect.top = self.client.context.screen.get_height()
         self.animate(
             monster_sprite.rect,
             bottom=feet[1],
@@ -598,7 +597,7 @@ class CombatAnimations(Menu[None], ABC):
         if self.background_sprite:
             self.background_sprite.kill()
 
-        full_surf = self.env.prepare_background(SCREEN_RECT.size)
+        full_surf = self.env.prepare_background(self.client.context.rect.size)
         spr = Sprite()
         spr.image = full_surf
         spr.rect = full_surf.get_rect()
@@ -623,7 +622,7 @@ class CombatAnimations(Menu[None], ABC):
         player_home = self.hud_manager.get_rect(player, "home")
         opp_home = self.hud_manager.get_rect(opponent, "home")
         layout = self.env.get_battle_layout(
-            SCREEN_RECT.size, player_home, opp_home
+            self.client.context.rect.size, player_home, opp_home
         )
 
         # Spawn Islands
@@ -639,7 +638,9 @@ class CombatAnimations(Menu[None], ABC):
         if self.combat_session.is_trainer_battle:
             enemy_pos = layout.get_combatant_pos("enemy", back_island.rect)
             enemy_surface = opponent.combat_sheet().front()
-            enemy_surface = graphics.scale_surface(enemy_surface, SCALE)
+            enemy_surface = graphics.scale_surface(
+                enemy_surface, self.client.context.scale
+            )
             enemy = self.load_surface(enemy_surface, **enemy_pos)
             self.sprite_map.add_sprite(opponent, enemy)
         else:
@@ -655,7 +656,9 @@ class CombatAnimations(Menu[None], ABC):
 
         player_pos = layout.get_combatant_pos("player", front_island.rect)
         player_surface = player.combat_sheet().back()
-        player_surface = graphics.scale_surface(player_surface, SCALE)
+        player_surface = graphics.scale_surface(
+            player_surface, self.client.context.scale
+        )
         player_back = self.load_surface(player_surface, **player_pos)
 
         self.sprites.add(enemy, player_back)

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -20,7 +20,7 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu, PopUpMenu
 from tuxemon.monster.monster import Monster
-from tuxemon.prepare import SCALE, SCREEN_RECT, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.sprite import Sprite
 from tuxemon.states.item_menu import ItemMenuState
 from tuxemon.states.monster_menu import MonsterMenuState
@@ -112,7 +112,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     self.sprites.remove(spr)
 
     def calculate_menu_rectangle(self) -> Rect:
-        rect_screen = SCREEN_RECT.copy()
+        rect_screen = self.client.context.rect.copy()
         menu_width = fix_measure(rect_screen.w, 102 / 256)
         menu_height = fix_measure(rect_screen.h, 36 / 144)
         rect = Rect(0, 0, menu_width, menu_height)
@@ -252,7 +252,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
         menu.on_menu_selection = swap_it  # type: ignore[assignment]
         menu.is_valid_entry = validate  # type: ignore[assignment]
         menu.anchor("bottom", self.rect.top)
-        menu.anchor("right", SCREEN_RECT.right)
+        menu.anchor("right", self.client.context.rect.right)
 
     def open_item_menu(self) -> None:
         """Open menu to choose item to use."""
@@ -383,7 +383,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
             # position the new menu
             menu.anchor("bottom", self.rect.top)
-            menu.anchor("right", SCREEN_RECT.right)
+            menu.anchor("right", self.client.context.rect.right)
 
             # set next menu after the selection is made
             menu.on_menu_selection = choose_target  # type: ignore[assignment]
@@ -429,7 +429,9 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     for i, t in enumerate(technique.types.current[:2]):
                         path = f"gfx/ui/icons/element/{t.name.lower()}_type_small.png"
                         try:
-                            icon_surface = load_and_scale(path, SCALE)
+                            icon_surface = load_and_scale(
+                                path, self.client.context.scale
+                            )
                             spr = Sprite()
                             spr.image = icon_surface
                             spr.rect = spr.image.get_rect()
@@ -456,7 +458,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 # --- Draw range icon ---
                 path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
                 try:
-                    surf = load_and_scale(path, SCALE)
+                    surf = load_and_scale(path, self.client.context.scale)
                     spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
@@ -475,7 +477,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
                 path = f"gfx/ui/icons/speed/{speed_val}.png"
                 try:
-                    surf = load_and_scale(path, SCALE)
+                    surf = load_and_scale(path, self.client.context.scale)
                     spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
@@ -666,7 +668,7 @@ class CombatTargetMenuState(Menu[Monster]):
 
     def _create_menu(self) -> None:
         """Sets up the menu UI."""
-        rect_screen = SCREEN_RECT.copy()
+        rect_screen = self.client.context.rect.copy()
         rect = Rect(0, 0, rect_screen.w // 2, rect_screen.h // 4)
         rect.bottomright = rect_screen.w, rect_screen.h
 

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -63,7 +63,6 @@ from tuxemon.menu.interface import MenuItem
 from tuxemon.monster.monster import Monster
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.sizes import PARTY_LIMIT
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.state.state import State
 from tuxemon.states.combat_animations import CombatAnimations
 from tuxemon.states.monster_menu import MonsterMenuState
@@ -335,7 +334,7 @@ class CombatState(CombatAnimations):
 
     def create_combat_dialog(self) -> None:
         """Create the area where battle messages are displayed."""
-        rect_screen = SCREEN_RECT.copy()
+        rect_screen = self.client.context.rect.copy()
         rect = Rect(0, 0, rect_screen.w, rect_screen.h // 4)
         rect.bottomright = rect_screen.w, rect_screen.h
         border = load_and_scale(self.borders_filename)

--- a/tuxemon/states/image_state.py
+++ b/tuxemon/states/image_state.py
@@ -9,7 +9,7 @@ from pygame_menu.locals import ALIGN_CENTER
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.sizes import NATIVE_RESOLUTION
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 
 
 class ImageState(PygameMenuState):
@@ -44,7 +44,9 @@ class ImageState(PygameMenuState):
                     f"{image} {image_size}: "
                     f"It must be less than the native resolution {native}"
                 )
-            new_image.scale(SCALE, SCALE)
+            new_image.scale(
+                self.client.context.scale, self.client.context.scale
+            )
             self.menu.add.image(
                 new_image,
                 align=ALIGN_CENTER,

--- a/tuxemon/states/intro_state.py
+++ b/tuxemon/states/intro_state.py
@@ -37,7 +37,11 @@ class IntroState(PopUpMenu[MenuGameObj]):
             IntroState._cached_sprites = self._load_sprite_files()
 
         if IntroState._cached_sprites:
-            self.load_animated_sprite(IntroState._cached_sprites, 0.07)
+            self.load_animated_sprite(
+                IntroState._cached_sprites,
+                delay=0.07,
+                scale=self.client.context.scale,
+            )
 
     def _load_sprite_files(self) -> list[str] | None:
         folder_path = Path(transform_resource_filename("animations/intro"))

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -24,7 +24,6 @@ from tuxemon.platform.const.graphics import (
 )
 from tuxemon.platform.const.sizes import MAX_MENU_ITEMS
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
 from tuxemon.tools import (
@@ -71,7 +70,7 @@ class ItemMenuState(Menu[Item]):
         self.inventory = self.filter_controller.get_filtered_inventory()
 
         # this is the area where the item description is displayed
-        rect = SCREEN_RECT.copy()
+        rect = self.client.context.rect.copy()
         rect.top = scale(106)
         rect.left = scale(3)
         rect.width = scale(250)

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -18,7 +18,7 @@ from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import BG_JOURNAL_INFO
 from tuxemon.platform.const.sizes import U_CM, U_FT, U_KG, U_LB
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
@@ -106,11 +106,15 @@ class JournalInfoState(PygameMenuState):
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
-        type_image_1.scale(SCALE, SCALE)
+        type_image_1.scale(
+            self.client.context.scale, self.client.context.scale
+        )
         if len(monster.types) > 1:
             path2 = f"gfx/ui/icons/element/{monster.types[1]}_type_small.png"
             type_image_2 = self._create_image(path2)
-            type_image_2.scale(SCALE, SCALE)
+            type_image_2.scale(
+                self.client.context.scale, self.client.context.scale
+            )
             menu.add.image(type_image_1, float=True).translate(
                 fxw(11.4 / 256), fxh(47.8 / 144)
             )
@@ -242,7 +246,7 @@ class JournalInfoState(PygameMenuState):
         )
         if handler is None:
             return
-        sprite = handler.get_sprite("front", scale=SCALE)
+        sprite = handler.get_sprite("front", scale=self.client.context.scale)
         new_image = self._create_image_from_surface(sprite.image)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/load_menu.py
+++ b/tuxemon/states/load_menu.py
@@ -8,7 +8,6 @@ from typing import ClassVar
 from pygame.rect import Rect
 
 from tuxemon.menu.interface import MenuItem
-from tuxemon.prepare import SCREEN_RECT
 
 from .save_menu import SLOT_HEIGHT_RATIO, SLOT_WIDTH_RATIO, SaveMenuState
 
@@ -25,7 +24,7 @@ class LoadMenuState(SaveMenuState):
             self.on_menu_selection(None)
 
     def initialize_items(self) -> None:
-        rect = SCREEN_RECT.copy()
+        rect = self.client.context.rect.copy()
         slot_rect = Rect(
             0,
             0,

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -16,7 +16,7 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.monster.sprite import MonsterSpriteHandler, SpriteLoader
 from tuxemon.platform.const.graphics import BG_MINIGAME, MISSING_IMAGE
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure, open_dialog
 
 lookup_cache: dict[str, MonsterModel] = {}
@@ -83,14 +83,16 @@ class MinigameState(PygameMenuState):
         )
         if handler is None:
             return
-        sprite = handler.get_sprite("front", scale=SCALE)
+        sprite = handler.get_sprite("front", scale=self.client.context.scale)
         if self.difficulty in ["easy", "normal"]:
             try:
                 image = self._create_image_from_surface(sprite.image)
                 menu.add.image(image_path=image.copy())
             except Exception:
                 image = self._create_image(MISSING_IMAGE)
-                image.scale(SCALE, SCALE)
+                image.scale(
+                    self.client.context.scale, self.client.context.scale
+                )
                 menu.add.image(image_path=image.copy())
 
         if self.difficulty == "hard":

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from pygame_menu.locals import ALIGN_CENTER, ALIGN_LEFT, POSITION_EAST
 from pygame_menu.menu import Menu
@@ -19,11 +19,8 @@ from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import INDIV_INFO
 from tuxemon.platform.const.sizes import U_CM, U_FT, U_KG, U_LB, U_M, U_T
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure, transform_resource_filename
-
-if TYPE_CHECKING:
-    from tuxemon.base_client import BaseClient
 
 lookup_cache: dict[str, MonsterModel] = {}
 lookup_tastes: dict[str, TasteModel] = {}
@@ -66,7 +63,7 @@ class MonsterInfoState(PygameMenuState):
         menu._width = fxw(1)
 
         background = self._create_image(INDIV_INFO)
-        background.scale(SCALE, SCALE)
+        background.scale(self.client.context.scale, self.client.context.scale)
         background_widget = menu.add.image(image_path=background)
         background_widget.set_float(origin_position=True)
         background_widget.translate(fxw(0 / 256), fxh(0 / 144))
@@ -264,7 +261,9 @@ class MonsterInfoState(PygameMenuState):
             type1_icon = self._create_image(
                 f"gfx/ui/icons/element/{types[0].slug}_type_watermark.png"
             )
-            type1_icon.scale(SCALE, SCALE)
+            type1_icon.scale(
+                self.client.context.scale, self.client.context.scale
+            )
             icon1_widget = menu.add.image(image_path=type1_icon)
             icon1_widget.set_float(origin_position=True)
             # Position of type 1 (set wherever you want)
@@ -274,7 +273,9 @@ class MonsterInfoState(PygameMenuState):
             type2_icon = self._create_image(
                 f"gfx/ui/icons/element/{types[1].slug}_type_watermark.png"
             )
-            type2_icon.scale(SCALE, SCALE)
+            type2_icon.scale(
+                self.client.context.scale, self.client.context.scale
+            )
             icon2_widget = menu.add.image(image_path=type2_icon)
             icon2_widget.set_float(origin_position=True)
             # Position of type 2 (independent from type 1)
@@ -374,8 +375,8 @@ class MonsterInfoState(PygameMenuState):
 
         plus_icon = self._create_image("gfx/ui/icons/plusminus/plus.png")
         minus_icon = self._create_image("gfx/ui/icons/plusminus/minus.png")
-        plus_icon.scale(SCALE, SCALE)
-        minus_icon.scale(SCALE, SCALE)
+        plus_icon.scale(self.client.context.scale, self.client.context.scale)
+        minus_icon.scale(self.client.context.scale, self.client.context.scale)
 
         # Helper: find which stat a taste affects
         def get_stat_for_taste(slug: str) -> str | None:
@@ -411,7 +412,9 @@ class MonsterInfoState(PygameMenuState):
             bond_file = monster.bond_handler.get_bond_icon_path()
             if bond_file:
                 bond_icon = self._create_image(bond_file)
-                bond_icon.scale(SCALE, SCALE)
+                bond_icon.scale(
+                    self.client.context.scale, self.client.context.scale
+                )
                 bond_widget = menu.add.image(image_path=bond_icon)
                 bond_widget.set_float(origin_position=True)
                 bond_widget.translate(fxw(20 / 256), fxh(29 / 144))
@@ -426,7 +429,7 @@ class MonsterInfoState(PygameMenuState):
         tuxeball = self._create_image(
             f"gfx/items/{monster.capture_device}.png"
         )
-        tuxeball.scale(SCALE, SCALE)
+        tuxeball.scale(self.client.context.scale, self.client.context.scale)
         capture_device = menu.add.image(image_path=tuxeball)
         capture_device.set_float(origin_position=True)
         capture_device.translate(fxw(17 / 256), fxh(110 / 144))
@@ -436,11 +439,12 @@ class MonsterInfoState(PygameMenuState):
             _lookup_monsters()
         if not lookup_tastes:
             _lookup_tastes()
-        monster: Monster | None = None
-        source = ""
-        for element in kwargs.values():
-            monster = element["monster"]
-            source = element["source"]
+
+        inner = next(iter(kwargs.values())) if kwargs else {}
+        monster: Monster | None = inner.get("monster")
+        source: str = inner.get("source") or ""
+        self._monsters: list[Monster] | None = inner.get("monsters")
+
         if monster is None:
             raise ValueError("No monster")
         width, height = SCREEN_SIZE
@@ -466,7 +470,12 @@ class MonsterInfoState(PygameMenuState):
             "MonsterMenuState",
             "MonsterTakeState",
         ]:
-            monsters = _get_monsters(client, self._monster, self._source)
+            monsters = self._monsters
+            if not monsters:
+                return None
+
+            param["monsters"] = monsters
+
             slot = monsters.index(self._monster)
 
             if event.button == buttons.RIGHT and self.valid_press(event):
@@ -485,18 +494,3 @@ class MonsterInfoState(PygameMenuState):
             client.remove_state_by_name("MonsterInfoState")
 
         return None
-
-
-def _get_monsters(
-    client: BaseClient, monster: Monster, source: str
-) -> list[Monster]:
-    owner = client.get_monster_owner(monster)
-    if owner is None:
-        return []
-    if source == "MonsterTakeState":
-        box = owner.monster_boxes.get_box_name(monster.instance_id)
-        if box is None:
-            raise ValueError("Box doesn't exist")
-        return owner.monster_boxes.get_monsters(box)
-    else:
-        return owner.monsters

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -214,13 +214,21 @@ class MonsterMenuHandler:
     def monster_stats(self, monster: Monster) -> None:
         """Displays monster statistics."""
         self.client.remove_state_by_name("ChoiceState")
-        params = {"monster": monster, "source": self.name}
+        params = {
+            "monster": monster,
+            "source": self.name,
+            "monsters": self.party.monsters,
+        }
         self.client.push_state("MonsterInfoState", kwargs=params)
 
     def monster_techs(self, monster: Monster) -> None:
         """Displays monster techniques."""
         self.client.remove_state_by_name("ChoiceState")
-        params = {"monster": monster, "source": self.name}
+        params = {
+            "monster": monster,
+            "source": self.name,
+            "monsters": self.party.monsters,
+        }
         self.client.push_state("MonsterMovesState", kwargs=params)
 
     def remove_item_direct(self, monster: Monster) -> None:

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -17,12 +17,11 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import TECH_INFO
 from tuxemon.platform.const.sizes import ACCURACY_RANGE, POTENCY_RANGE
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.technique.technique import Technique
 from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
-    from tuxemon.base_client import BaseClient
     from tuxemon.monster.monster import Monster
     from tuxemon.platform.events import PlayerInput
 
@@ -282,7 +281,7 @@ class MonsterMovesState(PygameMenuState):
             for i, t in enumerate(technique.types.current[:2]):
                 path = f"gfx/ui/icons/element/{t.name.lower()}_type_small.png"
                 img = self._create_image(path)
-                img.scale(SCALE, SCALE)
+                img.scale(self.client.context.scale, self.client.context.scale)
                 icon = menu.add.image(img.copy(), float=True)
                 icon.translate(fxw(x_positions[i]), fxh(y_position))
                 self.type_icon_widgets.append(icon)
@@ -291,7 +290,7 @@ class MonsterMovesState(PygameMenuState):
         if technique.range:
             path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
             rimg = self._create_image(path)
-            rimg.scale(SCALE, SCALE)
+            rimg.scale(self.client.context.scale, self.client.context.scale)
             self.range_icon_widget = menu.add.image(rimg.copy(), float=True)
             self.range_icon_widget.translate(fxw(4 / 256), fxh(86.8 / 144))
 
@@ -301,7 +300,7 @@ class MonsterMovesState(PygameMenuState):
 
         spath = f"gfx/ui/icons/speed/{speed_key}.png"
         simg = self._create_image(spath)
-        simg.scale(SCALE, SCALE)
+        simg.scale(self.client.context.scale, self.client.context.scale)
         self.speed_icon_widget = menu.add.image(simg.copy(), float=True)
         self.speed_icon_widget.translate(fxw(222 / 256), fxh(51.8 / 144))
 
@@ -339,11 +338,11 @@ class MonsterMovesState(PygameMenuState):
         if not lookup_cache:
             _lookup_monsters()
 
-        monster: Monster | None = None
-        source = ""
-        for element in kwargs.values():
-            monster = element["monster"]
-            source = element["source"]
+        inner = next(iter(kwargs.values())) if kwargs else {}
+        monster: Monster | None = inner.get("monster")
+        source: str = inner.get("source") or ""
+        self._monsters: list[Monster] | None = inner.get("monsters")
+
         if monster is None:
             raise ValueError("No monster")
 
@@ -368,7 +367,12 @@ class MonsterMovesState(PygameMenuState):
             "MonsterMenuState",
             "MonsterTakeState",
         ]:
-            monsters = _get_monsters(client, self._monster, self._source)
+            monsters = self._monsters
+            if not monsters:
+                return None
+
+            param["monsters"] = monsters
+
             slot = monsters.index(self._monster)
 
             # RIGHT → next monster (with repeat)
@@ -396,18 +400,3 @@ class MonsterMovesState(PygameMenuState):
                 return super().process_event(event)
 
         return None
-
-
-def _get_monsters(
-    client: BaseClient, monster: Monster, source: str
-) -> list[Monster]:
-    owner = client.get_monster_owner(monster)
-    if owner is None:
-        return []
-    if source == "MonsterTakeState":
-        box = owner.monster_boxes.get_box_name(monster.instance_id)
-        if box is None:
-            raise ValueError("Box doesn't exist")
-        return owner.monster_boxes.get_monsters(box)
-    else:
-        return owner.monsters

--- a/tuxemon/states/park_menu.py
+++ b/tuxemon/states/park_menu.py
@@ -15,7 +15,6 @@ from tuxemon.item.item import Item
 from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PopUpMenu
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.states.item_menu import ItemMenuState
 
 if TYPE_CHECKING:
@@ -76,7 +75,7 @@ class MainParkMenuState(PopUpMenu[MenuGameObj]):
         self.event_bus.publish("combat_dialog", message=message)
 
     def calculate_menu_rectangle(self) -> Rect:
-        rect_screen = SCREEN_RECT.copy()
+        rect_screen = self.client.context.rect.copy()
         menu_width = rect_screen.w // 2.5
         menu_height = rect_screen.h // 4
         rect = Rect(0, 0, menu_width, menu_height)

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -14,12 +14,13 @@ from pygame_menu import locals
 from pygame_menu.widgets.selection.highlight import HighlightSelection
 
 from tuxemon.animation import ScheduleType
+from tuxemon.graphics import scale_surface
 from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_PC_KENNEL
 from tuxemon.platform.const.sizes import MAX_KENNEL, PARTY_LIMIT
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.state.state import State
 from tuxemon.states.monster_menu import MonsterMenuState
 from tuxemon.tools import fix_measure, open_choice_dialog, open_dialog
@@ -121,14 +122,22 @@ class MonsterActionHandler:
         self._clear_states("ChoiceState")
         self.client.state_manager.push_state(
             "MonsterInfoState",
-            kwargs={"monster": mon, "source": self.source_state},
+            kwargs={
+                "monster": mon,
+                "source": self.source_state,
+                "monsters": self.monster_boxes.get_monsters(self.box_name),
+            },
         )
 
     def tech(self, mon: Monster) -> None:
         self._clear_states("ChoiceState")
         self.client.state_manager.push_state(
             "MonsterMovesState",
-            kwargs={"monster": mon, "source": self.source_state},
+            kwargs={
+                "monster": mon,
+                "source": self.source_state,
+                "monsters": self.monster_boxes.get_monsters(self.box_name),
+            },
         )
 
     def description_dialog(self, mon: Monster) -> None:
@@ -290,8 +299,8 @@ class MonsterTakeState(PygameMenuState):
             label = T.translate(monster.name).upper()
             iid = monster.instance_id.hex
             surface = monster.get_sprite("front").image
-            new_image = self._create_image_from_surface(surface)
-            new_image.scale(SCALE * 0.5, SCALE * 0.5)
+            scaled = scale_surface(surface, self.client.context.scale * 0.125)
+            new_image = self._create_image_from_surface(scaled)
             menu.add.banner(
                 new_image,
                 partial(self.kennel_options, iid, handler),
@@ -380,7 +389,6 @@ class MonsterBoxState(PygameMenuState):
 
         Returns:
             Sliding in animation.
-
         """
 
         width = self.menu.get_width(border=True)
@@ -397,7 +405,6 @@ class MonsterBoxState(PygameMenuState):
 
         Returns:
             Sliding out animation.
-
         """
         ani = self.animate(self, animation_offset=0, duration=0.50)
         ani.schedule(self.update_animation_position, ScheduleType.ON_UPDATE)

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -21,7 +21,7 @@ from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.quantity import QuantityMenu
 from tuxemon.platform.const.graphics import BG_PC_LOCKER
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.state.state import State
 from tuxemon.states.item_menu import ItemMenuState
 from tuxemon.tools import fix_measure, open_choice_dialog, open_dialog
@@ -244,7 +244,9 @@ class ItemTakeState(PygameMenuState):
             label = T.translate(itm.name).upper() + " x" + str(itm.quantity)
             iid = itm.instance_id.hex
             new_image = self._create_image(itm.sprite)
-            new_image.scale(SCALE, SCALE)
+            new_image.scale(
+                self.client.context.scale, self.client.context.scale
+            )
             menu.add.banner(
                 new_image,
                 partial(self.locker_options, iid, handler),

--- a/tuxemon/states/phone.py
+++ b/tuxemon/states/phone.py
@@ -16,7 +16,7 @@ from tuxemon.locale.locale import T
 from tuxemon.map.manager import MAP_TYPES, MapType
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_PHONE
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure, open_dialog
 
 if TYPE_CHECKING:
@@ -119,7 +119,9 @@ class NuPhone(PygameMenuState):
                 change = self._get_app_callback(item)
 
                 new_image = self._create_image(item.sprite)
-                new_image.scale(SCALE, SCALE)
+                new_image.scale(
+                    self.client.context.scale, self.client.context.scale
+                )
 
                 # App image (banner)
                 menu.add.banner(

--- a/tuxemon/states/phone_map.py
+++ b/tuxemon/states/phone_map.py
@@ -14,7 +14,7 @@ from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_PHONE_MAP
-from tuxemon.prepare import SCALE, SCREEN_SIZE
+from tuxemon.prepare import SCREEN_SIZE
 from tuxemon.tools import fix_measure
 
 if TYPE_CHECKING:
@@ -78,7 +78,7 @@ class NuPhoneMap(PygameMenuState):
         menu: pygame_menu.Menu,
     ) -> None:
         new_image = self._create_image(data.map_path)
-        new_image.scale(SCALE, SCALE)
+        new_image.scale(self.client.context.scale, self.client.context.scale)
         menu.add.image(image_path=new_image.copy())
         underline = False
         selectable = True

--- a/tuxemon/states/save_menu.py
+++ b/tuxemon/states/save_menu.py
@@ -18,7 +18,6 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PopUpMenu
 from tuxemon.platform.const.graphics import WHITE_COLOR
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.save import get_save_path
 from tuxemon.tools import open_choice_dialog
 from tuxemon.ui.menu_options import MenuOptions, create_choice_options
@@ -59,7 +58,7 @@ class SaveMenuState(PopUpMenu[None]):
             )
 
     def initialize_items(self) -> None:
-        rect = SCREEN_RECT.copy()
+        rect = self.client.context.rect.copy()
         slot_rect = Rect(
             0,
             0,

--- a/tuxemon/states/shop_base.py
+++ b/tuxemon/states/shop_base.py
@@ -27,7 +27,6 @@ from tuxemon.menu.quantity import QuantityAndCostMenu
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.sizes import MAX_MENU_ITEMS
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.sprite import Sprite
 from tuxemon.ui.paginator import Paginator
 from tuxemon.ui.text import TextArea
@@ -75,7 +74,7 @@ class ShopMenuState(Menu[T], Generic[T], ABC):
         self.inventory: list[T] = []
 
         # This is the area where the asset's description is displayed.
-        rect = SCREEN_RECT.copy()
+        rect = self.client.context.rect.copy()
         rect.top = tools.scale(106)
         rect.left = tools.scale(3)
         rect.width = tools.scale(250)

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -15,7 +15,6 @@ from tuxemon.platform.const.graphics import (
     DIMGRAY_COLOR,
     MISSING_IMAGE,
 )
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
 from tuxemon.technique.controller import TechController
@@ -59,7 +58,7 @@ class TechniqueMenuState(Menu[Technique]):
         self.menu_items.line_spacing = scale(7)
 
         # this is the area where the technique description is displayed
-        rect = SCREEN_RECT.copy()
+        rect = self.client.context.rect.copy()
         rect.top = scale(106)
         rect.left = scale(3)
         rect.width = scale(250)

--- a/tuxemon/states/transition_evolution.py
+++ b/tuxemon/states/transition_evolution.py
@@ -173,7 +173,7 @@ class EvolutionTransition(State):
             menu2_rect=sprites.menu2_rect,
         )
         assert handler
-        return handler.get_sprite("front")
+        return handler.get_sprite("front", self.client.context.scale)
 
     def _white_image(self, sprite: Surface) -> Surface:
         for x in range(sprite.get_width()):

--- a/tuxemon/states/transition_mosaic.py
+++ b/tuxemon/states/transition_mosaic.py
@@ -11,7 +11,6 @@ from pygame.rect import Rect
 from pygame.surface import Surface
 
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN
 from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
@@ -40,7 +39,7 @@ class MosaicTransition(State):
         self.resume()
 
     def resume(self) -> None:
-        self.screenshot = Surface.copy(SCREEN)
+        self.screenshot = Surface.copy(self.client.context.screen)
         for x in range(0, self.screenshot.get_width(), self.tile_size):
             for y in range(0, self.screenshot.get_height(), self.tile_size):
                 rect = Rect(x, y, self.tile_size, self.tile_size)

--- a/tuxemon/states/transition_static.py
+++ b/tuxemon/states/transition_static.py
@@ -9,7 +9,6 @@ from typing import ClassVar
 from pygame.surface import Surface
 
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN
 from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
@@ -34,7 +33,7 @@ class StaticTransition(State):
         self.screenshot: Surface | None = None
 
     def resume(self) -> None:
-        self.screenshot = Surface.copy(SCREEN)
+        self.screenshot = Surface.copy(self.client.context.screen)
 
     def update(self, time_delta: float) -> None:
         self.elapsed_time += time_delta

--- a/tuxemon/states/transition_swirl.py
+++ b/tuxemon/states/transition_swirl.py
@@ -9,7 +9,6 @@ from pygame.surface import Surface
 from pygame.transform import rotate, scale
 
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN
 from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
@@ -34,8 +33,8 @@ class SwirlTransition(State):
         super().__init__()
         logger.info("Initializing Swirl transition")
         self.image = image
-        self.center_x = SCREEN.get_width() // 2
-        self.center_y = SCREEN.get_height() // 2
+        self.center_x = self.client.context.screen.get_width() // 2
+        self.center_y = self.client.context.screen.get_height() // 2
         self.angle = 0.0
         self.scale = scale
         self.speed = speed

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -169,7 +169,7 @@ class TradingTransition(State):
             menu2_rect=sprites.menu2_rect,
         )
         assert handler
-        return handler.get_sprite("front")
+        return handler.get_sprite("front", self.client.context.scale)
 
     def _white_image(self, sprite: Surface) -> Surface:
         for x in range(sprite.get_width()):

--- a/tuxemon/states/transition_wipe.py
+++ b/tuxemon/states/transition_wipe.py
@@ -11,7 +11,6 @@ from pygame.surface import Surface
 from tuxemon.graphics import ColorLike
 from tuxemon.platform.const.graphics import BLACK_COLOR
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN
 from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
@@ -46,8 +45,8 @@ class WipeTransition(State):
         self.wipe_y = 0.0
         self.color = color
         self.speed = speed
-        self.height = SCREEN.get_height()
-        self.width = SCREEN.get_width()
+        self.height = self.client.context.screen.get_height()
+        self.width = self.client.context.screen.get_width()
 
     def update(self, time_delta: float) -> None:
         self.update_wipe_position(time_delta)

--- a/tuxemon/states/transition_zoom.py
+++ b/tuxemon/states/transition_zoom.py
@@ -9,7 +9,6 @@ from pygame.surface import Surface
 from pygame.transform import scale
 
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import SCREEN
 from tuxemon.state.state import State
 
 logger = logging.getLogger(__name__)
@@ -59,8 +58,8 @@ class ZoomOutTransition(State):
         )
         rect = scaled_image.get_rect(
             center=(
-                SCREEN.get_width() // 2,
-                SCREEN.get_height() // 2,
+                self.client.context.screen.get_width() // 2,
+                self.client.context.screen.get_height() // 2,
             )
         )
         surface.blit(scaled_image, rect)
@@ -113,8 +112,8 @@ class ZoomInTransition(State):
         )
         rect = scaled_image.get_rect(
             center=(
-                SCREEN.get_width() // 2,
-                SCREEN.get_height() // 2,
+                self.client.context.screen.get_width() // 2,
+                self.client.context.screen.get_height() // 2,
             )
         )
         surface.blit(scaled_image, rect)

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -24,7 +24,7 @@ from tuxemon.event.eventmiddleware import (
 )
 from tuxemon.faction.manager import FactionManager
 from tuxemon.platform.events import PlayerInput
-from tuxemon.prepare import DEV_TOOLS, TILE_SIZE
+from tuxemon.prepare import DEV_TOOLS
 from tuxemon.save_state import WorldSave
 from tuxemon.session import Session
 from tuxemon.state.state import State
@@ -59,13 +59,15 @@ class WorldState(State):
         self.input_translator_mw = mw
         self.session = session
         self.session.set_world(self)
-        self.tile_size = TILE_SIZE
+        self.tile_size = self.client.context.tile_size
         self.menu_manager = WorldMenuManager(self.client)
         self.transition_manager = WorldTransition(
             self, self.client.movement_manager
         )
         self.player = self.session.player
-        self.camera = Camera(self.player, self.client.boundary)
+        self.camera = Camera(
+            self.player, self.client.boundary, self.client.context
+        )
         self.client.camera_manager.add_camera(self.player.slug, self.camera)
         self.faction_manager = FactionManager(self.client.event_bus)
         self.client.map_transition.change_map(map_name, yaml_name)

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -37,7 +37,6 @@ from tuxemon.constants.asset_loader import fetch_asset
 from tuxemon.db import Comparison
 from tuxemon.locale.locale import T
 from tuxemon.math import Vector2
-from tuxemon.prepare import SCREEN_RECT
 from tuxemon.scaling import DefaultScaling, ScalingStrategy
 from tuxemon.ui.dialogue import calc_dialog_rect
 from tuxemon.ui.text_alignment import DialogPosition
@@ -125,18 +124,22 @@ def get_screen_rect(sprite: Sprite, internal_rect: Rect) -> Rect:
     return internal_rect.move(sprite.rect.topleft)
 
 
-def scale(number: int, scaling: ScalingStrategy | None = None) -> int:
+def scale(number: int | float, scaling: ScalingStrategy | None = None) -> int:
     """
-    Scale an integer by the configured scale factor.
+    Scale a number by the configured scale factor.
 
-    Parameter:
-        number: Integer to scale.
+    Parameters:
+        number: Integer or float to scale. Floats are rounded before scaling.
 
     Returns:
         Scaled integer.
     """
     scaling = scaling or DefaultScaling()
-    return scaling.scale_int(number)
+
+    if isinstance(number, float):
+        number = round(number)
+
+    return scaling.scale_int(int(number))
 
 
 TEnum = TypeVar("TEnum", bound=Enum)
@@ -232,7 +235,7 @@ def open_dialog(
         dialog_rect = custom_rect
     else:
         dialog_rect = calc_dialog_rect(
-            SCREEN_RECT, position, target_coords=target_coords
+            client.context.rect, position, target_coords=target_coords
         )
 
     return client.push_state(

--- a/tuxemon/ui/text_renderer.py
+++ b/tuxemon/ui/text_renderer.py
@@ -11,7 +11,7 @@ from pygame.surface import Surface
 
 from tuxemon.graphics import ColorLike
 from tuxemon.platform.const.graphics import FONT_SHADOW_COLOR, FONT_SIZE
-from tuxemon.prepare import SCALE
+from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.tools import scale
 
 
@@ -24,7 +24,7 @@ def create_layout(
     return func
 
 
-layout = create_layout(SCALE)
+layout = create_layout(DISPLAY_CONTEXT.scale)
 
 
 class TextRenderer:


### PR DESCRIPTION
PR completes the migration away from legacy global display state and finalizes the transition to the new `DisplayContext` architecture.

`pygame_init()` and `headless_init()` now construct and return a fully populated `DisplayContext` object containing the screen surface, viewport rect, scale factor, and tile size. This context is passed explicitly through the launcher into `main()` and `headless()`, and then into the `LocalPygameClient`.

All former display globals (`SCREEN`, `SCREEN_RECT`, `SCALE`, `TILE_SIZE`) have been removed. Subsystems now access display information exclusively through the injected `DisplayContext`, eliminating hidden dependencies and import‑order hazards.

This refactor does not change gameplay behavior. It is an internal architectural cleanup that makes display initialization explicit, testable, and deterministic. It also prepares the codebase for future improvements such as dynamic resolution switching, multi‑viewport rendering and headless testing.

Changes:
- removed all legacy display globals (`SCREEN`, `SCREEN_RECT`, `SCALE`, `TILE_SIZE`)
- added `DisplayContext` dataclass as the single authoritative container for display state
- updated `pygame_init()` and `headless_init()` to construct and return a `DisplayContext`
- updated launcher to pass the returned context into `main()` and `headless()`
- updated `main()` and `LocalPygameClient` to accept and store a `DisplayContext`
- replaced all remaining global display references with `context.screen`, `context.rect`, `context.scale`, and `context.tile_size`
- ensured both pygame and headless initialization paths produce consistent context objects
- no gameplay logic modified

PR removes the last global display dependencies and fully centralizes display state in `DisplayContext`. The engine is now easier to test, safer to initialize, and ready for future rendering improvements.

Additional:
- fixed a bug where `MonsterMovesState` and `MonsterInfoState` could crash with “No monster” or “Monster not in list” when opened from `MonsterTakeState`
- updated both states to correctly unpack kwargs from the state manager and to use explicit monster lists passed by the caller
- removed reliance on implicit state‑manager wrapping behavior and eliminated assumptions about box membership during navigation
- improved stability of LEFT/RIGHT monster navigation by ensuring `MonsterMovesState` always receives a valid, consistent monster list