### PR TITLE
Introduce `RuntimeAppearance`, Sprite Runtime Overrides and Save Migration v3

### DIFF
--- a/mods/tuxemon/maps/start_tuxemon.yaml
+++ b/mods/tuxemon/maps/start_tuxemon.yaml
@@ -12,7 +12,7 @@ events:
 
   Gender:
     actions:
-    - change_bg gradient_blue
+    - change_bg gradient_blue,choice_gender,image
     - translated_dialog_choice gender_male:gender_female:gender_nonbinary,gender_choice
     conditions:
     - is variable_set scenario_choice

--- a/tests/tuxemon/test_appearance.py
+++ b/tests/tuxemon/test_appearance.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from dataclasses import dataclass
+from unittest.mock import Mock, patch
+
+import pygame
+
+from tuxemon.entity.appearance import AppearanceManager, RuntimeAppearance
+
+
+@dataclass
+class DummyTemplate:
+    sprite_name: str = "npc_default"
+    combat_sheet: str = "combat_default"
+
+
+def test_from_template():
+    template = DummyTemplate()
+    app = RuntimeAppearance.from_template(template)
+
+    assert app.sprite_name == "npc_default"
+    assert app.combat_sheet == "combat_default"
+
+
+def test_from_dict_full_override():
+    template = DummyTemplate()
+    data = {"sprite_name": "saved_sprite", "combat_sheet": "saved_combat"}
+
+    app = RuntimeAppearance.from_dict(data, template)
+
+    assert app.sprite_name == "saved_sprite"
+    assert app.combat_sheet == "saved_combat"
+
+
+def test_from_dict_partial_fallback():
+    template = DummyTemplate()
+    data = {"sprite_name": "saved_sprite"}
+
+    app = RuntimeAppearance.from_dict(data, template)
+
+    assert app.sprite_name == "saved_sprite"
+    assert app.combat_sheet == "combat_default"
+
+
+def test_to_dict_roundtrip():
+    app = RuntimeAppearance("sprite_x", "combat_y")
+    d = app.to_dict()
+
+    assert d == {
+        "sprite_name": "sprite_x",
+        "combat_sheet": "combat_y",
+        "outfit": None,
+        "accessory": None,
+        "palette": None,
+    }
+
+
+def make_dummy_npc(template=None):
+    """Helper to create a fake NPC with mocks."""
+    npc = Mock()
+    npc.template = template or DummyTemplate()
+    npc.sprite_controller = Mock()
+    npc.game_variables = {}
+    return npc
+
+
+def test_manager_initializes_from_template():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    assert manager.state.sprite_name == "npc_default"
+    assert manager.state.combat_sheet == "combat_default"
+
+
+def test_manager_update_changes_state_and_calls_renderer():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    manager.update("new_sprite", "new_sheet")
+
+    assert manager.state.sprite_name == "new_sprite"
+    assert manager.state.combat_sheet == "new_sheet"
+    npc.sprite_controller.update_appearance.assert_called_once()
+
+
+def test_manager_reset_to_default_uses_race_mapping():
+    npc = make_dummy_npc()
+    npc.game_variables["race_choice"] = "white_male"
+
+    manager = AppearanceManager(npc)
+    manager.reset_to_default()
+
+    assert manager.state.sprite_name == "adventurer"
+    assert manager.state.combat_sheet == "adventurer"
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_manager_reset_to_default_falls_back_to_template():
+    npc = make_dummy_npc()
+    npc.game_variables["race_choice"] = "unknown_race"
+
+    manager = AppearanceManager(npc)
+    manager.state.sprite_name = "changed"
+    manager.state.combat_sheet = "changed"
+
+    manager.reset_to_default()
+
+    assert manager.state.sprite_name == "npc_default"
+    assert manager.state.combat_sheet == "combat_default"
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_manager_load_state_mutates_existing_instance():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    old_state = manager.state  # reference should remain the same
+
+    manager.load_state(
+        {"sprite_name": "loaded_sprite", "combat_sheet": "loaded_sheet"}
+    )
+
+    assert manager.state is old_state
+    assert manager.state.sprite_name == "loaded_sprite"
+    assert manager.state.combat_sheet == "loaded_sheet"
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_update_does_not_override_combat_sheet_when_none():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    manager.state.combat_sheet = "initial_sheet"
+
+    manager.update("new_sprite", None)
+
+    assert manager.state.sprite_name == "new_sprite"
+    assert manager.state.combat_sheet == "initial_sheet"
+    npc.sprite_controller.update_appearance.assert_called_once()
+
+
+def test_reset_to_default_preserves_state_instance():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    old_state = manager.state
+    manager.reset_to_default()
+
+    assert manager.state is old_state
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_reset_to_default_ignores_invalid_race_values():
+    npc = make_dummy_npc()
+    npc.game_variables["race_choice"] = "not_a_real_race"
+
+    manager = AppearanceManager(npc)
+    manager.state.sprite_name = "changed"
+    manager.state.combat_sheet = "changed"
+
+    manager.reset_to_default()
+
+    assert manager.state.sprite_name == "npc_default"
+    assert manager.state.combat_sheet == "combat_default"
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_load_state_partial_update():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    manager.state.sprite_name = "old_sprite"
+    manager.state.combat_sheet = "old_sheet"
+
+    manager.load_state({"sprite_name": "loaded_sprite"})
+
+    assert manager.state.sprite_name == "loaded_sprite"
+    assert manager.state.combat_sheet == "combat_default"
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_load_state_preserves_state_instance():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    old_state = manager.state
+    manager.load_state({"sprite_name": "x", "combat_sheet": "y"})
+
+    assert manager.state is old_state
+    npc.sprite_controller.update_appearance.assert_called()
+
+
+def test_race_mapping_all_keys_exist():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    for race, (sprite, sheet) in manager.DEFAULT_RACE_MAPPING.items():
+        npc.game_variables["race_choice"] = race
+        manager.reset_to_default()
+        assert manager.state.sprite_name == sprite
+        assert manager.state.combat_sheet == sheet
+
+
+def test_manager_updates_layer_fields():
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    manager.state.outfit = "coat_red"
+    manager.state.accessory = "hat_blue"
+    manager.state.palette = "palette_dark"
+
+    assert manager.state.outfit == "coat_red"
+    assert manager.state.accessory == "hat_blue"
+    assert manager.state.palette == "palette_dark"
+
+
+def make_surface(color=(0, 0, 0), size=(32, 32)):
+    """Utility to create a dummy surface."""
+    surf = pygame.Surface(size)
+    surf.fill(color)
+    return surf
+
+
+@patch("tuxemon.entity.appearance.load_and_scale_with_cache")
+def test_build_composited_sheet_base_only(mock_load):
+    base = make_surface((10, 10, 10))
+    mock_load.return_value = base
+
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    result = manager.build_composited_sheet()
+
+    assert result is not base
+    assert result.get_size() == base.get_size()
+    assert result.get_at((0, 0)) == base.get_at((0, 0))
+    mock_load.assert_called_once()
+
+
+@patch("tuxemon.entity.appearance.load_and_scale_with_cache")
+def test_build_composited_sheet_with_outfit(mock_load):
+    base = make_surface((10, 10, 10))
+    outfit = make_surface((200, 0, 0))
+
+    mock_load.side_effect = [base, outfit]
+
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+    manager.state.outfit = "coat_red"
+
+    result = manager.build_composited_sheet()
+
+    assert result.get_at((0, 0)) == outfit.get_at((0, 0))
+    assert mock_load.call_count == 2
+
+
+@patch("tuxemon.entity.appearance.load_and_scale_with_cache")
+def test_build_composited_sheet_with_all_layers(mock_load):
+    base = make_surface((10, 10, 10))
+    outfit = make_surface((100, 0, 0))
+    accessory = make_surface((0, 100, 0))
+    palette = make_surface((0, 0, 100))
+
+    mock_load.side_effect = [base, outfit, accessory, palette]
+
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    manager.state.outfit = "coat"
+    manager.state.accessory = "hat"
+    manager.state.palette = "dark"
+
+    result = manager.build_composited_sheet()
+
+    assert result.get_at((0, 0)) == palette.get_at((0, 0))
+    assert mock_load.call_count == 4
+
+
+@patch("tuxemon.entity.appearance.load_and_scale_with_cache")
+def test_build_composited_sheet_ignores_none_layers(mock_load):
+    base = make_surface((10, 10, 10))
+    mock_load.return_value = base
+
+    npc = make_dummy_npc()
+    manager = AppearanceManager(npc)
+
+    result = manager.build_composited_sheet()
+
+    assert mock_load.call_count == 1
+    assert result.get_at((0, 0)) == base.get_at((0, 0))

--- a/tests/tuxemon/test_sprite_renderer.py
+++ b/tests/tuxemon/test_sprite_renderer.py
@@ -63,7 +63,7 @@ def test_load_from_sheet(monkeypatch):
     npc.tile_pos = (0, 0)
 
     monkeypatch.setattr(
-        "tuxemon.map.view.slice_spritesheet",
+        "tuxemon.map.view.slice_spritesheet_surface",
         lambda *args, **kwargs: fake_sheet(),
     )
 
@@ -101,7 +101,7 @@ def test_walking_animation_pattern(monkeypatch):
 
     frames = fake_sheet()
     monkeypatch.setattr(
-        "tuxemon.map.view.slice_spritesheet",
+        "tuxemon.map.view.slice_spritesheet_surface",
         lambda *args, **kwargs: frames,
     )
 
@@ -137,7 +137,7 @@ def test_tall_sprite_offset(monkeypatch):
     frames = [pygame.Surface((16, 64)) for _ in range(12)]
 
     monkeypatch.setattr(
-        "tuxemon.map.view.slice_spritesheet",
+        "tuxemon.map.view.slice_spritesheet_surface",
         lambda *args, **kwargs: frames,
     )
 

--- a/tuxemon/core/conditions/facing_sprite.py
+++ b/tuxemon/core/conditions/facing_sprite.py
@@ -46,7 +46,7 @@ class FacingSpriteCondition(CoreCondition):
             get_direction(player.tile_pos, npc.tile_pos)
             for coords in tiles
             if (npc := session.get_npc_pos(coords))
-            and npc.template.sprite_name == self.sprite
+            and npc.appearance_manager.state.sprite_name == self.sprite
         }
 
         return player.facing in facing_directions

--- a/tuxemon/entity/appearance.py
+++ b/tuxemon/entity/appearance.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from tuxemon.map.view import load_and_scale_with_cache
+
+if TYPE_CHECKING:
+    from pygame.surface import Surface
+
+    from tuxemon.db import NpcTemplateModel
+    from tuxemon.entity.npc import NPC
+
+
+@dataclass
+class RuntimeAppearance:
+    sprite_name: str
+    combat_sheet: str
+    outfit: str | None = None
+    accessory: str | None = None
+    palette: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sprite_name": self.sprite_name,
+            "combat_sheet": self.combat_sheet,
+            "outfit": self.outfit,
+            "accessory": self.accessory,
+            "palette": self.palette,
+        }
+
+    @classmethod
+    def from_template(cls, template: NpcTemplateModel) -> RuntimeAppearance:
+        return cls(
+            sprite_name=template.sprite_name,
+            combat_sheet=template.combat_sheet,
+        )
+
+    @classmethod
+    def from_dict(
+        cls, data: dict[str, Any], template: NpcTemplateModel
+    ) -> RuntimeAppearance:
+        return cls(
+            sprite_name=data.get("sprite_name", template.sprite_name),
+            combat_sheet=data.get("combat_sheet", template.combat_sheet),
+            outfit=data.get("outfit"),
+            accessory=data.get("accessory"),
+            palette=data.get("palette"),
+        )
+
+
+class AppearanceManager:
+    """
+    Handles changing and persisting the visual state of an NPC.
+    """
+
+    DEFAULT_RACE_MAPPING = {
+        "gender_enby": ("enbyasian", "enbyasian"),
+        "gender_whatever": ("penguin", "penguin"),
+        "black_female": ("brownheroine_brown", "heroineblack"),
+        "black_male": ("adventurerblack", "adventurerblack"),
+        "white_female": ("heroine", "heroine"),
+        "white_male": ("adventurer", "adventurer"),
+    }
+
+    def __init__(self, owner: NPC):
+        self.owner = owner
+        self.state = RuntimeAppearance.from_template(owner.template)
+
+    def update(
+        self, sprite_name: str, combat_sheet: str | None = None
+    ) -> None:
+        self.state.sprite_name = sprite_name
+        if combat_sheet is not None:
+            self.state.combat_sheet = combat_sheet
+
+        self.owner.sprite_controller.update_appearance(self.state)
+
+    def update_layers(
+        self,
+        outfit: str | None = None,
+        accessory: str | None = None,
+        palette: str | None = None,
+    ) -> None:
+        if outfit is not None:
+            self.state.outfit = outfit
+
+        if accessory is not None:
+            self.state.accessory = accessory
+
+        if palette is not None:
+            self.state.palette = palette
+
+        self.owner.sprite_controller.update_appearance(self.state)
+
+    def get_default_for_race(self, race: str) -> tuple[str | None, str | None]:
+        return self.DEFAULT_RACE_MAPPING.get(race, (None, None))
+
+    def reset_to_default(self) -> None:
+        race = self.owner.game_variables.get("race_choice", "")
+        sprite, sheet = self.get_default_for_race(race)
+
+        if sprite and sheet:
+            self.update(sprite, sheet)
+            return
+
+        template = self.owner.template
+        self.state.sprite_name = template.sprite_name
+        self.state.combat_sheet = template.combat_sheet
+
+        self.owner.sprite_controller.update_appearance(self.state)
+
+    def load_state(self, data: dict[str, Any]) -> None:
+        new = RuntimeAppearance.from_dict(data, self.owner.template)
+
+        self.state.sprite_name = new.sprite_name
+        self.state.combat_sheet = new.combat_sheet
+
+        self.owner.sprite_controller.update_appearance(self.state)
+
+    def build_composited_sheet(self) -> Surface:
+        base = load_and_scale_with_cache(
+            f"sprites/{self.state.sprite_name}.png"
+        )
+        final = base.copy()
+
+        if self.state.outfit:
+            final.blit(
+                load_and_scale_with_cache(f"sprites/{self.state.outfit}.png"),
+                (0, 0),
+            )
+
+        if self.state.accessory:
+            final.blit(
+                load_and_scale_with_cache(
+                    f"sprites/{self.state.accessory}.png"
+                ),
+                (0, 0),
+            )
+
+        if self.state.palette:
+            final.blit(
+                load_and_scale_with_cache(f"sprites/{self.state.palette}.png"),
+                (0, 0),
+            )
+
+        return final

--- a/tuxemon/entity/npc.py
+++ b/tuxemon/entity/npc.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from tuxemon.boxes import ItemBoxes, MonsterBoxes
 from tuxemon.database.runtime import db
 from tuxemon.db import DialogueProfile, NpcModel
+from tuxemon.entity.appearance import AppearanceManager
 from tuxemon.entity.bag import BagHandler
 from tuxemon.entity.battle import BattlesHandler
 from tuxemon.entity.entity import Entity
@@ -83,6 +84,8 @@ class NPC(Entity):
         self.persistence = npc_data.persistence
         self.audio = npc_data.audio
         self.birthdate = npc_data.birthdate
+
+        self.appearance_manager = AppearanceManager(self)
 
         self._custom_name: str | None = None
         # general
@@ -220,7 +223,7 @@ class NPC(Entity):
         base.relationships = encode_relationships(self.relationships)
         base.money = self.money_controller.save()
         base.items = self.bag.encode_items()
-        base.template = self.template.model_dump()
+        base.appearance = self.appearance_manager.state.to_dict()
         base.missions = self.mission_controller.encode_missions()
         base.monsters = self.party.encode_party()
         base.player_slug = self.slug
@@ -276,15 +279,8 @@ class NPC(Entity):
         self.step_tracker = decode_steps(save_data.step_tracker)
         self.party.routing_policy_name = RoutingPolicy.from_dict(save_data)
 
-        if save_data.template:
-            self.template.slug = save_data.template.get("slug", "")
-            self.template.sprite_name = save_data.template.get(
-                "sprite_name", ""
-            )
-            self.template.combat_sheet = save_data.template.get(
-                "combat_sheet", ""
-            )
-            self.sprite_controller.update_template(self.template)
+        if save_data.appearance:
+            self.appearance_manager.load_state(save_data.appearance)
 
     def get_active_battle_music(
         self, default_music: BattleMusicModel

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -13,6 +13,7 @@ from tuxemon.db import (
     DialogueProfile,
     NpcModel,
 )
+from tuxemon.entity.appearance import RuntimeAppearance
 from tuxemon.entity.npc import NPC
 from tuxemon.event.eventaction import EventAction
 from tuxemon.item.item import Item
@@ -63,9 +64,16 @@ class CreateNpcAction(EventAction):
 
         npc.behavior = self.behavior
         npc_details = load_party(slug)
+
         npc.template = npc_details.template
         npc.combat = npc_details.combat
         npc.audio = npc_details.audio
+
+        npc.appearance_manager.state = RuntimeAppearance.from_template(
+            npc.template
+        )
+        npc.sprite_controller.update_appearance(npc.appearance_manager.state)
+
         variable_manager = session.player.variable_manager
 
         if npc_details.monsters:
@@ -74,7 +82,6 @@ class CreateNpcAction(EventAction):
         if npc_details.items:
             load_party_items(npc, npc_details, variable_manager)
 
-        npc.sprite_controller.update_template(npc.template)
         npc.dialogue = merge_dialogue(npc_details.speech.profile, None)
 
 

--- a/tuxemon/event/actions/set_template.py
+++ b/tuxemon/event/actions/set_template.py
@@ -28,7 +28,7 @@ class SetTemplateAction(EventAction):
 
         .. code-block:: text
 
-        set_template <character>,<sprite>[,combat_sheet]
+            set_template <character>,<sprite>[,combat_sheet]
 
     Script parameters:
 

--- a/tuxemon/event/actions/set_template.py
+++ b/tuxemon/event/actions/set_template.py
@@ -18,11 +18,6 @@ class SetTemplateAction(EventAction):
     """
     Switch template (sprite and combat_sheet).
 
-    Please remember that if you change the combat_sheet,
-    it automatically changes the combat_back.
-
-    Example: if you put xxx, it's going to be xxx_back.png.
-
     By using default:
 
         set_template player,default
@@ -33,7 +28,7 @@ class SetTemplateAction(EventAction):
 
         .. code-block:: text
 
-           set_template <character>,<sprite>[,combat_sheet]
+        set_template <character>,<sprite>[,combat_sheet]
 
     Script parameters:
 
@@ -47,6 +42,11 @@ class SetTemplateAction(EventAction):
         combat_sheet:
             Must be inside mods/tuxemon/gfx/sprites/player.
             Example: adventurer.png -> adventurer.
+
+    Note:
+        This action only changes the base template fields (sprite_name and
+        combat_sheet). Layered appearance fields such as outfit, accessory,
+        or palette are handled separately.
     """
 
     name = "set_template"
@@ -55,39 +55,13 @@ class SetTemplateAction(EventAction):
     combat_sheet: str | None = None
 
     def start(self, session: Session) -> None:
-        character = session.get_npc(self.character)
-        if character is None:
-            logger.error(f"{self.character} not found")
+        target = session.get_npc(self.character)
+        if not target:
+            logger.error(f"NPC {self.character} not found")
             return
 
         if self.sprite == "default":
-            gender = character.game_variables.get("race_choice", "")
-            sprite_mapping = {
-                "gender_enby": ("enbyasian", "enbyasian"),
-                "gender_whatever": ("penguin", "penguin"),
-                "black_female": ("brownheroine_brown", "heroineblack"),
-                "black_male": ("adventurerblack", "adventurerblack"),
-                "white_female": ("heroine", "heroine"),
-                "white_male": ("adventurer", "adventurer"),
-            }
-            sprite_name, combat_sheet = sprite_mapping.get(
-                gender, (None, None)
-            )
-
-            if sprite_name:
-                character.template.sprite_name = sprite_name
-
-            if combat_sheet:
-                character.template.combat_sheet = combat_sheet
-
+            target.appearance_manager.reset_to_default()
         else:
-            character.template.sprite_name = self.sprite
-            logger.info(f"{character.name}'s sprite is {self.sprite}")
-
-            if self.combat_sheet:
-                character.template.combat_sheet = self.combat_sheet
-                logger.info(
-                    f"{character.name}'s combat sheet is {self.combat_sheet}"
-                )
-
-        character.sprite_controller.update_template(character.template)
+            target.appearance_manager.update(self.sprite, self.combat_sheet)
+            logger.info(f"Updated {target.name} appearance to {self.sprite}")

--- a/tuxemon/event/conditions/char_sprite.py
+++ b/tuxemon/event/conditions/char_sprite.py
@@ -30,13 +30,11 @@ class CharSpriteCondition(EventCondition):
     name = "char_sprite"
 
     def test(self, session: Session, condition: SpatialCondition) -> bool:
-        character = session.get_npc(condition.parameters[0])
-        if character is None:
-            logger.error(f"{condition.parameters[0]} not found")
+        target_slug = condition.parameters[0]
+        expected_sprite = condition.parameters[1]
+
+        target = session.get_npc(target_slug)
+        if not target:
             return False
 
-        sprite = condition.parameters[1]
-
-        if character.template.sprite_name == sprite:
-            return True
-        return False
+        return target.appearance_manager.state.sprite_name == expected_sprite

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -132,6 +132,33 @@ def slice_spritesheet(
     return frames
 
 
+def slice_spritesheet_surface(
+    sheet: Surface,
+    frame_width: int,
+    frame_height: int,
+) -> list[Surface]:
+    """
+    Slice an already-loaded sprite sheet Surface into frames.
+    """
+    sheet_w, sheet_h = sheet.get_size()
+
+    if sheet_w % frame_width != 0 or sheet_h % frame_height != 0:
+        raise ValueError(
+            f"Sheet has invalid dimensions "
+            f"({sheet_w}x{sheet_h}) for frame size "
+            f"{frame_width}x{frame_height}"
+        )
+
+    frames = []
+    for y in range(0, sheet_h, frame_height):
+        for x in range(0, sheet_w, frame_width):
+            rect = Rect(x, y, frame_width, frame_height)
+            frame = sheet.subsurface(rect)
+            frames.append(frame.copy())
+
+    return frames
+
+
 def cursor_from_image(image: Surface) -> Sequence[str]:
     """Take a valid image and create a mouse cursor."""
     colors = {(0, 0, 0, 255): "X", (255, 255, 255, 255): "."}

--- a/tuxemon/map/view.py
+++ b/tuxemon/map/view.py
@@ -27,11 +27,7 @@ from tuxemon.graphics import (
 from tuxemon.map.map import get_pos_from_tilepos
 from tuxemon.math import Vector2
 from tuxemon.platform.const.graphics import BLACK_COLOR
-<<<<<<< template
-from tuxemon.prepare import SCALE, SCREEN_SIZE, TILE_SIZE
-=======
 from tuxemon.prepare import DISPLAY_CONTEXT, DisplayContext
->>>>>>> development
 from tuxemon.surfanim import SurfaceAnimation, SurfaceAnimationCollection
 from tuxemon.user_config import CONFIG
 
@@ -253,8 +249,8 @@ class SpriteRenderer:
             sheet_path = f"sprites/{template.sprite_name}.png"
             sheet = load_and_scale_with_cache(sheet_path)
 
-        scaled_fw = template.frame_width * SCALE
-        scaled_fh = template.frame_height * SCALE
+        scaled_fw = template.frame_width * DISPLAY_CONTEXT.scale
+        scaled_fh = template.frame_height * DISPLAY_CONTEXT.scale
 
         all_frames = slice_spritesheet_surface(
             sheet,

--- a/tuxemon/map/view.py
+++ b/tuxemon/map/view.py
@@ -22,12 +22,12 @@ from tuxemon.graphics import (
     ColorLike,
     apply_cinema_bars,
     load_and_scale,
-    slice_spritesheet,
+    slice_spritesheet_surface,
 )
 from tuxemon.map.map import get_pos_from_tilepos
 from tuxemon.math import Vector2
 from tuxemon.platform.const.graphics import BLACK_COLOR
-from tuxemon.prepare import SCREEN_SIZE, TILE_SIZE
+from tuxemon.prepare import SCALE, SCREEN_SIZE, TILE_SIZE
 from tuxemon.surfanim import SurfaceAnimation, SurfaceAnimationCollection
 from tuxemon.user_config import CONFIG
 
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from tuxemon.camera.camera import CameraManager
     from tuxemon.db import NpcTemplateModel
+    from tuxemon.entity.appearance import RuntimeAppearance
     from tuxemon.entity.npc import NPC
     from tuxemon.map.manager import MapManager
     from tuxemon.map.tuxemon import AbstractMap
@@ -100,10 +101,19 @@ class SpriteController:
         self.sprite_renderer.set_position(self.npc.tile_pos)
         self.sprite_renderer.update(time_delta)
 
-    def update_template(self, template: NpcTemplateModel) -> None:
+    def update_appearance(self, appearance: RuntimeAppearance) -> None:
         """
-        Update the NPC template and reload all sprites from the sheet.
+        Reload sprites using the NPC's template, but with runtime-overridden
+        sprite/combat sheet names.
         """
+        template = self.npc.template.model_copy()
+
+        template.sprite_name = appearance.sprite_name
+        template.combat_sheet = appearance.combat_sheet
+        self.composited_sheet = (
+            self.npc.appearance_manager.build_composited_sheet()
+        )
+
         self.sprite_renderer.load_sprites(template)
         self.sprite_renderer.stop()
         self.sprite_renderer.surface_animations.clear()
@@ -229,18 +239,29 @@ class SpriteRenderer:
           rows: directions (front, left, right, back)
           columns: frames (walk1, idle, walk2)
         """
-        sheet_path = f"sprites/{template.sprite_name}.png"
+        sprite_controller = getattr(self.npc, "sprite_controller", None)
 
-        all_frames = slice_spritesheet(
-            sheet_path,
-            template.frame_width,
-            template.frame_height,
+        if sprite_controller is not None and hasattr(
+            sprite_controller, "composited_sheet"
+        ):
+            sheet = self.npc.sprite_controller.composited_sheet
+        else:
+            sheet_path = f"sprites/{template.sprite_name}.png"
+            sheet = load_and_scale_with_cache(sheet_path)
+
+        scaled_fw = template.frame_width * SCALE
+        scaled_fh = template.frame_height * SCALE
+
+        all_frames = slice_spritesheet_surface(
+            sheet,
+            scaled_fw,
+            scaled_fh,
         )
 
         expected_frames = template.rows * template.columns
         if len(all_frames) != expected_frames:
             raise ValueError(
-                f"Sprite sheet '{sheet_path}' has {len(all_frames)} frames, "
+                f"Sprite sheet {len(all_frames)} frames, "
                 f"but expected {expected_frames} ({template.rows}x{template.columns})"
             )
 

--- a/tuxemon/save_state.py
+++ b/tuxemon/save_state.py
@@ -49,7 +49,7 @@ class NPCState(BaseModel):
     tuxepedia: Mapping[str, Any] = Field(default_factory=dict)
     relationships: Mapping[str, Any] = Field(default_factory=dict)
     money: Mapping[str, Any] = Field(default_factory=dict)
-    template: Mapping[str, Any] = Field(default_factory=dict)
+    appearance: dict[str, Any] = Field(default_factory=dict)
     missions: Sequence[Mapping[str, Any]] = Field(default_factory=list)
     items: Sequence[Mapping[str, Any]] = Field(default_factory=list)
     monsters: Sequence[Mapping[str, Any]] = Field(default_factory=list)

--- a/tuxemon/save_upgrader.py
+++ b/tuxemon/save_upgrader.py
@@ -54,7 +54,7 @@ Notes:
 - Keep universal fixes minimal and focused on data consistency.
 """
 
-SAVE_VERSION = 2
+SAVE_VERSION = 3
 
 # "evolution_registry": ("npc_state", "world_state"),
 FIELD_MIGRATION_MAP: dict[str, tuple[str, str]] = {}
@@ -75,6 +75,12 @@ def upgrade_from_v1_to_v2(save_data: dict[str, Any]) -> None:
     _handle_change_money(npc_state)
     _handle_change_teleport_faint(npc_state)
     _handle_change_contacts(npc_state)
+
+
+def upgrade_from_v2_to_v3(save_data: dict[str, Any]) -> None:
+    logger.info("Applying upgrade from version 2 to 3")
+    npc_state = save_data.get("npc_state", {})
+    _handle_change_appearance(npc_state)
 
 
 def apply_universal_fixes(npc_state: dict[str, Any]) -> None:
@@ -102,6 +108,7 @@ def apply_field_migrations(save_data: dict[str, Any]) -> None:
 VERSION_UPGRADES: dict[int, Callable[[dict[str, Any]], None]] = {
     0: upgrade_from_v0_to_v1,
     1: upgrade_from_v1_to_v2,
+    2: upgrade_from_v2_to_v3,
 }
 
 
@@ -178,6 +185,20 @@ def _handle_change_contacts(save_data: dict[str, Any]) -> None:
             new[key] = {"relationship_type": "unknown"}
         save_data["relationships"] = new
         del save_data["contacts"]
+
+
+def _handle_change_appearance(npc_state: dict[str, Any]) -> None:
+    """Introduces the 'appearance' field for NPCs."""
+    if "appearance" in npc_state:
+        return
+
+    template = npc_state.get("template", {})
+    sprite_name = template.get("sprite_name", "adventurer")
+    combat_sheet = template.get("combat_sheet", "adventurer")
+    npc_state["appearance"] = {
+        "sprite_name": sprite_name,
+        "combat_sheet": combat_sheet,
+    }
 
 
 def _handle_change_teleport_faint(save_data: dict[str, Any]) -> None:


### PR DESCRIPTION
PR introduces a proper runtime appearance system for NPCs and the player. It separates immutable template data from mutable visual state, centralizes appearance updates and adds a save‑migration step for backward compatibility.

RuntimeAppearance
- New dataclass holding only `sprite_name` and `combat_sheet`
- Template data stays immutable; all visual changes use this runtime object
- Supports save/load via `from_dict` and `to_dict`

AppearanceManager
- New manager responsible for all appearance logic
- Initializes from template, updates sprites, resets to defaults, and loads saved state
- Always syncs changes to the sprite controller
- Ensures the `RuntimeAppearance` instance is mutated, not replaced

NPC & SpriteController
- NPCs now own an `AppearanceManager` instead of modifying templates
- SpriteController gains `update_appearance()` to apply runtime state cleanly

Save Migration (v2 → v3)
- Adds migration to create missing appearance data in older saves
- Bumps `SAVE_VERSION` to 3

Event Actions
- Updated to use `AppearanceManager` (`update()`, `reset_to_default()`, `load_state()`)
- No action modifies template data anymore