### PR TITLE
Add Scaling Support to UI Dataclasses and Begin Transition Away from Global DisplayContext

### DIFF
--- a/tests/tuxemon/test_alert_manager.py
+++ b/tests/tuxemon/test_alert_manager.py
@@ -7,6 +7,7 @@ import pygame
 
 from tuxemon.event.eventbus import EventBus
 from tuxemon.menu.alert import AlertManager
+from tuxemon.scaling import DefaultScaling
 from tuxemon.ui.text import TextArea
 from tuxemon.user_config import CONFIG
 
@@ -23,8 +24,7 @@ class TestAlertManager(unittest.TestCase):
     def setUp(self):
         font = pygame.font.Font(None, 16)
         self.text_area = TextArea(
-            font=font,
-            font_color=(255, 255, 255),
+            font=font, font_color=(255, 255, 255), scaling=DefaultScaling(1)
         )
         self.event_bus = EventBus()
         self.manager = AlertManager(self.event_bus)

--- a/tests/tuxemon/test_camera_view.py
+++ b/tests/tuxemon/test_camera_view.py
@@ -87,7 +87,6 @@ def test_get_center_zero_tile_size(context):
     fake_context = DisplayContext(
         screen=context.screen,
         rect=context.rect,
-        scale=1,
         tile_size=(0, 0),
         scaling=DefaultScaling(1),
     )
@@ -103,7 +102,6 @@ def test_get_center_extreme_tile_size(context):
     fake_context = DisplayContext(
         screen=context.screen,
         rect=context.rect,
-        scale=1,
         tile_size=tile_size,
         scaling=DefaultScaling(1),
     )

--- a/tests/tuxemon/test_camera_view.py
+++ b/tests/tuxemon/test_camera_view.py
@@ -5,6 +5,7 @@ import pytest
 from tuxemon.camera.camera import CameraView, project
 from tuxemon.math import Vector2
 from tuxemon.prepare import DISPLAY_CONTEXT, DisplayContext
+from tuxemon.scaling import DefaultScaling
 
 
 @pytest.fixture
@@ -88,6 +89,7 @@ def test_get_center_zero_tile_size(context):
         rect=context.rect,
         scale=1,
         tile_size=(0, 0),
+        scaling=DefaultScaling(1),
     )
     view = CameraView(fake_context)
     px, py = project(fake_context, (1.0, 1.0))
@@ -103,6 +105,7 @@ def test_get_center_extreme_tile_size(context):
         rect=context.rect,
         scale=1,
         tile_size=tile_size,
+        scaling=DefaultScaling(1),
     )
     view = CameraView(fake_context)
     px, py = project(fake_context, (1.0, 1.0))

--- a/tests/tuxemon/test_combat_ui.py
+++ b/tests/tuxemon/test_combat_ui.py
@@ -4,13 +4,21 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tuxemon.tools import scale
 from tuxemon.ui.combat_bars import CombatBars
 
 
 @pytest.fixture
-def combat_ui():
-    return CombatBars()
+def fake_context():
+    ctx = MagicMock()
+    ctx.scaling = MagicMock()
+    ctx.scaling.scale_int = lambda x: x * 2
+    ctx.scaling.scale_tuple = lambda t: tuple(x * 2 for x in t)
+    return ctx
+
+
+@pytest.fixture
+def combat_ui(fake_context):
+    return CombatBars(fake_context)
 
 
 @pytest.fixture
@@ -62,14 +70,14 @@ def test_draw_bars_hp_and_exp(combat_ui, graphics, hp_ratio, exp_ratio):
         assert not combat_ui._exp_bars[monster].draw.called
 
 
-def test_create_rect_for_bar(combat_ui):
+def test_create_rect_for_bar(combat_ui, fake_context):
     hud = MagicMock()
     hud.image.get_width.return_value = 100
     rect = combat_ui.create_rect_for_bar(hud, 70, 8, 0, 8)
-    assert rect.width == scale(70)
-    assert rect.height == scale(8)
-    assert rect.right == 100 - scale(8)
-    assert rect.top == scale(0)
+    assert rect.width == fake_context.scaling.scale_int(70)
+    assert rect.height == fake_context.scaling.scale_int(8)
+    assert rect.right == 100 - fake_context.scaling.scale_int(8)
+    assert rect.top == fake_context.scaling.scale_int(0)
 
 
 @pytest.mark.parametrize("ratio", [0.0, 0.4, 0.6, 1.0])

--- a/tests/tuxemon/test_menu_cursor.py
+++ b/tests/tuxemon/test_menu_cursor.py
@@ -23,7 +23,16 @@ def menu_sprites():
 
 
 @pytest.fixture
-def controller(menu_sprites):
+def fake_context():
+    ctx = MagicMock()
+    ctx.scaling = MagicMock()
+    ctx.scaling.scale_int = lambda x: x * 2
+    ctx.scaling.scale_tuple = lambda t: tuple(x * 2 for x in t)
+    return ctx
+
+
+@pytest.fixture
+def controller(menu_sprites, fake_context):
     cursor_filename = "gfx/arrow.png"
     get_selected_item = MagicMock(return_value=None)
     animate = MagicMock(return_value=None)
@@ -35,6 +44,7 @@ def controller(menu_sprites):
         get_selected_item,
         animate,
         duration,
+        fake_context,
         remove_animations,
     )
     return ctrl

--- a/tests/tuxemon/test_state_draw.py
+++ b/tests/tuxemon/test_state_draw.py
@@ -155,36 +155,41 @@ class TestEventDebugDrawer(unittest.TestCase):
     def tearDownClass(cls):
         pygame.quit()
 
+    def make_context(self):
+        context = MagicMock()
+        context.screen = MagicMock()
+        context.scaling = MagicMock()
+        context.scaling.scale_sequence.return_value = (1, 1)
+        context.scaling.scale_int.return_value = 15
+        return context
+
     def test_init(self):
-        screen = MagicMock()
-        event_debug_drawer = EventDebugDrawer(screen)
-        self.assertEqual(event_debug_drawer.screen, screen)
-        self.assertEqual(event_debug_drawer.max_width, 1000)
-        self.assertEqual(event_debug_drawer.x_offset, 20)
-        self.assertEqual(event_debug_drawer.y_offset, 200)
-        self.assertEqual(event_debug_drawer.initial_x, 4)
-        self.assertEqual(event_debug_drawer.initial_y, 20)
-        self.assertEqual(event_debug_drawer.success_color, GREEN_COLOR)
-        self.assertEqual(event_debug_drawer.failure_color, RED_COLOR)
+        context = self.make_context()
+        drawer = EventDebugDrawer(context)
+        self.assertEqual(drawer.screen, context.screen)
+        self.assertEqual(drawer.scaling, context.scaling)
+        self.assertEqual(drawer.max_width, 1000)
+        self.assertEqual(drawer.x_offset, 20)
+        self.assertEqual(drawer.y_offset, 200)
+        self.assertEqual(drawer.initial_x, 4)
+        self.assertEqual(drawer.initial_y, 20)
+        self.assertEqual(drawer.success_color, GREEN_COLOR)
+        self.assertEqual(drawer.failure_color, RED_COLOR)
 
     def test_draw_event_debug(self):
-        screen = MagicMock()
-        event_debug_drawer = EventDebugDrawer(screen)
+        context = self.make_context()
+        drawer = EventDebugDrawer(context)
         event1 = [(True, MagicMock()), (False, MagicMock())]
         event1[0][1].parameters = ["param1", "param2"]
         event1[1][1].parameters = ["param3", "param4"]
         event2 = [(True, MagicMock()), (False, MagicMock())]
         event2[0][1].parameters = ["param5", "param6"]
         event2[1][1].parameters = ["param7", "param8"]
-        event_debug_drawer.draw_event_debug([event1, event2])
-        self.assertTrue(screen.blit.called)
+        drawer.draw_event_debug([event1, event2])
+        self.assertTrue(context.screen.blit.called)
 
     def test_render_text(self):
-        screen = MagicMock()
-        event_debug_drawer = EventDebugDrawer(screen)
-        text = "Test text"
-        color = (255, 0, 0)
-        position = (10, 20)
-        font_size = 15
-        event_debug_drawer.render_text(text, color, position, font_size)
-        self.assertTrue(screen.blit.called)
+        context = self.make_context()
+        drawer = EventDebugDrawer(context)
+        drawer.render_text("Test text", (255, 0, 0), (10, 20), 15)
+        self.assertTrue(context.screen.blit.called)

--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -4,6 +4,7 @@ import unittest
 
 import pygame
 
+from tuxemon.scaling import DefaultScaling
 from tuxemon.ui.draw import (
     TextOverflow,
     iter_render_text,
@@ -33,7 +34,9 @@ class TestTextArea(unittest.TestCase):
 
     def setUp(self):
         font = pygame.font.Font(None, 16)
-        self.text_area = TextArea(font=font, font_color=(255, 255, 255))
+        self.text_area = TextArea(
+            font=font, font_color=(255, 255, 255), scaling=DefaultScaling(1)
+        )
         self.text_area._iter = None
 
     def test_initial_state(self):
@@ -123,7 +126,9 @@ class TestTextAreaStress(unittest.TestCase):
 
     def setUp(self):
         font = pygame.font.Font(None, 16)
-        self.text_area = TextArea(font=font, font_color=(255, 255, 255))
+        self.text_area = TextArea(
+            font=font, font_color=(255, 255, 255), scaling=DefaultScaling(1)
+        )
         self.text_area.rect = pygame.Rect(0, 0, 100, 20)
 
     def test_fast_click_before_update(self):
@@ -159,7 +164,9 @@ class TestTextAreaStress(unittest.TestCase):
 
     def test_surface_size_zero(self):
         ta = TextArea(
-            font=pygame.font.Font(None, 16), font_color=(255, 255, 255)
+            font=pygame.font.Font(None, 16),
+            font_color=(255, 255, 255),
+            scaling=DefaultScaling(1),
         )
         ta.rect = pygame.Rect(0, 0, 0, 0)
         ta.text = "ZeroRect"

--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -9,8 +9,6 @@ from tuxemon.ui.draw import (
     iter_render_text,
 )
 from tuxemon.ui.text import TextArea
-from tuxemon.ui.text_alignment import HorizontalAlignment, VerticalAlignment
-from tuxemon.ui.text_renderer import TextRenderer
 
 
 class DummyChar:

--- a/tests/tuxemon/test_ui_combat_layout.py
+++ b/tests/tuxemon/test_ui_combat_layout.py
@@ -6,6 +6,7 @@ import pytest
 from pygame.rect import Rect
 
 from tuxemon.entity.npc import NPC
+from tuxemon.scaling import DefaultScaling
 from tuxemon.ui.combat_layout import (
     LayoutManager,
     LayoutRectFactory,
@@ -40,7 +41,7 @@ def repo(tmp_path, raw_layouts, layout_groups, monkeypatch):
     monkeypatch.setattr(module, "load_layout_groups", lambda _: layout_groups)
     yaml_path = tmp_path / "combat_layouts.yaml"
     yaml_path.write_text("fake: true")
-    return LayoutRepository(yaml_path)
+    return LayoutRepository(yaml_path, DefaultScaling(1))
 
 
 @pytest.fixture
@@ -55,7 +56,7 @@ def rect_factory():
 
 @pytest.fixture
 def manager(tmp_path, repo):
-    return LayoutManager(tmp_path / "combat_layouts.yaml")
+    return LayoutManager(tmp_path / "combat_layouts.yaml", DefaultScaling(1))
 
 
 @pytest.fixture

--- a/tests/tuxemon/test_ui_draw_methods.py
+++ b/tests/tuxemon/test_ui_draw_methods.py
@@ -11,6 +11,7 @@ from pygame.surface import Surface
 
 from tuxemon.constants.paths import mods_folder
 from tuxemon.platform.const.graphics import FONT_SIZE
+from tuxemon.scaling import DefaultScaling
 from tuxemon.tools import scale
 from tuxemon.ui.draw import (
     RenderMode,
@@ -50,42 +51,82 @@ class TestIterRenderText(unittest.TestCase):
     def test_iter_render_text(self):
         text = "This is a test message"
         renders = list(
-            iter_render_text(text, self.font, self.fg, self.bg, self.rect)
+            iter_render_text(
+                text,
+                self.font,
+                self.fg,
+                self.bg,
+                self.rect,
+                scaling=DefaultScaling(1),
+            )
         )
         self.assertGreater(len(renders), 0)
 
     def test_iter_render_text_empty_string(self):
         text = ""
         renders = list(
-            iter_render_text(text, self.font, self.fg, self.bg, self.rect)
+            iter_render_text(
+                text,
+                self.font,
+                self.fg,
+                self.bg,
+                self.rect,
+                scaling=DefaultScaling(1),
+            )
         )
         self.assertEqual(len(renders), 0)
 
     def test_iter_render_text_single_line(self):
         text = "This is a short message"
         renders = list(
-            iter_render_text(text, self.font, self.fg, self.bg, self.rect)
+            iter_render_text(
+                text,
+                self.font,
+                self.fg,
+                self.bg,
+                self.rect,
+                scaling=DefaultScaling(1),
+            )
         )
         self.assertGreater(len(renders), 0)
 
     def test_iter_render_text_single_word(self):
         text = "This"
         renders = list(
-            iter_render_text(text, self.font, self.fg, self.bg, self.rect)
+            iter_render_text(
+                text,
+                self.font,
+                self.fg,
+                self.bg,
+                self.rect,
+                scaling=DefaultScaling(1),
+            )
         )
         self.assertEqual(len(renders), len(list(build_line(text))))
 
     def test_iter_render_text_skips_trailing_spaces(self):
         text = "This is a test message "
         renders = list(
-            iter_render_text(text, self.font, self.fg, self.bg, self.rect)
+            iter_render_text(
+                text,
+                self.font,
+                self.fg,
+                self.bg,
+                self.rect,
+                scaling=DefaultScaling(1),
+            )
         )
         self.assertEqual(
             len(renders),
             len(
                 list(
                     iter_render_text(
-                        text.strip(), self.font, self.fg, self.bg, self.rect
+                        text.strip(),
+                        self.font,
+                        self.fg,
+                        self.bg,
+                        self.rect,
+                        scaling=DefaultScaling(1),
                     )
                 )
             ),
@@ -100,6 +141,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 h_alignment=HorizontalAlignment.LEFT,
             )
         )
@@ -114,6 +156,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 h_alignment=HorizontalAlignment.CENTER,
             )
         )
@@ -131,6 +174,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 h_alignment=HorizontalAlignment.RIGHT,
             )
         )
@@ -148,6 +192,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 h_alignment=HorizontalAlignment.LEFT,
                 v_alignment=VerticalAlignment.TOP,
             )
@@ -163,6 +208,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 h_alignment=HorizontalAlignment.LEFT,
                 v_alignment=VerticalAlignment.CENTER,
             )
@@ -184,6 +230,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 h_alignment=HorizontalAlignment.LEFT,
                 v_alignment=VerticalAlignment.BOTTOM,
             )
@@ -203,6 +250,7 @@ class TestIterRenderText(unittest.TestCase):
                 self.fg,
                 self.bg,
                 self.rect,
+                scaling=DefaultScaling(1),
                 mode=RenderMode.TOKEN,
             )
         )
@@ -383,6 +431,7 @@ class TestDrawText(unittest.TestCase):
             surface=self.surface,
             text=text,
             rect=self.rect,
+            scaling=DefaultScaling(1),
             h_alignment=HorizontalAlignment.LEFT,
             v_alignment=VerticalAlignment.TOP,
             font=self.font,
@@ -397,6 +446,7 @@ class TestDrawText(unittest.TestCase):
             surface=self.surface,
             text=text,
             rect=self.rect,
+            scaling=DefaultScaling(1),
             h_alignment=HorizontalAlignment.CENTER,
             v_alignment=VerticalAlignment.CENTER,
             font=self.font,
@@ -424,6 +474,7 @@ class TestDrawText(unittest.TestCase):
             surface=self.surface,
             text=text,
             rect=self.rect,
+            scaling=DefaultScaling(1),
             h_alignment=HorizontalAlignment.RIGHT,
             v_alignment=VerticalAlignment.BOTTOM,
             font=self.font,
@@ -450,6 +501,7 @@ class TestDrawText(unittest.TestCase):
             surface=self.surface,
             text=text,
             rect=self.rect,
+            scaling=DefaultScaling(1),
             h_alignment=HorizontalAlignment.LEFT,
             v_alignment=VerticalAlignment.TOP,
             font=self.font,
@@ -466,6 +518,7 @@ class TestDrawText(unittest.TestCase):
             surface=self.surface,
             text=text,
             rect=self.rect,
+            scaling=DefaultScaling(1),
             h_alignment=HorizontalAlignment.LEFT,
             v_alignment=VerticalAlignment.TOP,
             font=self.font,

--- a/tests/tuxemon/test_ui_text_renderer.py
+++ b/tests/tuxemon/test_ui_text_renderer.py
@@ -5,6 +5,7 @@ import unittest
 import pygame
 from pygame.surface import Surface
 
+from tuxemon.scaling import DefaultScaling
 from tuxemon.ui.text_renderer import TextRenderer
 
 
@@ -19,7 +20,7 @@ class TestTextRenderer(unittest.TestCase):
         pygame.quit()
 
     def setUp(self):
-        self.text_renderer = TextRenderer((255, 255, 255))
+        self.text_renderer = TextRenderer(DefaultScaling(1), (255, 255, 255))
 
     def test_init(self):
         self.assertEqual(self.text_renderer.font_color, (255, 255, 255))

--- a/tests/tuxemon/test_ui_text_renderer_multiline.py
+++ b/tests/tuxemon/test_ui_text_renderer_multiline.py
@@ -5,6 +5,7 @@ import unittest
 import pygame
 from pygame.surface import Surface
 
+from tuxemon.scaling import DefaultScaling
 from tuxemon.ui.text import MultilineTextRenderer
 from tuxemon.ui.text_renderer import TextRenderer
 
@@ -20,7 +21,7 @@ class TestMultilineTextRenderer(unittest.TestCase):
         pygame.quit()
 
     def setUp(self):
-        self.text_renderer = TextRenderer((255, 255, 255))
+        self.text_renderer = TextRenderer(DefaultScaling(1), (255, 255, 255))
         self.multiline_text_renderer = MultilineTextRenderer(
             self.text_renderer
         )

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -180,7 +180,7 @@ class BaseClient(ABC):
 
         # Various Sessions
         self.trade_manager = TradeManager(self.npc_manager)
-        self.environment_manager = EnvironmentManager()
+        self.environment_manager = EnvironmentManager(self.context)
         self.encounter_manager = EncounterManager()
         self.park_session = ParkSession()
         self.weather_manager = WorldWeatherManager()

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -64,7 +64,7 @@ class LocalPygameClient(BaseClient):
         self.state_drawer = StateDrawer(
             self.screen, self.state_manager, config
         )
-        self.event_debug_drawer = EventDebugDrawer(self.screen)
+        self.event_debug_drawer = EventDebugDrawer(self.context)
         self.renderer = Renderer(
             self.screen,
             self.state_drawer,

--- a/tuxemon/environment.py
+++ b/tuxemon/environment.py
@@ -275,7 +275,7 @@ class Environment:
     def prepare_background(self, screen_size: tuple[int, int]) -> Surface:
         """Processes the background sprite to fit the screen dimensions."""
         graphics = self.data.get_battle_graphics()
-        scale_int = self.context.scaling.scale_int(1)
+        scale_int = self.context.scaling.factor
         surf = load_and_scale(graphics.background, scale_int)
 
         full_width, full_height = screen_size
@@ -325,7 +325,7 @@ class IslandSheet:
         front_raw = sheet.subsurface(
             (self.frame_w, 0, self.frame_w, self.frame_h)
         )
-        scale_int = self.context.scaling.scale_int(1)
+        scale_int = self.context.scaling.factor
         back_scaled = scale_surface(back_raw, scale_int)
         front_scaled = scale_surface(front_raw, scale_int)
 

--- a/tuxemon/environment.py
+++ b/tuxemon/environment.py
@@ -16,8 +16,7 @@ from tuxemon.db import (
     EnvironmentModel,
 )
 from tuxemon.graphics import load_and_scale, load_raw_image, scale_surface
-from tuxemon.prepare import DISPLAY_CONTEXT
-from tuxemon.tools import scale
+from tuxemon.prepare import DisplayContext
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +31,15 @@ class PartyLayout:
 
     @classmethod
     def create(
-        cls, side: str, home: Rect, hud: BattleHudModel, hud_layer: int
+        cls,
+        context: DisplayContext,
+        side: str,
+        home: Rect,
+        hud: BattleHudModel,
+        hud_layer: int,
     ) -> PartyLayout:
-        center_off = scale(hud.tray_center_offset)
-        spacing_off = scale(hud.icon_spacing_offset)
+        center_off = context.scaling.scale_int(hud.tray_center_offset)
+        spacing_off = context.scaling.scale_int(hud.icon_spacing_offset)
 
         if side == "opponent":
             return cls(
@@ -74,23 +78,32 @@ class BattleLayout:
     @classmethod
     def create(
         cls,
+        context: DisplayContext,
         graphics: BattleGraphicsModel,
         screen_rect: tuple[int, int],
         player_home: Rect,
         opp_home: Rect,
     ) -> BattleLayout:
         w, _ = screen_rect
-        y_mod = scale(graphics.island_offset_y)
+        y_mod = context.scaling.scale_int(graphics.island_offset_y)
 
         return cls(
             back_island_pos={"bottom": opp_home.bottom + y_mod, "right": 0},
             front_island_pos={"bottom": player_home.bottom - y_mod, "left": w},
             offsets={
-                "enemy_y": scale(graphics.enemy_base_offset),
-                "monster_y": scale(graphics.monster_base_offset),
-                "player_y": scale(graphics.player_base_offset),
+                "enemy_y": context.scaling.scale_int(
+                    graphics.enemy_base_offset
+                ),
+                "monster_y": context.scaling.scale_int(
+                    graphics.monster_base_offset
+                ),
+                "player_y": context.scaling.scale_int(
+                    graphics.player_base_offset
+                ),
             },
-            entry_jump_distance=scale(graphics.entry_jump_distance),
+            entry_jump_distance=context.scaling.scale_int(
+                graphics.entry_jump_distance
+            ),
             entry_duration=graphics.entry_duration,
         )
 
@@ -123,7 +136,8 @@ class EnvironmentManager:
     Ensures safe access to the active environment context.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, context: DisplayContext) -> None:
+        self.context = context
         self._active_handler: Environment | None = None
         logger.debug("EnvironmentManager initialized.")
 
@@ -139,7 +153,7 @@ class EnvironmentManager:
         self._active_handler = None
         try:
             env_data = EnvironmentData(slug)
-            self._active_handler = Environment(env_data)
+            self._active_handler = Environment(env_data, self.context)
             logger.debug(f"Successfully loaded environment: {slug}")
             return True
         except Exception as e:
@@ -190,8 +204,11 @@ class Environment:
     for graphics, music, and combat menu state used during battles.
     """
 
-    def __init__(self, environment_data: EnvironmentData) -> None:
+    def __init__(
+        self, environment_data: EnvironmentData, context: DisplayContext
+    ) -> None:
         self.data = environment_data
+        self.context = context
         self.elapsed_time = 0.0
         self._party_layouts: dict[str, PartyLayout] = {}
         self._battle_layout: BattleLayout | None = None
@@ -210,7 +227,8 @@ class Environment:
         graphics = self.data.get_battle_graphics()
 
         sheet = IslandSheet(
-            graphics.island_sheet,
+            context=self.context,
+            file_path=graphics.island_sheet,
             frame_w=graphics.island_width,
             frame_h=graphics.island_height,
         )
@@ -226,7 +244,7 @@ class Environment:
         if side not in self._party_layouts:
             hud = self.data.get_battle_graphics().hud
             self._party_layouts[side] = PartyLayout.create(
-                side, home, hud, hud_layer
+                self.context, side, home, hud, hud_layer
             )
         return self._party_layouts[side]
 
@@ -236,14 +254,15 @@ class Environment:
         if not self._battle_layout:
             graphics = self.data.get_battle_graphics()
             self._battle_layout = BattleLayout.create(
-                graphics, screen_rect, player_home, opp_home
+                self.context, graphics, screen_rect, player_home, opp_home
             )
         return self._battle_layout
 
     def prepare_background(self, screen_size: tuple[int, int]) -> Surface:
         """Processes the background sprite to fit the screen dimensions."""
         graphics = self.data.get_battle_graphics()
-        surf = load_and_scale(graphics.background, DISPLAY_CONTEXT.scale)
+        scale_int = self.context.scaling.scale_int(1)
+        surf = load_and_scale(graphics.background, scale_int)
 
         full_width, full_height = screen_size
         full_surf = Surface((full_width, full_height))
@@ -262,7 +281,14 @@ class Environment:
 
 
 class IslandSheet:
-    def __init__(self, file_path: str, frame_w: int, frame_h: int):
+    def __init__(
+        self,
+        context: DisplayContext,
+        file_path: str,
+        frame_w: int,
+        frame_h: int,
+    ):
+        self.context = context
         self.file_path = file_path
         self.frame_w = frame_w
         self.frame_h = frame_h
@@ -285,9 +311,9 @@ class IslandSheet:
         front_raw = sheet.subsurface(
             (self.frame_w, 0, self.frame_w, self.frame_h)
         )
-
-        back_scaled = scale_surface(back_raw, DISPLAY_CONTEXT.scale)
-        front_scaled = scale_surface(front_raw, DISPLAY_CONTEXT.scale)
+        scale_int = self.context.scaling.scale_int(1)
+        back_scaled = scale_surface(back_raw, scale_int)
+        front_scaled = scale_surface(front_raw, scale_int)
 
         return {
             "back": back_scaled,

--- a/tuxemon/event/actions/change_bg_char.py
+++ b/tuxemon/event/actions/change_bg_char.py
@@ -69,7 +69,8 @@ class ChangeBgNpcAction(EventAction):
         npc_data = NpcModel.lookup(self.slug, db)
         sheet = get_combat_sheet(npc_data.template)
         surface = sheet.front()
-        scaled = scale_surface(surface, session.client.context.scale)
+        scale_int = session.client.context.scaling.scale_int(1)
+        scaled = scale_surface(surface, scale_int)
         sprite = load_surface(scaled)
 
         client.push_state(

--- a/tuxemon/event/actions/change_bg_char.py
+++ b/tuxemon/event/actions/change_bg_char.py
@@ -69,7 +69,7 @@ class ChangeBgNpcAction(EventAction):
         npc_data = NpcModel.lookup(self.slug, db)
         sheet = get_combat_sheet(npc_data.template)
         surface = sheet.front()
-        scale_int = session.client.context.scaling.scale_int(1)
+        scale_int = session.client.context.scaling.factor
         scaled = scale_surface(surface, scale_int)
         sprite = load_surface(scaled)
 

--- a/tuxemon/event/actions/change_bg_monster.py
+++ b/tuxemon/event/actions/change_bg_monster.py
@@ -73,7 +73,8 @@ class ChangeBgMonsterAction(EventAction):
             menu2_rect=sprites.menu2_rect,
         )
 
-        sprite = handler.get_sprite("front", session.client.context.scale)
+        scale_int = session.client.context.scaling.scale_int(1)
+        sprite = handler.get_sprite("front", scale_int)
 
         client.push_state(
             "MonsterImageState",

--- a/tuxemon/event/actions/change_bg_monster.py
+++ b/tuxemon/event/actions/change_bg_monster.py
@@ -73,7 +73,7 @@ class ChangeBgMonsterAction(EventAction):
             menu2_rect=sprites.menu2_rect,
         )
 
-        scale_int = session.client.context.scaling.scale_int(1)
+        scale_int = session.client.context.scaling.factor
         sprite = handler.get_sprite("front", scale_int)
 
         client.push_state(

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -88,11 +88,11 @@ class SetMonsterFlairAction(EventAction):
 
         monster.sprite_handler.refresh_flairs(monster.flairs)
 
+        scale_int = session.client.context.scaling.scale_int(1)
+
         if sprite_types:
             for sprite_type in sprite_types:
-                monster.sprite_handler.get_sprite(
-                    sprite_type, session.client.context.scale
-                )
+                monster.sprite_handler.get_sprite(sprite_type, scale_int)
 
         if flair_model.slug not in monster.flair_slugs:
             monster.flair_slugs.add(flair_model.slug)

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -88,7 +88,7 @@ class SetMonsterFlairAction(EventAction):
 
         monster.sprite_handler.refresh_flairs(monster.flairs)
 
-        scale_int = session.client.context.scaling.scale_int(1)
+        scale_int = session.client.context.scaling.factor
 
         if sprite_types:
             for sprite_type in sprite_types:

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -27,7 +27,7 @@ from tuxemon.database.runtime import db
 from tuxemon.db import MonsterModel, NpcModel
 from tuxemon.platform.const.graphics import FUCHSIA_COLOR
 from tuxemon.prepare import DISPLAY_CONTEXT
-from tuxemon.scaling import DefaultScaling, ScalingStrategy
+from tuxemon.scaling import ScalingStrategy
 from tuxemon.session import Session
 from tuxemon.sprite import Sprite
 from tuxemon.surfanim import SurfaceAnimation
@@ -429,7 +429,9 @@ def scaled_image_loader(
     Returns:
         The loader to use.
     """
-    scaling = scaling or DefaultScaling()
+    if scaling is None:
+        scaling = DISPLAY_CONTEXT.scaling
+
     colorkey_color = Color(f"#{colorkey}") if colorkey else None
 
     # load the tileset image
@@ -476,9 +478,11 @@ def get_avatar(session: Session, avatar: str) -> Sprite | None:
     """
     from tuxemon.monster.sprite import MonsterSpriteHandler, SpriteLoader
 
+    scale_int = session.client.context.scaling.scale_int(1)
+
     if avatar.isdigit():
         monster = session.player.monsters[int(avatar)]
-        return monster.get_sprite("menu", scale=session.client.context.scale)
+        return monster.get_sprite("menu", scale=scale_int)
 
     if avatar in db.database.get("monster", {}):
         model = MonsterModel.lookup(avatar, db)
@@ -495,7 +499,7 @@ def get_avatar(session: Session, avatar: str) -> Sprite | None:
         )
         if handler is None:
             return None
-        return handler.get_sprite("menu", session.client.context.scale)
+        return handler.get_sprite("menu", scale=scale_int)
 
     if avatar in db.database.get("npc", {}):
         from tuxemon.entity.sheet import get_combat_sheet

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -126,7 +126,7 @@ def slice_spritesheet(
         for x in range(0, sheet_w, frame_width):
             rect = Rect(x, y, frame_width, frame_height)
             frame = full_sheet.subsurface(rect)
-            scaled = scale_surface(frame, DISPLAY_CONTEXT.scale)
+            scaled = scale_surface(frame, DISPLAY_CONTEXT.scaling.factor)
             frames.append(scaled)
 
     return frames
@@ -180,7 +180,7 @@ def cursor_from_image(image: Surface) -> Sequence[str]:
 
 
 def load_and_scale(
-    filename: str, scale: float = DISPLAY_CONTEXT.scale
+    filename: str, scale: float = DISPLAY_CONTEXT.scaling.factor
 ) -> Surface:
     """
     Load an image and scale it according to game settings.
@@ -505,7 +505,7 @@ def get_avatar(session: Session, avatar: str) -> Sprite | None:
     """
     from tuxemon.monster.sprite import MonsterSpriteHandler, SpriteLoader
 
-    scale_int = session.client.context.scaling.scale_int(1)
+    scale_int = session.client.context.scaling.factor
 
     if avatar.isdigit():
         monster = session.player.monsters[int(avatar)]

--- a/tuxemon/map/view.py
+++ b/tuxemon/map/view.py
@@ -249,8 +249,8 @@ class SpriteRenderer:
             sheet_path = f"sprites/{template.sprite_name}.png"
             sheet = load_and_scale_with_cache(sheet_path)
 
-        scaled_fw = template.frame_width * DISPLAY_CONTEXT.scale
-        scaled_fh = template.frame_height * DISPLAY_CONTEXT.scale
+        scaled_fw = template.frame_width * DISPLAY_CONTEXT.scaling.factor
+        scaled_fh = template.frame_height * DISPLAY_CONTEXT.scaling.factor
 
         all_frames = slice_spritesheet_surface(
             sheet,

--- a/tuxemon/menu/cursor.py
+++ b/tuxemon/menu/cursor.py
@@ -9,11 +9,11 @@ from pygame.surface import Surface
 
 from tuxemon.graphics import load_and_scale
 from tuxemon.sprite import Sprite
-from tuxemon.tools import scale
 
 if TYPE_CHECKING:
     from tuxemon.animation import Animation
     from tuxemon.menu.interface import MenuItem
+    from tuxemon.prepare import DisplayContext
     from tuxemon.sprite import SpriteGroup
 
 T = TypeVar("T", covariant=True)
@@ -60,6 +60,7 @@ class MenuCursorController(Generic[T]):
         get_selected_item: Callable[[], MenuItem[T] | None],
         animate: Callable[..., Animation],
         duration: float,
+        context: DisplayContext,
         remove_animations: Callable[[Any], None],
         offset: tuple[int, int] = (0, 0),
         cursor_image: Surface | None = None,
@@ -89,17 +90,17 @@ class MenuCursorController(Generic[T]):
         self.get_item = get_selected_item
         self.animate = animate
         self.duration = duration
+        self.context = context
         self.remove_animations = remove_animations
 
     def get_margin(self) -> tuple[int, int]:
         """
         Calculates margin using ratios derived from the original hardcoded scale values.
-        Keeps layout behavior consistent with (-scale(11), -scale(5)).
         """
-        x = -scale(
+        x = -self.context.scaling.scale_int(
             int(self.arrow.image.get_width() / CURSOR_X_RATIO_DENOMINATOR)
         )
-        y = -scale(
+        y = -self.context.scaling.scale_int(
             int(self.arrow.image.get_height() / CURSOR_Y_RATIO_DENOMINATOR)
         )
         return (x, y)
@@ -157,7 +158,7 @@ class MenuCursorController(Generic[T]):
             return None
 
         x, y = item.rect.midleft
-        x -= scale(2)
+        x -= self.context.scaling.scale_int(2)
 
         if animate:
             self.remove_animations(self.arrow.rect)

--- a/tuxemon/menu/interface.py
+++ b/tuxemon/menu/interface.py
@@ -2,13 +2,12 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pygame import draw as pg_draw
 from pygame.rect import Rect
 from pygame.surface import Surface
 
-from tuxemon import tools
 from tuxemon.graphics import ColorLike, load_and_scale
 from tuxemon.platform.const.graphics import (
     BLACK_COLOR,
@@ -23,18 +22,23 @@ from tuxemon.platform.const.graphics import (
 from tuxemon.sprite import Sprite
 from tuxemon.ui.graphic_box import GraphicBox
 
+if TYPE_CHECKING:
+    from tuxemon.prepare import DisplayContext
+
 
 class Bar:
     """Common bar class for UI elements."""
 
     _graphics_cache: dict[str, Surface] = {}
-    INNER_TOP_PADDING = tools.scale(2)
-    INNER_BOTTOM_PADDING = tools.scale(2)
-    INNER_LEFT_PADDING = tools.scale(9)
-    INNER_RIGHT_PADDING = tools.scale(2)
+
+    BASE_INNER_TOP_PADDING = 2
+    BASE_INNER_BOTTOM_PADDING = 2
+    BASE_INNER_LEFT_PADDING = 9
+    BASE_INNER_RIGHT_PADDING = 2
 
     def __init__(
         self,
+        context: DisplayContext,
         value: float,
         border_filename: str,
         fg_color: ColorLike = WHITE_COLOR,
@@ -49,11 +53,18 @@ class Bar:
             fg_color: The foreground color of the bar.
             bg_color: The background color of the bar.
         """
+        self.context = context
         self._value = max(0.0, min(1.0, value))
         self.border_filename = border_filename
         self.fg_color = fg_color
         self.bg_color = bg_color
         self.border: GraphicBox | None = None
+
+        s = context.scaling.scale_int
+        self.INNER_TOP_PADDING = s(self.BASE_INNER_TOP_PADDING)
+        self.INNER_BOTTOM_PADDING = s(self.BASE_INNER_BOTTOM_PADDING)
+        self.INNER_LEFT_PADDING = s(self.BASE_INNER_LEFT_PADDING)
+        self.INNER_RIGHT_PADDING = s(self.BASE_INNER_RIGHT_PADDING)
 
     @property
     def value(self) -> float:
@@ -135,7 +146,7 @@ class Bar:
 class HpBar(Bar):
     """HP bar for UI elements."""
 
-    def __init__(self, value: float = 1.0) -> None:
+    def __init__(self, context: DisplayContext, value: float = 1.0) -> None:
         """
         Initializes the HP bar with a given value.
 
@@ -143,6 +154,7 @@ class HpBar(Bar):
             value: The initial value of the HP bar.
         """
         super().__init__(
+            context,
             max(0.0, min(1.0, value)),
             GFX_HP_BAR,
             HP_COLOR_FG,
@@ -153,7 +165,7 @@ class HpBar(Bar):
 class ExpBar(Bar):
     """EXP bar for UI elements."""
 
-    def __init__(self, value: float = 1.0) -> None:
+    def __init__(self, context: DisplayContext, value: float = 1.0) -> None:
         """
         Initializes the EXP bar with a given value.
 
@@ -161,6 +173,7 @@ class ExpBar(Bar):
             value: The initial value of the EXP bar.
         """
         super().__init__(
+            context,
             max(0.0, min(1.0, value)),
             GFX_XP_BAR,
             XP_COLOR_FG,

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -59,7 +59,7 @@ from tuxemon.sprite import (
     VisualSpriteList,
 )
 from tuxemon.state.state import State
-from tuxemon.tools import scale, transform_resource_filename
+from tuxemon.tools import transform_resource_filename
 from tuxemon.ui.graphic_box import GraphicBox
 from tuxemon.ui.text_renderer import TextRenderer
 from tuxemon.user_config import CONFIG
@@ -67,18 +67,31 @@ from tuxemon.user_config import CONFIG
 if TYPE_CHECKING:
     from tuxemon.menu.alert import AlertManager
     from tuxemon.platform.events import PlayerInput
+    from tuxemon.prepare import DisplayContext
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class FontSettings:
-    smaller: int = scale(FONT_SIZE_SMALLER)
-    small: int = scale(FONT_SIZE_SMALL)
-    medium: int = scale(FONT_SIZE)
-    big: int = scale(FONT_SIZE_BIG)
-    bigger: int = scale(FONT_SIZE_BIGGER)
-    biggest: int = scale(FONT_SIZE_BIGGEST)
+    smaller: int
+    small: int
+    medium: int
+    big: int
+    bigger: int
+    biggest: int
+
+    @classmethod
+    def from_context(cls, context: DisplayContext) -> FontSettings:
+        s = context.scaling.scale_int
+        return cls(
+            smaller=s(FONT_SIZE_SMALLER),
+            small=s(FONT_SIZE_SMALL),
+            medium=s(FONT_SIZE),
+            big=s(FONT_SIZE_BIG),
+            bigger=s(FONT_SIZE_BIGGER),
+            biggest=s(FONT_SIZE_BIGGEST),
+        )
 
 
 T = TypeVar("T", covariant=True)
@@ -101,8 +114,10 @@ class PygameMenuState(State):
         font_settings: FontSettings | None = None,
         **kwargs: Any,
     ) -> None:
-        self.font_type = font_settings or FontSettings()
         super().__init__()
+        self.font_type = font_settings or FontSettings.from_context(
+            self.client.context
+        )
         theme = theme or get_theme()
         self._initialize_attributes()
         self._create_menu(width, height, theme, sound_engine, **kwargs)
@@ -407,6 +422,7 @@ class Menu(Generic[T], State):
             get_selected_item=self.get_selected_item,
             animate=self.animate,
             duration=self.cursor_move_duration,
+            context=self.client.context,
             remove_animations=self.remove_animations_of,
         )
 
@@ -556,8 +572,8 @@ class Menu(Generic[T], State):
         # expand the bounding box by the border and some padding
         # TODO: do not hardcode these values
         # border is 12, padding is the rest
-        rect1.width += scale(18)
-        rect1.height += scale(19)
+        rect1.width += self.client.context.scaling.scale_int(18)
+        rect1.height += self.client.context.scaling.scale_int(19)
         rect1.topleft = 0, 0
 
         # set our rect and adjust the centers to match
@@ -692,12 +708,12 @@ class Menu(Generic[T], State):
         if size < self.min_font_size:
             size = self.min_font_size
 
-        self.line_spacing = scale(line_spacing)
+        self.line_spacing = self.client.context.scaling.scale_int(line_spacing)
 
         if self.client.config.large_gui:
-            self.font_size = scale(size + 1)
+            self.font_size = self.client.context.scaling.scale_int(size + 1)
         else:
-            self.font_size = scale(size)
+            self.font_size = self.client.context.scaling.scale_int(size)
 
         self.font = Font(font, self.font_size)
         return self.font

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -410,6 +410,7 @@ class Menu(Generic[T], State):
         self.reload_sounds()  # load default sounds
         self._input_handler = MenuInputHandler(self)
         self._text_renderer = TextRenderer(
+            scaling=self.client.context.scaling,
             font=self.font,
             font_filename=self.font_filename,
             font_color=self.font_color,

--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -22,14 +22,14 @@ from tuxemon.platform.const.graphics import (
     TRANSPARENT_COLOR,
 )
 from tuxemon.prepare import DISPLAY_CONTEXT
-from tuxemon.tools import scale, transform_resource_filename
+from tuxemon.tools import transform_resource_filename
 from tuxemon.user_config import CONFIG
 
 _theme: Theme | None = None
 
 
 class TuxemonArrowSelection(Selection):
-    def __init__(self) -> None:
+    def __init__(self, scale_factor: int) -> None:
         # Call the constructor of the Selection providing the left, right,
         # top and bottom margins of your Selection effect box.
         #
@@ -41,7 +41,6 @@ class TuxemonArrowSelection(Selection):
         #  --------------------------
         #
 
-        scale_factor = max(DISPLAY_CONTEXT.scale, 1)
         arrow = BaseImage(
             image_path=transform_resource_filename(CONFIG.menu_cursor),
         ).scale(scale_factor, scale_factor, smooth=False)
@@ -81,7 +80,7 @@ def get_theme() -> Theme:
     if _theme is not None:
         return _theme
 
-    scale_factor = max(DISPLAY_CONTEXT.scale, 1)
+    scale_factor = max(DISPLAY_CONTEXT.scaling.scale_int(1), 1)
     tuxemon_border = BaseImage(
         image_path=transform_resource_filename(CONFIG.menu_border),
     ).scale(scale_factor, scale_factor, smooth=False)
@@ -101,7 +100,7 @@ def get_theme() -> Theme:
         background_color=tuxemon_background,
         widget_alignment=ALIGN_LEFT,
         title=False,
-        widget_selection_effect=TuxemonArrowSelection(),
+        widget_selection_effect=TuxemonArrowSelection(scale_factor),
         border_color=tuxemon_border,
         scrollarea_position=SCROLLAREA_POSITION_NONE,
         widget_padding=(10, 20),
@@ -111,8 +110,8 @@ def get_theme() -> Theme:
     )
 
     # Set common font sizes and colors as part of the theme definition
-    theme.widget_font_size = scale(FONT_SIZE)
-    theme.title_font_size = scale(FONT_SIZE_BIG)
+    theme.widget_font_size = DISPLAY_CONTEXT.scaling.scale_int(FONT_SIZE)
+    theme.title_font_size = DISPLAY_CONTEXT.scaling.scale_int(FONT_SIZE_BIG)
     theme.widget_font_color = FONT_COLOR
     theme.selection_color = FONT_COLOR
     theme.scrollbar_color = SCROLLBAR_COLOR

--- a/tuxemon/menu/theme.py
+++ b/tuxemon/menu/theme.py
@@ -80,7 +80,7 @@ def get_theme() -> Theme:
     if _theme is not None:
         return _theme
 
-    scale_factor = max(DISPLAY_CONTEXT.scaling.scale_int(1), 1)
+    scale_factor = max(DISPLAY_CONTEXT.scaling.factor, 1)
     tuxemon_border = BaseImage(
         image_path=transform_resource_filename(CONFIG.menu_border),
     ).scale(scale_factor, scale_factor, smooth=False)

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -399,13 +399,14 @@ class Monster:
             {"doc": self.capture_string},
         )
 
-    def load_sprites(self, scale: float = DISPLAY_CONTEXT.scale) -> None:
+    def load_sprites(
+        self, scale: float = DISPLAY_CONTEXT.scaling.factor
+    ) -> None:
         """
         Delegates the task of loading sprites to the sprite handler.
 
         Parameters:
             scale: The scaling factor to resize the sprite images.
-                Defaults to the predefined scale value in 'DISPLAY_CONTEXT.scale'.
         """
         self.sprite_handler.load_sprites(scale)
 
@@ -472,7 +473,7 @@ class Monster:
         self,
         sprite_type: str,
         frame_duration: float = 0.25,
-        scale: float = DISPLAY_CONTEXT.scale,
+        scale: float = DISPLAY_CONTEXT.scaling.factor,
         **kwargs: Any,
     ) -> Sprite:
         """

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 class DisplayContext:
     screen: pg.Surface
     rect: pg.Rect
-    scale: int
     tile_size: tuple[int, int]
     scaling: ScalingStrategy
 
@@ -33,7 +32,6 @@ _default_rect = _default_surface.get_rect()
 DISPLAY_CONTEXT: DisplayContext = DisplayContext(
     screen=_default_surface,
     rect=_default_rect,
-    scale=1,
     tile_size=(1, 1),
     scaling=DefaultScaling(1),
 )
@@ -89,7 +87,6 @@ def pygame_init() -> DisplayContext:
     DISPLAY_CONTEXT = DisplayContext(
         screen=screen,
         rect=rect,
-        scale=scale,
         tile_size=tile_size,
         scaling=DefaultScaling(scale),
     )
@@ -116,7 +113,6 @@ def headless_init() -> DisplayContext:
     DISPLAY_CONTEXT = DisplayContext(
         screen=screen,
         rect=rect,
-        scale=1,
         tile_size=NATIVE_TILE_SIZE,
         scaling=DefaultScaling(1),
     )

--- a/tuxemon/prepare.py
+++ b/tuxemon/prepare.py
@@ -12,6 +12,7 @@ import pygame as pg
 
 from tuxemon.platform.const.sizes import NATIVE_RESOLUTION
 from tuxemon.platform.const.sizes import TILE_SIZE as NATIVE_TILE_SIZE
+from tuxemon.scaling import DefaultScaling, ScalingStrategy
 from tuxemon.user_config import CONFIG
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class DisplayContext:
     rect: pg.Rect
     scale: int
     tile_size: tuple[int, int]
+    scaling: ScalingStrategy
 
 
 _default_surface = pg.Surface((1, 1))
@@ -33,6 +35,7 @@ DISPLAY_CONTEXT: DisplayContext = DisplayContext(
     rect=_default_rect,
     scale=1,
     tile_size=(1, 1),
+    scaling=DefaultScaling(1),
 )
 
 
@@ -88,6 +91,7 @@ def pygame_init() -> DisplayContext:
         rect=rect,
         scale=scale,
         tile_size=tile_size,
+        scaling=DefaultScaling(scale),
     )
 
     return DISPLAY_CONTEXT
@@ -114,6 +118,7 @@ def headless_init() -> DisplayContext:
         rect=rect,
         scale=1,
         tile_size=NATIVE_TILE_SIZE,
+        scaling=DefaultScaling(1),
     )
 
     return DISPLAY_CONTEXT

--- a/tuxemon/scaling.py
+++ b/tuxemon/scaling.py
@@ -2,9 +2,8 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol, TypeVar, overload
-
-from tuxemon.prepare import DISPLAY_CONTEXT
 
 TVarSequence = TypeVar("TVarSequence", bound=tuple[int, ...])
 
@@ -16,14 +15,26 @@ class ScalingStrategy(Protocol):
 
     def scale_tuple(self, coords: TVarSequence) -> TVarSequence: ...
     def scale_int(self, value: int) -> int: ...
+    def scale_float(self, value: float) -> float: ...
+    def scale_sequence(self, seq: Sequence[float]) -> list[float]:
+        return [self.scale_float(x) for x in seq]
 
 
 class DefaultScaling:
+    def __init__(self, scale: int):
+        self.scale = scale
+
     def scale_tuple(self, coords: TVarSequence) -> TVarSequence:
-        return type(coords)(i * DISPLAY_CONTEXT.scale for i in coords)
+        return type(coords)(i * self.scale for i in coords)
 
     def scale_int(self, value: int) -> int:
-        return value * DISPLAY_CONTEXT.scale
+        return value * self.scale
+
+    def scale_float(self, value: float) -> float:
+        return value * self.scale
+
+    def scale_sequence(self, seq: Sequence[float]) -> list[float]:
+        return [self.scale_float(x) for x in seq]
 
 
 class ResolutionScaling:
@@ -38,6 +49,12 @@ class ResolutionScaling:
     def scale_int(self, value: int) -> int:
         # scale uniformly using width ratio
         return int(value * (self.curr_w / self.base_w))
+
+    def scale_float(self, value: float) -> float:
+        return value * (self.curr_w / self.base_w)
+
+    def scale_sequence(self, seq: Sequence[float]) -> list[float]:
+        return [self.scale_float(x) for x in seq]
 
     @overload
     def scale_tuple(self, coords: tuple[int, int]) -> tuple[int, int]: ...

--- a/tuxemon/scaling.py
+++ b/tuxemon/scaling.py
@@ -16,22 +16,28 @@ class ScalingStrategy(Protocol):
     def scale_tuple(self, coords: TVarSequence) -> TVarSequence: ...
     def scale_int(self, value: int) -> int: ...
     def scale_float(self, value: float) -> float: ...
-    def scale_sequence(self, seq: Sequence[float]) -> list[float]:
-        return [self.scale_float(x) for x in seq]
+    def scale_sequence(self, seq: Sequence[float]) -> list[float]: ...
+
+    @property
+    def factor(self) -> int: ...
 
 
 class DefaultScaling:
     def __init__(self, scale: int):
-        self.scale = scale
+        self._scale = scale
+
+    @property
+    def factor(self) -> int:
+        return self._scale
 
     def scale_tuple(self, coords: TVarSequence) -> TVarSequence:
-        return type(coords)(i * self.scale for i in coords)
+        return type(coords)(i * self._scale for i in coords)
 
     def scale_int(self, value: int) -> int:
-        return value * self.scale
+        return value * self._scale
 
     def scale_float(self, value: float) -> float:
-        return value * self.scale
+        return value * self._scale
 
     def scale_sequence(self, seq: Sequence[float]) -> list[float]:
         return [self.scale_float(x) for x in seq]
@@ -45,6 +51,10 @@ class ResolutionScaling:
     ):
         self.base_w, self.base_h = base_resolution
         self.curr_w, self.curr_h = current_resolution
+
+    @property
+    def factor(self) -> float:
+        return self.curr_w / self.base_w
 
     def scale_int(self, value: int) -> int:
         # scale uniformly using width ratio

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -26,13 +26,13 @@ from tuxemon import graphics
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.surfanim import SurfaceAnimation
-from tuxemon.tools import scale as tuxemon_scale
 
 if TYPE_CHECKING:
     from tuxemon.db import BattleIconsModel
     from tuxemon.entity.party import PartyHandler
     from tuxemon.menu.interface import MenuItem
     from tuxemon.monster.monster import Monster
+    from tuxemon.prepare import DisplayContext
 
 logger = logging.getLogger()
 
@@ -364,13 +364,13 @@ class HordeSprite(Sprite):
         opponent_party: PartyHandler,
         tray_rect: Rect,
         shadow_text_func: Callable[[str], Surface],
-        scale_func: Callable[[int], int],
+        context: DisplayContext,
     ) -> None:
         super().__init__()
         self.opponent_party = opponent_party
         self.tray_rect = tray_rect
         self.shadow_text = shadow_text_func
-        self.scale = scale_func
+        self.context = context
         self.update_count_display()
 
     def update_count_display(self) -> bool:
@@ -380,8 +380,8 @@ class HordeSprite(Sprite):
         horde_size = len(self.opponent_party.alive)
         horde_text = f"x{horde_size}"
         text_surface = self.shadow_text(horde_text)
-        x_pad = self.scale(2)
-        y_pad = self.scale(4)
+        x_pad = self.context.scaling.scale_int(2)
+        y_pad = self.context.scaling.scale_int(4)
         width = text_surface.get_width() + x_pad * 2
         height = text_surface.get_height() + y_pad * 2
         self.image = Surface((width, height), SRCALPHA)
@@ -407,12 +407,14 @@ class CaptureDeviceSprite(Sprite):
         monster: Monster | None,
         sprite: Sprite,
         icon: BattleIconsModel,
+        context: DisplayContext,
     ) -> None:
         super().__init__()
         self.tray = tray
         self.monster = monster
         self.sprite = sprite
         self.icon = icon
+        self.context = context
         self.state = self.resolve_status()
         self.update_image()
 
@@ -448,7 +450,10 @@ class CaptureDeviceSprite(Sprite):
         sprite.image = graphics.convert_alpha_to_colorkey(sprite.image)
         sprite.image.set_alpha(0)
         animate(sprite.image, set_alpha=255, initial=0)
-        animate(sprite.rect, bottom=self.tray.rect.top + tuxemon_scale(3))
+        animate(
+            sprite.rect,
+            bottom=self.tray.rect.top + self.context.scaling.scale_int(3),
+        )
 
 
 _GroupElement = TypeVar("_GroupElement", bound=Sprite)

--- a/tuxemon/state/draw.py
+++ b/tuxemon/state/draw.py
@@ -16,6 +16,7 @@ from tuxemon.ui.text_renderer import TextRenderer
 if TYPE_CHECKING:
     from tuxemon.config import TuxemonConfig
     from tuxemon.db import SpatialCondition
+    from tuxemon.prepare import DisplayContext
     from tuxemon.state.manager import StateManager
     from tuxemon.state.state import State
 
@@ -136,7 +137,7 @@ class StateDrawer:
 class EventDebugDrawer:
     def __init__(
         self,
-        screen: Surface,
+        context: DisplayContext,
         max_width: int = 1000,
         x_offset: int = 20,
         y_offset: int = 200,
@@ -164,7 +165,8 @@ class EventDebugDrawer:
             valid_color: Color used to indicate valid conditions.
             invalid_color: Color used to indicate invalid conditions.
         """
-        self.screen = screen
+        self.screen = context.screen
+        self.scaling = context.scaling
         self.max_width = max_width
         self.x_offset = x_offset
         self.y_offset = y_offset
@@ -207,7 +209,9 @@ class EventDebugDrawer:
         font_size: int = 15,
     ) -> tuple[int, int]:
         font = Font(get_default_font(), font_size)
-        renderer = TextRenderer(font=font, font_color=color)
+        renderer = TextRenderer(
+            scaling=self.scaling, font=font, font_color=color
+        )
         image = renderer.shadow_text(text)
         self.screen.blit(image, position)
         return image.get_size()

--- a/tuxemon/state/state.py
+++ b/tuxemon/state/state.py
@@ -63,7 +63,6 @@ class State(AnimationMixin, RenderMixin, ABC):
 
         # All sprites that draw on the screen
         self.sprites: SpriteGroup[Sprite] = SpriteGroup()
-
         self.client = local_session.client
         self.event_bus = get_event_bus()
 
@@ -124,6 +123,14 @@ class State(AnimationMixin, RenderMixin, ABC):
             handlers. Otherwise, return the input event.
         """
         return event
+
+    def scale_int(self, value: int) -> int:
+        """Convenience wrapper for client scaling."""
+        return self.client.context.scaling.scale_int(value)
+
+    def scale_tuple(self, value: int) -> int:
+        """Convenience wrapper for client scaling."""
+        return self.client.context.scaling.scale_tuple(value)
 
     def update(self, time_delta: float) -> None:
         """

--- a/tuxemon/state/state.py
+++ b/tuxemon/state/state.py
@@ -128,10 +128,6 @@ class State(AnimationMixin, RenderMixin, ABC):
         """Convenience wrapper for client scaling."""
         return self.client.context.scaling.scale_int(value)
 
-    def scale_tuple(self, value: int) -> int:
-        """Convenience wrapper for client scaling."""
-        return self.client.context.scaling.scale_tuple(value)
-
     def update(self, time_delta: float) -> None:
         """
         Time update function for state. Must be overloaded in children.

--- a/tuxemon/state/state.py
+++ b/tuxemon/state/state.py
@@ -63,6 +63,7 @@ class State(AnimationMixin, RenderMixin, ABC):
 
         # All sprites that draw on the screen
         self.sprites: SpriteGroup[Sprite] = SpriteGroup()
+
         self.client = local_session.client
         self.event_bus = get_event_bus()
 
@@ -74,6 +75,10 @@ class State(AnimationMixin, RenderMixin, ABC):
             raise TypeError(
                 f"{cls.__name__} must define a class variable 'name'"
             )
+
+    @property
+    def factor(self) -> int:
+        return self.client.context.scaling.factor
 
     def load_sprite(self, filename: str, **kwargs: Any) -> Sprite:
         """Load a sprite and add it to this state."""

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -193,7 +193,7 @@ class CharacterState(PygameMenuState):
         lab8.translate(fxw(0.45), fxh(0.10))
         # image
         surface = self.char.combat_sheet().front()
-        scaled = scale_surface(surface, self.scale_int(1))
+        scaled = scale_surface(surface, self.factor)
         new_image = self._create_image_from_surface(scaled)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -193,7 +193,7 @@ class CharacterState(PygameMenuState):
         lab8.translate(fxw(0.45), fxh(0.10))
         # image
         surface = self.char.combat_sheet().front()
-        scaled = scale_surface(surface, self.client.context.scale)
+        scaled = scale_surface(surface, self.scale_int(1))
         new_image = self._create_image_from_surface(scaled)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/choice_item.py
+++ b/tuxemon/states/choice_item.py
@@ -93,7 +93,7 @@ class ChoiceItem(PygameMenuState):
     ) -> None:
         item = ItemModel.lookup(slug, db)
         new_image = self._create_image(item.sprite)
-        scaled = self.client.context.scale * self.config.scale_sprite
+        scaled = self.scale_int(1) * self.config.scale_sprite
         new_image.scale(scaled, scaled)
         self.menu.add.image(new_image)
         self.menu.add.button(

--- a/tuxemon/states/choice_item.py
+++ b/tuxemon/states/choice_item.py
@@ -93,7 +93,7 @@ class ChoiceItem(PygameMenuState):
     ) -> None:
         item = ItemModel.lookup(slug, db)
         new_image = self._create_image(item.sprite)
-        scaled = self.scale_int(1) * self.config.scale_sprite
+        scaled = self.factor * self.config.scale_sprite
         new_image.scale(scaled, scaled)
         self.menu.add.image(new_image)
         self.menu.add.button(

--- a/tuxemon/states/choice_monster.py
+++ b/tuxemon/states/choice_monster.py
@@ -91,7 +91,7 @@ class ChoiceMonster(PygameMenuState):
         if handler is None:
             return
         sprite = handler.get_sprite(
-            "front", scale=self.client.context.scale * self.config.scale_sprite
+            "front", scale=self.scale_int(1) * self.config.scale_sprite
         )
         image = self._create_image_from_surface(sprite.image)
         self.menu.add.image(image, align=ALIGN_CENTER)

--- a/tuxemon/states/choice_monster.py
+++ b/tuxemon/states/choice_monster.py
@@ -91,7 +91,7 @@ class ChoiceMonster(PygameMenuState):
         if handler is None:
             return
         sprite = handler.get_sprite(
-            "front", scale=self.scale_int(1) * self.config.scale_sprite
+            "front", scale=self.factor * self.config.scale_sprite
         )
         image = self._create_image_from_surface(sprite.image)
         self.menu.add.image(image, align=ALIGN_CENTER)

--- a/tuxemon/states/choice_npc.py
+++ b/tuxemon/states/choice_npc.py
@@ -80,7 +80,7 @@ class ChoiceNpc(PygameMenuState):
         sheet = get_combat_sheet(npc.template)
         surface = sheet.front()
         scaled = scale_surface(
-            surface, self.client.context.scale * self.config.scale_sprite
+            surface, self.scale_int(1) * self.config.scale_sprite
         )
         new_image = self._create_image_from_surface(scaled)
         self.menu.add.image(new_image, align=ALIGN_CENTER)

--- a/tuxemon/states/choice_npc.py
+++ b/tuxemon/states/choice_npc.py
@@ -79,9 +79,7 @@ class ChoiceNpc(PygameMenuState):
         npc = NpcModel.lookup(slug, db)
         sheet = get_combat_sheet(npc.template)
         surface = sheet.front()
-        scaled = scale_surface(
-            surface, self.scale_int(1) * self.config.scale_sprite
-        )
+        scaled = scale_surface(surface, self.factor * self.config.scale_sprite)
         new_image = self._create_image_from_surface(scaled)
         self.menu.add.image(new_image, align=ALIGN_CENTER)
         # replace slug not translated

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -548,7 +548,7 @@ class CombatAnimations(Menu[None], ABC):
             else list(range(PARTY_LIMIT))
         )
 
-        scaled_top = self.scale_int(1)
+        scaled_top = self.factor
 
         for index, pos in enumerate(positions):
             monster = player.monsters[index] if index < monster_count else None
@@ -646,9 +646,7 @@ class CombatAnimations(Menu[None], ABC):
         if self.combat_session.is_trainer_battle:
             enemy_pos = layout.get_combatant_pos("enemy", back_island.rect)
             enemy_surface = opponent.combat_sheet().front()
-            enemy_surface = graphics.scale_surface(
-                enemy_surface, self.scale_int(1)
-            )
+            enemy_surface = graphics.scale_surface(enemy_surface, self.factor)
             enemy = self.load_surface(enemy_surface, **enemy_pos)
             self.sprite_map.add_sprite(opponent, enemy)
         else:
@@ -664,9 +662,7 @@ class CombatAnimations(Menu[None], ABC):
 
         player_pos = layout.get_combatant_pos("player", front_island.rect)
         player_surface = player.combat_sheet().back()
-        player_surface = graphics.scale_surface(
-            player_surface, self.scale_int(1)
-        )
+        player_surface = graphics.scale_surface(player_surface, self.factor)
         player_back = self.load_surface(player_surface, **player_pos)
 
         self.sprites.add(enemy, player_back)

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -25,7 +25,6 @@ from tuxemon.environment import BattleLayout
 from tuxemon.menu.menu import Menu
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.sprite import CaptureDeviceSprite, HordeSprite, Sprite
-from tuxemon.tools import scale
 from tuxemon.ui.combat_bars import CombatBars
 from tuxemon.ui.combat_hud import CombatLayoutManager
 from tuxemon.ui.combat_layout import LayoutManager
@@ -73,8 +72,10 @@ class CombatAnimations(Menu[None], ABC):
         self.sprite_map = MonsterSpriteMap()
         self.capdevs: list[CaptureDeviceSprite] = []
         self.horde_sprite: HordeSprite | None = None
-        self.bars = CombatBars()
-        layout_manager = LayoutManager(mods_folder / "combat_layouts.yaml")
+        self.bars = CombatBars(self.client.context)
+        layout_manager = LayoutManager(
+            mods_folder / "combat_layouts.yaml", self.client.context.scaling
+        )
         _layout = layout_manager.prepare_all(teams)
         self.hud_manager = CombatLayoutManager(_layout)
         self.status_icons = StatusIconManager(self, _layout, self.hud_manager)
@@ -132,7 +133,7 @@ class CombatAnimations(Menu[None], ABC):
             raise KeyError(f"Sprite not found for entity: {trainer.name}")
 
         graphics = self.env.get_battle_graphics()
-        dist = scale(-graphics.trainer_exit_offset)
+        dist = self.scale_int(-graphics.trainer_exit_offset)
         duration = graphics.trainer_exit_duration
         x_offset = self.combat_zone.get_horizontal_offset(sprite.rect, dist)
         self.animate(sprite.rect, x=x_offset, relative=True, duration=duration)
@@ -161,7 +162,7 @@ class CombatAnimations(Menu[None], ABC):
         # Load and scale capture device sprite
         capdev = self.load_sprite(f"gfx/items/{monster.capture_device}.png")
         graphics.scale_sprite(capdev, 0.4)
-        capdev.rect.center = (feet[0], feet[1] - scale(60))
+        capdev.rect.center = (feet[0], feet[1] - self.scale_int(60))
 
         # Animate capture device falling
         fall_time = 0.7
@@ -181,7 +182,7 @@ class CombatAnimations(Menu[None], ABC):
             self.animate, duration=fade_duration, delay=delay
         )
         animate_fade(capdev, width=1, height=h * 1.5)
-        animate_fade(capdev.rect, y=-scale(14), relative=True)
+        animate_fade(capdev.rect, y=-self.scale_int(14), relative=True)
 
         # Convert capture device sprite for easy fading
         def convert_sprite() -> None:
@@ -233,7 +234,9 @@ class CombatAnimations(Menu[None], ABC):
         _, horizontal = self.combat_zone.get_zone(attacker.rect)
 
         delta = (
-            scale(14) if horizontal is HorizontalAlignment.LEFT else -scale(14)
+            self.scale_int(14)
+            if horizontal is HorizontalAlignment.LEFT
+            else -self.scale_int(14)
         )
 
         self.animate(
@@ -275,10 +278,10 @@ class CombatAnimations(Menu[None], ABC):
             duration=1,
             transition="in_out_elastic",
         )
-        ani = animate(x=original_x, initial=original_x + scale(400))
+        ani = animate(x=original_x, initial=original_x + self.scale_int(400))
         # just want the end of the animation, not the entire thing
         ani._elapsed = 0.735
-        ani = animate(y=original_y, initial=original_y - scale(400))
+        ani = animate(y=original_y, initial=original_y - self.scale_int(400))
         # just want the end of the animation, not the entire thing
         ani._elapsed = 0.735
 
@@ -349,7 +352,7 @@ class CombatAnimations(Menu[None], ABC):
             raise KeyError(f"Sprite not found for entity: {monster.name}")
 
         x_offset = self.combat_zone.get_horizontal_offset(
-            sprite.rect, scale(-150)
+            sprite.rect, self.scale_int(-150)
         )
 
         cry = (
@@ -467,7 +470,11 @@ class CombatAnimations(Menu[None], ABC):
             self.combat_session.is_trainer_battle
             and not self.combat_session.is_double
         ):
-            return None, home.right - scale(13), scale(8)
+            return (
+                None,
+                home.right - self.scale_int(13),
+                self.scale_int(8),
+            )
 
         hud_data = self.env.data.get_battle_graphics().hud
         party_layout = self.env.get_party_layout("opponent", home, HUD_LAYER)
@@ -518,7 +525,7 @@ class CombatAnimations(Menu[None], ABC):
                 opponent_party=player.party,
                 tray_rect=home,
                 shadow_text_func=self.shadow_text,
-                scale_func=scale,
+                context=self.client.context,
             )
             self.sprites.add(self.horde_sprite, layer=HUD_LAYER)
 
@@ -541,7 +548,7 @@ class CombatAnimations(Menu[None], ABC):
             else list(range(PARTY_LIMIT))
         )
 
-        scaled_top = scale(1)
+        scaled_top = self.scale_int(1)
 
         for index, pos in enumerate(positions):
             monster = player.monsters[index] if index < monster_count else None
@@ -561,6 +568,7 @@ class CombatAnimations(Menu[None], ABC):
                 tray=tray,
                 monster=monster,
                 icon=self.env.get_battle_graphics().icons,
+                context=self.client.context,
             )
             self.capdevs.append(capdev)
             animate = partial(
@@ -639,7 +647,7 @@ class CombatAnimations(Menu[None], ABC):
             enemy_pos = layout.get_combatant_pos("enemy", back_island.rect)
             enemy_surface = opponent.combat_sheet().front()
             enemy_surface = graphics.scale_surface(
-                enemy_surface, self.client.context.scale
+                enemy_surface, self.scale_int(1)
             )
             enemy = self.load_surface(enemy_surface, **enemy_pos)
             self.sprite_map.add_sprite(opponent, enemy)
@@ -657,7 +665,7 @@ class CombatAnimations(Menu[None], ABC):
         player_pos = layout.get_combatant_pos("player", front_island.rect)
         player_surface = player.combat_sheet().back()
         player_surface = graphics.scale_surface(
-            player_surface, self.client.context.scale
+            player_surface, self.scale_int(1)
         )
         player_back = self.load_surface(player_surface, **player_pos)
 
@@ -752,7 +760,7 @@ class CombatAnimations(Menu[None], ABC):
             self.animate, sprite.rect, transition="in_quad", duration=1.0
         )
         graphics.scale_sprite(sprite, 0.4)
-        sprite.rect.center = scale(0), scale(0)
+        sprite.rect.center = self.scale_int(0), self.scale_int(0)
         animate(x=monster_sprite.rect.centerx)
         animate(y=monster_sprite.rect.centery)
         return sprite
@@ -795,7 +803,7 @@ class CombatAnimations(Menu[None], ABC):
         def shake_up() -> Animation:
             return self.animate(
                 capdev.rect,
-                y=scale(3),
+                y=self.scale_int(3),
                 relative=True,
                 duration=0.1,
                 transition="in_quad",
@@ -804,7 +812,7 @@ class CombatAnimations(Menu[None], ABC):
         def shake_down() -> Animation:
             return self.animate(
                 capdev.rect,
-                y=-scale(6),
+                y=-self.scale_int(6),
                 relative=True,
                 duration=0.2,
                 transition="in_quad",
@@ -813,7 +821,7 @@ class CombatAnimations(Menu[None], ABC):
         def shake_up2() -> Animation:
             return self.animate(
                 capdev.rect,
-                y=scale(3),
+                y=self.scale_int(3),
                 relative=True,
                 duration=0.1,
                 transition="in_quad",

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -429,9 +429,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     for i, t in enumerate(technique.types.current[:2]):
                         path = f"gfx/ui/icons/element/{t.name.lower()}_type_small.png"
                         try:
-                            icon_surface = load_and_scale(
-                                path, self.scale_int(1)
-                            )
+                            icon_surface = load_and_scale(path, self.factor)
                             spr = Sprite()
                             spr.image = icon_surface
                             spr.rect = spr.image.get_rect()
@@ -458,7 +456,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 # --- Draw range icon ---
                 path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
                 try:
-                    surf = load_and_scale(path, self.scale_int(1))
+                    surf = load_and_scale(path, self.factor)
                     spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
@@ -477,7 +475,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
                 path = f"gfx/ui/icons/speed/{speed_val}.png"
                 try:
-                    surf = load_and_scale(path, self.scale_int(1))
+                    surf = load_and_scale(path, self.factor)
                     spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
@@ -663,7 +661,7 @@ class CombatTargetMenuState(Menu[Monster]):
             raise KeyError(f"Sprite not found for entity: {monster.name}")
         item = MenuItem(self.surface, None, monster.name, monster)
         item.rect = sprite.rect.copy()
-        item.rect.inflate_ip(self.scale_int(1), self.scale_int(1))
+        item.rect.inflate_ip(self.factor, self.factor)
         return item
 
     def _create_menu(self) -> None:
@@ -680,7 +678,11 @@ class CombatTargetMenuState(Menu[Monster]):
         self.window.rect = rect
         self.sprites.add(self.window, layer=100)
 
-        self.text_area = TextArea(self.font, self.font_color)
+        self.text_area = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+        )
         self.text_area.rect = self.window.calc_inner_rect(self.window.rect)
         self.sprites.add(self.text_area, layer=100)
 

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -25,7 +25,7 @@ from tuxemon.sprite import Sprite
 from tuxemon.states.item_menu import ItemMenuState
 from tuxemon.states.monster_menu import MonsterMenuState
 from tuxemon.technique.technique import Technique
-from tuxemon.tools import fix_measure, open_dialog, scale
+from tuxemon.tools import fix_measure, open_dialog
 from tuxemon.ui.graphic_box import GraphicBox
 from tuxemon.ui.text import TextArea
 
@@ -430,7 +430,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                         path = f"gfx/ui/icons/element/{t.name.lower()}_type_small.png"
                         try:
                             icon_surface = load_and_scale(
-                                path, self.client.context.scale
+                                path, self.scale_int(1)
                             )
                             spr = Sprite()
                             spr.image = icon_surface
@@ -458,7 +458,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 # --- Draw range icon ---
                 path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
                 try:
-                    surf = load_and_scale(path, self.client.context.scale)
+                    surf = load_and_scale(path, self.scale_int(1))
                     spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
@@ -477,7 +477,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
                 path = f"gfx/ui/icons/speed/{speed_val}.png"
                 try:
-                    surf = load_and_scale(path, self.client.context.scale)
+                    surf = load_and_scale(path, self.scale_int(1))
                     spr = Sprite()
                     spr.image = surf
                     spr.rect = surf.get_rect()
@@ -663,7 +663,7 @@ class CombatTargetMenuState(Menu[Monster]):
             raise KeyError(f"Sprite not found for entity: {monster.name}")
         item = MenuItem(self.surface, None, monster.name, monster)
         item.rect = sprite.rect.copy()
-        item.rect.inflate_ip(scale(1), scale(1))
+        item.rect.inflate_ip(self.scale_int(1), self.scale_int(1))
         return item
 
     def _create_menu(self) -> None:
@@ -718,7 +718,7 @@ class CombatTargetMenuState(Menu[Monster]):
                 return
 
             selected.image = Surface(selected.rect.size, SRCALPHA)
-            BORDER_OFFSET = scale(12)
+            BORDER_OFFSET = self.client.context.scaling.scale_int(12)
             selected.rect.center = (
                 pos.rect.centerx - BORDER_OFFSET,
                 pos.rect.centery - BORDER_OFFSET,

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -341,7 +341,11 @@ class CombatState(CombatAnimations):
         dialog_box = GraphicBox(border=border, color=self.background_color)
         dialog_box.rect = rect
 
-        self.text_area = TextArea(self.font, self.font_color)
+        self.text_area = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+        )
         self.text_area.rect = dialog_box.calc_inner_rect(dialog_box.rect)
         self.show_combat_dialog(dialog_box, self.text_area)
 

--- a/tuxemon/states/dialog_state.py
+++ b/tuxemon/states/dialog_state.py
@@ -11,7 +11,6 @@ from tuxemon.menu.menu import PopUpMenu
 from tuxemon.platform.const import buttons
 from tuxemon.platform.events import PlayerInput
 from tuxemon.sprite import Sprite
-from tuxemon.tools import scale
 from tuxemon.ui.text import TextArea
 from tuxemon.ui.text_alignment import HorizontalAlignment, VerticalAlignment
 
@@ -80,7 +79,8 @@ class DialogState(PopUpMenu[None]):
         _border = load_and_scale(final_box_style["border"])
         self.window._set_border(_border)
         self.window._color = final_box_style["bg_color"]
-        line_spacing = scale(final_box_style["line_spacing"])
+        scaling = self.client.context.scaling
+        line_spacing = scaling.scale_int(final_box_style["line_spacing"])
 
         self.dialog_box = TextArea(
             font=self.font,

--- a/tuxemon/states/dialog_state.py
+++ b/tuxemon/states/dialog_state.py
@@ -85,6 +85,7 @@ class DialogState(PopUpMenu[None]):
         self.dialog_box = TextArea(
             font=self.font,
             font_color=final_box_style["font_color"],
+            scaling=self.client.context.scaling,
             font_shadow=final_box_style["font_shadow"],
             h_alignment=final_box_style["h_alignment"],
             v_alignment=final_box_style["v_alignment"],

--- a/tuxemon/states/image_state.py
+++ b/tuxemon/states/image_state.py
@@ -44,9 +44,7 @@ class ImageState(PygameMenuState):
                     f"{image} {image_size}: "
                     f"It must be less than the native resolution {native}"
                 )
-            new_image.scale(
-                self.client.context.scale, self.client.context.scale
-            )
+            new_image.scale(self.scale_int(1), self.scale_int(1))
             self.menu.add.image(
                 new_image,
                 align=ALIGN_CENTER,

--- a/tuxemon/states/image_state.py
+++ b/tuxemon/states/image_state.py
@@ -44,7 +44,7 @@ class ImageState(PygameMenuState):
                     f"{image} {image_size}: "
                     f"It must be less than the native resolution {native}"
                 )
-            new_image.scale(self.scale_int(1), self.scale_int(1))
+            new_image.scale(self.factor, self.factor)
             self.menu.add.image(
                 new_image,
                 align=ALIGN_CENTER,

--- a/tuxemon/states/input.py
+++ b/tuxemon/states/input.py
@@ -103,6 +103,7 @@ class InputMenu(Menu[InputMenuObj]):
         self.leaving_char_variant_dialog = False
 
         self.input_display = InputDisplay(
+            context=self.client.context,
             font=self.font,
             font_color=self.font_color,
             prompt_text=prompt,

--- a/tuxemon/states/intro_state.py
+++ b/tuxemon/states/intro_state.py
@@ -40,7 +40,7 @@ class IntroState(PopUpMenu[MenuGameObj]):
             self.load_animated_sprite(
                 IntroState._cached_sprites,
                 delay=0.07,
-                scale=self.client.context.scale,
+                scale=self.scale_int(1),
             )
 
     def _load_sprite_files(self) -> list[str] | None:

--- a/tuxemon/states/intro_state.py
+++ b/tuxemon/states/intro_state.py
@@ -40,7 +40,7 @@ class IntroState(PopUpMenu[MenuGameObj]):
             self.load_animated_sprite(
                 IntroState._cached_sprites,
                 delay=0.07,
-                scale=self.scale_int(1),
+                scale=self.factor,
             )
 
     def _load_sprite_files(self) -> list[str] | None:

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -71,10 +71,19 @@ class ItemMenuState(Menu[Item]):
         rect.left = self.client.context.scaling.scale_int(3)
         rect.width = self.client.context.scaling.scale_int(250)
         rect.height = self.client.context.scaling.scale_int(32)
-        self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
+        self.text_area = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+            font_shadow=(96, 96, 128),
+        )
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
-        self.page_number_display = TextArea(self.font, self.font_color)
+        self.page_number_display = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+        )
         self.sprites.add(self.page_number_display, layer=100)
         self.page_size = MAX_MENU_ITEMS
 

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -26,11 +26,7 @@ from tuxemon.platform.const.sizes import MAX_MENU_ITEMS
 from tuxemon.platform.events import PlayerInput
 from tuxemon.session import local_session
 from tuxemon.sprite import Sprite
-from tuxemon.tools import (
-    open_choice_dialog,
-    open_dialog,
-    scale,
-)
+from tuxemon.tools import open_choice_dialog, open_dialog
 from tuxemon.ui.paginator import Paginator
 from tuxemon.ui.text import TextArea
 
@@ -64,17 +60,17 @@ class ItemMenuState(Menu[Item]):
         self.item_sprite = Sprite()
         self.sprites.add(self.item_sprite)
 
-        self.menu_items.line_spacing = scale(7)
+        self.menu_items.line_spacing = self.client.context.scaling.scale_int(7)
         self.current_page = 0
         self.total_pages = 0
         self.inventory = self.filter_controller.get_filtered_inventory()
 
         # this is the area where the item description is displayed
         rect = self.client.context.rect.copy()
-        rect.top = scale(106)
-        rect.left = scale(3)
-        rect.width = scale(250)
-        rect.height = scale(32)
+        rect.top = self.client.context.scaling.scale_int(106)
+        rect.left = self.client.context.scaling.scale_int(3)
+        rect.width = self.client.context.scaling.scale_int(250)
+        rect.height = self.client.context.scaling.scale_int(32)
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -102,11 +102,11 @@ class JournalInfoState(PygameMenuState):
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
-        type_image_1.scale(self.scale_int(1), self.scale_int(1))
+        type_image_1.scale(self.factor, self.factor)
         if len(monster.types) > 1:
             path2 = f"gfx/ui/icons/element/{monster.types[1]}_type_small.png"
             type_image_2 = self._create_image(path2)
-            type_image_2.scale(self.scale_int(1), self.scale_int(1))
+            type_image_2.scale(self.factor, self.factor)
             menu.add.image(type_image_1, float=True).translate(
                 fxw(11.4 / 256), fxh(47.8 / 144)
             )
@@ -238,7 +238,7 @@ class JournalInfoState(PygameMenuState):
         )
         if handler is None:
             return
-        sprite = handler.get_sprite("front", scale=self.scale_int(1))
+        sprite = handler.get_sprite("front", scale=self.factor)
         new_image = self._create_image_from_surface(sprite.image)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -106,15 +106,11 @@ class JournalInfoState(PygameMenuState):
         # type
         path1 = f"gfx/ui/icons/element/{monster.types[0]}_type_small.png"
         type_image_1 = self._create_image(path1)
-        type_image_1.scale(
-            self.client.context.scale, self.client.context.scale
-        )
+        type_image_1.scale(self.scale_int(1), self.scale_int(1))
         if len(monster.types) > 1:
             path2 = f"gfx/ui/icons/element/{monster.types[1]}_type_small.png"
             type_image_2 = self._create_image(path2)
-            type_image_2.scale(
-                self.client.context.scale, self.client.context.scale
-            )
+            type_image_2.scale(self.scale_int(1), self.scale_int(1))
             menu.add.image(type_image_1, float=True).translate(
                 fxw(11.4 / 256), fxh(47.8 / 144)
             )
@@ -246,7 +242,7 @@ class JournalInfoState(PygameMenuState):
         )
         if handler is None:
             return
-        sprite = handler.get_sprite("front", scale=self.client.context.scale)
+        sprite = handler.get_sprite("front", scale=self.scale_int(1))
         new_image = self._create_image_from_surface(sprite.image)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -83,16 +83,14 @@ class MinigameState(PygameMenuState):
         )
         if handler is None:
             return
-        sprite = handler.get_sprite("front", scale=self.client.context.scale)
+        sprite = handler.get_sprite("front", scale=self.scale_int(1))
         if self.difficulty in ["easy", "normal"]:
             try:
                 image = self._create_image_from_surface(sprite.image)
                 menu.add.image(image_path=image.copy())
             except Exception:
                 image = self._create_image(MISSING_IMAGE)
-                image.scale(
-                    self.client.context.scale, self.client.context.scale
-                )
+                image.scale(self.scale_int(1), self.scale_int(1))
                 menu.add.image(image_path=image.copy())
 
         if self.difficulty == "hard":

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -83,14 +83,14 @@ class MinigameState(PygameMenuState):
         )
         if handler is None:
             return
-        sprite = handler.get_sprite("front", scale=self.scale_int(1))
+        sprite = handler.get_sprite("front", scale=self.factor)
         if self.difficulty in ["easy", "normal"]:
             try:
                 image = self._create_image_from_surface(sprite.image)
                 menu.add.image(image_path=image.copy())
             except Exception:
                 image = self._create_image(MISSING_IMAGE)
-                image.scale(self.scale_int(1), self.scale_int(1))
+                image.scale(self.factor, self.factor)
                 menu.add.image(image_path=image.copy())
 
         if self.difficulty == "hard":

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -63,7 +63,7 @@ class MonsterInfoState(PygameMenuState):
         menu._width = fxw(1)
 
         background = self._create_image(INDIV_INFO)
-        background.scale(self.client.context.scale, self.client.context.scale)
+        background.scale(self.scale_int(1), self.scale_int(1))
         background_widget = menu.add.image(image_path=background)
         background_widget.set_float(origin_position=True)
         background_widget.translate(fxw(0 / 256), fxh(0 / 144))
@@ -261,9 +261,7 @@ class MonsterInfoState(PygameMenuState):
             type1_icon = self._create_image(
                 f"gfx/ui/icons/element/{types[0].slug}_type_watermark.png"
             )
-            type1_icon.scale(
-                self.client.context.scale, self.client.context.scale
-            )
+            type1_icon.scale(self.scale_int(1), self.scale_int(1))
             icon1_widget = menu.add.image(image_path=type1_icon)
             icon1_widget.set_float(origin_position=True)
             # Position of type 1 (set wherever you want)
@@ -273,9 +271,7 @@ class MonsterInfoState(PygameMenuState):
             type2_icon = self._create_image(
                 f"gfx/ui/icons/element/{types[1].slug}_type_watermark.png"
             )
-            type2_icon.scale(
-                self.client.context.scale, self.client.context.scale
-            )
+            type2_icon.scale(self.scale_int(1), self.scale_int(1))
             icon2_widget = menu.add.image(image_path=type2_icon)
             icon2_widget.set_float(origin_position=True)
             # Position of type 2 (independent from type 1)
@@ -375,8 +371,8 @@ class MonsterInfoState(PygameMenuState):
 
         plus_icon = self._create_image("gfx/ui/icons/plusminus/plus.png")
         minus_icon = self._create_image("gfx/ui/icons/plusminus/minus.png")
-        plus_icon.scale(self.client.context.scale, self.client.context.scale)
-        minus_icon.scale(self.client.context.scale, self.client.context.scale)
+        plus_icon.scale(self.scale_int(1), self.scale_int(1))
+        minus_icon.scale(self.scale_int(1), self.scale_int(1))
 
         # Helper: find which stat a taste affects
         def get_stat_for_taste(slug: str) -> str | None:
@@ -412,9 +408,7 @@ class MonsterInfoState(PygameMenuState):
             bond_file = monster.bond_handler.get_bond_icon_path()
             if bond_file:
                 bond_icon = self._create_image(bond_file)
-                bond_icon.scale(
-                    self.client.context.scale, self.client.context.scale
-                )
+                bond_icon.scale(self.scale_int(1), self.scale_int(1))
                 bond_widget = menu.add.image(image_path=bond_icon)
                 bond_widget.set_float(origin_position=True)
                 bond_widget.translate(fxw(20 / 256), fxh(29 / 144))
@@ -429,7 +423,7 @@ class MonsterInfoState(PygameMenuState):
         tuxeball = self._create_image(
             f"gfx/items/{monster.capture_device}.png"
         )
-        tuxeball.scale(self.client.context.scale, self.client.context.scale)
+        tuxeball.scale(self.scale_int(1), self.scale_int(1))
         capture_device = menu.add.image(image_path=tuxeball)
         capture_device.set_float(origin_position=True)
         capture_device.translate(fxw(17 / 256), fxh(110 / 144))

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -63,7 +63,7 @@ class MonsterInfoState(PygameMenuState):
         menu._width = fxw(1)
 
         background = self._create_image(INDIV_INFO)
-        background.scale(self.scale_int(1), self.scale_int(1))
+        background.scale(self.factor, self.factor)
         background_widget = menu.add.image(image_path=background)
         background_widget.set_float(origin_position=True)
         background_widget.translate(fxw(0 / 256), fxh(0 / 144))
@@ -261,7 +261,7 @@ class MonsterInfoState(PygameMenuState):
             type1_icon = self._create_image(
                 f"gfx/ui/icons/element/{types[0].slug}_type_watermark.png"
             )
-            type1_icon.scale(self.scale_int(1), self.scale_int(1))
+            type1_icon.scale(self.factor, self.factor)
             icon1_widget = menu.add.image(image_path=type1_icon)
             icon1_widget.set_float(origin_position=True)
             # Position of type 1 (set wherever you want)
@@ -271,7 +271,7 @@ class MonsterInfoState(PygameMenuState):
             type2_icon = self._create_image(
                 f"gfx/ui/icons/element/{types[1].slug}_type_watermark.png"
             )
-            type2_icon.scale(self.scale_int(1), self.scale_int(1))
+            type2_icon.scale(self.factor, self.factor)
             icon2_widget = menu.add.image(image_path=type2_icon)
             icon2_widget.set_float(origin_position=True)
             # Position of type 2 (independent from type 1)
@@ -371,8 +371,8 @@ class MonsterInfoState(PygameMenuState):
 
         plus_icon = self._create_image("gfx/ui/icons/plusminus/plus.png")
         minus_icon = self._create_image("gfx/ui/icons/plusminus/minus.png")
-        plus_icon.scale(self.scale_int(1), self.scale_int(1))
-        minus_icon.scale(self.scale_int(1), self.scale_int(1))
+        plus_icon.scale(self.factor, self.factor)
+        minus_icon.scale(self.factor, self.factor)
 
         # Helper: find which stat a taste affects
         def get_stat_for_taste(slug: str) -> str | None:
@@ -408,7 +408,7 @@ class MonsterInfoState(PygameMenuState):
             bond_file = monster.bond_handler.get_bond_icon_path()
             if bond_file:
                 bond_icon = self._create_image(bond_file)
-                bond_icon.scale(self.scale_int(1), self.scale_int(1))
+                bond_icon.scale(self.factor, self.factor)
                 bond_widget = menu.add.image(image_path=bond_icon)
                 bond_widget.set_float(origin_position=True)
                 bond_widget.translate(fxw(20 / 256), fxh(29 / 144))
@@ -423,7 +423,7 @@ class MonsterInfoState(PygameMenuState):
         tuxeball = self._create_image(
             f"gfx/items/{monster.capture_device}.png"
         )
-        tuxeball.scale(self.scale_int(1), self.scale_int(1))
+        tuxeball.scale(self.factor, self.factor)
         capture_device = menu.add.image(image_path=tuxeball)
         capture_device.set_float(origin_position=True)
         capture_device.translate(fxw(17 / 256), fxh(110 / 144))

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -22,9 +22,8 @@ from tuxemon.monster.monster import Monster
 from tuxemon.platform.const.graphics import BG_MONSTERS, TRANSPARENT_COLOR
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.prepare import SCREEN_SIZE
-from tuxemon.scaling import DefaultScaling
 from tuxemon.sprite import Sprite
-from tuxemon.tools import open_choice_dialog, open_dialog, scale
+from tuxemon.tools import open_choice_dialog, open_dialog
 from tuxemon.ui.graphic_box import GraphicBox
 from tuxemon.ui.menu_options import (
     MenuOptions,
@@ -38,6 +37,7 @@ if TYPE_CHECKING:
     from tuxemon.entity.party import PartyHandler
     from tuxemon.item.item import Item
     from tuxemon.monster.monster import Monster
+    from tuxemon.prepare import DisplayContext
 
 LAYER_MONSTER_ICONS = 20
 LAYER_PORTRAIT = 30
@@ -62,23 +62,22 @@ class MonsterMenuState(Menu[Monster | None]):
         monster_filter: MonsterFilter | None = None,
     ) -> None:
         super().__init__()
-        self.scaling = DefaultScaling()
         self.monster_filter = monster_filter or MonsterFilter()
         self.monsters = self.monster_filter.get_filtered_monsters(monsters)
 
         # make a text area to show messages
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
-        self.text_area.rect = Rect(self.scaling.scale_tuple((20, 80, 80, 100)))
+        self.text_area.rect = Rect(self.scale_tuple((20, 80, 80, 100)))
         self.sprites.add(self.text_area, layer=100)
         self.monster_stats_display = MonsterStatsDisplay(self)
         self.monster_sprite_displays: list[MonsterSpriteDisplay] = []
         self.monster_portrait_display = MonsterPortraitDisplay(self)
 
         # Set up the border images used for the monster slots
-        self.hp_bar = HpBar()
-        self.exp_bar = ExpBar()
+        self.hp_bar = HpBar(self.client.context)
+        self.exp_bar = ExpBar(self.client.context)
         self.slot_renderer = MonsterSlotRenderer(
-            self.font, self.hp_bar, self.font_color
+            self.client.context, self.font, self.hp_bar, self.font_color
         )
 
         # Load monster visuals
@@ -486,6 +485,7 @@ class MonsterSpriteDisplay:
 
     def __init__(self, menu_state: MonsterMenuState) -> None:
         self.menu_state = menu_state
+        self.scaling = self.menu_state.client.context.scaling
         self.sprite: Sprite | None = None
         self.monster: Monster | None = None
 
@@ -508,7 +508,7 @@ class MonsterSpriteDisplay:
             width = SCREEN_SIZE[0]
             margin = int(width * 0.005)
             self.sprite.rect.x = width - (self.sprite.rect.width + margin)
-            self.sprite.rect.y = rect.y + scale(10)
+            self.sprite.rect.y = rect.y + self.scaling.scale_int(10)
 
         else:
             self.remove_sprite()
@@ -523,6 +523,7 @@ class MonsterSpriteDisplay:
 class MonsterPortraitDisplay:
     def __init__(self, menu_state: MonsterMenuState) -> None:
         self.menu_state = menu_state
+        self.scaling = self.menu_state.client.context.scaling
         self.portrait = Sprite()
         self.portrait.rect = Rect(0, 0, 0, 0)
         self.menu_state.sprites.add(self.portrait, layer=LAYER_PORTRAIT)
@@ -547,7 +548,7 @@ class MonsterPortraitDisplay:
     def animate_down(self) -> None:
         ani = self.menu_state.animate(
             self.portrait.rect,
-            y=-scale(5),
+            y=-self.scaling.scale_int(5),
             duration=1,
             transition="in_out_quad",
             relative=True,
@@ -557,7 +558,7 @@ class MonsterPortraitDisplay:
     def animate_up(self) -> None:
         ani = self.menu_state.animate(
             self.portrait.rect,
-            y=scale(5),
+            y=self.scaling.scale_int(5),
             duration=1,
             transition="in_out_quad",
             relative=True,
@@ -594,7 +595,15 @@ class MonsterSlotBorder:
 class MonsterSlotRenderer:
     """Unified renderer for monster slot layout."""
 
-    def __init__(self, font: Font, hp_bar: HpBar, font_color: ColorLike):
+    def __init__(
+        self,
+        context: DisplayContext,
+        font: Font,
+        hp_bar: HpBar,
+        font_color: ColorLike,
+    ):
+        self.context = context
+        self.scaling = context.scaling
         self.font = font
         self.hp_bar = hp_bar
         self.font_color = font_color
@@ -616,20 +625,20 @@ class MonsterSlotRenderer:
         if not monster:
             return
 
-        padding = scale(6)
+        padding = self.scaling.scale_int(6)
         content = rect.inflate(-padding, -padding)
 
         upper_label = f"{monster.name}{monster.gender_symbol}"
 
-        text_rect = rect.inflate(-scale(6), -scale(6))
+        text_rect = rect.inflate(-padding, -padding)
         draw_text(surface, upper_label, text_rect, font=self.font)
 
-        text_rect.top = rect.bottom - scale(7)
+        text_rect.top = rect.bottom - self.scaling.scale_int(7)
         bottom_label = f"  Lv {monster.level}"
         draw_text(surface, bottom_label, text_rect, font=self.font)
 
         hp_width = int(content.width * 0.35)
-        hp_rect = Rect(0, 0, hp_width, scale(8))
+        hp_rect = Rect(0, 0, hp_width, self.scaling.scale_int(8))
         hp_rect.right = content.right
         hp_rect.centery = content.centery
 
@@ -644,13 +653,13 @@ class MonsterSlotRenderer:
         monster: Monster,
         content: Rect,
     ) -> None:
-        icon_y = content.top + scale(4)
+        icon_y = content.top + self.scaling.scale_int(4)
 
         for i, status in enumerate(monster.status.get_statuses()):
             if status.icon:
                 img = load_and_scale(status.icon)
                 x = int(content.width * 0.45) + i * (
-                    img.get_width() + scale(4)
+                    img.get_width() + self.scaling.scale_int(4)
                 )
                 x += content.left
                 surface.blit(img, (x, icon_y))
@@ -659,6 +668,6 @@ class MonsterSlotRenderer:
             item_img = load_and_scale(monster.held_item.sprite, 1.5)
             x = int(content.width * 0.45) + len(
                 monster.status.get_statuses()
-            ) * (scale(4) + item_img.get_width())
+            ) * (self.scaling.scale_int(4) + item_img.get_width())
             x += content.left
             surface.blit(item_img, (x, icon_y))

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -67,7 +67,8 @@ class MonsterMenuState(Menu[Monster | None]):
 
         # make a text area to show messages
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
-        self.text_area.rect = Rect(self.scale_tuple((20, 80, 80, 100)))
+        rect = self.client.context.scaling.scale_tuple((20, 80, 80, 100))
+        self.text_area.rect = Rect(rect)
         self.sprites.add(self.text_area, layer=100)
         self.monster_stats_display = MonsterStatsDisplay(self)
         self.monster_sprite_displays: list[MonsterSpriteDisplay] = []

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -66,7 +66,12 @@ class MonsterMenuState(Menu[Monster | None]):
         self.monsters = self.monster_filter.get_filtered_monsters(monsters)
 
         # make a text area to show messages
-        self.text_area = TextArea(self.font, self.font_color, (96, 96, 96))
+        self.text_area = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+            font_shadow=(96, 96, 96),
+        )
         rect = self.client.context.scaling.scale_tuple((20, 80, 80, 100))
         self.text_area.rect = Rect(rect)
         self.sprites.add(self.text_area, layer=100)
@@ -441,7 +446,9 @@ class MonsterStatsDisplay:
     def __init__(self, menu_state: MonsterMenuState) -> None:
         self.menu_state = menu_state
         self.sprite = TextArea(
-            self.menu_state.font, self.menu_state.font_color
+            font=self.menu_state.font,
+            font_color=self.menu_state.font_color,
+            scaling=self.menu_state.client.context.scaling,
         )
         self.menu_state.sprites.add(self.sprite, layer=LAYER_MONSTER_ICONS)
 
@@ -632,11 +639,23 @@ class MonsterSlotRenderer:
         upper_label = f"{monster.name}{monster.gender_symbol}"
 
         text_rect = rect.inflate(-padding, -padding)
-        draw_text(surface, upper_label, text_rect, font=self.font)
+        draw_text(
+            surface,
+            upper_label,
+            text_rect,
+            scaling=self.scaling,
+            font=self.font,
+        )
 
         text_rect.top = rect.bottom - self.scaling.scale_int(7)
         bottom_label = f"  Lv {monster.level}"
-        draw_text(surface, bottom_label, text_rect, font=self.font)
+        draw_text(
+            surface,
+            bottom_label,
+            text_rect,
+            scaling=self.scaling,
+            font=self.font,
+        )
 
         hp_width = int(content.width * 0.35)
         hp_rect = Rect(0, 0, hp_width, self.scaling.scale_int(8))

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -281,7 +281,7 @@ class MonsterMovesState(PygameMenuState):
             for i, t in enumerate(technique.types.current[:2]):
                 path = f"gfx/ui/icons/element/{t.name.lower()}_type_small.png"
                 img = self._create_image(path)
-                img.scale(self.client.context.scale, self.client.context.scale)
+                img.scale(self.scale_int(1), self.scale_int(1))
                 icon = menu.add.image(img.copy(), float=True)
                 icon.translate(fxw(x_positions[i]), fxh(y_position))
                 self.type_icon_widgets.append(icon)
@@ -290,7 +290,7 @@ class MonsterMovesState(PygameMenuState):
         if technique.range:
             path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
             rimg = self._create_image(path)
-            rimg.scale(self.client.context.scale, self.client.context.scale)
+            rimg.scale(self.scale_int(1), self.scale_int(1))
             self.range_icon_widget = menu.add.image(rimg.copy(), float=True)
             self.range_icon_widget.translate(fxw(4 / 256), fxh(86.8 / 144))
 
@@ -300,7 +300,7 @@ class MonsterMovesState(PygameMenuState):
 
         spath = f"gfx/ui/icons/speed/{speed_key}.png"
         simg = self._create_image(spath)
-        simg.scale(self.client.context.scale, self.client.context.scale)
+        simg.scale(self.scale_int(1), self.scale_int(1))
         self.speed_icon_widget = menu.add.image(simg.copy(), float=True)
         self.speed_icon_widget.translate(fxw(222 / 256), fxh(51.8 / 144))
 

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -275,7 +275,7 @@ class MonsterMovesState(PygameMenuState):
             for i, t in enumerate(technique.types.current[:2]):
                 path = f"gfx/ui/icons/element/{t.name.lower()}_type_small.png"
                 img = self._create_image(path)
-                img.scale(self.scale_int(1), self.scale_int(1))
+                img.scale(self.factor, self.factor)
                 icon = menu.add.image(img.copy(), float=True)
                 icon.translate(fxw(x_positions[i]), fxh(y_position))
                 self.type_icon_widgets.append(icon)
@@ -284,7 +284,7 @@ class MonsterMovesState(PygameMenuState):
         if technique.range:
             path = f"gfx/ui/icons/range/{technique.range.name.lower()}.png"
             rimg = self._create_image(path)
-            rimg.scale(self.scale_int(1), self.scale_int(1))
+            rimg.scale(self.factor, self.factor)
             self.range_icon_widget = menu.add.image(rimg.copy(), float=True)
             self.range_icon_widget.translate(fxw(4 / 256), fxh(86.8 / 144))
 
@@ -294,7 +294,7 @@ class MonsterMovesState(PygameMenuState):
 
         spath = f"gfx/ui/icons/speed/{speed_key}.png"
         simg = self._create_image(spath)
-        simg.scale(self.scale_int(1), self.scale_int(1))
+        simg.scale(self.factor, self.factor)
         self.speed_icon_widget = menu.add.image(simg.copy(), float=True)
         self.speed_icon_widget.translate(fxw(222 / 256), fxh(51.8 / 144))
 

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -299,7 +299,7 @@ class MonsterTakeState(PygameMenuState):
             label = T.translate(monster.name).upper()
             iid = monster.instance_id.hex
             surface = monster.get_sprite("front").image
-            scaled = scale_surface(surface, self.client.context.scale * 0.125)
+            scaled = scale_surface(surface, self.scale_int(1) * 0.125)
             new_image = self._create_image_from_surface(scaled)
             menu.add.banner(
                 new_image,

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -297,7 +297,7 @@ class MonsterTakeState(PygameMenuState):
             label = T.translate(monster.name).upper()
             iid = monster.instance_id.hex
             surface = monster.get_sprite("front").image
-            scaled = scale_surface(surface, self.scale_int(1) * 0.125)
+            scaled = scale_surface(surface, self.factor * 0.125)
             new_image = self._create_image_from_surface(scaled)
             menu.add.banner(
                 new_image,

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -242,7 +242,7 @@ class ItemTakeState(PygameMenuState):
             label = T.translate(itm.name).upper() + " x" + str(itm.quantity)
             iid = itm.instance_id.hex
             new_image = self._create_image(itm.sprite)
-            new_image.scale(self.scale_int(1), self.scale_int(1))
+            new_image.scale(self.factor, self.factor)
             menu.add.banner(
                 new_image,
                 partial(self.locker_options, iid, handler),

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -244,9 +244,7 @@ class ItemTakeState(PygameMenuState):
             label = T.translate(itm.name).upper() + " x" + str(itm.quantity)
             iid = itm.instance_id.hex
             new_image = self._create_image(itm.sprite)
-            new_image.scale(
-                self.client.context.scale, self.client.context.scale
-            )
+            new_image.scale(self.scale_int(1), self.scale_int(1))
             menu.add.banner(
                 new_image,
                 partial(self.locker_options, iid, handler),

--- a/tuxemon/states/phone.py
+++ b/tuxemon/states/phone.py
@@ -119,7 +119,7 @@ class NuPhone(PygameMenuState):
                 change = self._get_app_callback(item)
 
                 new_image = self._create_image(item.sprite)
-                new_image.scale(self.scale_int(1), self.scale_int(1))
+                new_image.scale(self.factor, self.factor)
 
                 # App image (banner)
                 menu.add.banner(

--- a/tuxemon/states/phone.py
+++ b/tuxemon/states/phone.py
@@ -119,9 +119,7 @@ class NuPhone(PygameMenuState):
                 change = self._get_app_callback(item)
 
                 new_image = self._create_image(item.sprite)
-                new_image.scale(
-                    self.client.context.scale, self.client.context.scale
-                )
+                new_image.scale(self.scale_int(1), self.scale_int(1))
 
                 # App image (banner)
                 menu.add.banner(

--- a/tuxemon/states/phone_map.py
+++ b/tuxemon/states/phone_map.py
@@ -78,7 +78,7 @@ class NuPhoneMap(PygameMenuState):
         menu: Menu,
     ) -> None:
         new_image = self._create_image(data.map_path)
-        new_image.scale(self.scale_int(1), self.scale_int(1))
+        new_image.scale(self.factor, self.factor)
         menu.add.image(image_path=new_image.copy())
         underline = False
         selectable = True

--- a/tuxemon/states/phone_map.py
+++ b/tuxemon/states/phone_map.py
@@ -78,7 +78,7 @@ class NuPhoneMap(PygameMenuState):
         menu: pygame_menu.Menu,
     ) -> None:
         new_image = self._create_image(data.map_path)
-        new_image.scale(self.client.context.scale, self.client.context.scale)
+        new_image.scale(self.scale_int(1), self.scale_int(1))
         menu.add.image(image_path=new_image.copy())
         underline = False
         selectable = True

--- a/tuxemon/states/save_menu.py
+++ b/tuxemon/states/save_menu.py
@@ -76,6 +76,7 @@ class SaveMenuState(PopUpMenu[None]):
             slot_image,
             T.translate("empty_slot"),
             rect,
+            scaling=self.client.context.scaling,
             font=self.font,
         )
         return slot_image
@@ -132,6 +133,7 @@ class SaveMenuState(PopUpMenu[None]):
             slot_image,
             f"{T.translate('slot')} {slot_num}",
             rect,
+            scaling=self.client.context.scaling,
             font=self.font,
         )
 
@@ -141,6 +143,7 @@ class SaveMenuState(PopUpMenu[None]):
                 slot_image,
                 save_data.npc_state.player_name,
                 (x, 0, 500, 500),
+                scaling=self.client.context.scaling,
                 font=self.font,
             )
         if save_data.time:
@@ -148,6 +151,7 @@ class SaveMenuState(PopUpMenu[None]):
                 slot_image,
                 save_data.time,
                 (x, 50, 500, 500),
+                scaling=self.client.context.scaling,
                 font=self.font,
             )
 

--- a/tuxemon/states/shop_base.py
+++ b/tuxemon/states/shop_base.py
@@ -78,7 +78,11 @@ class ShopMenuState(Menu[T], Generic[T], ABC):
         rect.left = self.scale_int(3)
         rect.width = self.scale_int(250)
         rect.height = self.scale_int(32)
-        self.text_area = TextArea(self.font, self.font_color)
+        self.text_area = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+        )
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 

--- a/tuxemon/states/shop_base.py
+++ b/tuxemon/states/shop_base.py
@@ -16,7 +16,6 @@ from typing import (
 from pygame.rect import Rect
 from pygame.surface import Surface
 
-from tuxemon import tools
 from tuxemon.economy.applier import EconomyApplier
 from tuxemon.economy.transaction import TransactionManager
 from tuxemon.entity.npc import NPC
@@ -68,17 +67,17 @@ class ShopMenuState(Menu[T], Generic[T], ABC):
         self.asset_sprite = Sprite()
         self.sprites.add(self.asset_sprite)
 
-        self.menu_items.line_spacing = tools.scale(7)
+        self.menu_items.line_spacing = self.scale_int(7)
         self.current_page = 0
         self.total_pages = 0
         self.inventory: list[T] = []
 
         # This is the area where the asset's description is displayed.
         rect = self.client.context.rect.copy()
-        rect.top = tools.scale(106)
-        rect.left = tools.scale(3)
-        rect.width = tools.scale(250)
-        rect.height = tools.scale(32)
+        rect.top = self.scale_int(106)
+        rect.left = self.scale_int(3)
+        rect.width = self.scale_int(250)
+        rect.height = self.scale_int(32)
         self.text_area = TextArea(self.font, self.font_color)
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -59,7 +59,12 @@ class TechniqueMenuState(Menu[Technique]):
         rect.left = self.client.context.scaling.scale_int(3)
         rect.width = self.client.context.scaling.scale_int(250)
         rect.height = self.client.context.scaling.scale_int(32)
-        self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
+        self.text_area = TextArea(
+            font=self.font,
+            font_color=self.font_color,
+            scaling=self.client.context.scaling,
+            font_shadow=(96, 96, 128),
+        )
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -21,11 +21,7 @@ from tuxemon.technique.controller import TechController
 from tuxemon.technique.filter import TechFilter
 from tuxemon.technique.sorter import TechSorter
 from tuxemon.technique.technique import Technique
-from tuxemon.tools import (
-    open_choice_dialog,
-    open_dialog,
-    scale,
-)
+from tuxemon.tools import open_choice_dialog, open_dialog
 from tuxemon.ui.text import TextArea
 
 if TYPE_CHECKING:
@@ -55,14 +51,14 @@ class TechniqueMenuState(Menu[Technique]):
         self.item_center = self.rect.width * 0.164, self.rect.height * 0.13
         self.technique_sprite = Sprite()
         self.sprites.add(self.technique_sprite)
-        self.menu_items.line_spacing = scale(7)
+        self.menu_items.line_spacing = self.client.context.scaling.scale_int(7)
 
         # this is the area where the technique description is displayed
         rect = self.client.context.rect.copy()
-        rect.top = scale(106)
-        rect.left = scale(3)
-        rect.width = scale(250)
-        rect.height = scale(32)
+        rect.top = self.client.context.scaling.scale_int(106)
+        rect.left = self.client.context.scaling.scale_int(3)
+        rect.width = self.client.context.scaling.scale_int(250)
+        rect.height = self.client.context.scaling.scale_int(32)
         self.text_area = TextArea(self.font, self.font_color, (96, 96, 128))
         self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)

--- a/tuxemon/states/transition_evolution.py
+++ b/tuxemon/states/transition_evolution.py
@@ -173,7 +173,7 @@ class EvolutionTransition(State):
             menu2_rect=sprites.menu2_rect,
         )
         assert handler
-        return handler.get_sprite("front", self.client.context.scale)
+        return handler.get_sprite("front", self.scale_int(1))
 
     def _white_image(self, sprite: Surface) -> Surface:
         for x in range(sprite.get_width()):

--- a/tuxemon/states/transition_evolution.py
+++ b/tuxemon/states/transition_evolution.py
@@ -175,7 +175,7 @@ class EvolutionTransition(State):
             menu2_rect=sprites.menu2_rect,
         )
         assert handler
-        return handler.get_sprite("front", self.scale_int(1))
+        return handler.get_sprite("front", self.factor)
 
     def _white_image(self, sprite: Surface) -> Surface:
         for x in range(sprite.get_width()):

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -169,7 +169,7 @@ class TradingTransition(State):
             menu2_rect=sprites.menu2_rect,
         )
         assert handler
-        return handler.get_sprite("front", self.scale_int(1))
+        return handler.get_sprite("front", self.factor)
 
     def _white_image(self, sprite: Surface) -> Surface:
         for x in range(sprite.get_width()):

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -169,7 +169,7 @@ class TradingTransition(State):
             menu2_rect=sprites.menu2_rect,
         )
         assert handler
-        return handler.get_sprite("front", self.client.context.scale)
+        return handler.get_sprite("front", self.scale_int(1))
 
     def _white_image(self, sprite: Surface) -> Surface:
         for x in range(sprite.get_width()):

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -37,7 +37,7 @@ from tuxemon.constants.asset_loader import fetch_asset
 from tuxemon.db import Comparison
 from tuxemon.locale.locale import T
 from tuxemon.math import Vector2
-from tuxemon.scaling import DefaultScaling, ScalingStrategy
+from tuxemon.scaling import ScalingStrategy
 from tuxemon.ui.dialogue import calc_dialog_rect
 from tuxemon.ui.text_alignment import DialogPosition
 from tuxemon.ui.text_formatter import TextFormatter
@@ -124,22 +124,14 @@ def get_screen_rect(sprite: Sprite, internal_rect: Rect) -> Rect:
     return internal_rect.move(sprite.rect.topleft)
 
 
-def scale(number: int | float, scaling: ScalingStrategy | None = None) -> int:
-    """
-    Scale a number by the configured scale factor.
+def scale(number: int, scaling: ScalingStrategy | None = None) -> int:
+    """Scale a number by the configured scale factor."""
+    if scaling is None:
+        from tuxemon.prepare import DISPLAY_CONTEXT
 
-    Parameters:
-        number: Integer or float to scale. Floats are rounded before scaling.
+        scaling = DISPLAY_CONTEXT.scaling
 
-    Returns:
-        Scaled integer.
-    """
-    scaling = scaling or DefaultScaling()
-
-    if isinstance(number, float):
-        number = round(number)
-
-    return scaling.scale_int(int(number))
+    return scaling.scale_int(number)
 
 
 TEnum = TypeVar("TEnum", bound=Enum)

--- a/tuxemon/ui/combat_bars.py
+++ b/tuxemon/ui/combat_bars.py
@@ -10,13 +10,13 @@ from pygame.rect import Rect
 
 from tuxemon.menu.interface import ExpBar, HpBar
 from tuxemon.sprite import Sprite
-from tuxemon.tools import scale
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from tuxemon.db import BattleGraphicsModel
     from tuxemon.monster.monster import Monster
+    from tuxemon.prepare import DisplayContext
 
 
 class CombatBars:
@@ -24,7 +24,8 @@ class CombatBars:
     A class responsible for drawing the combat UI, including HP and EXP bars.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, context: DisplayContext) -> None:
+        self.context = context
         self._hp_bars: MutableMapping[Monster, HpBar] = {}
         self._exp_bars: MutableMapping[Monster, ExpBar] = {}
 
@@ -68,20 +69,29 @@ class CombatBars:
         hud: Sprite,
         width: int,
         height: int,
-        top_offset: int,
+        top: int,
         right_padding: int,
     ) -> Rect:
-        rect = Rect(0, 0, scale(width), scale(height))
-        rect.right = hud.image.get_width() - scale(right_padding)
-        rect.top += scale(top_offset)
+        s = self.context.scaling.scale_int
+
+        width = s(width)
+        height = s(height)
+        top = s(top)
+        right_padding = s(right_padding)
+
+        rect = Rect(0, 0, width, height)
+        rect.top = top
+        rect.right = hud.image.get_width() - right_padding
         return rect
 
     def get_hp_bar(self, monster: Monster) -> HpBar:
-        return self._hp_bars.setdefault(monster, HpBar(monster.hp_ratio))
+        return self._hp_bars.setdefault(
+            monster, HpBar(self.context, monster.hp_ratio)
+        )
 
     def get_exp_bar(self, monster: Monster) -> ExpBar:
         return self._exp_bars.setdefault(
-            monster, ExpBar(monster.experience_progress_percent)
+            monster, ExpBar(self.context, monster.experience_progress_percent)
         )
 
     def remove_monster(self, monster: Monster) -> None:

--- a/tuxemon/ui/combat_layout.py
+++ b/tuxemon/ui/combat_layout.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from pygame.rect import Rect
 
 from tuxemon.database.yaml_utils import load_yaml
-from tuxemon.scaling import DefaultScaling, ScalingStrategy
+from tuxemon.scaling import ScalingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +49,11 @@ class LayoutRepository:
     def __init__(
         self,
         yaml_path: Path,
-        scaling: ScalingStrategy | None = None,
+        scaling: ScalingStrategy,
     ):
         self.raw_layouts = load_layouts_from_yaml(yaml_path)
         self.groups = load_layout_groups(yaml_path)
-        self.scaling = scaling or DefaultScaling()
+        self.scaling = scaling
 
     def get_raw_layout(self, name: str) -> dict[str, tuple[int, ...]]:
         if name not in self.raw_layouts:
@@ -100,7 +100,7 @@ class LayoutManager:
     def __init__(
         self,
         yaml_path: Path,
-        scaling: ScalingStrategy | None = None,
+        scaling: ScalingStrategy,
     ):
         self.repo = LayoutRepository(yaml_path, scaling=scaling)
         self.selector = LayoutSelector(self.repo)

--- a/tuxemon/ui/draw.py
+++ b/tuxemon/ui/draw.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from pygame.font import Font
 from pygame.rect import Rect
@@ -15,6 +16,9 @@ from pygame.surface import Surface
 from tuxemon.graphics import ColorLike
 from tuxemon.ui.text_alignment import HorizontalAlignment, VerticalAlignment
 from tuxemon.ui.text_renderer import TextRenderer
+
+if TYPE_CHECKING:
+    from tuxemon.scaling import ScalingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +237,7 @@ def iter_render_text(
     fg: ColorLike,
     bg: ColorLike,
     rect: Rect,
+    scaling: ScalingStrategy,
     h_alignment: HorizontalAlignment = HorizontalAlignment.LEFT,
     v_alignment: VerticalAlignment = VerticalAlignment.TOP,
     text_renderer: TextRenderer | None = None,
@@ -254,7 +259,7 @@ def iter_render_text(
 
     if text_renderer is None:
         text_renderer = TextRenderer(
-            font_color=fg, font_shadow_color=bg, font=font
+            scaling=scaling, font_color=fg, font_shadow_color=bg, font=font
         )
 
     for line_index, line in enumerate(lines):

--- a/tuxemon/ui/input_display.py
+++ b/tuxemon/ui/input_display.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from pygame.font import Font
 from pygame.rect import Rect
 
-from tuxemon import tools
 from tuxemon.graphics import ColorLike
 from tuxemon.sprite import Sprite, SpriteGroup
 from tuxemon.ui.text import TextArea
+
+if TYPE_CHECKING:
+    from tuxemon.prepare import DisplayContext
 
 
 @dataclass
@@ -35,6 +38,7 @@ class InputDisplay:
 
     def __init__(
         self,
+        context: DisplayContext,
         font: Font,
         font_color: ColorLike,
         prompt_text: str,
@@ -42,6 +46,7 @@ class InputDisplay:
         area_rect: Rect,
         config: InputDisplayConfig | None = None,
     ) -> None:
+        self.scaling = context.scaling
         self.sprites: SpriteGroup[Sprite] = SpriteGroup()
         self.config = config or InputDisplayConfig()
         self.area_rect = area_rect
@@ -50,10 +55,10 @@ class InputDisplay:
         self.prompt = TextArea(font, font_color, (96, 96, 96))
         self.prompt.animated = False
         self.prompt.rect = Rect(
-            area_rect.x + tools.scale(self.config.prompt_offset_x),
-            area_rect.y + tools.scale(self.config.prompt_offset_y),
-            tools.scale(self.config.prompt_width),
-            tools.scale(self.config.prompt_height),
+            area_rect.x + self.scaling.scale_int(self.config.prompt_offset_x),
+            area_rect.y + self.scaling.scale_int(self.config.prompt_offset_y),
+            self.scaling.scale_int(self.config.prompt_width),
+            self.scaling.scale_int(self.config.prompt_height),
         )
         self.prompt.text = prompt_text
         self.sprites.add(self.prompt)
@@ -62,10 +67,12 @@ class InputDisplay:
         self.text_area = TextArea(font, font_color, (96, 96, 96))
         self.text_area.animated = False
         self.text_area.rect = Rect(
-            area_rect.x + tools.scale(self.config.text_area_offset_x),
-            area_rect.y + tools.scale(self.config.text_area_offset_y),
-            tools.scale(self.config.text_area_width),
-            tools.scale(self.config.text_area_height),
+            area_rect.x
+            + self.scaling.scale_int(self.config.text_area_offset_x),
+            area_rect.y
+            + self.scaling.scale_int(self.config.text_area_offset_y),
+            self.scaling.scale_int(self.config.text_area_width),
+            self.scaling.scale_int(self.config.text_area_height),
         )
         self.text_area.text = initial_input_string
         self.sprites.add(self.text_area)
@@ -84,7 +91,7 @@ class InputDisplay:
         self.char_counter.text = f"{remaining_chars}"
         self.char_counter.rect.topleft = (
             self.area_rect.right
-            - tools.scale(self.config.char_counter_offset_x),
+            - self.scaling.scale_int(self.config.char_counter_offset_x),
             self.area_rect.top
-            + tools.scale(self.config.char_counter_offset_y),
+            + self.scaling.scale_int(self.config.char_counter_offset_y),
         )

--- a/tuxemon/ui/input_display.py
+++ b/tuxemon/ui/input_display.py
@@ -52,7 +52,12 @@ class InputDisplay:
         self.area_rect = area_rect
 
         # Prompt area
-        self.prompt = TextArea(font, font_color, (96, 96, 96))
+        self.prompt = TextArea(
+            font=font,
+            font_color=font_color,
+            scaling=self.scaling,
+            font_shadow=(96, 96, 96),
+        )
         self.prompt.animated = False
         self.prompt.rect = Rect(
             area_rect.x + self.scaling.scale_int(self.config.prompt_offset_x),
@@ -64,7 +69,12 @@ class InputDisplay:
         self.sprites.add(self.prompt)
 
         # Input text area
-        self.text_area = TextArea(font, font_color, (96, 96, 96))
+        self.text_area = TextArea(
+            font=font,
+            font_color=font_color,
+            scaling=self.scaling,
+            font_shadow=(96, 96, 96),
+        )
         self.text_area.animated = False
         self.text_area.rect = Rect(
             area_rect.x
@@ -78,7 +88,12 @@ class InputDisplay:
         self.sprites.add(self.text_area)
 
         # Character counter
-        self.char_counter = TextArea(font, font_color, (96, 96, 96))
+        self.char_counter = TextArea(
+            font=font,
+            font_color=font_color,
+            scaling=self.scaling,
+            font_shadow=(96, 96, 96),
+        )
         self.char_counter.animated = False
         self.sprites.add(self.char_counter)
 

--- a/tuxemon/ui/text.py
+++ b/tuxemon/ui/text.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 from pygame import SRCALPHA
 from pygame.draw import line, rect
@@ -23,6 +24,9 @@ from tuxemon.ui.draw import (
 )
 from tuxemon.ui.text_alignment import HorizontalAlignment, VerticalAlignment
 from tuxemon.ui.text_renderer import TextRenderer
+
+if TYPE_CHECKING:
+    from tuxemon.scaling import ScalingStrategy
 
 
 class TextAreaDiagnostics:
@@ -76,6 +80,7 @@ class TextArea(Sprite):
         self,
         font: Font,
         font_color: ColorLike,
+        scaling: ScalingStrategy,
         font_shadow: ColorLike = FONT_SHADOW_COLOR,
         background_color: ColorLike | None = None,
         background_image: Surface | None = None,
@@ -91,7 +96,9 @@ class TextArea(Sprite):
         self.font = font
         self.font_color = font_color
         self.font_shadow = font_shadow
+        self.scaling = scaling
         self._text_renderer = TextRenderer(
+            scaling=scaling,
             font=self.font,
             font_color=self.font_color,
             font_shadow_color=self.font_shadow,
@@ -183,6 +190,7 @@ class TextArea(Sprite):
             fg=self.font_color,
             bg=self.font_shadow,
             rect=self.image.get_rect(),
+            scaling=self.scaling,
             h_alignment=self.h_alignment,
             v_alignment=self.v_alignment,
             text_renderer=self._text_renderer,
@@ -265,6 +273,7 @@ def draw_text(
     surface: Surface,
     text: str,
     rect: Rect | tuple[int, int, int, int],
+    scaling: ScalingStrategy,
     *,
     h_alignment: HorizontalAlignment = HorizontalAlignment.LEFT,
     v_alignment: VerticalAlignment = VerticalAlignment.TOP,
@@ -299,7 +308,9 @@ def draw_text(
         font_color = FONT_COLOR
 
     if text_renderer is None:
-        text_renderer = TextRenderer(font_color=font_color, font=font)
+        text_renderer = TextRenderer(
+            scaling=scaling, font_color=font_color, font=font
+        )
 
     if not text:
         return

--- a/tuxemon/ui/text_renderer.py
+++ b/tuxemon/ui/text_renderer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Sequence
 
 from pygame import SRCALPHA
 from pygame.font import Font
@@ -12,19 +11,6 @@ from pygame.surface import Surface
 from tuxemon.graphics import ColorLike
 from tuxemon.platform.const.graphics import FONT_SHADOW_COLOR, FONT_SIZE
 from tuxemon.prepare import DISPLAY_CONTEXT
-from tuxemon.tools import scale
-
-
-def create_layout(
-    scale: float,
-) -> Callable[[Sequence[float]], Sequence[float]]:
-    def func(area: Sequence[float]) -> Sequence[float]:
-        return [scale * i for i in area]
-
-    return func
-
-
-layout = create_layout(DISPLAY_CONTEXT.scale)
 
 
 class TextRenderer:
@@ -39,7 +25,9 @@ class TextRenderer:
         if font_shadow_color is None:
             font_shadow_color = FONT_SHADOW_COLOR
         self.font_shadow_color = font_shadow_color
-        self.font = font or Font(font_filename, scale(FONT_SIZE))
+        self.font = font or Font(
+            font_filename, DISPLAY_CONTEXT.scaling.scale_int(FONT_SIZE)
+        )
 
     def shadow_text(
         self,
@@ -66,7 +54,7 @@ class TextRenderer:
             bg = self.font_shadow_color
         font_color = self.font.render(text, True, fg)
         shadow_color = self.font.render(text, True, bg)
-        _offset = layout(offset)
+        _offset = DISPLAY_CONTEXT.scaling.scale_sequence(offset)
         size = [
             int(math.ceil(a + b))
             for a, b in zip(_offset, font_color.get_size())

--- a/tuxemon/ui/text_renderer.py
+++ b/tuxemon/ui/text_renderer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 from pygame import SRCALPHA
 from pygame.font import Font
@@ -10,23 +11,27 @@ from pygame.surface import Surface
 
 from tuxemon.graphics import ColorLike
 from tuxemon.platform.const.graphics import FONT_SHADOW_COLOR, FONT_SIZE
-from tuxemon.prepare import DISPLAY_CONTEXT
+
+if TYPE_CHECKING:
+    from tuxemon.scaling import ScalingStrategy
 
 
 class TextRenderer:
     def __init__(
         self,
+        scaling: ScalingStrategy,
         font_color: ColorLike,
         font_shadow_color: ColorLike | None = None,
         font_filename: str | None = None,
         font: Font | None = None,
     ) -> None:
+        self.scaling = scaling
         self.font_color = font_color
         if font_shadow_color is None:
             font_shadow_color = FONT_SHADOW_COLOR
         self.font_shadow_color = font_shadow_color
         self.font = font or Font(
-            font_filename, DISPLAY_CONTEXT.scaling.scale_int(FONT_SIZE)
+            font_filename, self.scaling.scale_int(FONT_SIZE)
         )
 
     def shadow_text(
@@ -54,7 +59,7 @@ class TextRenderer:
             bg = self.font_shadow_color
         font_color = self.font.render(text, True, fg)
         shadow_color = self.font.render(text, True, bg)
-        _offset = DISPLAY_CONTEXT.scaling.scale_sequence(offset)
+        _offset = self.scaling.scale_sequence(offset)
         size = [
             int(math.ceil(a + b))
             for a, b in zip(_offset, font_color.get_size())


### PR DESCRIPTION
waiting
- [x] #3417

PR introduces display‑scaling support to the UI‑related dataclasses, allowing them to adapt cleanly to different resolutions and scaling strategies. As part of this work, the PR also advances the broader refactor to remove the legacy `tools.scale` helper and eliminate reliance on the global `DisplayContext`. These changes move the codebase toward a more explicit, dependency‑driven architecture and reduce hidden global state.

Changes:
- Added scaling support to dataclasses that represent coordinates, sizes, and rect‑like structures
- Integrated the new `ScalingStrategy` interface so dataclasses can scale values consistently using either `DefaultScaling` or `ResolutionScaling`
- Preserved existing behavior when scale factor is `1` to avoid regressions
- Updated internal usage sites to rely on scaled dataclass values rather than the deprecated `tools.scale` helper
- Began removing implicit dependencies on the global `DisplayContext` by passing scaling information explicitly where needed
- This PR is part of the ongoing effort to fully replace the old scaling utilities and eliminate global state from rendering and layout code