### PR TITLE
Fix various

### DIFF
--- a/mods/tuxemon/maps/start_tuxemon.yaml
+++ b/mods/tuxemon/maps/start_tuxemon.yaml
@@ -36,7 +36,7 @@ events:
     actions:
     - set_char_attribute player,gender,female
     - change_bg gradient_blue,choice_gender,image
-    - translated_dialog_choice white_female:white_female,race_choice
+    - translated_dialog_choice black_female:white_female,race_choice
     conditions:
     - is variable_set scenario_choice
     - is variable_set gender_choice:gender_female

--- a/tests/tuxemon/test_appearance.py
+++ b/tests/tuxemon/test_appearance.py
@@ -12,6 +12,9 @@ from tuxemon.entity.appearance import AppearanceManager, RuntimeAppearance
 class DummyTemplate:
     sprite_name: str = "npc_default"
     combat_sheet: str = "combat_default"
+    combat_frame_width: int = 32
+    combat_frame_height: int = 32
+    is_static_prop: bool = False
 
 
 def test_from_template():
@@ -52,6 +55,8 @@ def test_to_dict_roundtrip():
         "outfit": None,
         "accessory": None,
         "palette": None,
+        "combat_frame_width": None,
+        "combat_frame_height": None,
     }
 
 

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -165,6 +165,7 @@ class FishingEffect(CoreEffect):
                     == "night"
                     else self._fish.environment.get("default")
                 )
+                env = env or "ocean"
                 session.client.environment_manager.load_environment(env)
                 session.client.environment_manager.lock_environment()
                 rgb = ":".join(map(str, self._fish.animation_color))

--- a/tuxemon/entity/appearance.py
+++ b/tuxemon/entity/appearance.py
@@ -22,6 +22,9 @@ class RuntimeAppearance:
     accessory: str | None = None
     palette: str | None = None
 
+    combat_frame_width: int | None = None
+    combat_frame_height: int | None = None
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "sprite_name": self.sprite_name,
@@ -29,6 +32,8 @@ class RuntimeAppearance:
             "outfit": self.outfit,
             "accessory": self.accessory,
             "palette": self.palette,
+            "combat_frame_width": self.combat_frame_width,
+            "combat_frame_height": self.combat_frame_height,
         }
 
     @classmethod
@@ -36,6 +41,8 @@ class RuntimeAppearance:
         return cls(
             sprite_name=template.sprite_name,
             combat_sheet=template.combat_sheet,
+            combat_frame_width=template.combat_frame_width,
+            combat_frame_height=template.combat_frame_height,
         )
 
     @classmethod
@@ -48,6 +55,12 @@ class RuntimeAppearance:
             outfit=data.get("outfit"),
             accessory=data.get("accessory"),
             palette=data.get("palette"),
+            combat_frame_width=data.get(
+                "combat_frame_width", template.combat_frame_width
+            ),
+            combat_frame_height=data.get(
+                "combat_frame_height", template.combat_frame_height
+            ),
         )
 
 
@@ -117,13 +130,22 @@ class AppearanceManager:
 
         self.state.sprite_name = new.sprite_name
         self.state.combat_sheet = new.combat_sheet
+        self.state.outfit = new.outfit
+        self.state.accessory = new.accessory
+        self.state.palette = new.palette
+        self.state.combat_frame_width = new.combat_frame_width
+        self.state.combat_frame_height = new.combat_frame_height
 
         self.owner.sprite_controller.update_appearance(self.state)
 
     def build_composited_sheet(self) -> Surface:
-        base = load_and_scale_with_cache(
-            f"sprites/{self.state.sprite_name}.png"
-        )
+        if self.owner.template.is_static_prop:
+            base_path = f"sprites_obj/{self.state.sprite_name}.png"
+        else:
+            base_path = f"sprites/{self.state.sprite_name}.png"
+
+        base = load_and_scale_with_cache(base_path)
+
         final = base.copy()
 
         if self.state.outfit:

--- a/tuxemon/entity/npc.py
+++ b/tuxemon/entity/npc.py
@@ -17,7 +17,7 @@ from tuxemon.entity.entity import Entity
 from tuxemon.entity.party import PartyHandler
 from tuxemon.entity.path import PathController
 from tuxemon.entity.routing import RoutingPolicy
-from tuxemon.entity.sheet import CombatSheet, get_combat_sheet
+from tuxemon.entity.sheet import CombatSheet
 from tuxemon.entity.steps import StepManager
 from tuxemon.game_variables import GameVariablesManager, PlayerVariablesManager
 from tuxemon.locale.locale import T
@@ -196,7 +196,17 @@ class NPC(Entity):
         return self.path_controller.move_destination
 
     def combat_sheet(self) -> CombatSheet:
-        return get_combat_sheet(self.template)
+        a = self.appearance_manager.state
+
+        sheet = a.combat_sheet or self.template.combat_sheet
+        fw = a.combat_frame_width or self.template.combat_frame_width
+        fh = a.combat_frame_height or self.template.combat_frame_height
+
+        return CombatSheet(
+            file_path=f"gfx/sprites/player/{sheet}.png",
+            frame_w=fw,
+            frame_h=fh,
+        )
 
     def get_state(self, session: Session) -> NPCState:
         """

--- a/tuxemon/environment.py
+++ b/tuxemon/environment.py
@@ -160,10 +160,10 @@ class EnvironmentManager:
         """Returns the currently active Environment, or None if none is loaded."""
         return self._active_handler
 
-    def lock_environment(self):
+    def lock_environment(self) -> None:
         self._override_lock = True
 
-    def unlock_environment(self):
+    def unlock_environment(self) -> None:
         self._override_lock = False
 
     def is_locked(self) -> bool:


### PR DESCRIPTION
PR fixes a bunch of small issues, including the `get_sprite` bug where the engine ignored the updated appearance and always grabbed the template sprite. Basically, changing outfits or accessories didn’t actually change what got rendered. Now `get_sprite` pulls from the runtime appearance, so the layered system works properly.