### PR TITLE
Extract `MonsterRenderer` and remove rendering state from Monster

### DIFF
--- a/tests/tuxemon/test_monster_renderer.py
+++ b/tests/tuxemon/test_monster_renderer.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from dataclasses import dataclass
+
+import pytest
+
+from tuxemon.db import SoundProperties
+from tuxemon.monster.renderer import MonsterRenderer, SoundConfig, SpriteConfig
+
+
+@dataclass
+class DummyMonster:
+    slug: str
+    sprite_config: SpriteConfig
+    sound_config: SoundConfig
+    flairs: dict
+    flair_slugs: set
+
+
+class DummyHandler:
+    """A fake MonsterSpriteHandler that records calls."""
+
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    def load_sprites(self, scale):
+        self.calls.append(("load_sprites", scale))
+
+    def get_sprite(self, sprite_type, scale, frame_duration, **kwargs):
+        self.calls.append(
+            ("get_sprite", sprite_type, scale, frame_duration, kwargs)
+        )
+        return f"sprite:{sprite_type}"
+
+
+@pytest.fixture(autouse=True)
+def patch_handler(monkeypatch):
+    monkeypatch.setattr(
+        "tuxemon.monster.renderer.MonsterSpriteHandler", DummyHandler
+    )
+
+
+def test_renderer_initialization():
+    monster = DummyMonster(
+        slug="testmon",
+        sprite_config=SpriteConfig(
+            slug="testmon",
+            sheet_path="path/to/sheet",
+            front_rect=(0, 0, 10, 10),
+            back_rect=(0, 0, 10, 10),
+            menu1_rect=(0, 0, 10, 10),
+            menu2_rect=(0, 0, 10, 10),
+            flair_slugs=set(),
+        ),
+        sound_config=SoundConfig(
+            combat=None,
+            faint=None,
+            default_combat="sound_test_call",
+            default_faint="sound_test_faint",
+        ),
+        flairs={},
+        flair_slugs=set(),
+    )
+
+    renderer = MonsterRenderer(monster, scale=2.0)
+
+    assert renderer.sprite_handler.calls[0] == ("load_sprites", 2.0)
+
+
+def test_get_sprite_forwards_kwargs():
+    monster = DummyMonster(
+        slug="testmon",
+        sprite_config=SpriteConfig(
+            slug="testmon",
+            sheet_path="path/to/sheet",
+            front_rect=(0, 0, 10, 10),
+            back_rect=(0, 0, 10, 10),
+            menu1_rect=(0, 0, 10, 10),
+            menu2_rect=(0, 0, 10, 10),
+            flair_slugs=set(),
+        ),
+        sound_config=SoundConfig(
+            combat=None,
+            faint=None,
+            default_combat="sound_test_call",
+            default_faint="sound_test_faint",
+        ),
+        flairs={},
+        flair_slugs=set(),
+    )
+
+    renderer = MonsterRenderer(monster, scale=1.5)
+    sprite = renderer.get_sprite("front", midbottom=(5, 5))
+
+    assert sprite == "sprite:front"
+
+    _, sprite_type, scale, frame_duration, kwargs = (
+        renderer.sprite_handler.calls[-1]
+    )
+    assert sprite_type == "front"
+    assert scale == 1.5
+    assert kwargs == {"midbottom": (5, 5)}
+
+
+def test_sound_resolution():
+    props = SoundProperties(sfx="sound_confirm", volume=0.8)
+
+    monster = DummyMonster(
+        slug="testmon",
+        sprite_config=SpriteConfig(
+            slug="testmon",
+            sheet_path="path/to/sheet",
+            front_rect=(0, 0, 10, 10),
+            back_rect=(0, 0, 10, 10),
+            menu1_rect=(0, 0, 10, 10),
+            menu2_rect=(0, 0, 10, 10),
+            flair_slugs=set(),
+        ),
+        sound_config=SoundConfig(
+            combat=props,
+            faint=None,
+            default_combat="sound_default_call",
+            default_faint="sound_default_faint",
+        ),
+        flairs={},
+        flair_slugs=set(),
+    )
+
+    renderer = MonsterRenderer(monster)
+
+    assert renderer.get_combat_sound() == ("sound_confirm", 0.8)
+    assert renderer.get_faint_sound() == ("sound_default_faint", 1.0)

--- a/tuxemon/event/actions/cipher_dialog.py
+++ b/tuxemon/event/actions/cipher_dialog.py
@@ -9,8 +9,9 @@ from typing import Any, final
 from tuxemon.database.runtime import db
 from tuxemon.db import DialogueModel
 from tuxemon.event.eventaction import EventAction
-from tuxemon.graphics import get_avatar, string_to_colorlike
+from tuxemon.graphics import string_to_colorlike
 from tuxemon.locale.locale import T
+from tuxemon.monster.avatar import get_avatar
 from tuxemon.session import Session
 from tuxemon.tools import open_dialog, safe_enum_value
 from tuxemon.ui.text_alignment import (

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -9,6 +9,7 @@ from typing import final
 from tuxemon.database.runtime import db
 from tuxemon.db import FlairModel
 from tuxemon.event.eventaction import EventAction
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.monster.sprite import Flair
 from tuxemon.session import Session
 from tuxemon.tools import get_valid_uuid
@@ -53,7 +54,8 @@ class SetMonsterFlairAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
-            return  # Exit early if no valid UUID
+            return
+
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
@@ -86,16 +88,14 @@ class SetMonsterFlairAction(EventAction):
             color=flair_model.color,
         )
 
-        monster.sprite_handler.refresh_flairs(monster.flairs)
-
-        scale_int = session.client.context.scaling.factor
+        monster.flair_slugs.add(flair_model.slug)
+        scale = session.client.context.scaling.factor
+        renderer = MonsterRenderer(monster, scale)
+        renderer.sprite_handler.refresh_flairs(monster.flairs)
 
         if sprite_types:
             for sprite_type in sprite_types:
-                monster.sprite_handler.get_sprite(sprite_type, scale_int)
-
-        if flair_model.slug not in monster.flair_slugs:
-            monster.flair_slugs.add(flair_model.slug)
+                renderer.get_sprite(sprite_type)
 
         if category in monster.flairs:
             logger.info(

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass
 from typing import Any, final
 
 from tuxemon.event.eventaction import EventAction
-from tuxemon.graphics import get_avatar, string_to_colorlike
+from tuxemon.graphics import string_to_colorlike
 from tuxemon.locale.locale import T
+from tuxemon.monster.avatar import get_avatar
 from tuxemon.session import Session
 from tuxemon.tools import open_dialog, safe_enum_value
 from tuxemon.ui.dialogue import DialogueStyleCache

--- a/tuxemon/graphics.py
+++ b/tuxemon/graphics.py
@@ -23,12 +23,9 @@ from pygame.transform import scale
 from pytmx.pytmx import TileFlags
 from pytmx.util_pygame import handle_transformation, smart_convert
 
-from tuxemon.database.runtime import db
-from tuxemon.db import MonsterModel, NpcModel
 from tuxemon.platform.const.graphics import FUCHSIA_COLOR
 from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.scaling import ScalingStrategy
-from tuxemon.session import Session
 from tuxemon.sprite import Sprite
 from tuxemon.surfanim import SurfaceAnimation
 from tuxemon.tools import transform_resource_filename
@@ -490,56 +487,6 @@ def scaled_image_loader(
         return tile
 
     return load_image
-
-
-def get_avatar(session: Session, avatar: str) -> Sprite | None:
-    """
-    Retrieves the avatar sprite of a monster or NPC.
-
-    Parameters:
-        session: Game session.
-        avatar: The identifier of the avatar to be used.
-
-    Returns:
-        The sprite for the monster or NPC avatar, or None if not found.
-    """
-    from tuxemon.monster.sprite import MonsterSpriteHandler, SpriteLoader
-
-    scale_int = session.client.context.scaling.factor
-
-    if avatar.isdigit():
-        monster = session.player.monsters[int(avatar)]
-        return monster.get_sprite("menu", scale=scale_int)
-
-    if avatar in db.database.get("monster", {}):
-        model = MonsterModel.lookup(avatar, db)
-        loader = SpriteLoader()
-        sprites = model.sprites
-        assert sprites
-        handler = MonsterSpriteHandler(
-            slug=model.slug,
-            sheet_path=loader.resolve_path(sprites.sheet),
-            front_rect=sprites.front_rect,
-            back_rect=sprites.back_rect,
-            menu1_rect=sprites.menu1_rect,
-            menu2_rect=sprites.menu2_rect,
-        )
-        if handler is None:
-            return None
-        return handler.get_sprite("menu", scale=scale_int)
-
-    if avatar in db.database.get("npc", {}):
-        from tuxemon.entity.sheet import get_combat_sheet
-
-        npc_data = NpcModel.lookup(avatar, db)
-        sheet = get_combat_sheet(npc_data.template)
-        surface = sheet.front()
-        sprite = load_surface(surface)
-        scale_sprite(sprite, 0.5)
-        return sprite
-
-    logger.debug(f"Avatar '{avatar}' not found")
-    return None
 
 
 def string_to_colorlike(color: str) -> ColorLike:

--- a/tuxemon/monster/avatar.py
+++ b/tuxemon/monster/avatar.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from tuxemon.database.runtime import db
+from tuxemon.db import MonsterModel, NpcModel
+from tuxemon.entity.sheet import get_combat_sheet
+from tuxemon.graphics import load_surface, scale_sprite
+from tuxemon.monster.renderer import MonsterRenderer
+from tuxemon.monster.sprite import MonsterSpriteHandler, SpriteLoader
+from tuxemon.session import Session
+from tuxemon.sprite import Sprite
+
+
+def get_avatar(session: Session, avatar: str) -> Sprite | None:
+    """
+    Retrieves the avatar sprite of a monster or NPC.
+
+    Parameters:
+        session: Game session.
+        avatar: The identifier of the avatar to be used.
+
+    Returns:
+        The sprite for the monster or NPC avatar, or None if not found.
+    """
+    scale_int = session.client.context.scaling.factor
+
+    if avatar.isdigit():
+        monster = session.player.monsters[int(avatar)]
+        renderer = MonsterRenderer(monster, scale=scale_int)
+        return renderer.get_sprite("front")
+
+    if avatar in db.database.get("monster", {}):
+        model = MonsterModel.lookup(avatar, db)
+
+        if model.sprites is None:
+            return None
+
+        loader = SpriteLoader()
+        handler = MonsterSpriteHandler(
+            slug=model.slug,
+            sheet_path=loader.resolve_path(model.sprites.sheet),
+            front_rect=model.sprites.front_rect,
+            back_rect=model.sprites.back_rect,
+            menu1_rect=model.sprites.menu1_rect,
+            menu2_rect=model.sprites.menu2_rect,
+        )
+        return handler.get_sprite("menu", scale=scale_int)
+
+    if avatar in db.database.get("npc", {}):
+        sheet = get_combat_sheet(NpcModel.lookup(avatar, db).template)
+        sprite = load_surface(sheet.front())
+        scale_sprite(sprite, 0.5)
+        return sprite
+
+    return None

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -18,7 +18,6 @@ from tuxemon.db import (
     GenderType,
     MonsterModel,
     MonsterSpritesModel,
-    SoundProperties,
     StatType,
 )
 from tuxemon.element import ElementTypesHandler
@@ -30,12 +29,8 @@ from tuxemon.monster.experience import MonsterExperience
 from tuxemon.monster.held_item import MonsterItemHandler
 from tuxemon.monster.moves import MonsterMovesHandler
 from tuxemon.monster.plague import MonsterPlagueHandler
-from tuxemon.monster.sprite import (
-    Flair,
-    FlairApplier,
-    MonsterSpriteHandler,
-    SpriteLoader,
-)
+from tuxemon.monster.renderer import SoundConfig, SpriteConfig
+from tuxemon.monster.sprite import Flair, FlairApplier
 from tuxemon.monster.stats import (
     BasicStats,
     CustomStatBoosts,
@@ -46,9 +41,7 @@ from tuxemon.monster.stats import (
 )
 from tuxemon.monster.status import MonsterStatusHandler
 from tuxemon.platform.const.sizes import MONTH_KEYS
-from tuxemon.prepare import DISPLAY_CONTEXT
 from tuxemon.shape import ShapeHandler
-from tuxemon.sprite import Sprite
 from tuxemon.taste import Taste
 from tuxemon.time_handler import random_month_day, today_month_day
 
@@ -166,46 +159,32 @@ class Monster:
         self.body = Body()
 
     def _init_assets(self, db_data: MonsterModel) -> None:
-        """Configures visual and auditory assets from DB data."""
-        self.flair_slugs = db_data.flairs
-        self.flairs = FlairApplier.create(self.flair_slugs)
+        """Store only metadata for assets. No loading, no SpriteLoader."""
+        self.flair_slugs = set(db_data.flairs or [])
+        self.flairs: dict[str, Flair] = {}
 
-        loader = SpriteLoader()
         sprites = db_data.sprites or MonsterSpritesModel(
             sheet=f"gfx/sprites/battle/{self.slug}-sheet",
         )
 
-        self.sprite_handler = MonsterSpriteHandler(
+        self.sprite_config = SpriteConfig(
             slug=self.slug,
-            sheet_path=loader.resolve_path(sprites.sheet),
+            sheet_path=sprites.sheet,
             front_rect=sprites.front_rect,
             back_rect=sprites.back_rect,
             menu1_rect=sprites.menu1_rect,
             menu2_rect=sprites.menu2_rect,
-            flairs=self.flairs,
+            flair_slugs=self.flair_slugs,
         )
 
         primary_slug = self.types.primary.slug
 
-        if db_data.sounds and db_data.sounds.combat_call:
-            self.combat_call = db_data.sounds.combat_call
-            if self.combat_call.sfx is None:
-                self.combat_call.sfx = f"sound_{primary_slug}_call"
-        else:
-            self.combat_call = SoundProperties(
-                sfx=f"sound_{primary_slug}_call",
-                volume=1.5,
-            )
-
-        if db_data.sounds and db_data.sounds.faint_call:
-            self.faint_call = db_data.sounds.faint_call
-            if self.faint_call.sfx is None:
-                self.faint_call.sfx = f"sound_{primary_slug}_faint"
-        else:
-            self.faint_call = SoundProperties(
-                sfx=f"sound_{primary_slug}_faint",
-                volume=1.5,
-            )
+        self.sound_config = SoundConfig(
+            combat=db_data.sounds.combat_call if db_data.sounds else None,
+            faint=db_data.sounds.faint_call if db_data.sounds else None,
+            default_combat=f"sound_{primary_slug}_call",
+            default_faint=f"sound_{primary_slug}_faint",
+        )
 
     @classmethod
     def spawn_base(cls, slug: str, level: int) -> Monster:
@@ -262,18 +241,18 @@ class Monster:
                 monster.custom_stats = CustomStatBoosts.from_dict(value)
             elif key == "individual_values" and value:
                 monster.individual_values = IndividualValues.from_dict(value)
-            elif key == "flairs" and value:
-                monster.flairs = {
-                    category: Flair.from_state(flair_data)
-                    for category, flair_data in value.items()
-                }
-            elif key == "flair_slugs" and value:
-                monster.flair_slugs = set(value)
-                if "flairs" not in save_data:
-                    monster.flairs = FlairApplier.create(monster.flair_slugs)
+
+        monster.flair_slugs = set(save_data.get("flair_slugs", []))
+
+        if "flairs" in save_data:
+            monster.flairs = {
+                category: Flair.from_state(flair_data)
+                for category, flair_data in save_data["flairs"].items()
+            }
+        elif monster.flair_slugs:
+            monster.flairs = FlairApplier.create(monster.flair_slugs)
 
         monster.set_stats()
-        monster.load_sprites()
 
         return monster
 
@@ -399,17 +378,6 @@ class Monster:
             {"doc": self.capture_string},
         )
 
-    def load_sprites(
-        self, scale: float = DISPLAY_CONTEXT.scaling.factor
-    ) -> None:
-        """
-        Delegates the task of loading sprites to the sprite handler.
-
-        Parameters:
-            scale: The scaling factor to resize the sprite images.
-        """
-        self.sprite_handler.load_sprites(scale)
-
     def get_owner(self) -> NPC:
         """Returns the character associated with this monster."""
         if not self.owner:
@@ -468,23 +436,6 @@ class Monster:
             )
 
         return exp_multiplier
-
-    def get_sprite(
-        self,
-        sprite_type: str,
-        frame_duration: float = 0.25,
-        scale: float = DISPLAY_CONTEXT.scaling.factor,
-        **kwargs: Any,
-    ) -> Sprite:
-        """
-        Retrieves a specific sprite via the sprite handler.
-        """
-        return self.sprite_handler.get_sprite(
-            sprite_type=sprite_type,
-            scale=scale,
-            frame_duration=frame_duration,
-            **kwargs,
-        )
 
     def return_stat(self, stat: StatType | str) -> int:
         """

--- a/tuxemon/monster/renderer.py
+++ b/tuxemon/monster/renderer.py
@@ -61,17 +61,14 @@ class MonsterRenderer:
         self.sprite_handler = self._setup_handler()
 
     def _resolve_flairs(self) -> dict[str, Flair]:
-        """
-        Returns the correct flair objects for rendering:
-        - Use saved flair state if present
-        - Otherwise generate fresh flairs from slugs
-        """
+        """Return the monster's saved flairs or generate new ones from slugs."""
         if self.monster.flairs:
             return self.monster.flairs
 
         return FlairApplier.create(self.monster.flair_slugs)
 
     def _setup_handler(self) -> MonsterSpriteHandler:
+        """Initialize and load the monster's sprite handler."""
         cfg = self.monster.sprite_config
         loader = SpriteLoader()
 
@@ -89,6 +86,7 @@ class MonsterRenderer:
         return handler
 
     def get_sprite(self, sprite_type: str = "front", **kwargs: Any) -> Sprite:
+        """Return a rendered sprite of the specified type."""
         return self.sprite_handler.get_sprite(
             sprite_type=sprite_type,
             scale=self.scale,
@@ -97,6 +95,7 @@ class MonsterRenderer:
         )
 
     def get_combat_sound(self) -> tuple[str, float]:
+        """Return the monster's combat sound effect and volume."""
         cfg = self.monster.sound_config
         call = cfg.combat
 
@@ -108,6 +107,7 @@ class MonsterRenderer:
         return cfg.default_combat, 1.0
 
     def get_faint_sound(self) -> tuple[str, float]:
+        """Return the monster's faint sound effect and volume."""
         cfg = self.monster.sound_config
         call = cfg.faint
 

--- a/tuxemon/monster/renderer.py
+++ b/tuxemon/monster/renderer.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from tuxemon.db import SoundProperties
+from tuxemon.monster.sprite import (
+    Flair,
+    FlairApplier,
+    MonsterSpriteHandler,
+    SpriteLoader,
+)
+from tuxemon.sprite import Sprite
+
+if TYPE_CHECKING:
+    from tuxemon.monster.monster import Monster
+
+logger = logging.getLogger(__name__)
+
+from dataclasses import dataclass
+
+from tuxemon.db import SoundProperties
+
+
+@dataclass
+class SoundConfig:
+    combat: SoundProperties | None
+    faint: SoundProperties | None
+    default_combat: str
+    default_faint: str
+
+
+@dataclass
+class SpriteConfig:
+    slug: str
+    sheet_path: str
+    front_rect: tuple[int, int, int, int]
+    back_rect: tuple[int, int, int, int]
+    menu1_rect: tuple[int, int, int, int]
+    menu2_rect: tuple[int, int, int, int]
+    flair_slugs: set[str]
+
+
+class MonsterRenderer:
+    """
+    Handles all rendering concerns for a Monster.
+    Loads sprites, applies scaling, and returns Sprite objects.
+    """
+
+    def __init__(
+        self,
+        monster: Monster,
+        scale: float | None = None,
+        frame_duration: float | None = None,
+    ):
+        self.monster = monster
+        self.scale = scale or 1.0
+        self.frame_duration = frame_duration or 0.25
+        self.sprite_handler = self._setup_handler()
+
+    def _resolve_flairs(self) -> dict[str, Flair]:
+        """
+        Returns the correct flair objects for rendering:
+        - Use saved flair state if present
+        - Otherwise generate fresh flairs from slugs
+        """
+        if self.monster.flairs:
+            return self.monster.flairs
+
+        return FlairApplier.create(self.monster.flair_slugs)
+
+    def _setup_handler(self) -> MonsterSpriteHandler:
+        cfg = self.monster.sprite_config
+        loader = SpriteLoader()
+
+        handler = MonsterSpriteHandler(
+            slug=cfg.slug,
+            sheet_path=loader.resolve_path(cfg.sheet_path),
+            front_rect=cfg.front_rect,
+            back_rect=cfg.back_rect,
+            menu1_rect=cfg.menu1_rect,
+            menu2_rect=cfg.menu2_rect,
+            flairs=FlairApplier.create(cfg.flair_slugs),
+        )
+
+        handler.load_sprites(self.scale)
+        return handler
+
+    def get_sprite(self, sprite_type: str = "front", **kwargs: Any) -> Sprite:
+        return self.sprite_handler.get_sprite(
+            sprite_type=sprite_type,
+            scale=self.scale,
+            frame_duration=self.frame_duration,
+            **kwargs,
+        )
+
+    def get_combat_sound(self) -> tuple[str, float]:
+        cfg = self.monster.sound_config
+        call = cfg.combat
+
+        if isinstance(call, SoundProperties):
+            sfx = call.sfx if call.sfx is not None else cfg.default_combat
+            volume = float(call.volume)
+            return sfx, volume
+
+        return cfg.default_combat, 1.0
+
+    def get_faint_sound(self) -> tuple[str, float]:
+        cfg = self.monster.sound_config
+        call = cfg.faint
+
+        if isinstance(call, SoundProperties):
+            sfx = call.sfx if call.sfx is not None else cfg.default_faint
+            volume = float(call.volume)
+            return sfx, volume
+
+        return cfg.default_faint, 1.0

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -23,6 +23,7 @@ from tuxemon.constants.paths import mods_folder
 from tuxemon.database.rules import config_combat
 from tuxemon.environment import BattleLayout
 from tuxemon.menu.menu import Menu
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.sprite import CaptureDeviceSprite, HordeSprite, Sprite
 from tuxemon.ui.combat_bars import CombatBars
@@ -198,7 +199,8 @@ class CombatAnimations(Menu[None], ABC):
         self.task(capdev.kill, interval=fall_time + delay + fade_duration)
 
         # Load monster sprite and set final position
-        monster_sprite = monster.get_sprite(
+        renderer = MonsterRenderer(monster, scale=self.factor)
+        monster_sprite = renderer.get_sprite(
             "back" if npc == self.combat_session.left_player else "front"
         )
         monster_sprite.rect.midbottom = feet
@@ -222,10 +224,12 @@ class CombatAnimations(Menu[None], ABC):
         self.task(partial(self.sprites.add, sprite), interval=1.3)
 
         # Load and play combat call sound
+        sound, volume = renderer.get_combat_sound()
+
         self.event_bus.publish(
             "play_sound_combat",
-            sound=monster.combat_call.sfx,
-            value=monster.combat_call.volume,
+            sound=sound,
+            value=volume,
         )
 
     def animate_sprite_tackle(self, attacker: Sprite) -> None:
@@ -355,13 +359,17 @@ class CombatAnimations(Menu[None], ABC):
             sprite.rect, self.scale_int(-150)
         )
 
-        cry = (
-            monster.combat_call
-            if monster.current_hp > 0
-            else monster.faint_call
-        )
+        renderer = MonsterRenderer(monster)
+
+        if monster.current_hp > 0:
+            sound, volume = renderer.get_combat_sound()
+        else:
+            sound, volume = renderer.get_faint_sound()
+
         self.event_bus.publish(
-            "play_sound_combat", sound=cry.sfx, value=cry.volume
+            "play_sound_combat",
+            sound=sound,
+            value=volume,
         )
         self.animate(sprite.rect, x=x_offset, relative=True, duration=2)
         self.status_icons.animate_icons(monster, self.animate)
@@ -651,7 +659,8 @@ class CombatAnimations(Menu[None], ABC):
             self.sprite_map.add_sprite(opponent, enemy)
         else:
             monster_pos = layout.get_combatant_pos("monster", back_island.rect)
-            enemy = opp_mon.get_sprite("front")
+            renderer = MonsterRenderer(opp_mon, scale=self.factor)
+            enemy = renderer.get_sprite("front")
             enemy.rect.midbottom = (
                 monster_pos["centerx"],
                 monster_pos["bottom"],
@@ -673,9 +682,13 @@ class CombatAnimations(Menu[None], ABC):
         )
 
         if not self.combat_session.is_trainer_battle:
-            sound = self.combat_session.right_player.monsters[0].combat_call
+            renderer = MonsterRenderer(opp_mon)
+            sound, volume = renderer.get_combat_sound()
+
             self.event_bus.publish(
-                "play_sound_combat", sound=sound.sfx, value=sound.volume
+                "play_sound_combat",
+                sound=sound,
+                value=volume,
             )
 
         self.event_bus.publish(
@@ -864,10 +877,13 @@ class CombatAnimations(Menu[None], ABC):
 
             def show_monster() -> None:
                 toggle_visible(monster_sprite)
+                renderer = MonsterRenderer(monster)
+                sound, volume = renderer.get_combat_sound()
+
                 self.event_bus.publish(
                     "play_sound_combat",
-                    sound=monster.combat_call.sfx,
-                    value=monster.combat_call.volume,
+                    sound=sound,
+                    value=volume,
                 )
 
             def capture_capsule() -> None:

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -61,6 +61,7 @@ from tuxemon.item.item import Item
 from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.monster.monster import Monster
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.state.state import State
@@ -1086,10 +1087,12 @@ class CombatState(CombatAnimations):
         assert user_sprite and target_sprite
 
         if direction == "both":
-            front_user = user.get_sprite(
+            u_renderer = MonsterRenderer(user, scale=self.factor)
+            front_user = u_renderer.get_sprite(
                 "front", midbottom=target_sprite.rect.midbottom
             )
-            back_target = target.get_sprite(
+            t_renderer = MonsterRenderer(user, scale=self.factor)
+            back_target = t_renderer.get_sprite(
                 "back", midbottom=user_sprite.rect.midbottom
             )
             self.sprites.add(front_user)
@@ -1103,7 +1106,8 @@ class CombatState(CombatAnimations):
             _, h_align = self.combat_zone.get_zone(user_sprite.rect)
             side = "front" if h_align is HorizontalAlignment.LEFT else "back"
 
-            front_user = user.get_sprite(
+            renderer = MonsterRenderer(user, scale=self.factor)
+            front_user = renderer.get_sprite(
                 side, midbottom=target_sprite.rect.midbottom
             )
             self.sprites.add(front_user)
@@ -1114,7 +1118,8 @@ class CombatState(CombatAnimations):
             _, h_align = self.combat_zone.get_zone(user_sprite.rect)
             side = "back" if h_align is HorizontalAlignment.LEFT else "front"
 
-            back_target = target.get_sprite(
+            renderer = MonsterRenderer(target, scale=self.factor)
+            back_target = renderer.get_sprite(
                 side, midbottom=user_sprite.rect.midbottom
             )
             self.sprites.add(back_target)

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -15,6 +15,7 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.menu.theme import get_theme
 from tuxemon.monster.monster import Monster
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import INDIV_INFO
 from tuxemon.platform.const.sizes import U_CM, U_FT, U_KG, U_LB, U_M, U_T
@@ -414,7 +415,8 @@ class MonsterInfoState(PygameMenuState):
                 bond_widget.translate(fxw(20 / 256), fxh(29 / 144))
 
         # image
-        surface = monster.get_sprite("front").image
+        renderer = MonsterRenderer(monster, scale=self.factor)
+        surface = renderer.get_sprite("front").image
         new_image = self._create_image_from_surface(surface)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -19,6 +19,7 @@ from tuxemon.menu.interface import ExpBar, HpBar, MenuItem
 from tuxemon.menu.menu import Menu
 from tuxemon.monster.filter import MonsterFilter
 from tuxemon.monster.monster import Monster
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const.graphics import BG_MONSTERS, TRANSPARENT_COLOR
 from tuxemon.platform.const.sizes import PARTY_LIMIT
 from tuxemon.prepare import SCREEN_SIZE
@@ -85,10 +86,6 @@ class MonsterMenuState(Menu[Monster | None]):
         self.slot_renderer = MonsterSlotRenderer(
             self.client.context, self.font, self.hp_bar, self.font_color
         )
-
-        # Load monster visuals
-        for monster in self.monsters:
-            monster.load_sprites()
 
     def calc_menu_items_rect(self) -> Rect:
         width, height = self.rect.size
@@ -510,7 +507,8 @@ class MonsterSpriteDisplay:
             if self.sprite:
                 self.menu_state.sprites.remove(self.sprite)
 
-            self.sprite = monster.get_sprite("menu", 0.25, 2.5)
+            renderer = MonsterRenderer(monster, scale=2.5, frame_duration=0.25)
+            self.sprite = renderer.get_sprite("menu")
             self.menu_state.sprites.add(self.sprite, layer=LAYER_MONSTER_ICONS)
 
             width = SCREEN_SIZE[0]
@@ -540,10 +538,12 @@ class MonsterPortraitDisplay:
         image = None
         if monster is not None:
             try:
-                sprite = monster.get_sprite("front")
+                renderer = MonsterRenderer(monster, scale=self.scaling.factor)
+                sprite = renderer.get_sprite("front")
                 image = sprite.image
-            except AttributeError:
+            except Exception:
                 pass
+
         image = image or Surface((1, 1), SRCALPHA)
 
         self.portrait.image = image

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -14,6 +14,7 @@ from tuxemon.database.runtime import db
 from tuxemon.db import MonsterModel, SpeedLabel
 from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const import buttons
 from tuxemon.platform.const.graphics import TECH_INFO
 from tuxemon.platform.const.sizes import ACCURACY_RANGE, POTENCY_RANGE
@@ -93,7 +94,8 @@ class MonsterMovesState(PygameMenuState):
             ).translate(fxw(83.6 / 256), fxh(_height))
 
         # Monster image (manual position)
-        surface = monster.get_sprite("front").image
+        renderer = MonsterRenderer(monster, scale=self.factor)
+        surface = renderer.get_sprite("front").image
         new_image = self._create_image_from_surface(surface)
         image_widget = menu.add.image(image_path=new_image.copy())
         image_widget.set_float(origin_position=True)

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -18,6 +18,7 @@ from tuxemon.graphics import scale_surface
 from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import PygameMenuState
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const.graphics import BG_PC_KENNEL
 from tuxemon.platform.const.sizes import MAX_KENNEL, PARTY_LIMIT
 from tuxemon.prepare import SCREEN_SIZE
@@ -296,7 +297,8 @@ class MonsterTakeState(PygameMenuState):
         for monster in _sorted:
             label = T.translate(monster.name).upper()
             iid = monster.instance_id.hex
-            surface = monster.get_sprite("front").image
+            renderer = MonsterRenderer(monster, scale=self.factor)
+            surface = renderer.get_sprite("front").image
             scaled = scale_surface(surface, self.factor * 0.125)
             new_image = self._create_image_from_surface(scaled)
             menu.add.banner(

--- a/tuxemon/states/shop_healing.py
+++ b/tuxemon/states/shop_healing.py
@@ -15,6 +15,7 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.quantity import QuantityAndCostMenu
 from tuxemon.monster.monster import Monster
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.session import local_session
 from tuxemon.states.shop_base import ShopMenuState
 
@@ -76,7 +77,8 @@ class ShopHealingMenuState(ShopMenuState[Monster]):
         self.update_background(self.config.background)
 
     def _get_asset_image(self, asset: MenuItem[Monster]) -> Surface | None:
-        image = asset.game_object.get_sprite("front")
+        renderer = MonsterRenderer(asset.game_object, scale=self.factor)
+        image = renderer.get_sprite("front")
         return image.image if image else None
 
     def _display_asset_description(self, asset: MenuItem[Monster]) -> None:

--- a/tuxemon/states/shop_monster.py
+++ b/tuxemon/states/shop_monster.py
@@ -13,6 +13,7 @@ from tuxemon.item.shop_utils import (
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.quantity import QuantityAndCostMenu, QuantityAndPriceMenu
 from tuxemon.monster.monster import Monster
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.states.shop_base import ShopMenuState
 
 if TYPE_CHECKING:
@@ -35,7 +36,8 @@ class ShopMonsterMenuState(ShopMenuState[Monster]):
         self.update_background(self.economy.model.background)
 
     def _get_asset_image(self, asset: MenuItem[Monster]) -> Surface | None:
-        image = asset.game_object.get_sprite("front")
+        renderer = MonsterRenderer(asset.game_object, scale=self.factor)
+        image = renderer.get_sprite("front")
         return image.image if image else None
 
     def _display_asset_description(self, asset: MenuItem[Monster]) -> None:

--- a/tuxemon/states/shop_training.py
+++ b/tuxemon/states/shop_training.py
@@ -16,6 +16,7 @@ from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.quantity import QuantityAndCostMenu
 from tuxemon.monster.monster import Monster
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.states.shop_base import ShopMenuState
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,8 @@ class ShopTrainingMenuState(ShopMenuState[Monster]):
 
     def _get_asset_image(self, asset: MenuItem[Monster]) -> Surface | None:
         """Returns the front sprite image for a monster."""
-        image = asset.game_object.get_sprite("front")
+        renderer = MonsterRenderer(asset.game_object, scale=self.factor)
+        image = renderer.get_sprite("front")
         return image.image if image else None
 
     def _display_asset_description(self, asset: MenuItem[Monster]) -> None:

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -10,6 +10,7 @@ from pygame.rect import Rect
 from tuxemon.locale.locale import T
 from tuxemon.menu.interface import MenuItem
 from tuxemon.menu.menu import Menu
+from tuxemon.monster.renderer import MonsterRenderer
 from tuxemon.platform.const.graphics import (
     BG_MOVES,
     DIMGRAY_COLOR,
@@ -125,7 +126,8 @@ class TechniqueMenuState(Menu[Technique]):
             mon = self.char.party.find_monster_by_tech_id(tech.instance_id)
 
             if mon:
-                sprite = mon.get_sprite("front")
+                renderer = MonsterRenderer(mon, scale=self.factor)
+                sprite = renderer.get_sprite("front")
                 sprite.rect.center = self.backpack_center
                 self.sprites.add(sprite, layer=100)
             else:


### PR DESCRIPTION
waiting
- [x] #3429 

PR separates all rendering and audiovisual responsibilities from the `Monster` model and moves them into a dedicated `MonsterRenderer` class. The goal is to make `Monster` a pure data container and ensure that all sprite loading, flair application, and sound resolution happen in a single, well‑defined place.
  
Changes:
- introduced `MonsterRenderer`, responsible for: loading and scaling sprites, applying flairs, resolving combat and faint sounds and returning ready‑to‑use `Sprite` objects  
- removed all rendering state from `Monster`: `sprite_handler` no longer lives on the model, `combat_call` and `faint_call` attributes removed and flair state remains, but rendering is handled externally  
- added typed metadata containers: `SpriteConfig` dataclass for sprite sheet paths, rects, and flair slugs and `SoundConfig` dataclass for combat/faint sound metadata and defaults
- updated all call sites to use `MonsterRenderer` instead of accessing rendering state on `Monster`
- updated flair‑related event actions to rebuild a renderer on demand and refresh flairs through it

Migration notes
- any code that previously accessed `monster.sprite_handler` must now instantiate `MonsterRenderer(monster, scale)` and use its methods
- sound playback must use `renderer.get_combat_sound()` or `renderer.get_faint_sound()`
- flair updates modify `monster.flairs`, and the renderer applies them when created