### PR TITLE
Stat Pipeline: Improved `TrainingPoints` Scaling, Updated `TP` Gain Logic and Centralized `Taste` Modifiers

### DIFF
--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -78,6 +78,7 @@ def shape_model(monkeypatch):
 
 @pytest.fixture
 def tastes(monkeypatch):
+    """Inject fake tastes with modifiers."""
     Taste._tastes = {}
 
     def make_taste(slug, values, mult):

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -78,18 +78,31 @@ def shape_model(monkeypatch):
 
 @pytest.fixture
 def tastes(monkeypatch):
-    """Inject fake tastes with modifiers."""
     Taste._tastes = {}
 
     def make_taste(slug, values, mult):
         t = MagicMock(spec=Taste)
         t.slug = slug
         t.taste_type = "warm"
-        mod = MagicMock(spec=Modifier)
-        mod.attribute = "stat"
+
+        mod = MagicMock()
         mod.values = values
         mod.multiplier = mult
         t.modifiers = [mod]
+
+        def get_multiplier(stat_name):
+            m = 1.0
+            for mod in t.modifiers:
+                if stat_name in mod.values:
+                    m *= mod.multiplier
+            return m
+
+        def apply_to_stat(stat_name, value):
+            return round(value * get_multiplier(stat_name))
+
+        t.get_multiplier.side_effect = get_multiplier
+        t.apply_to_stat.side_effect = apply_to_stat
+
         Taste._tastes[slug] = t
         return t
 

--- a/tests/tuxemon/test_stat_calculator.py
+++ b/tests/tuxemon/test_stat_calculator.py
@@ -29,17 +29,40 @@ def mock_shape():
 @pytest.fixture
 def mock_tastes():
     cold = MagicMock(spec=Taste)
-    cold.slug = "cold"
+    warm = MagicMock(spec=Taste)
+
     cold.modifiers = [
         MagicMock(values=["speed"], multiplier=1.2),
         MagicMock(values=["hp"], multiplier=0.9),
     ]
-    warm = MagicMock(spec=Taste)
-    warm.slug = "warm"
-    warm.modifiers = [MagicMock(values=["melee"], multiplier=1.1)]
+    warm.modifiers = [
+        MagicMock(values=["melee"], multiplier=1.1),
+    ]
+
+    def get_multiplier(taste, stat_name: str) -> float:
+        m = 1.0
+        for mod in taste.modifiers:
+            if stat_name in mod.values:
+                m *= mod.multiplier
+        return m
+
+    def apply_to_stat(taste, stat_name: str, value: int) -> int:
+        return round(value * get_multiplier(taste, stat_name))
+
+    cold.get_multiplier.side_effect = lambda stat: get_multiplier(cold, stat)
+    warm.get_multiplier.side_effect = lambda stat: get_multiplier(warm, stat)
+
+    cold.apply_to_stat.side_effect = lambda stat, val: apply_to_stat(
+        cold, stat, val
+    )
+    warm.apply_to_stat.side_effect = lambda stat, val: apply_to_stat(
+        warm, stat, val
+    )
+
     Taste.get = MagicMock(
         side_effect=lambda name: {"cold": cold, "warm": warm}[name]
     )
+
     return cold, warm
 
 
@@ -225,3 +248,60 @@ def test_taste_multiplier_stacking(analyzer, mock_tastes):
         pytest.approx(breakdown["hp"]["taste_multiplier"], rel=1e-2)
         == 1.5 * 2.0
     )
+
+
+# TrainingPoints invariant tests
+
+
+def test_tp_validate_individual_clamp():
+    tp = TrainingPoints(armour=config_monster.max_tps + 50)
+    tp.validate()
+    assert tp.armour == config_monster.max_tps
+
+
+def test_tp_validate_total_clamp_proportional():
+    tp = TrainingPoints(
+        armour=200, dodge=200, hp=200, melee=200, ranged=200, speed=200
+    )
+    tp.validate()
+    total_after = tp.sum()
+    assert total_after <= config_monster.max_total_tps
+    assert pytest.approx(tp.armour, rel=0.1) == tp.dodge
+    assert pytest.approx(tp.armour, rel=0.1) == tp.hp
+
+
+def test_tp_validate_no_change_when_valid():
+    tp = TrainingPoints(armour=10, dodge=5, hp=3, melee=2, ranged=1, speed=4)
+    before = tp.to_dict().copy()
+    tp.validate()
+    assert tp.to_dict() == before
+
+
+def test_tp_validate_individual_then_total():
+    tp = TrainingPoints(
+        armour=config_monster.max_tps + 20,
+        dodge=config_monster.max_tps + 10,
+        hp=50,
+        melee=50,
+        ranged=50,
+        speed=50,
+    )
+    tp.validate()
+    assert tp.armour <= config_monster.max_tps
+    assert tp.dodge <= config_monster.max_tps
+    assert tp.sum() <= config_monster.max_total_tps
+
+
+def test_tp_validate_scaling_preserves_zero_stats():
+    tp = TrainingPoints(
+        armour=100,
+        dodge=0,
+        hp=100,
+        melee=0,
+        ranged=100,
+        speed=0,
+    )
+    tp.validate()
+    assert tp.dodge == 0
+    assert tp.melee == 0
+    assert tp.speed == 0

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import random
 from collections.abc import Mapping, Sequence
-from dataclasses import fields
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -258,6 +257,7 @@ class Monster:
                     monster.equip_item(item)
             elif key == "training_points" and value:
                 monster.training_points = TrainingPoints.from_dict(value)
+                monster.training_points.validate()
             elif key == "modifiers" and value:
                 monster.custom_stats = CustomStatBoosts.from_dict(value)
             elif key == "individual_values" and value:
@@ -520,35 +520,33 @@ class Monster:
         self, stat_name: str, value: int = config_monster.default_tp_gain
     ) -> None:
         """
-        Gives TP points to the monster's TrainingPoints after a battle,
-        respecting the per-stat and total TP limits.
+        Gives TP points to the monster, respecting global and per-stat limits.
         """
-        max_tps = config_monster.max_tps
-        max_total_tps = config_monster.max_total_tps
-        total_tps = sum(
-            getattr(self.training_points, field.name)
-            for field in fields(self.training_points)
-        )
-        stat_tps = getattr(self.training_points, stat_name)
+        if stat_name not in BasicStats.names():
+            raise ValueError(f"Invalid stat name: {stat_name}")
+
+        current_tps = self.training_points.to_dict()
+        total_tps = sum(current_tps.values())
+
+        remaining_total = config_monster.max_total_tps - total_tps
+        current_stat_val = getattr(self.training_points, stat_name)
+        remaining_stat = config_monster.max_tps - current_stat_val
+
+        points_to_add = max(0, min(value, remaining_total, remaining_stat))
+
+        if points_to_add == 0:
+            logger.debug(
+                f"No TP added to '{stat_name}' — cap reached "
+                f"(remaining_total={remaining_total}, remaining_stat={remaining_stat})."
+            )
+            return
+
+        new_val = current_stat_val + points_to_add
+        setattr(self.training_points, stat_name, new_val)
+        self.training_points.validate()
         logger.debug(
-            f"Attempting to give {value} training_points to '{stat_name}'"
+            f"Added {points_to_add} TP to '{stat_name}'. New total: {new_val}"
         )
-        logger.debug(f"Current training_points for '{stat_name}': {stat_tps}")
-        logger.debug(f"Current total training_points: {total_tps}")
-        logger.debug(
-            f"Remaining total training_points: {max_total_tps - total_tps}"
-        )
-        logger.debug(
-            f"Remaining training_points for '{stat_name}': {max_tps - stat_tps}"
-        )
-        remaining_total_tps = max_total_tps - total_tps
-        points_to_add = min(value, remaining_total_tps, max_tps - stat_tps)
-        logger.debug(
-            f"training_points to be added to '{stat_name}': {points_to_add}"
-        )
-        new_stat_tps = stat_tps + points_to_add
-        setattr(self.training_points, stat_name, new_stat_tps)
-        logger.debug(f"New training_points for '{stat_name}': {new_stat_tps}")
         self.set_stats()
 
     def set_stats(self) -> None:

--- a/tuxemon/monster/stats.py
+++ b/tuxemon/monster/stats.py
@@ -6,11 +6,13 @@ import logging
 import random
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tuxemon.database.rules import config_monster
-from tuxemon.shape import ShapeHandler
 from tuxemon.taste import Taste
+
+if TYPE_CHECKING:
+    from tuxemon.shape import ShapeHandler
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +45,16 @@ class BasicStats:
                 new_stats, name, getattr(self, name) + getattr(other, name)
             )
         return new_stats
+
+    def copy(self) -> BasicStats:
+        return BasicStats(
+            armour=self.armour,
+            dodge=self.dodge,
+            hp=self.hp,
+            melee=self.melee,
+            ranged=self.ranged,
+            speed=self.speed,
+        )
 
 
 @dataclass
@@ -111,6 +123,35 @@ class TrainingPoints(BasicStats):
         valid_fields = {field.name for field in fields(cls)}
         filtered_data = {k: v for k, v in data.items() if k in valid_fields}
         return cls(**filtered_data)
+
+    def get_contribution(self, level: int) -> BasicStats:
+        """Returns the floor-level scaled contribution of TPs."""
+        contribution = BasicStats()
+        level_scale = level / 100
+        for name in self.names():
+            raw_tp = getattr(self, name)
+            setattr(contribution, name, int(raw_tp * level_scale))
+        return contribution
+
+    def validate(self) -> None:
+        """Clamps individual stats and the total to configuration limits."""
+        max_stat = config_monster.max_tps
+        max_total = config_monster.max_total_tps
+
+        # Clamp individual stats
+        for name in self.names():
+            val = getattr(self, name)
+            if val > max_stat:
+                setattr(self, name, max_stat)
+
+        # Clamp total if needed (proportional scaling)
+        current_total = self.sum()
+        if current_total > max_total:
+            ratio = max_total / current_total
+            for name in self.names():
+                val = getattr(self, name)
+                setattr(self, name, int(val * ratio))
+            logger.warning(f"TPs exceeded {max_total} and were scaled down.")
 
 
 class StatCalculator:
@@ -198,19 +239,11 @@ class StatCalculator:
         taste_warm: Taste | None,
     ) -> int:
         """Applies taste modifiers to a single stat value."""
-        modified_stat = float(stat_value)
-
+        modified = stat_value
         for taste in (taste_cold, taste_warm):
             if taste:
-                for modifier in taste.modifiers:
-                    if stat_name in modifier.values:
-                        logger.debug(
-                            f"Applying modifier {modifier.multiplier} to {stat_name} "
-                            f"from taste {taste.slug}"
-                        )
-                        modified_stat *= modifier.multiplier
-
-        return round(modified_stat)
+                modified = taste.apply_to_stat(stat_name, modified)
+        return modified
 
     def calculate_at_level(self, target_level: int) -> BasicStats:
         """Returns final stats at a specific level without modifying internal state."""
@@ -232,46 +265,57 @@ class StatAnalyzer:
     def get_breakdown(self) -> dict[str, dict[str, Any]]:
         """Returns a detailed breakdown of each stat's calculation."""
         breakdown = {}
-        multiplier = self.calculator.level + config_monster.coeff_stats
-        level_scale = self.calculator.level / 100
+        level = self.calculator.level
+        multiplier = level + config_monster.coeff_stats
+
+        # Use the new TP scaling logic
+        tp_contribution = self.calculator.training_points.get_contribution(
+            level
+        )
+
         cold = Taste.get(self.calculator.taste_cold)
         warm = Taste.get(self.calculator.taste_warm)
 
         for stat_name in BasicStats.names():
-            base_value = (
+            # Base from shape
+            base_part = (
                 getattr(self.calculator.shape.attributes, stat_name)
                 * multiplier
             )
-            iv_value = getattr(self.calculator.individual_values, stat_name, 0)
-            raw_tp = getattr(self.calculator.training_points, stat_name, 0)
-            scaled_tp = int(raw_tp * level_scale)
-            modifier_value = getattr(
-                self.calculator.custom_stats, stat_name, 0
-            )
 
-            pre_taste_total = (
-                base_value + iv_value + scaled_tp + modifier_value
-            )
+            # IVs
+            iv_part = getattr(self.calculator.individual_values, stat_name, 0)
 
+            # Scaled TPs (already floor-scaled)
+            tp_part = getattr(tp_contribution, stat_name)
+
+            # Custom stat boosts
+            mod_part = getattr(self.calculator.custom_stats, stat_name, 0)
+
+            # Pre‑taste total
+            pre_taste_total = base_part + iv_part + tp_part + mod_part
+
+            # Taste multiplier
             taste_multiplier = 1.0
             for taste in (cold, warm):
                 if taste:
-                    for modifier in taste.modifiers:
-                        if stat_name in modifier.values:
-                            taste_multiplier *= modifier.multiplier
+                    taste_multiplier *= taste.get_multiplier(stat_name)
 
             final_value = round(pre_taste_total * taste_multiplier)
 
             breakdown[stat_name] = {
-                "base_value": int(base_value),
-                "individual_value": iv_value,
-                "training_points_raw": raw_tp,
-                "training_points_scaled": scaled_tp,
-                "temporary_modifier": modifier_value,
+                "base_value": int(base_part),
+                "individual_value": iv_part,
+                "training_points_raw": getattr(
+                    self.calculator.training_points, stat_name
+                ),
+                "training_points_scaled": tp_part,
+                "temporary_modifier": mod_part,
                 "pre_taste_total": int(pre_taste_total),
                 "taste_multiplier": taste_multiplier,
                 "final_value": final_value,
             }
+
         return breakdown
 
     def evaluate_taste_efficiency(self) -> float:

--- a/tuxemon/taste.py
+++ b/tuxemon/taste.py
@@ -144,6 +144,22 @@ class Taste:
 
         return cold_slug, warm_slug
 
+    def get_multiplier(self, stat_name: str) -> float:
+        """
+        Returns the combined multiplier for a given stat based on this taste's modifiers.
+        """
+        multiplier = 1.0
+        for modifier in self.modifiers:
+            if stat_name in modifier.values:
+                multiplier *= modifier.multiplier
+        return multiplier
+
+    def apply_to_stat(self, stat_name: str, value: int) -> int:
+        """
+        Applies this taste's modifiers to a stat value and returns the modified result.
+        """
+        return round(value * self.get_multiplier(stat_name))
+
     def __repr__(self) -> str:
         return (
             f"Taste(slug={self.slug}, "


### PR DESCRIPTION
waiting
- [x] #3429 

PR strengthens the monster stat system by making `TrainingPoints` behavior explicit and predictable, fixing TP gain logic, and consolidating all taste‑based stat modification inside the `Taste` class. The goal is to remove duplicated logic, ensure consistent stat calculations, and make the system easier to maintain and extend.

Changes:
- Added a clear method for computing level‑scaled TP contributions
- Updated TP gain logic so all adjustments pass through validation and respect per‑stat and total caps
- Ensured proportional downscaling and zero‑preservation work reliably
- Added `get_multiplier(stat_name)` to compute the combined multiplier for a stat
- Added `apply_to_stat(stat_name, value)` to apply the multiplier and return the final value
- These methods now serve as the single source of truth for taste effects
- Updated to use the new Taste API instead of reimplementing multiplier logic
- Removed duplicated code and ensured calculator and analyzer remain perfectly aligned
- Expanded coverage for TP edge cases, taste stacking, and breakdown consistency
- Updated mocks to reflect the new Taste API