### PR TITLE
Preserve empty arguments in `split_escaped` to support optional action parameters

### DIFF
--- a/tests/tuxemon/test_parser.py
+++ b/tests/tuxemon/test_parser.py
@@ -18,10 +18,10 @@ from tuxemon.script.parser import (
         (" spam", ["spam"]),
         (" spam ", ["spam"]),
         ("spam , eggs  ", ["spam", "eggs"]),
-        ("spam , eggs,", ["spam", "eggs"]),  # empty removed
-        ("spam , eggs  ,, ", ["spam", "eggs"]),  # empties removed
+        ("spam , eggs,", ["spam", "eggs", ""]),
+        ("spam , eggs  ,, ", ["spam", "eggs", "", ""]),
         ("", []),
-        (",", []),  # both empty segments removed
+        (",", ["", ""]),
         ("spam\\,eggs,ham", ["spam,eggs", "ham"]),
         ("spam\\,eggs\\,ham", ["spam,eggs,ham"]),
     ],
@@ -36,11 +36,11 @@ def test_split_escaped(input_str, expected):
         ("spam", ("spam", [])),
         ("spam eggs", ("spam", ["eggs"])),
         ("spam eggs,parrot", ("spam", ["eggs", "parrot"])),
-        ("spam , ", ("spam", [])),  # empty args removed
-        ("spam eggs, ", ("spam", ["eggs"])),
+        ("spam , ", ("spam", ["", ""])),
+        ("spam eggs, ", ("spam", ["eggs", ""])),
         ("spam,eggs", ("spam,eggs", [])),
         ("   spam   ", ("", ["spam"])),
-        ("spam ,,", ("spam", [])),
+        ("spam ,,", ("spam", ["", "", ""])),
         ("spam ex parrot", ("spam", ["ex parrot"])),
         ("spam eggs,  ex parrot", ("spam", ["eggs", "ex parrot"])),
     ],
@@ -63,7 +63,7 @@ def test_no_type():
         ("spam eggs, parrot", ("spam", "eggs,", ["parrot"])),
         (
             " spam eggs parrot, cheese, ",
-            ("", "spam", ["eggs parrot", "cheese"]),
+            ("", "spam", ["eggs parrot", "cheese", ""]),
         ),
         (
             "spam eggs  ex parrot, cheese shop",

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -113,6 +113,12 @@ class EvolutionAction(EventAction):
         self.client.push_state(
             "EvolutionState",
             monster=monster,
-            evolved=evolved,
+            target=evolved,
             character=self.char,
         )
+
+    def update(self, session: Session, dt: float) -> None:
+        try:
+            session.client.get_state_by_name("EvolutionState")
+        except ValueError:
+            self.stop()

--- a/tuxemon/script/parser.py
+++ b/tuxemon/script/parser.py
@@ -28,7 +28,6 @@ def split_escaped(string_to_split: str, delimeter: str = ",") -> Sequence[str]:
     return [
         item.replace(f"\\{delimeter}", delimeter).strip()
         for item in split_list
-        if item.strip()
     ]
 
 


### PR DESCRIPTION
PR fixes #3433 and fixes #3434 where `split_escaped()` removed empty segments. That behavior broke actions relying on optional leading parameters. The previous implementation collapsed both into the same argument list, making it impossible for actions to detect “no variable provided”. The updated parser now preserves empty arguments, and the test suite has been updated to reflect the new, correct semantics.