### PR TITLE
Refactor XP Animation Scheduling to Remove Race Conditions and Simplify Input Blocking

### DIFF
--- a/tests/tuxemon/test_combat_notifier.py
+++ b/tests/tuxemon/test_combat_notifier.py
@@ -63,7 +63,7 @@ def test_trigger_xp_and_wait_for_input(notifier, state, text_area):
     notifier.text_anim.add_xp_message("XP +10")
     notifier.text_anim.add_xp_message("XP +20")
     notifier.trigger_xp_and_wait_for_input(text_area, delay=1.0)
-    assert state.task.call_count == 2
+    assert state.task.call_count == 1
 
 
 def test_show_message_ignores_empty(notifier, text_area):
@@ -86,16 +86,7 @@ def test_show_message_override_lock_false(notifier, state, text_area):
     state.task.assert_not_called()
 
 
-def test_trigger_xp_schedules_two_tasks(notifier, state, text_area):
+def test_trigger_xp_schedules_one_task(notifier, state, text_area):
     notifier.text_anim.add_xp_message("XP +10")
     notifier.trigger_xp_and_wait_for_input(text_area, delay=1.0)
-    assert state.task.call_count == 2
-
-
-def test_trigger_xp_clears_pending_duration(notifier, state, text_area):
-    notifier.text_anim.add_xp_message("XP +10")
-    notifier.trigger_xp_and_wait_for_input(text_area, delay=1.0)
-    after_cb = state.task.call_args_list[1][0][0]
-    notifier.text_anim._pending_xp_duration = 5.0
-    after_cb()
-    assert notifier.text_anim._pending_xp_duration is None
+    assert state.task.call_count == 1

--- a/tests/tuxemon/test_text_animation_manager.py
+++ b/tests/tuxemon/test_text_animation_manager.py
@@ -53,13 +53,13 @@ def test_xp_messages_are_batched(manager):
     manager.add_xp_message("XP +20")
     alert = MagicMock()
     text_area = MagicMock()
-    manager.trigger_xp_animation(alert, text_area)
+    duration = manager.trigger_xp_animation(alert, text_area)
     assert len(manager.text_queue) == 1
-    anim, duration = manager.text_queue[0]
+    anim, queued_duration = manager.text_queue[0]
+    assert queued_duration == duration
     anim()
     alert.assert_called_once_with("XP +10\nXP +20", text_area)
     assert manager._xp_messages == []
-    assert manager._pending_xp_duration == duration
 
 
 def test_zero_duration_triggers_immediately(manager):
@@ -98,9 +98,10 @@ def test_trigger_xp_animation_sets_pending_duration(manager):
     manager.add_xp_message("XP +20")
     alert = MagicMock()
     text_area = MagicMock()
-    manager.trigger_xp_animation(alert, text_area)
+    duration = manager.trigger_xp_animation(alert, text_area)
     assert manager._xp_messages == []
-    assert manager._pending_xp_duration is not None
+    assert duration is not None
+    assert duration > 0
 
 
 def test_xp_animation_calls_alert(manager):
@@ -111,3 +112,80 @@ def test_xp_animation_calls_alert(manager):
     anim, duration = manager.text_queue[0]
     anim()
     alert.assert_called_once_with("XP +10", text_area)
+
+
+def test_is_animating_false_when_empty(manager):
+    assert manager.is_animating() is False
+
+
+def test_is_animating_true_when_queue_not_empty(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 1.0)
+    assert manager.is_animating() is True
+
+
+def test_is_animating_true_when_time_left_positive(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 1.0)
+    manager.update_text_animation(0.1)
+    assert manager._text_time_left > 0
+    assert manager.is_animating() is True
+
+
+def test_is_animating_false_after_animation_finishes(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 1.0)
+    manager.update_text_animation(1.1)
+    manager.update_text_animation(1.1)
+    assert manager.is_animating() is False
+
+
+def test_is_animating_with_zero_duration(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 0)
+    assert manager.is_animating() is True
+    manager.update_text_animation(0.01)
+    assert manager.is_animating() is False
+
+
+class FakeState:
+    def __init__(self, text_anim, current_state):
+        self.text_anim = text_anim
+        self.client = MagicMock()
+        self.client.current_state = current_state
+
+    def is_blocked(self):
+        if self.text_anim.is_animating():
+            return True
+
+        cs = self.client.current_state
+        if cs and cs.name == "WaitForInputState":
+            return True
+
+        return False
+
+
+def test_is_blocked_false_when_idle(manager):
+    fake = FakeState(text_anim=manager, current_state=None)
+    assert fake.is_blocked() is False
+
+
+def test_is_blocked_true_when_animating(manager):
+    fn = MagicMock()
+    manager.add_text_animation(fn, 1.0)
+    fake = FakeState(text_anim=manager, current_state=None)
+    assert fake.is_blocked() is True
+
+
+def test_is_blocked_true_when_wait_for_input_state(manager):
+    mock_state = MagicMock()
+    mock_state.name = "WaitForInputState"
+    fake = FakeState(text_anim=manager, current_state=mock_state)
+    assert fake.is_blocked() is True
+
+
+def test_is_blocked_false_when_other_state(manager):
+    mock_state = MagicMock()
+    mock_state.name = "SomeOtherState"
+    fake = FakeState(text_anim=manager, current_state=mock_state)
+    assert fake.is_blocked() is False

--- a/tuxemon/animation.py
+++ b/tuxemon/animation.py
@@ -615,7 +615,7 @@ class Animation(TaskBase):
         else:
             setattr(target, name, value)
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
 
         if self._state in (AnimationState.FINISHED, AnimationState.ABORTED):
             return
@@ -627,7 +627,7 @@ class Animation(TaskBase):
             self.finish()
             return
 
-        self._elapsed += time_delta
+        self._elapsed += dt
 
         if self.delay > 0:
             if self._elapsed >= self.delay:

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -279,7 +279,7 @@ class BaseClient(ABC):
         """
 
     @abstractmethod
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """
         Main loop for entire game.
 

--- a/tuxemon/client.py
+++ b/tuxemon/client.py
@@ -136,14 +136,9 @@ class LocalPygameClient(BaseClient):
                 self.perform_cleanup()
                 self.state = ClientState.DONE
 
-    def update(self, time_delta: float) -> None:
-        """
-        Main loop for entire game.
-
-        Parameters:
-            time_delta: Elapsed time since last frame.
-        """
-        self.update_states(time_delta)
+    def update(self, dt: float) -> None:
+        """Main loop for entire game."""
+        self.update_states(dt)
 
     def queue_command(self, command: Callable[[], None]) -> None:
         self.command_queue.put(command)

--- a/tuxemon/entity/entity.py
+++ b/tuxemon/entity/entity.py
@@ -46,12 +46,10 @@ class Body:
         """Returns whether the entity is currently moving."""
         return self.velocity != Vector2(0, 0)
 
-    def update(self, time_delta: float) -> None:
-        """
-        Updates the position based on velocity and time.
-        """
-        self.velocity += self.acceleration * time_delta
-        self.position += self.velocity * time_delta
+    def update(self, dt: float) -> None:
+        """Updates the position based on velocity and time."""
+        self.velocity += self.acceleration * dt
+        self.position += self.velocity * dt
 
     def reset(
         self,

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -173,9 +173,6 @@ class EventEngine:
     def update(self, dt: float) -> None:
         """
         Check all the MapEvents and start their actions if conditions are met.
-
-        Parameters:
-            dt: Amount of time passed in seconds since last frame.
         """
         if self._suspended:
             return

--- a/tuxemon/headless_client.py
+++ b/tuxemon/headless_client.py
@@ -58,11 +58,6 @@ class HeadlessClient(BaseClient):
         self.command_queue.put(command)
         logger.debug("Queued command for execution in main thread.")
 
-    def update(self, time_delta: float) -> None:
-        """
-        Main loop for entire game.
-
-        Parameters:
-            time_delta: Elapsed time since last frame.
-        """
-        self.update_states(time_delta)
+    def update(self, dt: float) -> None:
+        """Main loop for entire game."""
+        self.update_states(dt)

--- a/tuxemon/map/view.py
+++ b/tuxemon/map/view.py
@@ -93,13 +93,13 @@ class SpriteController:
         self.sprite_renderer = SpriteRenderer(npc)
         self.sprite_renderer.load_sprites(npc.template)
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """
         Update the sprite renderer and reposition the sprite
         based on the NPC's current tile position.
         """
         self.sprite_renderer.set_position(self.npc.tile_pos)
-        self.sprite_renderer.update(time_delta)
+        self.sprite_renderer.update(dt)
 
     def update_appearance(self, appearance: RuntimeAppearance) -> None:
         """
@@ -327,9 +327,9 @@ class SpriteRenderer:
             * template.animation_speed
         )
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """Update all registered animations."""
-        self.surface_animations.update(time_delta)
+        self.surface_animations.update(dt)
 
     def get_animation_frame(
         self, ani: str, animations: dict[str, SurfaceAnimation], npc: NPC
@@ -383,7 +383,7 @@ class AbstractRenderer(ABC):
         ...
 
     @abstractmethod
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """Update internal state, animations, etc."""
 
     @abstractmethod
@@ -401,7 +401,7 @@ class NullRenderer(AbstractRenderer):
     def label(self) -> str:
         return "null_renderer"
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         pass
 
     def draw(self, surface: Surface, current_map: AbstractMap | None) -> None:
@@ -449,10 +449,10 @@ class MapRenderer(AbstractRenderer):
         if CONFIG.collision_map:
             self.debug_renderer.draw_debug(current_map, surface)
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """Update the map animations."""
-        self.camera_manager.update(time_delta)
-        self.map_animations.update_all(time_delta)
+        self.camera_manager.update(dt)
+        self.map_animations.update_all(dt)
 
     def _prepare_map_rendering(self, current_map: AbstractMap) -> None:
         """Prepares the map renderer for drawing."""

--- a/tuxemon/platform/input_history.py
+++ b/tuxemon/platform/input_history.py
@@ -69,10 +69,10 @@ class InputHistory:
             self.history.append(translated_event)
             self.last_history_event = translated_event
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         self.update_history(max_age_s=self.combo_window_seconds)
         for button in list(self.held_timers.keys()):
-            self.held_timers[button] += time_delta
+            self.held_timers[button] += dt
 
     def update_history(self, max_age_s: float | None = None) -> None:
         """

--- a/tuxemon/platform/input_manager.py
+++ b/tuxemon/platform/input_manager.py
@@ -101,10 +101,10 @@ class InputManager:
 
             yield event
 
-    def update(self, time_delta: float) -> None:
-        self.input_history.update(time_delta)
-        self.event_queue.update_handlers(time_delta)
-        self.afk_manager.update(time_delta)
+    def update(self, dt: float) -> None:
+        self.input_history.update(dt)
+        self.event_queue.update_handlers(dt)
+        self.afk_manager.update(dt)
 
     def draw_overlay(self, screen: Surface) -> None:
         if self.core_devices.overlay:

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -100,7 +100,7 @@ class StateManager:
         base_count = base_count or DEFAULT_BASE_STATE_COUNT
         return len(self.active_states) > base_count
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """
         Run update on all active states, which doing some internal housekeeping.
 
@@ -111,11 +111,11 @@ class StateManager:
             time_delta: Amount of time passed since last frame.
         """
         logger.debug("updating states")
-        self.trigger_global_event("pre_state_update", time_delta)
+        self.trigger_global_event("pre_state_update", dt)
         for state in self.active_states:
             self._check_resume(state)
-            state.update(time_delta)
-        self.trigger_global_event("post_state_update", time_delta)
+            state.update(dt)
+        self.trigger_global_event("post_state_update", dt)
 
     def _check_resume(self, state: State) -> None:
         """

--- a/tuxemon/state/state.py
+++ b/tuxemon/state/state.py
@@ -151,15 +151,12 @@ class State(AnimationMixin, RenderMixin, ABC):
         """Convenience wrapper for client scaling."""
         return self.client.context.scaling.scale_int(value)
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         """
         Time update function for state. Must be overloaded in children.
-
-        Parameters:
-            time_delta: Amount of time in fractional seconds since last update.
         """
-        self.update_animations(time_delta)
-        self.sprites.update(time_delta)
+        self.update_animations(dt)
+        self.sprites.update(dt)
 
     def resume(self) -> None:
         """

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -218,14 +218,10 @@ class CombatState(CombatAnimations):
 
         return False
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update the combat state.
-
-        This method is responsible for updating the text animation and the combat phase.
-        """
-        super().update(time_delta)
-        self.text_anim.update_text_animation(time_delta)
+    def update(self, dt: float) -> None:
+        """Update the combat state."""
+        super().update(dt)
+        self.text_anim.update_text_animation(dt)
         self.update_combat_phase()
 
     def transition_phase(self, phase: CombatPhase) -> None:

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -190,16 +190,24 @@ class CombatState(CombatAnimations):
         """
         Update the combat phase.
         """
-        if self.client.current_state:
-            if self.client.current_state.name == "WaitForInputState":
-                return
-        time_left = self.text_anim.get_text_animation_time_left()
-        if time_left <= 0 and all(map(self.is_task_finished, self.animations)):
+        if not self.text_anim.is_animating() and all(
+            map(self.is_task_finished, self.animations)
+        ):
             new_phase = self.machine.determine_next_phase(self.phase)
             if new_phase:
                 self.phase = new_phase
                 self.transition_phase(new_phase)
             self.update_phase()
+
+    def is_blocked(self) -> bool:
+        if self.text_anim.is_animating():
+            return True
+
+        cs = self.client.current_state
+        if cs and cs.name == "WaitForInputState":
+            return True
+
+        return False
 
     def update(self, time_delta: float) -> None:
         """

--- a/tuxemon/states/transition_evolution.py
+++ b/tuxemon/states/transition_evolution.py
@@ -86,7 +86,7 @@ class EvolutionTransition(State):
         self.x = (screen_width - sprite_width) // 2
         self.y = (screen_height - sprite_height) // 2
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         current_time = pygame.time.get_ticks()
         self.elapsed_time = (current_time - self.transition_start_time) / 1000
         self.percentage = (self.elapsed_time / self.total_seconds) * 100

--- a/tuxemon/states/transition_fade.py
+++ b/tuxemon/states/transition_fade.py
@@ -67,8 +67,8 @@ class FadeTransitionBase(State):
     def process_event(self, event: PlayerInput) -> PlayerInput | None:
         return None
 
-    def update(self, time_delta: float) -> None:
-        self.animations.update(time_delta)
+    def update(self, dt: float) -> None:
+        self.animations.update(dt)
 
     @abstractmethod
     def create_fade_animation(self) -> None:

--- a/tuxemon/states/transition_flash.py
+++ b/tuxemon/states/transition_flash.py
@@ -58,24 +58,17 @@ class FlashTransition(State):
     def resume(self) -> None:
         self.transition_surface.fill(self.color)
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update function for state.
-
-        Parameters:
-            time_delta: Time since last update in seconds
-
-        """
+    def update(self, dt: float) -> None:
         logger.info("Battle transition!")
 
         if self.flash_state == "up":
             self.transition_alpha = min(
                 255,
-                self.transition_alpha + 255 * (time_delta / self.flash_time),
+                self.transition_alpha + 255 * (dt / self.flash_time),
             )
         elif self.flash_state == "down":
             self.transition_alpha = max(
-                0, self.transition_alpha - 255 * (time_delta / self.flash_time)
+                0, self.transition_alpha - 255 * (dt / self.flash_time)
             )
 
         if self.transition_alpha >= 255:

--- a/tuxemon/states/transition_mosaic.py
+++ b/tuxemon/states/transition_mosaic.py
@@ -55,15 +55,8 @@ class MosaicTransition(State):
                 self.tiles.append(rect)
                 self.tile_surfaces.append(self.screenshot.subsurface(rect))
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update function for state.
-
-        Parameters:
-            time_delta: Time since last update in seconds
-
-        """
-        self.elapsed_time += time_delta
+    def update(self, dt: float) -> None:
+        self.elapsed_time += dt
         if self.elapsed_time > self.duration:
             logger.info("Mosaic transition finished.")
             self.client.pop_state()

--- a/tuxemon/states/transition_negative.py
+++ b/tuxemon/states/transition_negative.py
@@ -35,15 +35,8 @@ class NegativeTransition(State):
         self.start_time = 0.0
         self.elapsed_time = 0.0
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update function for state.
-
-        Parameters:
-            time_delta: Time since last update in seconds
-
-        """
-        self.elapsed_time += time_delta
+    def update(self, dt: float) -> None:
+        self.elapsed_time += dt
         if self.elapsed_time > self.duration:
             logger.info("Negative colors transition finished.")
             self.client.pop_state()

--- a/tuxemon/states/transition_pixelation.py
+++ b/tuxemon/states/transition_pixelation.py
@@ -44,15 +44,8 @@ class PixelationTransition(State):
         self.start_time = 0.0
         self.elapsed_time = 0.0
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update function for state.
-
-        Parameters:
-            time_delta: Time since last update in seconds
-
-        """
-        self.elapsed_time += time_delta
+    def update(self, dt: float) -> None:
+        self.elapsed_time += dt
         if self.elapsed_time > self.duration:
             logger.info("Pixelation transition finished.")
             self.client.pop_state()

--- a/tuxemon/states/transition_static.py
+++ b/tuxemon/states/transition_static.py
@@ -40,8 +40,8 @@ class StaticTransition(State):
     def resume(self) -> None:
         self.screenshot = Surface.copy(self.client.context.screen)
 
-    def update(self, time_delta: float) -> None:
-        self.elapsed_time += time_delta
+    def update(self, dt: float) -> None:
+        self.elapsed_time += dt
         if self.elapsed_time > self.duration:
             logger.info("Static transition finished.")
             self.client.pop_state()

--- a/tuxemon/states/transition_swirl.py
+++ b/tuxemon/states/transition_swirl.py
@@ -47,9 +47,9 @@ class SwirlTransition(State):
         self.scale = scale
         self.speed = speed
 
-    def update(self, time_delta: float) -> None:
-        self.angle += self.speed * time_delta
-        self.scale += 0.01 * time_delta
+    def update(self, dt: float) -> None:
+        self.angle += self.speed * dt
+        self.scale += 0.01 * dt
         if self.angle > 360:
             logger.info("Swirl transition finished.")
             self.client.pop_state()

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -87,7 +87,7 @@ class TradingTransition(State):
         self.received_x = (3 * screen_width // 4) - (sprite_width // 2)
         self.sprite_y = (screen_height - sprite_height) // 2
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         current_time = pygame.time.get_ticks()
         self.elapsed_time = (current_time - self.transition_start_time) / 1000
         self.percentage = (self.elapsed_time / self.total_seconds) * 100

--- a/tuxemon/states/transition_wipe.py
+++ b/tuxemon/states/transition_wipe.py
@@ -53,8 +53,8 @@ class WipeTransition(State):
         self.height = self.client.context.screen.get_height()
         self.width = self.client.context.screen.get_width()
 
-    def update(self, time_delta: float) -> None:
-        self.update_wipe_position(time_delta)
+    def update(self, dt: float) -> None:
+        self.update_wipe_position(dt)
         self.check_boundary()
 
     def update_wipe_position(self, time_delta: float) -> None:

--- a/tuxemon/states/transition_zoom.py
+++ b/tuxemon/states/transition_zoom.py
@@ -46,9 +46,9 @@ class ZoomOutTransition(State):
         self.scale = scale
         self.speed = speed  # scale factor per second
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         if self.scale < 1.0:
-            self.scale += self.speed * time_delta
+            self.scale += self.speed * dt
         else:
             self.scale = 1.0
 
@@ -105,9 +105,9 @@ class ZoomInTransition(State):
         self.scale = scale
         self.speed = speed  # scale factor per second
 
-    def update(self, time_delta: float) -> None:
+    def update(self, dt: float) -> None:
         if self.scale > 0.1:
-            self.scale -= self.speed * time_delta
+            self.scale -= self.speed * dt
         else:
             self.scale = 0.1
 

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -144,18 +144,12 @@ class WorldState(State):
             self.client, self.player, self.client.network_manager
         )
 
-    def update(self, time_delta: float) -> None:
-        """
-        The primary game loop that executes the world's functions every frame.
-
-        Parameters:
-            time_delta: Amount of time passed since last frame.
-        """
-        super().update(time_delta)
-        self.faction_manager.update(time_delta, self.session)
-        self.client.npc_manager.update_npcs(time_delta, self.client)
-        self.client.npc_manager.update_npcs_off_map(time_delta, self.client)
-        self.client.map_renderer.update(time_delta)
+    def update(self, dt: float) -> None:
+        super().update(dt)
+        self.faction_manager.update(dt, self.session)
+        self.client.npc_manager.update_npcs(dt, self.client)
+        self.client.npc_manager.update_npcs_off_map(dt, self.client)
+        self.client.map_renderer.update(dt)
 
     def draw(self, surface: Surface) -> None:
         """Draw the game world to the screen."""

--- a/tuxemon/surfanim.py
+++ b/tuxemon/surfanim.py
@@ -216,14 +216,9 @@ class SurfaceAnimation:
         """Reset the animation to the beginning and set state to stopped."""
         self._state = State.STOPPED
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update the internal clock with the elapsed time.
-
-        Parameters:
-            time_delta: Time elapsed since last call to update.
-        """
-        self._internal_clock += time_delta
+    def update(self, dt: float) -> None:
+        """Update the internal clock with the elapsed time."""
+        self._internal_clock += dt
 
     def flip(self, flip_axes: FlipAxes) -> None:
         """Flip all frames of an animation along the X-axis and/or Y-axis."""
@@ -530,16 +525,10 @@ class SurfaceAnimationCollection:
             anim_obj.stop()
         self._state = State.STOPPED
 
-    def update(self, time_delta: float) -> None:
-        """
-        Update the internal clock with the elapsed time.
-
-        Parameters:
-            time_delta: Time elapsed since last call to update.
-
-        """
+    def update(self, dt: float) -> None:
+        """Update the internal clock with the elapsed time."""
         for anim_obj in self._animations:
-            anim_obj.update(time_delta)
+            anim_obj.update(dt)
 
 
 T = TypeVar("T", bound=float)

--- a/tuxemon/ui/combat_notifier.py
+++ b/tuxemon/ui/combat_notifier.py
@@ -27,7 +27,6 @@ class TextAnimationManager:
         self.text_queue: deque[tuple[Callable[[], None], float]] = deque()
         self._text_time_left: float = 0
         self._xp_messages: list[str] = []
-        self._pending_xp_duration: float | None = None
 
     @staticmethod
     def compute_text_anim_time(message: str) -> float:
@@ -61,6 +60,9 @@ class TextAnimationManager:
     def get_text_animation_time_left(self) -> float:
         return self._text_time_left
 
+    def is_animating(self) -> bool:
+        return self._text_time_left > 0 or bool(self.text_queue)
+
     def add_xp_message(self, message: str) -> None:
         self._xp_messages.append(message)
         logger.debug(
@@ -69,20 +71,16 @@ class TextAnimationManager:
 
     def trigger_xp_animation(
         self, alert_func: Callable[..., None], text_area: TextArea
-    ) -> None:
-        if self._xp_messages:
-            combined_message = "\n".join(self._xp_messages)
-            logger.debug(
-                f"Triggering XP animation with combined message: {combined_message!r}"
-            )
-            duration = self.compute_text_anim_time(combined_message)
-            self._pending_xp_duration = duration
-            timed_text_animation = partial(
-                alert_func, combined_message, text_area
-            )
-            self.add_text_animation(timed_text_animation, duration)
-            self._xp_messages.clear()
-            logger.debug("Cleared XP messages after triggering animation")
+    ) -> float | None:
+        if not self._xp_messages:
+            return None
+
+        combined_message = "\n".join(self._xp_messages)
+        duration = self.compute_text_anim_time(combined_message)
+        timed_text_animation = partial(alert_func, combined_message, text_area)
+        self.add_text_animation(timed_text_animation, duration)
+        self._xp_messages.clear()
+        return duration
 
 
 class CombatNotifier:
@@ -141,31 +139,15 @@ class CombatNotifier:
         Triggers XP animation and schedules input block based on actual animation duration.
         """
 
-        def after_xp_triggered() -> None:
-            duration = self.text_anim._pending_xp_duration
-
-            if duration and self._lock_update:
-                logger.debug(
-                    f"Using XP duration: {duration:.2f}s to block input"
-                )
-                self.state.task(
-                    partial(self.state.client.push_state, "WaitForInputState"),
-                    interval=delay + duration,
-                )
-            self.text_anim._pending_xp_duration = None
-
-        # First queue the XP animation trigger
-        self.state.task(
-            partial(
-                self.text_anim.trigger_xp_animation,
+        def trigger_and_block() -> None:
+            duration = self.text_anim.trigger_xp_animation(
                 self.alert_manager.alert,
                 text_area,
-            ),
-            interval=delay,
-        )
+            )
+            if duration and self._lock_update:
+                self.state.task(
+                    partial(self.state.client.push_state, "WaitForInputState"),
+                    interval=duration,
+                )
 
-        # Then queue the block decision to run after animation has been triggered
-        self.state.task(
-            after_xp_triggered,
-            interval=delay + 0.01,  # Slight buffer to ensure XP is queued
-        )
+        self.state.task(trigger_and_block, interval=delay)


### PR DESCRIPTION
This change replaces the previous two‑stage XP animation scheduling logic with a single, deterministic trigger. The old implementation scheduled two separate tasks (one to enqueue the XP animation and another to block input based on an assumed duration), which could desynchronize when the animation queue was long or when no XP messages were present. The new implementation schedules a single task that both triggers the XP animation and blocks input only when XP messages actually exist. This makes the behavior predictable, avoids unnecessary tasks and aligns input blocking with the real animation duration.

Unified all `update` method signatures by renaming the `time_delta` parameter to `dt` to match common game‑loop conventions and improve readability.