### PR TITLE
Apply missing HP reduction for multi‑hit techniques + BugFix

### DIFF
--- a/tests/tuxemon/test_npc_bag_handler.py
+++ b/tests/tuxemon/test_npc_bag_handler.py
@@ -177,3 +177,12 @@ def test_get_all_item_quantities(handler):
     totals = handler.get_all_item_quantities()
     assert totals["test_item"] == 5
     assert totals["potion"] == 2
+
+
+def test_remove_item_after_consumption_to_zero(handler):
+    item = FakeItem("consumable", qty=1)
+    handler.add_item(item)
+    item.stock.try_remove(1)
+    assert item.quantity == 0
+    handler.remove_item(item)
+    assert handler.find_item("consumable") is None

--- a/tuxemon/core/effects/multiattack.py
+++ b/tuxemon/core/effects/multiattack.py
@@ -34,8 +34,7 @@ class MultiAttackEffect(CoreEffect):
     .. code-block:: json
 
         "effects": [
-            "multiattack 3",
-            "damage"
+            "multiattack 3"
         ]
     """
 
@@ -66,6 +65,7 @@ class MultiAttackEffect(CoreEffect):
         success = hit_count > 0
 
         if success:
+            target.current_hp = max(0, target.current_hp - total_damage)
             params = {"hit_count": hit_count}
             extract_text = T.format("combat_multiattack", params)
             extras = [extract_text]

--- a/tuxemon/entity/bag.py
+++ b/tuxemon/entity/bag.py
@@ -94,6 +94,10 @@ class BagHandler:
             logger.debug(f"Item '{item.slug}' not found in bag.")
             return False
 
+        if item.quantity == 0:
+            self._items.remove(item)
+            return True
+
         # Try to remove from stock
         if not item.stock.try_remove(quantity):
             logger.debug(

--- a/tuxemon/states/control_state.py
+++ b/tuxemon/states/control_state.py
@@ -110,7 +110,7 @@ class ControlState(PygameMenuState):
 
             def mute_music() -> None:
                 self.client.config.update_attribute(
-                    "gameplay", "music_volume", str(0)
+                    "gameplay", "music_volume", 0
                 )
                 self.client.current_music.set_volume(0)
 
@@ -158,7 +158,7 @@ class ControlState(PygameMenuState):
                 """
                 volume = round(val / 100, 1)
                 self.client.config.update_attribute(
-                    "gameplay", "music_volume", str(volume)
+                    "gameplay", "music_volume", volume
                 )
                 self.client.current_music.set_volume(volume)
 
@@ -168,7 +168,7 @@ class ControlState(PygameMenuState):
                 """
                 volume = round(val / 100, 1)
                 self.client.config.update_attribute(
-                    "gameplay", "sound_volume", str(volume)
+                    "gameplay", "sound_volume", volume
                 )
                 sound = self.menu.get_sound()
                 sound.set_sound_volume(SOUND_TYPE_WIDGET_SELECTION, volume)


### PR DESCRIPTION
Multi‑hit techniques were calculating damage but never subtracting it from the target’s HP, causing the health bar to stay unchanged. This patch updates `MultiAttackEffect` so that the total damage from all successful hits is applied to the target’s HP, restoring correct combat behavior for multi‑attack moves.

In addition, this patch fixes #3452 an inventory bug where consumable items with a final quantity of zero would remain visible in the player’s bag as “x0”. The issue was caused by `BagHandler.remove_item()` attempting to subtract quantity a second time after `consume_if_needed()` had already reduced the item’s stock to zero, causing the removal to silently fail. The fix adds a small guard clause to `remove_item()` that immediately removes the item from the bag when its stock is already empty, ensuring that fully consumed items are correctly removed from the inventory and no longer appear in item menus.

In addition, fixes
```
/home/giorgio/Tuxemon/venv/lib/python3.12/site-packages/pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected `float` - serialized value may not be as expected [input_value='0.4', input_type=str])
  return self.__pydantic_serializer__.to_python(
```
when changing the volume

