### PR TITLE
Fix dialog text not rendering due to zero‑sized TextArea rect

### DIFF
--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -60,6 +60,7 @@ def test_initial_state(text_area):
 
 
 def test_text_setter_triggers_animation(text_area):
+    text_area.rect = pygame.Rect(0, 0, 200, 50)
     text_area._start_text_animation = lambda: setattr(
         text_area, "drawing_text", True
     )

--- a/tuxemon/states/dialog_state.py
+++ b/tuxemon/states/dialog_state.py
@@ -6,6 +6,9 @@ import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from pygame import SRCALPHA
+from pygame.surface import Surface
+
 from tuxemon.graphics import load_and_scale
 from tuxemon.menu.menu import PopUpMenu
 from tuxemon.platform.const import buttons
@@ -93,17 +96,25 @@ class DialogState(PopUpMenu[None]):
             v_alignment=final_box_style["v_alignment"],
             line_spacing=line_spacing,
         )
-        self.dialog_box.rect = self.calc_internal_rect()
         self.sprites.add(self.dialog_box)
+
+    def on_open(self) -> None:
+        """Start the dialog when the state is opened."""
+        super().on_open()
+
+        internal_rect = self.calc_internal_rect()
+        logger.debug(f"DialogState.on_open: internal rect {internal_rect}")
+        self.dialog_box.rect = internal_rect
+
+        self.dialog_box.image = Surface(internal_rect.size, SRCALPHA)
+        self.dialog_box.image = self.dialog_box._render_background()
 
         if self.avatar:
             avatar_rect = self.calc_final_rect()
             self.avatar.rect.bottomleft = avatar_rect.left, avatar_rect.top
-            self.sprites.add(self.avatar)
 
-    def on_open(self) -> None:
-        """Start the dialog when the state is opened."""
         self.next_text()
+
         if not self.text_queue and not self.auto_close:
             self._timer_active = False
 

--- a/tuxemon/ui/text.py
+++ b/tuxemon/ui/text.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
@@ -27,6 +28,8 @@ from tuxemon.ui.text_renderer import TextRenderer
 
 if TYPE_CHECKING:
     from tuxemon.scaling import ScalingStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class TextAreaDiagnostics:
@@ -150,6 +153,13 @@ class TextArea(Sprite):
         if not self._text:
             self.drawing_text = False
             self.image = Surface(self.rect.size, SRCALPHA)
+            return
+
+        if self.rect.width == 0 or self.rect.height == 0:
+            logger.error(
+                f"[TextArea] ERROR: Cannot render text — rect is zero-sized: {self.rect}"
+            )
+            self.drawing_text = False
             return
 
         if self.animated:


### PR DESCRIPTION
PR fixes #3467 where dialog text does not render because the `TextArea` receives a zero‑sized rect during initialization. The rect was being calculated in `DialogState.__init__` before the window border and layout were ready. The fix recalculates the internal rect in `on_open()` and rebuilds the `TextArea` surface after layout initialization. A safety check was added to prevent text rendering when the rect is zero.