### PR TITLE
Fix various

### DIFF
--- a/tuxemon/event/actions/breeding.py
+++ b/tuxemon/event/actions/breeding.py
@@ -37,8 +37,11 @@ class BreedingAction(EventAction):
     character: str
     gender: str
 
-    def set_var(self, menu_item: MenuItem[Monster]) -> None:
+    def set_var(self, menu_item: MenuItem[Monster | None]) -> None:
         monster = menu_item.game_object
+        if monster is None:
+            return
+
         parent = (
             "breeding_mother" if self.gender == "female" else "breeding_father"
         )
@@ -69,12 +72,14 @@ class BreedingAction(EventAction):
             self.stop()
             return
 
-        menu = session.client.push_state(
+        session.client.push_state(
             MonsterMenuState(
-                session.client, self.char.monsters, monster_filter
+                session.client,
+                self.char.monsters,
+                monster_filter,
+                on_selection=self.set_var,
             )
         )
-        menu.on_menu_selection = self.set_var  # type: ignore[assignment]
 
     def update(self, session: Session, dt: float) -> None:
         try:

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -134,11 +134,13 @@ class GetPlayerMonsterAction(EventAction):
 
         return False
 
-    def set_var(self, menu_item: MenuItem[Monster]) -> None:
+    def set_var(self, menu_item: MenuItem[Monster | None]) -> None:
         self.choose = True
-        player = self.session.player
         monster = menu_item.game_object
+        if monster is None:
+            return
 
+        player = self.session.player
         player.game_variables.set(self.variable_name, monster.instance_id.hex)
         self.session.client.pop_state()
 
@@ -148,10 +150,13 @@ class GetPlayerMonsterAction(EventAction):
         self.choose = False
         # pull up the monster menu so we know which one we are saving
         menu = session.client.push_state(
-            MonsterMenuState(session.client, session.player.monsters)
+            MonsterMenuState(
+                session.client,
+                session.player.monsters,
+                on_selection=self.set_var,
+                is_valid_entry=self.validate,
+            )
         )
-        menu.is_valid_entry = self.validate  # type: ignore[assignment]
-        menu.on_menu_selection = self.set_var  # type: ignore[assignment]
         # if without filters, no closing by clicking back
         if (
             self.filter_name is None

--- a/tuxemon/item/controller.py
+++ b/tuxemon/item/controller.py
@@ -64,12 +64,15 @@ class ItemController:
                         self.session.client, self.char.monsters
                     )
                     self.session.client.push_state(monster_menu)
-                    monster_menu.is_valid_entry = partial(
-                        self.item.validate_monster, self.session
-                    )  # type: ignore[method-assign]
-                    monster_menu.on_menu_selection = (
-                        self.get_monster_targeted_action(key)
-                    )  # type: ignore[assignment]
+                    monster_menu = MonsterMenuState(
+                        self.session.client,
+                        self.char.monsters,
+                        on_selection=self.get_monster_targeted_action(key),
+                        is_valid_entry=partial(
+                            self.item.validate_monster, self.session
+                        ),
+                    )
+                    self.session.client.push_state(monster_menu)
                 else:
                     result = self.item.use(self.session, self.char, None)
                     self.session.client.remove_state_by_name("ItemMenuState")
@@ -100,8 +103,12 @@ class ItemController:
 
     def get_monster_targeted_action(
         self, key: str
-    ) -> Callable[[MenuItem[Monster]], None]:
-        def action(menu_item: MenuItem[Monster]) -> None:
+    ) -> Callable[[MenuItem[Monster | None]], None]:
+        def action(menu_item: MenuItem[Monster | None]) -> None:
+            monster = menu_item.game_object
+            if monster is None:
+                return
+
             monster = menu_item.game_object
             result = self.item.use(self.session, self.char, monster)
             self.session.client.remove_state_by_name("MonsterMenuState")

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -670,11 +670,6 @@ class Menu(Generic[T], State):
             self.refresh_layout()
             self.validate_layout("refresh layout")
 
-        if self.menu_items:
-            self.selected_index = self.menu_items.snap_selection(
-                self.selected_index
-            )
-
         if not self.transparent:
             self.window.draw(surface, self.rect)
 

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -214,8 +214,12 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
     def open_swap_menu(self) -> None:
         """Open menus to swap monsters in party."""
 
-        def swap_it(menuitem: MenuItem[Monster]) -> None:
+        def swap_it(menuitem: MenuItem[Monster | None]) -> None:
             added = menuitem.game_object
+
+            if added is None:
+                return
+
             swap = Technique.create("swap")
             status = self.monster.status.current_status
             message = status.name.lower() if status else ""
@@ -243,16 +247,19 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return False
             return True
 
-        def validate(menu_item: MenuItem[Monster]) -> bool:
-            if isinstance(menu_item, Monster):
-                return validate_monster(menu_item)
-            return False
+        def validate(mon: Monster | None) -> bool:
+            if mon is None:
+                return False
+            return validate_monster(mon)
 
         menu = self.client.push_state(
-            MonsterMenuState(self.client, self.character.monsters)
+            MonsterMenuState(
+                self.client,
+                self.character.monsters,
+                on_selection=swap_it,
+                is_valid_entry=validate,
+            )
         )
-        menu.on_menu_selection = swap_it  # type: ignore[assignment]
-        menu.is_valid_entry = validate  # type: ignore[assignment]
         menu.anchor("bottom", self.rect.top)
         menu.anchor("right", self.client.context.rect.right)
 
@@ -286,11 +293,14 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                     mon = MenuItem(surface, None, None, enemy)
                     enqueue_item(item, mon)
                 else:
-                    state = self.client.push_state(
-                        MonsterMenuState(self.client, self.character.monsters)
+                    self.client.push_state(
+                        MonsterMenuState(
+                            self.client,
+                            self.character.monsters,
+                            on_selection=partial(enqueue_item, item),
+                            is_valid_entry=partial(validate, item),
+                        )
                     )
-                    state.is_valid_entry = partial(validate, item)  # type: ignore[method-assign]
-                    state.on_menu_selection = partial(enqueue_item, item)  # type: ignore[method-assign]
 
         def validate_item(item: Item | None) -> bool:
             if item and item.behaviors.throwable:
@@ -300,13 +310,17 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
                 return True
             return True
 
-        def validate(item: Item, menu_item: MenuItem[Monster]) -> bool:
-            if isinstance(menu_item, Monster):
-                return item.validate_monster(self.session, menu_item)
-            return False
+        def validate(item: Item, monster: Monster | None) -> bool:
+            if monster is None:
+                return False
+            return item.validate_monster(self.session, monster)
 
-        def enqueue_item(item: Item, menu_item: MenuItem[Monster]) -> None:
+        def enqueue_item(
+            item: Item, menu_item: MenuItem[Monster | None]
+        ) -> None:
             target = menu_item.game_object
+            if target is None:
+                return
 
             # check target status
             status = target.status.current_status

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -375,24 +375,31 @@ class CombatState(CombatAnimations):
             player: Player who has to select a Tuxemon.
         """
 
-        def add(menuitem: MenuItem[Monster]) -> None:
+        def add(menuitem: MenuItem[Monster | None]) -> None:
             monster = menuitem.game_object
+            if monster is None:
+                return
             self.combat_session.add_monster_into_play(
                 self.session, player, monster
             )
             self.client.remove_state_by_name("MonsterMenuState")
 
-        def validate(menu_item: MenuItem[Monster]) -> bool:
-            if isinstance(menu_item, Monster):
-                if menu_item.is_fainted:
-                    return False
-                if menu_item in self.combat_session.active_monsters:
-                    return False
-                return True
-            return False
+        def validate(monster: Monster | None) -> bool:
+            if monster is None:
+                return False
+            if monster.is_fainted:
+                return False
+            if monster in self.combat_session.active_monsters:
+                return False
+            return True
 
         state = self.client.push_state(
-            MonsterMenuState(self.client, player.monsters)
+            MonsterMenuState(
+                self.client,
+                player.monsters,
+                on_selection=add,
+                is_valid_entry=validate,
+            )
         )
         state.task(
             partial(
@@ -402,8 +409,6 @@ class CombatState(CombatAnimations):
             ),
             interval=0,
         )
-        state.is_valid_entry = validate  # type: ignore[assignment]
-        state.on_menu_selection = add  # type: ignore[assignment]
         state.escape_key_exits = False
 
     def handle_monster_entry(

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -61,9 +61,14 @@ class MonsterMenuState(Menu[Monster | None]):
         client: BaseClient,
         monsters: list[Monster],
         monster_filter: MonsterFilter | None = None,
+        *,
+        on_selection: Callable[[MenuItem[Monster | None]], None] | None = None,
+        is_valid_entry: Callable[[Monster | None], bool] | None = None,
         **kwargs: Any,
-    ) -> None:
+    ):
         super().__init__(client=client, **kwargs)
+        self._external_on_selection = on_selection
+        self._external_is_valid_entry = is_valid_entry
         self.monster_filter = monster_filter or MonsterFilter()
         self.monsters = self.monster_filter.get_filtered_monsters(monsters)
 
@@ -122,22 +127,14 @@ class MonsterMenuState(Menu[Monster | None]):
 
         self.refresh_menu_items()
 
-    def on_menu_selection(
-        self,
-        menu_item: MenuItem[Monster | None],
-    ) -> None:
-        pass
+    def on_menu_selection(self, item: MenuItem[Monster | None]) -> None:
+        if self._external_on_selection:
+            return self._external_on_selection(item)
+        return None
 
     def is_valid_entry(self, monster: Monster | None) -> bool:
-        """
-        Used to determine if a given monster should be selectable.
-
-        When other code creates a MonsterMenu, it should overwrite this method
-        to suit its needs.
-
-        Parameters:
-            monster: The monster corresponding to the menu item, if any.
-        """
+        if self._external_is_valid_entry:
+            return self._external_is_valid_entry(monster)
         return monster is not None
 
     def refresh_menu_items(self) -> None:
@@ -257,9 +254,9 @@ class MonsterMenuHandler:
                 self.client, self.party.owner, self.name, items_filtered
             )
         )
-        menu.on_menu_selection = lambda menu_item: self._equip_from_picker(
+        menu.on_menu_selection = lambda menu_item: self._equip_from_picker(  # type: ignore[method-assign]
             monster, menu_item
-        )  # type: ignore[method-assign]
+        )
 
     def _equip_from_picker(
         self, monster: Monster, menu_item: MenuItem[Item | None]
@@ -411,12 +408,14 @@ class MonsterMenuHandler:
     def open_monster_menu(self) -> None:
         """Pushes the monster menu state."""
         self.monster_menu = self.client.push_state(
-            MonsterMenuState(self.client, self.party.monsters)
+            MonsterMenuState(
+                self.client,
+                self.party.monsters,
+                on_selection=lambda item: self.handle_selection(
+                    item, self.monster_menu
+                ),
+            )
         )
-
-        self.monster_menu.on_menu_selection = lambda item: (
-            self.handle_selection(item, self.monster_menu)
-        )  # type: ignore[assignment]
 
         original_on_change = self.monster_menu.on_menu_selection_change
 

--- a/tuxemon/states/phone_banking.py
+++ b/tuxemon/states/phone_banking.py
@@ -101,12 +101,12 @@ class NuPhoneBanking(PygameMenuState):
         if op == "pay":
             max_value = mm.get_money()
 
-            def callback(amount):
+            def callback(amount: int) -> None:
                 return self._pay(amount, bill_name)
         else:
             max_value = mm.get_bank_balance()
 
-            def callback(amount):
+            def callback(amount: int) -> None:
                 return self._e_pay(amount, bill_name)
 
         self._open_amount_picker(

--- a/tuxemon/technique/controller.py
+++ b/tuxemon/technique/controller.py
@@ -59,15 +59,14 @@ class TechController:
             def action_use() -> None:
                 self.session.client.remove_state_by_name("ChoiceState")
                 monster_menu = MonsterMenuState(
-                    self.session.client, self.char.monsters
+                    self.session.client,
+                    self.char.monsters,
+                    on_selection=self.get_monster_targeted_action(key),
+                    is_valid_entry=partial(
+                        self.technique.validate_monster, self.session
+                    ),
                 )
                 self.session.client.push_state(monster_menu)
-                monster_menu.is_valid_entry = partial(
-                    self.technique.validate_monster, self.session
-                )  # type: ignore[method-assign]
-                monster_menu.on_menu_selection = (
-                    self.get_monster_targeted_action(key)
-                )  # type: ignore[assignment]
 
             return action_use
 
@@ -93,9 +92,12 @@ class TechController:
 
     def get_monster_targeted_action(
         self, key: str
-    ) -> Callable[[MenuItem[Monster]], None]:
-        def action(menu_item: MenuItem[Monster]) -> None:
+    ) -> Callable[[MenuItem[Monster | None]], None]:
+        def action(menu_item: MenuItem[Monster | None]) -> None:
             monster = menu_item.game_object
+            if monster is None:
+                return
+
             result = self.technique.use(self.session, monster, monster)
             self.session.client.remove_state_by_name("MonsterMenuState")
             self.session.client.remove_state_by_name("TechniqueMenuState")


### PR DESCRIPTION
PR fixes several issues introduced when pagination was added to the menu system. It updates type hints and removes a leftover debugging snippet that forced `selected_index` to be snapped unconditionally inside the base `Menu` class.

That logic belonged only in menus that actually use pagination, such as `ItemMenuState`, and keeping it in the base class broke directional navigation: moving down worked, but moving up or using left/right no longer behaved correctly. 

```
        if self.menu_items:
            self.selected_index = self.menu_items.snap_selection(
                self.selected_index
            )
```

The patch removes the generic snapping and restores the responsibility to the paginated submenus, which fixes selection movement and restores expected navigation behavior.

The change introduces two explicit callback parameters, `on_selection` and `is_valid_entry`, to the `MonsterMenuState` constructor. These replace the previous pattern of monkey‑patching methods after instantiation. All call sites that previously assigned `menu.on_menu_selection = ...` or `menu.is_valid_entry = ...` were updated to pass the appropriate functions directly through the constructor. This ensures consistent callback signatures, removes the need for `type: ignore`, and aligns all menu interactions with the intended API of `MonsterMenuState`.