### PR TITLE
Fix wild battle dialog appearing before combat UI is initialized

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,11 +4,6 @@ on:
   workflow_call:
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
-    with:
-      RUN_LINT: false  # Linting is skipped
-
   python-app:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
   push:
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/tuxemon/states/combat_animations.py
+++ b/tuxemon/states/combat_animations.py
@@ -112,9 +112,6 @@ class CombatAnimations(Menu[None], ABC):
         self.sprites.add(dialog_box, layer=HUD_LAYER)
         self.sprites.add(text_area, layer=HUD_LAYER)
 
-    def animate_open(self) -> None:
-        self.transition_none_normal()
-
     def transition_none_normal(self) -> None:
         """From newly opened to normal."""
         self.animate_parties_in()

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -179,6 +179,7 @@ class CombatState(CombatAnimations):
                 "Environment not set. Use set_environment before proceeding."
             )
         self.env = env
+        self.transition_none_normal()
 
     @staticmethod
     def is_task_finished(task: TaskBase) -> bool:


### PR DESCRIPTION
Wild encounters were displaying their first combat message before the combat dialog UI had been created. The parent class triggered its opening animation during construction, and that animation published the initial `combat_dialog` event while the `TextArea` still had a zero‑size rect. NPC battles didn’t follow this path, so they behaved correctly. This change removes the early animation call from the parent initialization and runs the intro transition at the end of `CombatState.__init__`, after the dialog box and text area have been created and sized. This ensures that all combat messages are shown only after the UI is ready. Wild battles now display their intro messages in the correct dialog box, matching NPC battle behavior.

Removes also lint.yml since it has been replaced by ruff and concurrency.