### PR TITLE
Fix dialog geometry by adding Rect support to TextArea and DialogState

### DIFF
--- a/tests/tuxemon/test_alert_manager.py
+++ b/tests/tuxemon/test_alert_manager.py
@@ -4,6 +4,8 @@ import time
 
 import pygame
 import pytest
+from pygame.font import Font
+from pygame.rect import Rect
 
 from tuxemon.event.eventbus import EventBus
 from tuxemon.menu.alert import AlertManager
@@ -21,13 +23,16 @@ def pygame_init():
 
 @pytest.fixture
 def font():
-    return pygame.font.Font(None, 16)
+    return Font(None, 16)
 
 
 @pytest.fixture
 def text_area(font):
     return TextArea(
-        font=font, font_color=(255, 255, 255), scaling=DefaultScaling(1)
+        font=font,
+        font_color=(255, 255, 255),
+        rect=Rect(0, 0, 200, 50),
+        scaling=DefaultScaling(1),
     )
 
 

--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -2,6 +2,11 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import pygame
 import pytest
+from pygame import SRCALPHA
+from pygame.color import Color
+from pygame.font import Font
+from pygame.rect import Rect
+from pygame.surface import Surface
 
 from tuxemon.scaling import DefaultScaling
 from tuxemon.ui.draw import TextOverflow, iter_render_text
@@ -11,7 +16,7 @@ from tuxemon.ui.text_alignment import HorizontalAlignment, VerticalAlignment
 
 class DummyChar:
     def __init__(self, ch="X"):
-        self.surface = pygame.Surface((1, 1))
+        self.surface = Surface((1, 1))
         self.rect = self.surface.get_rect()
 
 
@@ -29,14 +34,20 @@ def pygame_init():
 
 @pytest.fixture
 def font():
-    return pygame.font.Font(None, 16)
+    return Font(None, 16)
 
 
 @pytest.fixture
-def text_area(font):
+def rect():
+    return Rect(0, 0, 100, 40)
+
+
+@pytest.fixture
+def text_area(font, rect):
     ta = TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=rect,
         scaling=DefaultScaling(1),
     )
     ta._iter = None
@@ -44,14 +55,18 @@ def text_area(font):
 
 
 @pytest.fixture
-def stress_text_area(font):
-    ta = TextArea(
+def small_rect():
+    return Rect(0, 0, 100, 20)
+
+
+@pytest.fixture
+def stress_text_area(font, small_rect):
+    return TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=small_rect,
         scaling=DefaultScaling(1),
     )
-    ta.rect = pygame.Rect(0, 0, 100, 20)
-    return ta
 
 
 def test_initial_state(text_area):
@@ -59,14 +74,17 @@ def test_initial_state(text_area):
     assert text_area.drawing_text is False
 
 
-def test_text_setter_triggers_animation(text_area):
-    text_area.rect = pygame.Rect(0, 0, 200, 50)
-    text_area._start_text_animation = lambda: setattr(
-        text_area, "drawing_text", True
+def test_text_setter_triggers_animation(font):
+    ta = TextArea(
+        font=font,
+        font_color=(255, 255, 255),
+        rect=Rect(0, 0, 200, 50),
+        scaling=DefaultScaling(1),
     )
-    text_area.text = "Hello"
-    assert text_area.text == "Hello"
-    assert text_area.drawing_text is True
+    ta._start_text_animation = lambda: setattr(ta, "drawing_text", True)
+    ta.text = "Hello"
+    assert ta.text == "Hello"
+    assert ta.drawing_text is True
 
 
 def test_len_returns_length(text_area):
@@ -97,15 +115,21 @@ def test_overflow_behavior_setter(text_area):
     assert text_area.overflow_behavior == TextOverflow.WRAP
 
 
-def test_start_text_animation_resets_surface(text_area):
-    text_area.rect = pygame.Rect(0, 0, 10, 10)
+def test_start_text_animation_resets_surface(font):
+    ta = TextArea(
+        font=font,
+        font_color=(255, 255, 255),
+        rect=Rect(0, 0, 10, 10),
+        scaling=DefaultScaling(1),
+    )
+
     global iter_render_text
     old_iter = iter_render_text
     iter_render_text = dummy_iter_render_text
     try:
-        text_area.text = "abc"
-        assert text_area.drawing_text is True
-        assert text_area._iter is not None
+        ta.text = "abc"
+        assert ta.drawing_text is True
+        assert ta._iter is not None
     finally:
         iter_render_text = old_iter
 
@@ -187,34 +211,27 @@ def test_empty_string_animation_state(stress_text_area):
     assert stress_text_area.text == ""
 
 
-def test_background_and_diagnostics_integration(font):
+def test_background_and_diagnostics_integration(font, rect):
     ta = TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=rect,
         scaling=DefaultScaling(1),
         debug_rendering=True,
     )
-    ta.rect = pygame.Rect(0, 0, 50, 20)
     ta.text = "Hi"
-    assert ta.image is not None
     px = ta.image.get_at((0, 0))
     assert px.a > 0
 
 
-def test_static_rendering_draws_text(font):
-    ta = TextArea(
-        font=font,
-        font_color=(255, 255, 255),
-        scaling=DefaultScaling(1),
-    )
-    ta.animated = False
-    ta.rect = pygame.Rect(0, 0, 100, 30)
-    ta.text = "Hello"
+def test_static_rendering_draws_text(text_area):
+    text_area.animated = False
+    text_area.text = "Hello"
 
     nonzero = False
-    for x in range(ta.image.get_width()):
-        for y in range(ta.image.get_height()):
-            if ta.image.get_at((x, y)).a > 0:
+    for x in range(text_area.image.get_width()):
+        for y in range(text_area.image.get_height()):
+            if text_area.image.get_at((x, y)).a > 0:
                 nonzero = True
                 break
         if nonzero:
@@ -223,19 +240,13 @@ def test_static_rendering_draws_text(font):
     assert nonzero, "Static text should be drawn immediately"
 
 
-def test_animation_iterates_one_char_per_symbol(font):
-    ta = TextArea(
-        font=font,
-        font_color=(255, 255, 255),
-        scaling=DefaultScaling(1),
-    )
-    ta.rect = pygame.Rect(0, 0, 200, 50)
-    ta.text = "ABC"
+def test_animation_iterates_one_char_per_symbol(text_area):
+    text_area.text = "ABC"
 
     count = 0
     try:
         while True:
-            next(ta)
+            next(text_area)
             count += 1
     except StopIteration:
         pass
@@ -243,7 +254,7 @@ def test_animation_iterates_one_char_per_symbol(font):
     assert count == 3
 
 
-def test_overflow_behavior_passed_to_iter(font, monkeypatch):
+def test_overflow_behavior_passed_to_iter(text_area, monkeypatch):
     captured = {}
 
     def fake_iter_render_text(**kwargs):
@@ -254,14 +265,8 @@ def test_overflow_behavior_passed_to_iter(font, monkeypatch):
         "tuxemon.ui.text.iter_render_text", fake_iter_render_text
     )
 
-    ta = TextArea(
-        font=font,
-        font_color=(255, 255, 255),
-        scaling=DefaultScaling(1),
-    )
-    ta.rect = pygame.Rect(0, 0, 50, 20)
-    ta.set_overflow_behavior(TextOverflow.WRAP)
-    ta.text = "Hello"
+    text_area.set_overflow_behavior(TextOverflow.WRAP)
+    text_area.text = "Hello"
 
     assert captured["overflow_behavior"] == TextOverflow.WRAP
 
@@ -280,52 +285,47 @@ def test_alignment_parameters_passed(font, monkeypatch):
     ta = TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=Rect(0, 0, 100, 40),
         scaling=DefaultScaling(1),
         h_alignment=HorizontalAlignment.CENTER,
         v_alignment=VerticalAlignment.BOTTOM,
     )
-    ta.rect = pygame.Rect(0, 0, 100, 40)
     ta.text = "Hello"
 
     assert captured["h_alignment"] == HorizontalAlignment.CENTER
     assert captured["v_alignment"] == VerticalAlignment.BOTTOM
 
 
-def test_image_initialized_in_constructor(font):
-    ta = TextArea(
-        font=font,
-        font_color=(255, 255, 255),
-        scaling=DefaultScaling(1),
-    )
-    assert hasattr(ta, "image")
-    assert isinstance(ta.image, pygame.Surface)
+def test_image_initialized_in_constructor(text_area):
+    assert hasattr(text_area, "image")
+    assert isinstance(text_area.image, Surface)
 
 
 def test_static_text_does_not_use_background(font):
     ta = TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=Rect(0, 0, 100, 30),
         scaling=DefaultScaling(1),
         background_color=(255, 0, 0),
     )
     ta.animated = False
-    ta.rect = pygame.Rect(0, 0, 100, 30)
     ta.text = "Hello"
     px = ta.image.get_at((0, 0))
-    assert px == pygame.Color(255, 0, 0)
+    assert px == Color(255, 0, 0)
 
 
 def test_animated_text_uses_background(font):
     ta = TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=Rect(0, 0, 100, 30),
         scaling=DefaultScaling(1),
         background_color=(0, 255, 0),
     )
-    ta.rect = pygame.Rect(0, 0, 100, 30)
     ta.text = "Hi"
     px = ta.image.get_at((0, 0))
-    assert px == pygame.Color(0, 255, 0)
+    assert px == Color(0, 255, 0)
 
 
 def test_iter_returns_self(text_area):
@@ -336,10 +336,10 @@ def test_empty_text_resets_image(font):
     ta = TextArea(
         font=font,
         font_color=(255, 255, 255),
+        rect=Rect(0, 0, 50, 20),
         scaling=DefaultScaling(1),
     )
-    ta.rect.update(0, 0, 50, 20)
-    ta.image = pygame.Surface((50, 20), pygame.SRCALPHA)
+    ta.image = Surface((50, 20), SRCALPHA)
     ta.text = ""
     assert ta.image.get_size() == (50, 20)
     px = ta.image.get_at((0, 0))

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -700,9 +700,9 @@ class CombatTargetMenuState(Menu[Monster]):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=self.window.calc_inner_rect(self.window.rect),
             scaling=self.client.context.scaling,
         )
-        self.text_area.rect = self.window.calc_inner_rect(self.window.rect)
         self.sprites.add(self.text_area, layer=100)
 
         self.surface = Surface(self.window.rect.size, SRCALPHA)

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -362,9 +362,9 @@ class CombatState(CombatAnimations):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=dialog_box.calc_inner_rect(dialog_box.rect),
             scaling=self.client.context.scaling,
         )
-        self.text_area.rect = dialog_box.calc_inner_rect(dialog_box.rect)
         self.show_combat_dialog(dialog_box, self.text_area)
 
     def ask_player_for_monster(self, player: NPC) -> None:

--- a/tuxemon/states/dialog_state.py
+++ b/tuxemon/states/dialog_state.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pygame import SRCALPHA
+from pygame.rect import Rect
 from pygame.surface import Surface
 
 from tuxemon.graphics import load_and_scale
@@ -43,6 +44,7 @@ class DialogState(PopUpMenu[None]):
     def __init__(
         self,
         client: BaseClient,
+        rect: Rect,
         text: Sequence[str] = (),
         avatar: Sprite | None = None,
         box_style: dict[str, Any] | None = None,
@@ -54,7 +56,7 @@ class DialogState(PopUpMenu[None]):
         dialog_speed: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(client=client, **kwargs)
+        super().__init__(client=client, rect=rect.copy(), **kwargs)
         self.text_queue = list(text)
         self.avatar = avatar
         self.on_complete = on_complete
@@ -87,9 +89,12 @@ class DialogState(PopUpMenu[None]):
         scaling = self.client.context.scaling
         line_spacing = scaling.scale_int(final_box_style["line_spacing"])
 
+        internal_rect = self.calc_internal_rect().copy()
+
         self.dialog_box = TextArea(
             font=self.font,
             font_color=final_box_style["font_color"],
+            rect=internal_rect,
             scaling=self.client.context.scaling,
             font_shadow=final_box_style["font_shadow"],
             h_alignment=final_box_style["h_alignment"],

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -77,14 +77,15 @@ class ItemMenuState(Menu[Item]):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=rect,
             scaling=self.client.context.scaling,
             font_shadow=(96, 96, 128),
         )
-        self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
         self.page_number_display = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=Rect(0, 0, 1, 1),
             scaling=self.client.context.scaling,
         )
         self.sprites.add(self.page_number_display, layer=100)

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -73,14 +73,14 @@ class MonsterMenuState(Menu[Monster | None]):
         self.monsters = self.monster_filter.get_filtered_monsters(monsters)
 
         # make a text area to show messages
+        rect = self.client.context.scaling.scale_tuple((20, 80, 80, 100))
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=Rect(rect),
             scaling=self.client.context.scaling,
             font_shadow=(96, 96, 96),
         )
-        rect = self.client.context.scaling.scale_tuple((20, 80, 80, 100))
-        self.text_area.rect = Rect(rect)
         self.sprites.add(self.text_area, layer=100)
         self.monster_stats_display = MonsterStatsDisplay(self)
         self.monster_sprite_displays: list[MonsterSpriteDisplay] = []
@@ -452,6 +452,7 @@ class MonsterStatsDisplay:
         self.sprite = TextArea(
             font=self.menu_state.font,
             font_color=self.menu_state.font_color,
+            rect=Rect(0, 0, 1, 1),
             scaling=self.menu_state.client.context.scaling,
         )
         self.menu_state.sprites.add(self.sprite, layer=LAYER_MONSTER_ICONS)

--- a/tuxemon/states/shop_base.py
+++ b/tuxemon/states/shop_base.py
@@ -85,9 +85,9 @@ class ShopMenuState(Menu[T], Generic[T], ABC):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=rect,
             scaling=self.client.context.scaling,
         )
-        self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 
         self.image_center = self.rect.width * 0.16, self.rect.height * 0.45

--- a/tuxemon/states/technique_menu.py
+++ b/tuxemon/states/technique_menu.py
@@ -66,10 +66,10 @@ class TechniqueMenuState(Menu[Technique]):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
+            rect=rect,
             scaling=self.client.context.scaling,
             font_shadow=(96, 96, 128),
         )
-        self.text_area.rect = rect
         self.sprites.add(self.text_area, layer=100)
 
     def calc_internal_rect(self) -> Rect:

--- a/tuxemon/tools.py
+++ b/tuxemon/tools.py
@@ -231,9 +231,9 @@ def open_dialog(
 
     return client.push_state(
         "DialogState",
+        rect=dialog_rect,
         text=text,
         avatar=avatar,
-        rect=dialog_rect,
         box_style=box_style,
         on_complete=on_complete,
         dialog_speed=dialog_speed,

--- a/tuxemon/ui/input_display.py
+++ b/tuxemon/ui/input_display.py
@@ -52,31 +52,25 @@ class InputDisplay:
         self.area_rect = area_rect
 
         # Prompt area
-        self.prompt = TextArea(
-            font=font,
-            font_color=font_color,
-            scaling=self.scaling,
-            font_shadow=(96, 96, 96),
-        )
-        self.prompt.animated = False
-        self.prompt.rect = Rect(
+        rect_prompt_area = Rect(
             area_rect.x + self.scaling.scale_int(self.config.prompt_offset_x),
             area_rect.y + self.scaling.scale_int(self.config.prompt_offset_y),
             self.scaling.scale_int(self.config.prompt_width),
             self.scaling.scale_int(self.config.prompt_height),
         )
+        self.prompt = TextArea(
+            font=font,
+            font_color=font_color,
+            rect=rect_prompt_area,
+            scaling=self.scaling,
+            font_shadow=(96, 96, 96),
+        )
+        self.prompt.animated = False
         self.prompt.text = prompt_text
         self.sprites.add(self.prompt)
 
         # Input text area
-        self.text_area = TextArea(
-            font=font,
-            font_color=font_color,
-            scaling=self.scaling,
-            font_shadow=(96, 96, 96),
-        )
-        self.text_area.animated = False
-        self.text_area.rect = Rect(
+        rect_text_area = Rect(
             area_rect.x
             + self.scaling.scale_int(self.config.text_area_offset_x),
             area_rect.y
@@ -84,6 +78,14 @@ class InputDisplay:
             self.scaling.scale_int(self.config.text_area_width),
             self.scaling.scale_int(self.config.text_area_height),
         )
+        self.text_area = TextArea(
+            font=font,
+            font_color=font_color,
+            rect=rect_text_area,
+            scaling=self.scaling,
+            font_shadow=(96, 96, 96),
+        )
+        self.text_area.animated = False
         self.text_area.text = initial_input_string
         self.sprites.add(self.text_area)
 
@@ -91,6 +93,7 @@ class InputDisplay:
         self.char_counter = TextArea(
             font=font,
             font_color=font_color,
+            rect=Rect(0, 0, 50, 30),
             scaling=self.scaling,
             font_shadow=(96, 96, 96),
         )

--- a/tuxemon/ui/text.py
+++ b/tuxemon/ui/text.py
@@ -63,6 +63,7 @@ class TextArea(Sprite):
         self,
         font: Font,
         font_color: ColorLike,
+        rect: Rect,
         scaling: ScalingStrategy,
         font_shadow: ColorLike = FONT_SHADOW_COLOR,
         background_color: ColorLike | None = None,
@@ -74,7 +75,7 @@ class TextArea(Sprite):
         line_spacing: int = 0,
     ) -> None:
         super().__init__()
-        self.rect = Rect(0, 0, 0, 0)
+        self.rect = rect.copy()
         self.image = Surface(self.rect.size, SRCALPHA)
         self.drawing_text = False
 


### PR DESCRIPTION
PR adds explicit `Rect` support to the constructors of `TextArea` and `DialogState`, ensuring both components receive a well‑defined geometry at creation time. The previous implementation relied on inheriting the menu window’s rect, which caused the text area to initialize with incorrect dimensions and positions. Dialog boxes now render in the correct position, maintain consistent dimensions across multiple dialog states, and no longer inherit or revert to the menu window rect.

Changes:
- `TextArea` now accepts a `Rect` during construction and uses it as its authoritative layout rectangle
- `DialogState` now computes the internal dialog rectangle up front and passes it to the `TextArea` instead of reusing the menu window rect
- removed the code path that reused stale background surfaces, which previously caused the text area to revert to outdated sizes
- fixed a bug where the text area rect was reset between `on_open()` and text animation, leading to misaligned dialog text
- ensured that `AlertManager` always receives the correct rect for text animation