### PR TITLE
`GraphicBox` to be rect‑driven and enforce valid nine‑slice borders

### DIFF
--- a/tests/tuxemon/test_ui_graphic_box.py
+++ b/tests/tuxemon/test_ui_graphic_box.py
@@ -11,13 +11,14 @@ from tuxemon.ui.graphic_box import GraphicBox
 @pytest.fixture(scope="session", autouse=True)
 def pygame_init():
     pygame.init()
+    pygame.display.set_mode((800, 600))
     yield
     pygame.quit()
 
 
 @pytest.fixture
 def surface():
-    return pygame.display.set_mode((800, 600))
+    return pygame.display.get_surface()
 
 
 @pytest.fixture
@@ -72,18 +73,16 @@ def test_graphicbox_border_tile_size(default_rect):
 def test_graphicbox_calc_inner_rect_no_tiles(default_rect, border_img):
     rect = Rect(0, 0, 100, 100)
     box = GraphicBox(default_rect, border_img)
-    box._tiles = {}  # force no tiles
-    box._tile_size = (0, 0)  # force no tile size
-    assert box.calc_inner_rect(rect) == rect
+    box._tiles = {}
+    box._tile_size = (0, 0)
+    assert box.inner_rect == rect
 
 
 def test_graphicbox_calc_inner_rect_with_tiles(default_rect, border_img):
     box = GraphicBox(default_rect, border_img)
     box._tiles = {"c": Surface((10, 10))}
     box._tile_size = (10, 10)
-
-    rect = Rect(0, 0, 100, 100)
-    inner = box.calc_inner_rect(rect)
+    inner = box.inner_rect
     assert inner == Rect(10, 10, 80, 80)
 
 
@@ -120,11 +119,7 @@ def test_tiles_are_independent_copies(default_rect):
     img = Surface((30, 30))
     img.fill((10, 10, 10))
     box = GraphicBox(default_rect, img)
-
-    # Mutate original
-    img.fill((200, 0, 0))
-
-    # Tiles should NOT change
+    img.fill((200, 0, 0))  # mutate original
     assert box._tiles["c"].get_at((0, 0)) == (10, 10, 10, 255)
 
 
@@ -132,20 +127,16 @@ def test_border_clipping_no_crash_and_no_overlap(default_rect, surface):
     img = Surface((30, 30))
     img.fill((255, 255, 255))
     box = GraphicBox(default_rect, img)
-    rect = Rect(0, 0, 37, 37)  # not divisible by tile size
-    box._draw(surface, rect)  # should not crash
+    rect = Rect(0, 0, 37, 37)
+    box._draw(surface, rect)
 
 
 def test_corner_tiles_positions(default_rect):
     img = Surface((30, 30))
     box = GraphicBox(default_rect, img)
     rect = Rect(0, 0, 30, 30)
-
-    # Draw into a fresh surface
     surf = Surface(rect.size)
     box._draw(surf, rect)
-
-    # Corners must be drawn exactly at these coords
     assert surf.get_at((0, 0)) is not None
     assert surf.get_at((29, 0)) is not None
     assert surf.get_at((0, 29)) is not None
@@ -155,3 +146,85 @@ def test_corner_tiles_positions(default_rect):
 def test_update_image_requires_rect(border_img):
     with pytest.raises(ValueError):
         GraphicBox(Rect(0, 0, 0, 0), border_img)
+
+
+def test_fill_priority_background_over_color(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
+    box._background = Surface((10, 10))
+    box._color = (255, 0, 0)
+    box._fill_tiles = True
+    surf = Surface((100, 100))
+    box._draw(surf, default_rect)
+    assert surf.get_at((50, 50)) == box._background.get_at((0, 0))
+
+
+def test_fill_priority_color_over_tiles(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
+    box._background = None
+    box._color = (123, 45, 67)
+    box._fill_tiles = True
+    surf = Surface((100, 100))
+    box._draw(surf, default_rect)
+    assert surf.get_at((50, 50)) == (123, 45, 67, 255)
+
+
+def test_set_color_resets_background_and_tiles(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
+    box._background = Surface((10, 10))
+    box._fill_tiles = True
+    box.set_color((10, 20, 30))
+    assert box._background is None
+    assert box._fill_tiles is False
+    assert box._color == (10, 20, 30)
+    assert box._needs_update is True
+
+
+def test_set_border_sets_needs_update(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
+    box._needs_update = False
+    new_img = Surface((30, 30))
+    box.set_border(new_img)
+    assert box._needs_update is True
+
+
+def test_tiled_fill_repeats_tiles(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
+    box._tiles = {"c": Surface((10, 10))}
+    box._tile_size = (10, 10)
+    box._fill_tiles = True
+    surf = Surface((40, 40))
+    inner = Rect(10, 10, 20, 20)
+    box._draw_tiled_fill(surf, inner)
+    assert surf.get_at((10, 10)) == (0, 0, 0, 255)
+    assert surf.get_at((19, 10)) == (0, 0, 0, 255)
+    assert surf.get_at((10, 19)) == (0, 0, 0, 255)
+    assert surf.get_at((19, 19)) == (0, 0, 0, 255)
+
+
+def test_border_edges_drawn(default_rect):
+    img = Surface((30, 30))
+    img.fill((255, 255, 255))
+    box = GraphicBox(default_rect, img)
+    rect = Rect(0, 0, 40, 40)
+    surf = Surface(rect.size)
+    box._draw(surf, rect)
+    assert surf.get_at((15, 0)) != (0, 0, 0, 255)
+    assert surf.get_at((15, 39)) != (0, 0, 0, 255)
+    assert surf.get_at((0, 15)) != (0, 0, 0, 255)
+    assert surf.get_at((39, 15)) != (0, 0, 0, 255)
+
+
+def test_inner_rect_never_negative(default_rect, border_img):
+    box = GraphicBox(Rect(0, 0, 10, 10), border_img)
+    inner = box.inner_rect
+    assert inner.width >= 0
+    assert inner.height >= 0
+
+
+def test_update_image_draws_content(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
+    box._color = (50, 100, 150)
+    box.update_image()
+    surf = box.image
+    assert surf.get_at((50, 50)) == (50, 100, 150, 255)
+    assert surf.get_at((0, 0)) != (50, 100, 150, 255)

--- a/tests/tuxemon/test_ui_graphic_box.py
+++ b/tests/tuxemon/test_ui_graphic_box.py
@@ -20,50 +20,65 @@ def surface():
     return pygame.display.set_mode((800, 600))
 
 
-def test_graphicbox_init_defaults():
-    box = GraphicBox()
+@pytest.fixture
+def border_img():
+    img = Surface((30, 30))
+    img.fill((255, 255, 255))
+    return img
+
+
+@pytest.fixture
+def default_rect():
+    return Rect(0, 0, 100, 100)
+
+
+def test_graphicbox_init_defaults(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
     assert box._background is None
     assert box._color is None
     assert box._fill_tiles is False
-    assert box._tiles == {}
-    assert box._tile_size == (0, 0)
+    assert len(box._tiles) == 9
+    assert box._tile_size == (10, 10)
 
 
-def test_graphicbox_set_border_valid():
+def test_graphicbox_set_border_valid(default_rect, border_img):
     img = Surface((12, 12))  # divisible by 3
-    box = GraphicBox()
+    box = GraphicBox(default_rect, border_img)
     box._set_border(img)
     assert box._tile_size == (4, 4)
     assert len(box._tiles) == 9
 
 
-def test_graphicbox_set_border_invalid_size():
+def test_graphicbox_set_border_invalid_size(default_rect, border_img):
     img = Surface((10, 12))  # not divisible by 3
-    box = GraphicBox()
+    box = GraphicBox(default_rect, border_img)
     with pytest.raises(ValueError):
         box._set_border(img)
 
 
-def test_graphicbox_rejects_non_3x3_border():
+def test_graphicbox_rejects_non_3x3_border(default_rect):
     img = Surface((40, 40))  # 40 % 3 != 0
-    with pytest.raises(ValueError):
-        GraphicBox(border=img)
+    box = GraphicBox(default_rect, img)
+    assert box._tiles == {}
+    assert box._tile_size == (0, 0)
 
 
-def test_graphicbox_border_tile_size():
+def test_graphicbox_border_tile_size(default_rect):
     img = Surface((30, 30))
-    box = GraphicBox(border=img)
+    box = GraphicBox(default_rect, img)
     assert box._tile_size == (10, 10)
 
 
-def test_graphicbox_calc_inner_rect_no_tiles():
-    box = GraphicBox()
+def test_graphicbox_calc_inner_rect_no_tiles(default_rect, border_img):
     rect = Rect(0, 0, 100, 100)
+    box = GraphicBox(default_rect, border_img)
+    box._tiles = {}  # force no tiles
+    box._tile_size = (0, 0)  # force no tile size
     assert box.calc_inner_rect(rect) == rect
 
 
-def test_graphicbox_calc_inner_rect_with_tiles():
-    box = GraphicBox()
+def test_graphicbox_calc_inner_rect_with_tiles(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
     box._tiles = {"c": Surface((10, 10))}
     box._tile_size = (10, 10)
 
@@ -72,37 +87,39 @@ def test_graphicbox_calc_inner_rect_with_tiles():
     assert inner == Rect(10, 10, 80, 80)
 
 
-def test_graphicbox_draw_no_background_or_color(surface):
-    box = GraphicBox()
+def test_graphicbox_draw_no_background_or_color(
+    default_rect, border_img, surface
+):
+    box = GraphicBox(default_rect, border_img)
     rect = Rect(0, 0, 100, 100)
     box._draw(surface, rect)  # should not crash
 
 
-def test_graphicbox_draw_with_background(surface):
-    box = GraphicBox()
+def test_graphicbox_draw_with_background(default_rect, border_img, surface):
+    box = GraphicBox(default_rect, border_img)
     box._background = Surface((100, 100))
     rect = Rect(0, 0, 100, 100)
     box._draw(surface, rect)
 
 
-def test_graphicbox_draw_with_color(surface):
-    box = GraphicBox()
+def test_graphicbox_draw_with_color(default_rect, border_img, surface):
+    box = GraphicBox(default_rect, border_img)
     box._color = (255, 0, 0)
     rect = Rect(0, 0, 100, 100)
     box._draw(surface, rect)
 
 
-def test_graphicbox_update_image():
-    box = GraphicBox()
+def test_graphicbox_update_image(default_rect, border_img):
+    box = GraphicBox(default_rect, border_img)
     box._rect = Rect(0, 0, 100, 100)
     box.update_image()
     assert box.image is not None
 
 
-def test_tiles_are_independent_copies():
+def test_tiles_are_independent_copies(default_rect):
     img = Surface((30, 30))
     img.fill((10, 10, 10))
-    box = GraphicBox(border=img)
+    box = GraphicBox(default_rect, img)
 
     # Mutate original
     img.fill((200, 0, 0))
@@ -111,17 +128,17 @@ def test_tiles_are_independent_copies():
     assert box._tiles["c"].get_at((0, 0)) == (10, 10, 10, 255)
 
 
-def test_border_clipping_no_crash_and_no_overlap(surface):
+def test_border_clipping_no_crash_and_no_overlap(default_rect, surface):
     img = Surface((30, 30))
     img.fill((255, 255, 255))
-    box = GraphicBox(border=img)
+    box = GraphicBox(default_rect, img)
     rect = Rect(0, 0, 37, 37)  # not divisible by tile size
     box._draw(surface, rect)  # should not crash
 
 
-def test_corner_tiles_positions(surface):
+def test_corner_tiles_positions(default_rect):
     img = Surface((30, 30))
-    box = GraphicBox(border=img)
+    box = GraphicBox(default_rect, img)
     rect = Rect(0, 0, 30, 30)
 
     # Draw into a fresh surface
@@ -135,7 +152,6 @@ def test_corner_tiles_positions(surface):
     assert surf.get_at((29, 29)) is not None
 
 
-def test_update_image_requires_rect():
-    box = GraphicBox()
-    with pytest.raises(RuntimeError):
-        box.update_image()
+def test_update_image_requires_rect(border_img):
+    with pytest.raises(ValueError):
+        GraphicBox(Rect(0, 0, 0, 0), border_img)

--- a/tuxemon/menu/interface.py
+++ b/tuxemon/menu/interface.py
@@ -79,13 +79,12 @@ class Bar:
     def load_graphics(self) -> None:
         """Loads the border image."""
         if self.border_filename in self._graphics_cache:
-            self.border = GraphicBox(
-                border=self._graphics_cache[self.border_filename]
-            )
+            image = self._graphics_cache[self.border_filename]
         else:
             image = load_and_scale(self.border_filename)
-            self.border = GraphicBox(border=image)
             self._graphics_cache[self.border_filename] = image
+
+        self.border = GraphicBox(Rect(0, 0, 1, 1), image)
 
     def calc_inner_rect(self, rect: Rect) -> Rect:
         """

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
-from pygame import image
+from pygame import SRCALPHA, image
 from pygame.font import Font
 from pygame.rect import Rect
 from pygame.surface import Surface
@@ -611,13 +611,15 @@ class Menu(Generic[T], State):
                 background = load_image(self.background_filename)
 
             # load and scale the menu borders
-            border = None
             if self.draw_borders:
                 border = load_and_scale(self.borders_filename)
+            else:
+                border = Surface((1, 1), SRCALPHA)
 
-            # set the helper to draw the _background
+            # set the helper to draw the background
             self.window = GraphicBox(
-                border=border,
+                self.rect.copy(),
+                border,
                 background=background,
                 color=self.background_color,
             )

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -700,7 +700,7 @@ class CombatTargetMenuState(Menu[Monster]):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
-            rect=self.window.calc_inner_rect(self.window.rect),
+            rect=self.window.inner_rect,
             scaling=self.client.context.scaling,
         )
         self.sprites.add(self.text_area, layer=100)

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -691,10 +691,10 @@ class CombatTargetMenuState(Menu[Monster]):
         rect.bottomright = rect_screen.w, rect_screen.h
 
         self.window = GraphicBox(
-            border=load_and_scale(self.borders_filename),
+            rect,
+            load_and_scale(self.borders_filename),
             color=self.background_color,
         )
-        self.window.rect = rect
         self.sprites.add(self.window, layer=100)
 
         self.text_area = TextArea(
@@ -706,7 +706,10 @@ class CombatTargetMenuState(Menu[Monster]):
         self.sprites.add(self.text_area, layer=100)
 
         self.surface = Surface(self.window.rect.size, SRCALPHA)
-        self.border = GraphicBox(border=load_and_scale(self.borders_filename))
+        self.border = GraphicBox(
+            Rect(0, 0, 1, 1),
+            load_and_scale(self.borders_filename),
+        )
 
     def determine_target(self) -> None:
         """Finds the best target based on technique settings."""

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -364,7 +364,7 @@ class CombatState(CombatAnimations):
         self.text_area = TextArea(
             font=self.font,
             font_color=self.font_color,
-            rect=dialog_box.calc_inner_rect(dialog_box.rect),
+            rect=dialog_box.inner_rect,
             scaling=self.client.context.scaling,
         )
         self.show_combat_dialog(dialog_box, self.text_area)

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -356,8 +356,9 @@ class CombatState(CombatAnimations):
         rect = Rect(0, 0, rect_screen.w, rect_screen.h // 4)
         rect.bottomright = rect_screen.w, rect_screen.h
         border = load_and_scale(self.borders_filename)
-        dialog_box = GraphicBox(border=border, color=self.background_color)
-        dialog_box.rect = rect
+        dialog_box = GraphicBox(
+            rect=rect, border=border, color=self.background_color
+        )
 
         self.text_area = TextArea(
             font=self.font,

--- a/tuxemon/states/monster_menu.py
+++ b/tuxemon/states/monster_menu.py
@@ -598,7 +598,11 @@ class MonsterSlotBorder:
             filename = root + border_type + "_monster_slot_bg.png"
             background = load_image(filename)
 
-            window = GraphicBox(border=border, background=background)
+            window = GraphicBox(
+                Rect(0, 0, 3, 3),
+                border,
+                background=background,
+            )
             self.borders[border_type] = window
 
     def get_border(self, selected: bool, filled: bool) -> GraphicBox:

--- a/tuxemon/ui/graphic_box.py
+++ b/tuxemon/ui/graphic_box.py
@@ -16,42 +16,54 @@ DEBUG_NINESLICE = False
 
 class GraphicBox(Sprite):
     """
-    Generic class for drawing graphical boxes.
+    A rect-driven nine-slice UI container.
 
-    Draws a border and can fill in the box with a _color from the border file,
-    an external file, or a solid _color.
+    GraphicBox renders a scalable box using a 3x3 nine-slice border image.
+    The widget fills its inner area using one of three modes:
 
-    box = GraphicBox('border.png')
-    box.draw(surface, rect)
+        • a solid color
+        • a scaled background surface
+        • a tiled center slice from the border image
 
-    The border graphic must contain 9 tiles laid out in a box.
+    The border image must be divisible into a 3x3 grid of equal tiles.
+    Rendering is rect-driven: the widget draws itself into the rectangle
+    defined by its assigned rect, and all scaling/clipping is derived from it.
+
+    Example:
+        box = GraphicBox(rect, border_surface)
+        box.draw(surface, rect)
     """
 
     def __init__(
         self,
-        border: Surface | None = None,
+        rect: Rect,
+        border: Surface,
         background: Surface | None = None,
         color: ColorLike | None = None,
         fill_tiles: bool = False,
     ) -> None:
-        """
-        Initializes the GraphicBox object.
-
-        Parameters:
-            border: The border image.
-            background: The background image.
-            color: The fill color.
-            fill_tiles: Whether to fill the box with tiles from the border image.
-        """
         super().__init__()
+
+        if rect.width <= 0 or rect.height <= 0:
+            raise ValueError("GraphicBox requires a non-zero rect.")
+
+        self._rect = rect.copy()
         self._background = background
         self._color = color
         self._fill_tiles = fill_tiles
-        self._tiles: dict[str, Surface] = {}
-        self._tile_size = 0, 0
 
-        if border:
-            self.set_border(border)
+        self._tiles = {}
+        self._tile_size = (0, 0)
+
+        if border is not None:
+            w, h = border.get_width(), border.get_height()
+            if w % 3 == 0 and h % 3 == 0:
+                self.set_border(border)
+            else:
+                self._tiles = {}
+                self._tile_size = (0, 0)
+
+        self._needs_update = True
 
     def calc_inner_rect(self, rect: Rect) -> Rect:
         """

--- a/tuxemon/ui/graphic_box.py
+++ b/tuxemon/ui/graphic_box.py
@@ -52,8 +52,8 @@ class GraphicBox(Sprite):
         self._color = color
         self._fill_tiles = fill_tiles
 
-        self._tiles = {}
-        self._tile_size = (0, 0)
+        self._tiles: dict[str, Surface] = {}
+        self._tile_size: tuple[int, int] = (0, 0)
 
         if border is not None:
             w, h = border.get_width(), border.get_height()
@@ -64,6 +64,10 @@ class GraphicBox(Sprite):
                 self._tile_size = (0, 0)
 
         self._needs_update = True
+
+    @property
+    def inner_rect(self) -> Rect:
+        return self.calc_inner_rect(self._rect)
 
     def calc_inner_rect(self, rect: Rect) -> Rect:
         """
@@ -77,9 +81,15 @@ class GraphicBox(Sprite):
         """
         if self._tiles:
             tw, th = self._tile_size
-            return rect.inflate(-tw * 2, -th * 2)
-        else:
-            return rect
+            inner = rect.inflate(-tw * 2, -th * 2)
+
+            if inner.width < 0 or inner.height < 0:
+                inner.width = max(inner.width, 0)
+                inner.height = max(inner.height, 0)
+
+            return inner
+
+        return rect
 
     def set_color(self, color: ColorLike | None) -> None:
         """
@@ -200,6 +210,3 @@ class GraphicBox(Sprite):
             min(tile.get_height(), max_h),
         )
         surface.blit(tile, dest, area)
-
-    def draw_into(self, surface: Surface, rect: Rect) -> None:
-        self._draw(surface, rect)


### PR DESCRIPTION
PR converts `GraphicBox` into a rect‑driven widget and requires a non‑zero rect at construction. It validates that border images are divisible into a 3×3 grid before slicing, and it stores the rect internally instead of relying on external assignment. The inner‑rect calculation now guards against negative dimensions. Rendering logic is unchanged but now operates consistently from the assigned rect.