### PR TITLE
Add Flatpak bundle output, and enable Flatpak testing

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -41,7 +41,12 @@ jobs:
         manifest-path: buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
         cache: false
         branch: ${{ steps.flatpak_release_branch.outputs.value }}
-  
+
+    - name: Test Flatpak bundle
+      run: |
+        flatpak install --user --noninteractive Tuxemon.flatpak
+        flatpak run org.tuxemon.Tuxemon -h
+
     - name: Prepare Flatpak directory
       run: |
         mkdir -p Tuxemon-x86_64
@@ -52,3 +57,4 @@ jobs:
       with:
         name: Tuxemon-x86_64
         path: Tuxemon-x86_64/
+

--- a/.github/workflows/metainfo_validation.yml
+++ b/.github/workflows/metainfo_validation.yml
@@ -38,13 +38,3 @@ jobs:
       run: |
         flatpak-builder --run build-dir buildconfig/flatpak/org.tuxemon.Tuxemon.yaml \
           sh -c 'TUXEMON_MOD_PATH=/app/share/Tuxemon/mods python3 -c "from tuxemon.database.validate_mod_data import validate_mod_data; validate_mod_data()"'
-
-    - name: Test mod copy (wrapper script)
-      run: |
-        flatpak-builder --run build-dir buildconfig/flatpak/org.tuxemon.Tuxemon.yaml \
-          sh -c "ls -R ~/.tuxemon || true"
-
-    - name: Check that mod.yaml is detected
-      run: |
-        flatpak-builder --run build-dir buildconfig/flatpak/org.tuxemon.Tuxemon.yaml \
-          sh -c "test -f ~/.tuxemon/mods/tuxemon/mod.yaml || (echo 'mod.yaml missing' && exit 1)"

--- a/buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
+++ b/buildconfig/flatpak/org.tuxemon.Tuxemon.yaml
@@ -8,12 +8,12 @@ rename-icon: icon
 
 finish-args:
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=ipc
-  - --persist=.tuxemon  # Everything is stored in the .tuxemon folder, including save files
+  - --persist=.tuxemon/saves  # Everything is stored in the .tuxemon folder, including save files
   - --share=network
   - --socket=pulseaudio
-  - --device=all
+  - --device=all  # To be able to access gamepads device=all is required
 
 modules:
   # Needed by pygame; otherwise, an error message occurs which complains about setuptools
@@ -29,7 +29,7 @@ modules:
       - install -d /app/share/Tuxemon
       - cp -r tuxemon /app/share/Tuxemon
       - install -d /app/share/Tuxemon/mods
-      - cp -r mods/* /app/share/Tuxemon/mods/
+      - cp -r mods /app/share/Tuxemon/
       - install -Dm755 run_tuxemon.py /app/share/Tuxemon/org.tuxemon.Tuxemon.py
       - install -Dm755 org.tuxemon.Tuxemon /app/bin/org.tuxemon.Tuxemon
 
@@ -44,12 +44,10 @@ modules:
     sources:
       - type: git
         url: https://github.com/Tuxemon/Tuxemon.git
-        tag: development
+        commit: 4395a19ef951607da363298ff3ce92f5880289dc
 
       - type: script
         dest-filename: org.tuxemon.Tuxemon
         commands:
-          - PERSIST="$HOME/.tuxemon/mods"
-          - BUNDLED="/app/share/Tuxemon/mods"
-          - if [ ! -d "$PERSIST" ] || [ -z "$(ls -A "$PERSIST")" ]; then mkdir -p "$PERSIST"; cp -r "$BUNDLED"/* "$PERSIST"; fi
+          - export TUXEMON_MOD_PATH=/app/share/Tuxemon/mods
           - exec python3 /app/share/Tuxemon/org.tuxemon.Tuxemon.py "$@"


### PR DESCRIPTION
PR updates the workflow. Now builds the Flatpak bundle, installs it in CI, and performs a basic runtime check to ensure the package launches correctly. This adds early detection of packaging issues and validates the bundled mods before publishing.