### PR TITLE
Extract `TerrainManager` from `CollisionManager`

### DIFF
--- a/tests/tuxemon/test_collision_manager.py
+++ b/tests/tuxemon/test_collision_manager.py
@@ -26,48 +26,6 @@ def collision_manager(map_manager, npc_manager):
     return CollisionManager(map_manager, npc_manager)
 
 
-def test_get_all_tile_properties(collision_manager, map_manager):
-    surface_map = {
-        (0, 0): {"label1": 1.0, "label2": 2.0},
-        (1, 1): {"label1": 3.0, "label3": 4.0},
-    }
-    map_manager.surface_map = surface_map
-
-    result = collision_manager.get_all_tile_properties(surface_map, "label1")
-    assert result == [(0, 0), (1, 1)]
-
-
-@patch(
-    "tuxemon.map.collision_manager.SURFACE_KEYS",
-    ["label1", "label2", "label3"],
-)
-def test_update_tile_property(collision_manager, map_manager):
-    surface_map = {
-        (0, 0): {"label1": 1.0, "label2": 2.0},
-        (1, 1): {"label1": 3.0, "label3": 4.0},
-    }
-    map_manager.surface_map = surface_map
-
-    collision_manager.update_tile_property("label1", 5.0)
-
-    assert map_manager.surface_map[(0, 0)]["label1"] == 5.0
-    assert map_manager.surface_map[(1, 1)]["label1"] == 5.0
-
-
-@patch(
-    "tuxemon.map.collision_manager.SURFACE_KEYS",
-    ["label1", "label2", "label3"],
-)
-def test_all_tiles_modified(collision_manager, map_manager):
-    surface_map = {
-        (0, 0): {"label1": 5.0, "label2": 2.0},
-        (1, 1): {"label1": 5.0, "label3": 4.0},
-    }
-    map_manager.surface_map = surface_map
-
-    assert collision_manager.all_tiles_modified("label1", 5.0)
-
-
 def test_check_collision_zones(collision_manager, map_manager):
     collision_map = {
         (0, 0): RegionProperties([], [], [], None, "label1"),
@@ -87,7 +45,7 @@ def test_add_collision(collision_manager, map_manager):
     region = RegionProperties([], [], [], None, "label1")
     map_manager.collision_map = {(0, 0): region}
 
-    collision_manager.add_collision(entity, (0.0, 0.0))
+    collision_manager.add_collision(entity, (0, 0))
 
     assert map_manager.collision_map[(0, 0)].entity is not None
 

--- a/tests/tuxemon/test_collision_manager.py
+++ b/tests/tuxemon/test_collision_manager.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -8,74 +8,164 @@ from tuxemon.entity.entity import Entity
 from tuxemon.map.collision_manager import CollisionManager
 from tuxemon.map.manager import MapManager
 from tuxemon.map.region import RegionProperties
-from tuxemon.npc_manager import NPCManager
 
 
 @pytest.fixture
 def map_manager():
-    return MagicMock(spec=MapManager)
+    mm = MagicMock(spec=MapManager)
+    mm.collision_map = {}
+    mm.surface_map = {}
+    return mm
 
 
 @pytest.fixture
-def npc_manager():
-    return MagicMock(spec=NPCManager)
+def collision_manager(map_manager):
+    return CollisionManager(map_manager)
 
 
 @pytest.fixture
-def collision_manager(map_manager, npc_manager):
-    return CollisionManager(map_manager, npc_manager)
+def entity():
+    e = MagicMock(spec=Entity)
+    e.tile_pos = (1, 1)
+    return e
 
 
-def test_check_collision_zones(collision_manager, map_manager):
+# --- check_collision_zones ---
+
+
+def test_check_collision_zones_returns_matching_coords(collision_manager):
     collision_map = {
-        (0, 0): RegionProperties([], [], [], None, "label1"),
-        (1, 1): RegionProperties([], [], [], None, "label2"),
+        (0, 0): RegionProperties(key="warp"),
+        (1, 1): RegionProperties(key="slide"),
+        (2, 2): RegionProperties(key="warp"),
     }
-    map_manager.collision_map = collision_map
-
-    result = collision_manager.check_collision_zones(collision_map, "label1")
-    assert result == [(0, 0)]
+    result = collision_manager.check_collision_zones(collision_map, "warp")
+    assert set(result) == {(0, 0), (2, 2)}
 
 
-def test_add_collision(collision_manager, map_manager):
-    entity = MagicMock(spec=Entity)
-    entity.is_player = True
-    entity.tile_pos = (0, 0)
+def test_check_collision_zones_no_match(collision_manager):
+    collision_map = {(0, 0): RegionProperties(key="slide")}
+    result = collision_manager.check_collision_zones(collision_map, "warp")
+    assert result == []
 
-    region = RegionProperties([], [], [], None, "label1")
-    map_manager.collision_map = {(0, 0): region}
 
+def test_check_collision_zones_skips_none_props(collision_manager):
+    collision_map = {(0, 0): None, (1, 1): RegionProperties(key="warp")}
+    result = collision_manager.check_collision_zones(collision_map, "warp")
+    assert result == [(1, 1)]
+
+
+# --- add_collision / remove_collision ---
+
+
+def test_add_collision_registers_entity(collision_manager, entity):
+    collision_manager.add_collision(entity, (1, 1))
+    assert collision_manager.is_tile_occupied((1, 1))
+
+
+def test_add_collision_overwrites_existing(collision_manager, entity):
+    other = MagicMock(spec=Entity)
+    collision_manager.add_collision(other, (1, 1))
+    collision_manager.add_collision(entity, (1, 1))
+    assert collision_manager.get_entity_at((1, 1)) is entity
+
+
+def test_remove_collision_unregisters_entity(collision_manager, entity):
+    collision_manager.add_collision(entity, (1, 1))
+    collision_manager.remove_collision((1, 1))
+    assert not collision_manager.is_tile_occupied((1, 1))
+
+
+def test_remove_collision_on_empty_tile_is_safe(collision_manager):
+    collision_manager.remove_collision((5, 5))  # should not raise
+
+
+def test_remove_collision_does_not_affect_other_tiles(
+    collision_manager, entity
+):
+    other = MagicMock(spec=Entity)
+    collision_manager.add_collision(entity, (1, 1))
+    collision_manager.add_collision(other, (2, 2))
+    collision_manager.remove_collision((1, 1))
+    assert collision_manager.is_tile_occupied((2, 2))
+
+
+# --- is_tile_occupied / get_entity_at ---
+
+
+def test_is_tile_occupied_false_when_empty(collision_manager):
+    assert not collision_manager.is_tile_occupied((0, 0))
+
+
+def test_is_tile_occupied_true_after_add(collision_manager, entity):
     collision_manager.add_collision(entity, (0, 0))
+    assert collision_manager.is_tile_occupied((0, 0))
 
-    assert map_manager.collision_map[(0, 0)].entity is not None
+
+def test_get_entity_at_returns_none_when_empty(collision_manager):
+    assert collision_manager.get_entity_at((0, 0)) is None
 
 
-def test_remove_collision(collision_manager, map_manager):
-    region = RegionProperties([], [], [], None, "label1")
+def test_get_entity_at_returns_correct_entity(collision_manager, entity):
+    collision_manager.add_collision(entity, (3, 3))
+    assert collision_manager.get_entity_at((3, 3)) is entity
+
+
+# --- get_collision_map ---
+
+
+def test_get_collision_map_includes_static_tiles(
+    collision_manager, map_manager
+):
+    region = RegionProperties(key="warp")
     map_manager.collision_map = {(0, 0): region}
-
-    collision_manager.remove_collision((0, 0))
-
-    assert (0, 0) not in map_manager.collision_map
-
-
-def test_get_collision_map(collision_manager, map_manager, npc_manager):
-    map_manager.collision_map = {
-        (0, 0): RegionProperties([], [], [], None, "label1")
-    }
-    map_manager.surface_map = {(0, 0): {"label1": 0.0}}
-
-    npc = MagicMock(spec=Entity)
-    npc.tile_pos = (0, 0)
-    npc_manager.get_all_entities.return_value = [npc]
-
-    collision_map = collision_manager.get_collision_map()
-    assert (0, 0) in collision_map
+    result = collision_manager.get_collision_map()
+    assert (0, 0) in result
+    assert result[(0, 0)] is region
 
 
-def test_get_region_properties(collision_manager, map_manager):
-    region = RegionProperties([], [], [], None, "label1")
+def test_get_collision_map_surface_impassable_added(
+    collision_manager, map_manager
+):
+    map_manager.surface_map = {(1, 1): {"water": "0.0"}}
+    result = collision_manager.get_collision_map()
+    assert (1, 1) in result
+    assert result[(1, 1)].key == "water"
+
+
+def test_get_collision_map_surface_passable_excluded(
+    collision_manager, map_manager
+):
+    map_manager.surface_map = {(1, 1): {"grass": "1.0"}}
+    result = collision_manager.get_collision_map()
+    assert (1, 1) not in result
+
+
+def test_get_collision_map_entity_on_empty_tile_is_none(
+    collision_manager, entity, map_manager
+):
+    collision_manager.add_collision(entity, (2, 2))
+    result = collision_manager.get_collision_map()
+    assert (2, 2) in result
+    assert result[(2, 2)] is None
+
+
+def test_get_collision_map_entity_on_terrain_tile_preserved(
+    collision_manager, entity, map_manager
+):
+    region = RegionProperties(key="slide")
+    map_manager.collision_map = {(2, 2): region}
+    collision_manager.add_collision(entity, (2, 2))
+    result = collision_manager.get_collision_map()
+    # terrain data is preserved; entity blocking is handled via is_tile_occupied
+    assert result[(2, 2)] is region
+
+
+def test_get_collision_map_static_overwrites_surface(
+    collision_manager, map_manager
+):
+    region = RegionProperties(key="warp")
+    map_manager.surface_map = {(0, 0): {"water": "0.0"}}
     map_manager.collision_map = {(0, 0): region}
-
-    props = collision_manager._get_region_properties((0, 0), "label1")
-    assert props.key == "label1"
+    result = collision_manager.get_collision_map()
+    assert result[(0, 0)] is region

--- a/tests/tuxemon/test_map_loader_pytmx.py
+++ b/tests/tuxemon/test_map_loader_pytmx.py
@@ -60,7 +60,6 @@ def test_result_properties_correct(result):
         enter_from=[Direction.UP],
         exit_from=[Direction.DOWN],
         endure=[Direction.LEFT],
-        entity=None,
         key=None,
     )
 

--- a/tests/tuxemon/test_pathfinder.py
+++ b/tests/tuxemon/test_pathfinder.py
@@ -116,6 +116,7 @@ def test_is_tile_traversable_ignore_npc(client, pathfinder):
 
 
 def test_get_exits_with_tile_data(client, pathfinder):
+    client.collision_manager.is_tile_occupied.return_value = False
     position = (1, 1)
     collision_map = {
         position: RegionProperties([], ["down", "right"], [], None, None),
@@ -163,6 +164,7 @@ def test_get_exits_blocked_position(client, pathfinder):
 
 
 def test_get_exits_with_skip_nodes(client, pathfinder):
+    client.collision_manager.is_tile_occupied.return_value = False
     position = (1, 1)
     collision_map = {
         position: RegionProperties([], ["down"], [], None, None),
@@ -231,6 +233,7 @@ def test_pathfind_skips_blocked_tile(client, pathfinder):
 
 
 def test_get_exits_respects_facing(client, pathfinder):
+    client.collision_manager.is_tile_occupied.return_value = False
     position = (1, 1)
     collision_map = {
         position: RegionProperties([], ["up"], [], None, None),

--- a/tests/tuxemon/test_region_properties.py
+++ b/tests/tuxemon/test_region_properties.py
@@ -21,10 +21,9 @@ def test_empty_properties():
         pytest.param(
             {"enter_from": "up, left"},
             RegionProperties(
-                enter_from=[Direction.LEFT, Direction.UP],
+                enter_from=[Direction.UP, Direction.LEFT],
                 exit_from=[],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="enter_from_basic",
@@ -35,7 +34,6 @@ def test_empty_properties():
                 enter_from=[Direction.UP, Direction.LEFT, Direction.RIGHT],
                 exit_from=[Direction.DOWN],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="exit_from_basic",
@@ -48,10 +46,9 @@ def test_empty_properties():
                 "key": "door",
             },
             RegionProperties(
-                enter_from=[Direction.LEFT, Direction.UP],
+                enter_from=[Direction.UP, Direction.LEFT],
                 exit_from=[Direction.DOWN, Direction.RIGHT],
                 endure=[Direction.LEFT],
-                entity=None,
                 key="door",
             ),
             id="all_fields",
@@ -62,7 +59,6 @@ def test_empty_properties():
                 enter_from=list(Direction),
                 exit_from=list(Direction),
                 endure=list(Direction),
-                entity=None,
                 key="slide",
             ),
             id="key_only_defaults",
@@ -73,7 +69,6 @@ def test_empty_properties():
                 enter_from=[],
                 exit_from=[],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="enter_from_none",
@@ -81,10 +76,9 @@ def test_empty_properties():
         pytest.param(
             {"enter_from": "up, up, left"},
             RegionProperties(
-                enter_from=[Direction.LEFT, Direction.UP],
+                enter_from=[Direction.UP, Direction.LEFT],
                 exit_from=[],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="dedupe_values",
@@ -92,10 +86,9 @@ def test_empty_properties():
         pytest.param(
             {"enter_from": "Up, Left"},
             RegionProperties(
-                enter_from=[Direction.LEFT, Direction.UP],
+                enter_from=[Direction.UP, Direction.LEFT],
                 exit_from=[],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="case_insensitive",
@@ -103,10 +96,9 @@ def test_empty_properties():
         pytest.param(
             {"enter_from": " up , left "},
             RegionProperties(
-                enter_from=[Direction.LEFT, Direction.UP],
+                enter_from=[Direction.UP, Direction.LEFT],
                 exit_from=[],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="strip_whitespace",
@@ -117,7 +109,6 @@ def test_empty_properties():
                 enter_from=[],
                 exit_from=[],
                 endure=[Direction.LEFT],
-                entity=None,
                 key=None,
             ),
             id="endure_only",
@@ -125,10 +116,9 @@ def test_empty_properties():
         pytest.param(
             {"Enter_from": "up, left"},
             RegionProperties(
-                enter_from=[Direction.LEFT, Direction.UP],
+                enter_from=[Direction.UP, Direction.LEFT],
                 exit_from=[],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="case_insensitive_key",
@@ -139,7 +129,6 @@ def test_empty_properties():
                 enter_from=[Direction.UP, Direction.DOWN],
                 exit_from=[Direction.LEFT, Direction.RIGHT],
                 endure=[],
-                entity=None,
                 key=None,
             ),
             id="exit_from_multiple",
@@ -206,10 +195,9 @@ def test_extract_region_properties_mixed_valid_invalid_keys():
         "key": "door",
     }
     expected = RegionProperties(
-        enter_from=[Direction.LEFT, Direction.UP],
+        enter_from=[Direction.UP, Direction.LEFT],
         exit_from=[],
         endure=[],
-        entity=None,
         key="door",
     )
     assert extract_region_properties(properties) == expected
@@ -225,7 +213,6 @@ def test_push_tile_valid():
         enter_from=list(Direction),
         exit_from=list(Direction),
         endure=[],
-        entity=None,
         key="push_tile",
         push_effect=PushEffect(Direction.RIGHT, 2),
         speed_modifier=None,
@@ -244,7 +231,6 @@ def test_push_tile_with_speed_modifier():
         enter_from=list(Direction),
         exit_from=list(Direction),
         endure=[],
-        entity=None,
         key="push_tile",
         push_effect=PushEffect(Direction.DOWN, 4),
         speed_modifier=0.75,
@@ -262,7 +248,6 @@ def test_push_strength_as_int():
         enter_from=list(Direction),
         exit_from=list(Direction),
         endure=[],
-        entity=None,
         key="push_tile",
         push_effect=PushEffect(Direction.UP, 3),
         speed_modifier=None,
@@ -276,7 +261,6 @@ def test_slide_with_speed_modifier():
         enter_from=list(Direction),
         exit_from=list(Direction),
         endure=list(Direction),
-        entity=None,
         key="slide",
         push_effect=None,
         speed_modifier=1.5,
@@ -290,7 +274,6 @@ def test_slide_with_unknown_keys():
         enter_from=list(Direction),
         exit_from=list(Direction),
         endure=list(Direction),
-        entity=None,
         key="slide",
         push_effect=None,
         speed_modifier=1.2,

--- a/tests/tuxemon/test_terrain_manager.py
+++ b/tests/tuxemon/test_terrain_manager.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tuxemon.map.terrain import TerrainManager
+
+
+@pytest.fixture
+def map_manager():
+    mgr = MagicMock()
+    mgr.surface_map = {}
+    return mgr
+
+
+@pytest.fixture
+def terrain(map_manager):
+    return TerrainManager(map_manager)
+
+
+def test_get_all_tile_properties_basic(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 1.0},
+        (1, 1): {"water": 0.5},
+        (2, 2): {"grass": 2.0},
+    }
+
+    result = terrain.get_all_tile_properties("grass")
+    assert set(result) == {(0, 0), (2, 2)}
+
+
+def test_get_all_tile_properties_no_matches(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 1.0},
+        (1, 1): {"grass": 2.0},
+    }
+
+    assert terrain.get_all_tile_properties("lava") == []
+
+
+def test_get_all_tile_properties_empty_map(terrain, map_manager):
+    map_manager.surface_map = {}
+    assert terrain.get_all_tile_properties("grass") == []
+
+
+@patch("tuxemon.map.terrain.SURFACE_KEYS", ["grass", "water"])
+def test_update_tile_property_updates_existing_labels(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 1.0},
+        (1, 1): {"grass": 2.0, "water": 0.5},
+    }
+
+    terrain.update_tile_property("grass", 9.0)
+
+    assert map_manager.surface_map[(0, 0)]["grass"] == 9.0
+    assert map_manager.surface_map[(1, 1)]["grass"] == 9.0
+
+
+@patch("tuxemon.map.terrain.SURFACE_KEYS", ["grass", "water"])
+def test_update_tile_property_does_not_create_new_labels(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 1.0},
+    }
+
+    terrain.update_tile_property("water", 5.0)
+
+    assert "water" not in map_manager.surface_map[(0, 0)]
+
+
+@patch("tuxemon.map.terrain.SURFACE_KEYS", ["grass"])
+def test_update_tile_property_invalid_label_ignored(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 1.0},
+    }
+
+    terrain.update_tile_property("lava", 5.0)
+
+    assert map_manager.surface_map[(0, 0)]["grass"] == 1.0
+    assert "lava" not in map_manager.surface_map[(0, 0)]
+
+
+@patch("tuxemon.map.terrain.SURFACE_KEYS", ["grass"])
+def test_update_tile_property_no_mutation_when_value_same(
+    terrain, map_manager
+):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 3.0},
+    }
+
+    terrain.update_tile_property("grass", 3.0)
+    assert map_manager.surface_map[(0, 0)] == {"grass": 3.0}
+
+
+def test_all_tiles_modified_true(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 5.0},
+        (1, 1): {"grass": 5.0},
+    }
+
+    assert terrain.all_tiles_modified("grass", 5.0) is True
+
+
+def test_all_tiles_modified_false(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 5.0},
+        (1, 1): {"grass": 3.0},
+    }
+
+    assert terrain.all_tiles_modified("grass", 5.0) is False
+
+
+def test_all_tiles_modified_no_tiles(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"water": 1.0},
+    }
+
+    assert terrain.all_tiles_modified("grass", 5.0) is True
+
+
+def test_all_tiles_modified_missing_key_on_some_tiles(terrain, map_manager):
+    map_manager.surface_map = {
+        (0, 0): {"grass": 5.0},
+        (1, 1): {"grass": 5.0, "water": 1.0},
+        (2, 2): {"water": 1.0},  # does not contain "grass"
+    }
+
+    assert terrain.all_tiles_modified("grass", 5.0) is True

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -160,9 +160,7 @@ class BaseClient(ABC):
             self.event_manager, self.input_manager
         )
         self.terrain_manager = TerrainManager(self.map_manager)
-        self.collision_manager = CollisionManager(
-            self.map_manager, self.npc_manager
-        )
+        self.collision_manager = CollisionManager(self.map_manager)
         self.pathfinder = Pathfinder(
             self.npc_manager,
             self.map_manager,

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -33,6 +33,7 @@ from tuxemon.event.running import ConditionEvaluator
 from tuxemon.map.collision_manager import CollisionManager
 from tuxemon.map.loader import MapLoader
 from tuxemon.map.manager import MapManager
+from tuxemon.map.terrain import TerrainManager
 from tuxemon.map.transition import MapTransition
 from tuxemon.map.view import AbstractRenderer, NullRenderer
 from tuxemon.menu.alert import AlertManager
@@ -158,6 +159,7 @@ class BaseClient(ABC):
         self.movement_manager = MovementManager(
             self.event_manager, self.input_manager
         )
+        self.terrain_manager = TerrainManager(self.map_manager)
         self.collision_manager = CollisionManager(
             self.map_manager, self.npc_manager
         )

--- a/tuxemon/core/conditions/facing_tile.py
+++ b/tuxemon/core/conditions/facing_tile.py
@@ -45,9 +45,7 @@ class FacingTileCondition(CoreCondition):
         tiles = get_coords(player.tile_pos, client.map_manager.map_size)
 
         label = (
-            client.collision_manager.get_all_tile_properties(
-                client.map_manager.surface_map, self.facing_tile
-            )
+            client.terrain_manager.get_all_tile_properties(self.facing_tile)
             if self.facing_tile in SURFACE_KEYS
             else client.collision_manager.check_collision_zones(
                 client.map_manager.collision_map, self.facing_tile

--- a/tuxemon/event/actions/char_position.py
+++ b/tuxemon/event/actions/char_position.py
@@ -44,5 +44,4 @@ class CharPositionAction(EventAction):
                 f"Character is outside the boundaries of the map at ({position[0]}, {position[1]})"
             )
         character.remove_collision()
-        character.set_position(position)
-        character.on_tile_changed()
+        character.complete_tile_entry(position)

--- a/tuxemon/event/actions/update_tile_properties.py
+++ b/tuxemon/event/actions/update_tile_properties.py
@@ -35,6 +35,6 @@ class UpdateTilePropertiesAction(EventAction):
     moverate: float
 
     def start(self, session: Session) -> None:
-        session.client.collision_manager.update_tile_property(
+        session.client.terrain_manager.update_tile_property(
             self.label, self.moverate
         )

--- a/tuxemon/event/conditions/char_facing_tile.py
+++ b/tuxemon/event/conditions/char_facing_tile.py
@@ -57,8 +57,8 @@ class CharFacingTileCondition(EventCondition):
         # check if the NPC is facing a specific set of tiles
         if self.value:
             if self.value in SURFACE_KEYS:
-                label = client.collision_manager.get_all_tile_properties(
-                    client.map_manager.surface_map, self.value
+                label = client.terrain_manager.get_all_tile_properties(
+                    self.value
                 )
             else:
                 label = client.collision_manager.check_collision_zones(

--- a/tuxemon/event/conditions/char_in.py
+++ b/tuxemon/event/conditions/char_in.py
@@ -41,9 +41,7 @@ class CharInCondition(EventCondition):
 
         tiles = []
         if self.value in SURFACE_KEYS:
-            tiles = client.collision_manager.get_all_tile_properties(
-                client.map_manager.surface_map, self.value
-            )
+            tiles = client.terrain_manager.get_all_tile_properties(self.value)
         else:
             tiles = client.collision_manager.check_collision_zones(
                 client.map_manager.collision_map, self.value

--- a/tuxemon/event/conditions/tile_property_updated.py
+++ b/tuxemon/event/conditions/tile_property_updated.py
@@ -33,6 +33,6 @@ class TilePropertyUpdatedCondition(EventCondition):
     moverate: float
 
     def test(self, session: Session) -> bool:
-        return session.client.collision_manager.all_tiles_modified(
+        return session.client.terrain_manager.all_tiles_modified(
             self.label, self.moverate
         )

--- a/tuxemon/map/collision_manager.py
+++ b/tuxemon/map/collision_manager.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING
 
 from tuxemon.map.region import RegionProperties
-from tuxemon.platform.const.sizes import SURFACE_KEYS
 
 if TYPE_CHECKING:
     from tuxemon.entity.entity import Entity
@@ -35,68 +34,6 @@ class CollisionManager:
     ) -> None:
         self._map_manager = map_manager
         self._npc_manager = npc_manager
-
-    def get_all_tile_properties(
-        self,
-        surface_map: MutableMapping[tuple[int, int], dict[str, float]],
-        label: str,
-    ) -> list[tuple[int, int]]:
-        """
-        Retrieves the coordinates of all tiles with a specific property.
-
-        Parameters:
-            map: The surface map.
-            label: The label (SurfaceKeys).
-
-        Returns:
-            A list of coordinates (tuples) of tiles with the specified label.
-        """
-        return [
-            coords for coords, props in surface_map.items() if label in props
-        ]
-
-    def update_tile_property(self, label: str, moverate: float) -> None:
-        """
-        Updates the movement rate property for existing tile entries in the
-        surface map.
-
-        This method modifies the moverate value for tiles that already contain
-        the specified label, ensuring that no new dictionary entries are created.
-        If the label is not present in a tile's properties, the tile remains
-        unchanged. The update process runs efficiently to prevent unnecessary
-        modifications.
-
-        Parameters:
-            label: The property key to update (e.g., terrain type).
-            moverate: The new movement rate value to assign.
-        """
-        if label not in SURFACE_KEYS:
-            return
-
-        for coord in self.get_all_tile_properties(
-            self._map_manager.surface_map, label
-        ):
-            props = self._map_manager.surface_map.get(coord)
-            if props and props.get(label) != moverate:
-                props[label] = moverate
-
-    def all_tiles_modified(self, label: str, moverate: float) -> bool:
-        """
-        Checks if all tiles with the specified label have been modified.
-
-        Parameters:
-            label: The property key to check.
-            moverate: The expected movement rate.
-
-        Returns:
-            True if all tiles have the expected moverate, False otherwise.
-        """
-        return all(
-            self._map_manager.surface_map[coord].get(label) == moverate
-            for coord in self.get_all_tile_properties(
-                self._map_manager.surface_map, label
-            )
-        )
 
     def check_collision_zones(
         self,

--- a/tuxemon/map/collision_manager.py
+++ b/tuxemon/map/collision_manager.py
@@ -2,26 +2,17 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
-import logging
-from collections import defaultdict
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from tuxemon.map.region import RegionProperties
 
 if TYPE_CHECKING:
     from tuxemon.entity.entity import Entity
-    from tuxemon.entity.npc import NPC
     from tuxemon.map.manager import MapManager
-    from tuxemon.npc_manager import NPCManager
-
-logger = logging.getLogger(__name__)
 
 
-CollisionMap = Mapping[
-    tuple[int, int],
-    RegionProperties | None,
-]
+CollisionMap = Mapping[tuple[int, int], RegionProperties | None]
 
 
 class CollisionManager:
@@ -29,17 +20,13 @@ class CollisionManager:
     Manages collision data and performs collision checks within the game world.
     """
 
-    def __init__(
-        self, map_manager: MapManager, npc_manager: NPCManager
-    ) -> None:
+    def __init__(self, map_manager: MapManager) -> None:
         self._map_manager = map_manager
-        self._npc_manager = npc_manager
+        self._entity_map: dict[tuple[int, int], Entity] = {}
 
     def check_collision_zones(
         self,
-        collision_map: MutableMapping[
-            tuple[int, int], RegionProperties | None
-        ],
+        collision_map: CollisionMap,
         label: str,
     ) -> list[tuple[int, int]]:
         """
@@ -58,100 +45,42 @@ class CollisionManager:
             if props and props.key == label
         ]
 
-    def add_collision(
-        self,
-        entity: Entity,
-        coords: tuple[int, int],
-    ) -> None:
-        """
-        Registers the given entity's position within the collision zone.
+    def add_collision(self, entity: Entity, pos: tuple[int, int]) -> None:
+        """Register an NPC at a specific tile."""
+        self._entity_map[pos] = entity
 
-        Parameters:
-            entity: The entity object to be added to the collision zone.
-            pos: The X, Y coordinates (as floats) indicating the entity's position.
-        """
-        region = (
-            self._map_manager.collision_map.get(coords) or RegionProperties()
-        )
-        self._map_manager.collision_map[coords] = region.with_overrides(
-            entity=entity
-        )
+    def remove_collision(self, pos: tuple[int, int]) -> None:
+        """Unregister whatever NPC was at this tile."""
+        self._entity_map.pop(pos, None)
 
-    def remove_collision(self, tile_pos: tuple[int, int]) -> None:
-        """
-        Removes the specified tile position from the collision zone.
+    def is_tile_occupied(self, coords: tuple[int, int]) -> bool:
+        """Returns True if an entity is registered at the given tile."""
+        return coords in self._entity_map
 
-        Parameters:
-            tile_pos: The X, Y tile coordinates to be removed from the collision map.
-        """
-        region = self._map_manager.collision_map.get(tile_pos)
-        if not region:
-            return  # Nothing to remove
-
-        if region.enter_from or region.exit_from or region.endure:
-            self._map_manager.collision_map[tile_pos] = region.with_overrides(
-                entity=None
-            )
-        else:
-            # Remove region
-            del self._map_manager.collision_map[tile_pos]
+    def get_entity_at(self, coords: tuple[int, int]) -> Entity | None:
+        """Returns the entity at the given tile, or None if unoccupied."""
+        return self._entity_map.get(coords)
 
     def get_collision_map(self) -> CollisionMap:
-        """
-        Return dictionary for collision testing.
+        collision_dict: dict[tuple[int, int], RegionProperties | None] = {}
 
-        Returns a dictionary where keys are (x, y) tile tuples
-        and the values are tiles or NPCs.
-
-        # NOTE:
-        This will not respect map changes to collisions
-        after the map has been loaded!
-
-        Returns:
-            A dictionary of collision tiles.
-        """
-        collision_dict: defaultdict[
-            tuple[int, int], RegionProperties | None
-        ] = defaultdict(RegionProperties)
-
-        # Get all the NPCs' tile positions
-        for npc in self._npc_manager.get_all_entities():
-            collision_dict[npc.tile_pos] = self._get_region_properties(
-                npc.tile_pos, npc
-            )
-
-        # Add surface map entries to the collision dictionary
+        # Add surface map entries (impassable surfaces)
         for coords, surface in self._map_manager.surface_map.items():
             for label, value in surface.items():
                 if float(value) == 0:
-                    collision_dict[coords] = self._get_region_properties(
-                        coords, label
+                    region = (
+                        self._map_manager.collision_map.get(coords)
+                        or RegionProperties()
                     )
+                    collision_dict[coords] = region.with_overrides(key=label)
 
-        collision_dict.update(
-            {k: v for k, v in self._map_manager.collision_map.items()}
-        )
+        # Overlay static collision map
+        collision_dict.update(self._map_manager.collision_map)
 
-        return dict(collision_dict)
+        # Entity-occupied tiles with no terrain data are marked None (blocked)
+        # Tiles with terrain data are already in collision_dict and checked separately
+        for coords in self._entity_map:
+            if coords not in collision_dict:
+                collision_dict[coords] = None
 
-    def _get_region_properties(
-        self, coords: tuple[int, int], entity_or_label: NPC | str
-    ) -> RegionProperties:
-        """
-        Constructs a RegionProperties object for the given tile coordinates,
-        using either an NPC entity or a string label.
-
-        Parameters:
-            coords: The (x, y) tile position.
-            entity_or_label: Either an NPC or a label string.
-
-        Returns:
-            A RegionProperties object representing the collision state.
-        """
-        region = (
-            self._map_manager.collision_map.get(coords) or RegionProperties()
-        )
-        if isinstance(entity_or_label, str):
-            return region.with_overrides(key=entity_or_label)
-        else:
-            return region.with_overrides(entity=entity_or_label)
+        return collision_dict

--- a/tuxemon/map/region.py
+++ b/tuxemon/map/region.py
@@ -7,13 +7,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from tuxemon.db import Direction
 from tuxemon.platform.const.sizes import REGION_KEYS
-
-if TYPE_CHECKING:
-    from tuxemon.entity.entity import Entity
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +47,6 @@ class RegionProperties:
         default_factory=list,
         metadata={
             "description": "Directions from which an entity can remain in this region."
-        },
-    )
-    entity: Entity | None = field(
-        default=None,
-        metadata={
-            "description": "Optional entity associated with this region."
         },
     )
     key: str | None = field(
@@ -136,7 +127,6 @@ class DefaultTileStrategy(RegionPropertiesStrategy):
             enter_from=parsed_data.get("enter_from", []),
             exit_from=parsed_data.get("exit_from", []),
             endure=parsed_data.get("endure", []),
-            entity=None,
             key=parsed_data.get("key"),
             push_effect=None,
             speed_modifier=parsed_data.get("speed_modifier"),
@@ -156,7 +146,6 @@ class SlideTileStrategy(RegionPropertiesStrategy):
             enter_from=all_dirs,
             exit_from=all_dirs,
             endure=all_dirs,
-            entity=None,
             key=RegionKey.SLIDE.value,
             push_effect=None,
             speed_modifier=parsed_data.get("speed_modifier"),
@@ -188,7 +177,6 @@ class PushTileStrategy(RegionPropertiesStrategy):
             enter_from=enter_from,
             exit_from=exit_from,
             endure=parsed_data.get("endure", []),
-            entity=None,
             key=RegionKey.PUSH_TILE.value,
             push_effect=PushEffect(push_direction, push_strength),
             speed_modifier=parsed_data.get("speed_modifier"),
@@ -245,8 +233,10 @@ def _parse_raw_properties(
                     raise ValueError(
                         f"Invalid speed_modifier '{value}': must be a number."
                     )
-        # Optional: collect unknown keys for logging/debugging
+        else:
+            logger.debug(f"Unknown region property key '{k}' ignored.")
 
+    # If only exit_from is defined, infer enter_from as the complementary set.
     if parsed_data["exit_from"] and not parsed_data["enter_from"]:
         all_dirs = list(Direction)
         parsed_data["enter_from"] = sorted(
@@ -267,11 +257,6 @@ def create_region_properties(
         key = RegionKey.DEFAULT
 
     strategy_cls = REGION_STRATEGIES.get(key, DefaultTileStrategy)
-
-    # Note: If DefaultTileStrategy is registered, this fallback is technically
-    # redundant but harmless, and ensures a clean failure if someone deletes the
-    # default registration.
-
     return strategy_cls.create(parsed_data)
 
 
@@ -279,8 +264,8 @@ def extract_region_properties(
     properties: Mapping[str, str | None],
 ) -> RegionProperties | None:
     """
-    Given a dictionary from Tiled properties, return a dictionary
-    suitable for collision detection.
+    Given a dictionary from Tiled properties, return a RegionProperties
+    object suitable for collision detection.
 
     The function expects the input dictionary to contain keys from the following set:
     {"enter_from", "exit_from", "endure", "key"}. The values for "enter_from", "exit_from",
@@ -298,7 +283,7 @@ def extract_region_properties(
         properties: A dictionary from Tiled properties.
 
     Returns:
-        A RegionProperties NamedTuple suitable for collision detection.
+        A RegionProperties object suitable for collision detection, or None.
 
     Raises:
         ValueError: If the input dictionary contains an invalid value.
@@ -325,12 +310,14 @@ def direction_to_list(direction: str | None) -> list[Direction]:
     if not cleaned:
         raise ValueError("Direction string is empty or whitespace.")
 
+    all_dirs = list(Direction)
     try:
         return sorted(
             [
                 Direction(d)
                 for d in {d.strip().lower() for d in cleaned.split(",")}
-            ]
+            ],
+            key=lambda d: all_dirs.index(d),
         )
     except ValueError as e:
         raise ValueError(f"Invalid direction list: {direction}") from e

--- a/tuxemon/map/terrain.py
+++ b/tuxemon/map/terrain.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tuxemon.platform.const.sizes import SURFACE_KEYS
+
+if TYPE_CHECKING:
+    from tuxemon.map.manager import MapManager
+
+
+class TerrainManager:
+    """Manages terrain-related tile properties in the surface map."""
+
+    def __init__(self, map_manager: MapManager):
+        self.map_manager = map_manager
+
+    def get_all_tile_properties(
+        self,
+        label: str,
+    ) -> list[tuple[int, int]]:
+        """
+        Return all tile coordinates that contain the given surface label.
+        """
+        return [
+            coords
+            for coords, props in self.map_manager.surface_map.items()
+            if label in props
+        ]
+
+    def update_tile_property(self, label: str, moverate: float) -> None:
+        """
+        Update the moverate for all tiles that already contain `label`.
+
+        This preserves the original guarantee:
+        - no new dictionary entries are created
+        - only existing keys are updated
+        - invalid labels (not in SURFACE_KEYS) are ignored
+        """
+        if label not in SURFACE_KEYS:
+            return
+
+        for coord in self.get_all_tile_properties(label):
+            props = self.map_manager.surface_map.get(coord)
+            if props and props.get(label) != moverate:
+                props[label] = moverate
+
+    def all_tiles_modified(self, label: str, moverate: float) -> bool:
+        """
+        Check whether all tiles containing `label` have the expected moverate.
+        """
+        return all(
+            self.map_manager.surface_map[coord].get(label) == moverate
+            for coord in self.get_all_tile_properties(label)
+        )

--- a/tuxemon/movement.py
+++ b/tuxemon/movement.py
@@ -329,7 +329,7 @@ class Pathfinder:
             return False
 
         # Check if tile is blocked by entity
-        if tile_data.entity is not None:
+        if self.collision_manager.is_tile_occupied(neighbor):
             return False
 
         # Check if the reversed direction is in the tile's allowed entry directions.

--- a/tuxemon/npc_manager.py
+++ b/tuxemon/npc_manager.py
@@ -256,6 +256,5 @@ class NPCManager:
     ) -> None:
         npc.set_current_map(map_name)
         npc.cancel_path()
-        npc.set_position((x, y))
-        npc.on_tile_changed()
+        npc.complete_tile_entry((x, y))
         self.add_npc(npc)


### PR DESCRIPTION
PR moves all terrain‑related logic out of `CollisionManager` into a new `TerrainManager` class. The new manager handles surface tile queries and moverate updates, while `CollisionManager` keeps only collision responsibilities. This reduces mixed concerns, removes unused methods from `CollisionManager`, and keeps existing behavior unchanged.

PR introduces a `_entity_map` dict inside `CollisionManager` and removes the `entity` field from `RegionProperties`. Previously, entity positions were embedded into `RegionProperties` objects, mixing tile descriptor data with runtime entity state. The new structure keeps `RegionProperties` as a pure representation of static map data, while `_entity_map` owns entity position tracking as an explicit responsibility of `CollisionManager`. As a result, `add_collision` and `remove_collision` become single-line dict operations, the conditional logic in `remove_collision` that existed to avoid corrupting tile properties is gone, and `npc_manager` is no longer a dependency of `CollisionManager`.