### PR TITLE
Fix Monster and Stats classes

### DIFF
--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -8,6 +8,7 @@ from tuxemon.db import (
     Acquisition,
     BondComparison,
     Comparison,
+    EvolutionStage,
     GameCondition,
     GenderType,
     LearningMethod,
@@ -233,26 +234,6 @@ def test_acquisition_conditions(
 
 
 @pytest.mark.parametrize(
-    "party_slugs,expected",
-    [
-        pytest.param({"nut": 1}, True, id="party_single_match"),
-        pytest.param(
-            {"nut": 1, "rockitten": 1}, True, id="party_double_match"
-        ),
-        pytest.param({"agnidon": 1}, False, id="party_no_match"),
-    ],
-)
-def test_party_conditions(evolution_context, party_slugs, expected):
-    mon, _, _ = evolution_context
-    evo = MonsterEvolutionItemModel(
-        monster_slug="rockat",
-        party_conditions=PartyConditionsModel(monster_slugs=party_slugs),
-    )
-    context = {"map_inside": True}
-    assert mon.evolution_handler.can_evolve(evo, context) == expected
-
-
-@pytest.mark.parametrize(
     "taste_attr,taste_value,evo_taste,expected",
     [
         pytest.param(
@@ -380,21 +361,6 @@ def test_variables_conditions(
 
 
 @pytest.mark.parametrize(
-    "steps,evo_steps,expected",
-    [
-        pytest.param(10, 10, True, id="steps_match"),
-        pytest.param(5, 10, False, id="steps_mismatch"),
-    ],
-)
-def test_steps_conditions(evolution_context, steps, evo_steps, expected):
-    mon, _, _ = evolution_context
-    mon.steps = steps
-    evo = MonsterEvolutionItemModel(monster_slug="rockat", steps=evo_steps)
-    context = {"map_inside": True}
-    assert mon.evolution_handler.can_evolve(evo, context) == expected
-
-
-@pytest.mark.parametrize(
     "bond_value,evo_value,expected",
     [
         pytest.param(10, 10, True, id="bond_meets_requirement"),
@@ -500,11 +466,6 @@ def test_probability_conditions(
     assert mon.evolution_handler.can_evolve(evo, context) == expected
 
 
-from unittest.mock import MagicMock
-
-import pytest
-
-
 @pytest.mark.parametrize(
     "held_item_slug,evo_item_slug,expected",
     [
@@ -527,6 +488,26 @@ def test_held_item_conditions(
         held_item=evo_item_slug,
     )
 
+    context = {"map_inside": True}
+    assert mon.evolution_handler.can_evolve(evo, context) == expected
+
+
+@pytest.mark.parametrize(
+    "party_slugs,expected",
+    [
+        pytest.param({"nut": 1}, True, id="party_single_match"),
+        pytest.param(
+            {"nut": 1, "rockitten": 1}, True, id="party_double_match"
+        ),
+        pytest.param({"agnidon": 1}, False, id="party_no_match"),
+    ],
+)
+def test_party_conditions(evolution_context, party_slugs, expected):
+    mon, _, _ = evolution_context
+    evo = MonsterEvolutionItemModel(
+        monster_slug="rockat",
+        party_conditions=PartyConditionsModel(monster_slugs=party_slugs),
+    )
     context = {"map_inside": True}
     assert mon.evolution_handler.can_evolve(evo, context) == expected
 
@@ -601,6 +582,75 @@ def test_party_type_conditions(
     evo = MonsterEvolutionItemModel(
         monster_slug="rockat",
         party_conditions=PartyConditionsModel(monster_types=evo_types),
+    )
+    context = {"map_inside": True}
+    assert mon.evolution_handler.can_evolve(evo, context) == expected
+
+
+@pytest.mark.parametrize(
+    "party_size,evo_size,expected",
+    [
+        pytest.param(2, 2, True, id="party_size_match"),
+        pytest.param(2, 3, False, id="party_size_below"),
+    ],
+)
+def test_party_size_conditions(
+    evolution_context, party_size, evo_size, expected
+):
+    mon, player, _ = evolution_context
+    player.party._monsters = player.party._monsters[:party_size]
+    evo = MonsterEvolutionItemModel(
+        monster_slug="rockat",
+        party_conditions=PartyConditionsModel(party_size=evo_size),
+    )
+    context = {"map_inside": True}
+    assert mon.evolution_handler.can_evolve(evo, context) == expected
+
+
+@pytest.mark.parametrize(
+    "levels,evo_level,expected",
+    [
+        pytest.param([20, 20], 20, True, id="party_level_match"),
+        pytest.param([10, 10], 20, False, id="party_level_below"),
+    ],
+)
+def test_party_level_conditions(
+    evolution_context, levels, evo_level, expected
+):
+    mon, player, _ = evolution_context
+    for m, level in zip(player.party._monsters, levels):
+        m.set_level(level, level)
+    evo = MonsterEvolutionItemModel(
+        monster_slug="rockat",
+        party_conditions=PartyConditionsModel(party_level=evo_level),
+    )
+    context = {"map_inside": True}
+    assert mon.evolution_handler.can_evolve(evo, context) == expected
+
+
+@pytest.mark.parametrize(
+    "stages,evo_stages,expected",
+    [
+        pytest.param(
+            ["basic", "basic"], {"basic": 2}, True, id="party_stages_match"
+        ),
+        pytest.param(
+            ["basic", "basic"],
+            {"stage1": 1},
+            False,
+            id="party_stages_mismatch",
+        ),
+    ],
+)
+def test_party_stages_conditions(
+    evolution_context, stages, evo_stages, expected
+):
+    mon, player, _ = evolution_context
+    for m, stage in zip(player.party._monsters, stages):
+        m.stage = EvolutionStage(stage)
+    evo = MonsterEvolutionItemModel(
+        monster_slug="rockat",
+        party_conditions=PartyConditionsModel(party_stages=evo_stages),
     )
     context = {"map_inside": True}
     assert mon.evolution_handler.can_evolve(evo, context) == expected
@@ -748,7 +798,7 @@ def test_get_eligible_evolution_slug_requires_item_but_not_used(
 
     mon.evolutions = [evolution_item]
     evo.is_eligible_for_evolution = lambda: True
-    evo.can_evolve = lambda item, ctx: False
+    evo.can_evolve = lambda item, ctx, owner=None: False
     registry = MagicMock()
     registry.get_blocked.return_value = []
     player.evolution_registry = registry
@@ -799,11 +849,13 @@ def test_get_eligible_evolution_slug_blocked(evolution_context):
 def test_get_eligible_evolution_slug(evolution_context):
     mon, player, evo = evolution_context
 
-    evolution_item = MonsterEvolutionItemModel(monster_slug="rockat")
+    evolution_item = MonsterEvolutionItemModel.model_construct(
+        monster_slug="rockat", item=None
+    )
     mon.evolutions = [evolution_item]
 
     evo.is_eligible_for_evolution = lambda: True
-    evo.can_evolve = lambda item, ctx: True
+    evo.can_evolve = lambda item, ctx, owner=None: True
 
     registry = MagicMock()
     registry.get_blocked.return_value = []

--- a/tests/tuxemon/test_monster_exp_handler.py
+++ b/tests/tuxemon/test_monster_exp_handler.py
@@ -196,9 +196,3 @@ def test_excess_experience_not_maxed_out():
 
     if m.level < config_monster.level_range[1]:
         assert m.excess_experience() == 0
-
-
-def test_trigger_experience_flags_sets_both(monster):
-    monster.trigger_experience_flags()
-    assert monster.got_experience
-    assert monster.levelling_up

--- a/tests/tuxemon/test_steps.py
+++ b/tests/tuxemon/test_steps.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from unittest.mock import MagicMock
+
+from tuxemon.monster.listener import monster_update_listener
+
+
+def make_monster(steps=0, waiting_to_evolve=False, evolutions=None):
+    monster = MagicMock()
+    monster.steps = steps
+    monster.waiting_to_evolve = waiting_to_evolve
+    monster.evolutions = evolutions or []
+    monster.status = None
+    return monster
+
+
+def test_listener_increments_steps():
+    monster = make_monster(steps=0)
+    monster_update_listener(steps=5.0, monsters=[monster], session=MagicMock())
+    assert monster.steps == 5.0
+
+
+def test_listener_flags_waiting_to_evolve():
+    evo = MagicMock()
+    evo.steps = 10
+    monster = make_monster(steps=9, evolutions=[evo])
+    monster_update_listener(steps=1.0, monsters=[monster], session=MagicMock())
+    assert monster.waiting_to_evolve is True
+
+
+def test_listener_does_not_flag_if_steps_not_met():
+    evo = MagicMock()
+    evo.steps = 10
+    monster = make_monster(steps=0, evolutions=[evo])
+    monster_update_listener(steps=1.0, monsters=[monster], session=MagicMock())
+    assert monster.waiting_to_evolve is False
+
+
+def test_listener_skips_check_if_already_waiting():
+    evo = MagicMock()
+    evo.steps = 10
+    monster = make_monster(steps=10, waiting_to_evolve=True, evolutions=[evo])
+    monster_update_listener(steps=1.0, monsters=[monster], session=MagicMock())
+    # waiting_to_evolve was already True, no change expected
+    assert monster.waiting_to_evolve is True
+
+
+def test_listener_skips_evolution_with_no_steps_condition():
+    evo = MagicMock()
+    evo.steps = None
+    monster = make_monster(steps=100, evolutions=[evo])
+    monster_update_listener(steps=1.0, monsters=[monster], session=MagicMock())
+    assert monster.waiting_to_evolve is False

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -430,6 +430,54 @@ class PartyConditionsModel(BaseModel):
         None,
         description="The elemental alignment the party must lean toward for evolution to occur.",
     )
+    party_size: int | None = Field(
+        None,
+        ge=1,
+        le=sizes.PARTY_LIMIT,
+        description="Required number of monsters in the party.",
+    )
+    party_level: int | None = Field(
+        None,
+        ge=1,
+        description="Minimum average level of monsters in the party.",
+    )
+    party_stages: dict[str, int] | None = Field(
+        None,
+        description="Required evolution stages and their minimum counts (e.g. {'stage2': 2}).",
+    )
+
+    @model_validator(mode="after")
+    def at_least_one_condition(self) -> PartyConditionsModel:
+        if not any(
+            [
+                self.monster_slugs,
+                self.monster_types,
+                self.genders,
+                self.alignment,
+                self.party_size,
+                self.party_level,
+                self.party_stages,
+            ]
+        ):
+            raise ValueError("At least one party condition must be specified.")
+        return self
+
+    @field_validator("party_stages")
+    def validate_party_stages(
+        cls, v: dict[str, int] | None
+    ) -> dict[str, int] | None:
+        if v:
+            valid_stages = {stage.value for stage in EvolutionStage}
+            for stage, count in v.items():
+                if stage not in valid_stages:
+                    raise ValueError(
+                        f"Evolution stage '{stage}' is not valid. Must be one of {valid_stages}."
+                    )
+                if not (1 <= count < sizes.PARTY_LIMIT):
+                    raise ValueError(
+                        f"Count for stage '{stage}' must be between 1 and {sizes.PARTY_LIMIT - 1}."
+                    )
+        return v
 
     @field_validator("monster_slugs")
     def validate_monster_slugs(
@@ -441,9 +489,9 @@ class PartyConditionsModel(BaseModel):
                     raise ValueError(
                         f"Monster slug '{slug}' does not exist in the database."
                     )
-                if not (0 <= count < sizes.PARTY_LIMIT):
+                if not (1 <= count < sizes.PARTY_LIMIT):
                     raise ValueError(
-                        f"Count for monster slug '{slug}' must be between 0 and {sizes.PARTY_LIMIT - 1}."
+                        f"Count for monster slug '{slug}' must be between 1 and {sizes.PARTY_LIMIT - 1}."
                     )
         return v
 
@@ -453,9 +501,13 @@ class PartyConditionsModel(BaseModel):
     ) -> dict[str, int] | None:
         if v:
             for type_, count in v.items():
-                if not (0 <= count < sizes.PARTY_LIMIT):
+                if not has.db_entry("element", type_):
                     raise ValueError(
-                        f"Count for monster type '{type_}' must be between 0 and {sizes.PARTY_LIMIT - 1}."
+                        f"Monster type '{type_}' does not exist in the database."
+                    )
+                if not (1 <= count < sizes.PARTY_LIMIT):
+                    raise ValueError(
+                        f"Count for monster type '{type_}' must be between 1 and {sizes.PARTY_LIMIT - 1}."
                     )
         return v
 
@@ -465,11 +517,17 @@ class PartyConditionsModel(BaseModel):
     ) -> dict[GenderType, int] | None:
         if v:
             for gender, count in v.items():
-                if not (0 <= count < sizes.PARTY_LIMIT):
+                if not (1 <= count < sizes.PARTY_LIMIT):
                     raise ValueError(
-                        f"Count for gender '{gender}' must be between 0 and {sizes.PARTY_LIMIT - 1}."
+                        f"Count for gender '{gender}' must be between 1 and {sizes.PARTY_LIMIT - 1}."
                     )
         return v
+
+    @field_validator("alignment")
+    def validate_alignment(cls, v: str | None) -> str | None:
+        if not v or has.db_entry("element", v):
+            return v
+        raise ValueError(f"Alignment '{v}' does not exist in the database.")
 
 
 class Behaviors(BaseModel):
@@ -903,7 +961,7 @@ class MonsterEvolutionItemModel(BaseModel):
     at_level: int | None = Field(
         None,
         description="The level at which the monster evolves.",
-        ge=0,
+        ge=1,
     )
     element: str | None = Field(
         None,
@@ -932,7 +990,6 @@ class MonsterEvolutionItemModel(BaseModel):
     variables: Sequence[GameCondition] = Field(
         default_factory=list,
         description="The game variables that must exist and match a specific value for the monster to evolve.",
-        min_length=1,
     )
     stats: StatsComparison | None = Field(
         None,
@@ -946,6 +1003,7 @@ class MonsterEvolutionItemModel(BaseModel):
     steps: int | None = Field(
         None,
         description="The minimum number of steps the monster must have walked to evolve.",
+        ge=1,
     )
     tech: str | None = Field(
         None,
@@ -970,6 +1028,8 @@ class MonsterEvolutionItemModel(BaseModel):
     probability: float | None = Field(
         None,
         description="Chance (0.0 to 1.0) that this evolution occurs when conditions are met.",
+        ge=0.0,
+        le=1.0,
     )
     held_item: str | None = Field(
         None, description="Item slug the monster must be holding to evolve."
@@ -980,19 +1040,14 @@ class MonsterEvolutionItemModel(BaseModel):
     )
 
     @field_validator("moves")
-    def move_exists(cls, v: Sequence[str]) -> Sequence[str]:
-        if v:
-            for element in v:
-                if not has.db_entry("technique", element):
-                    raise ValueError(
-                        f"A technique {element} doesn't exist in the db"
-                    )
-        return v
-
-    @field_validator("moves")
     def validate_moves(cls, v: Sequence[str]) -> Sequence[str]:
         if not v:
-            raise ValueError(f"Moves must contain at least 1 technique")
+            raise ValueError("Moves must contain at least 1 technique.")
+        for slug in v:
+            if not has.db_entry("technique", slug):
+                raise ValueError(
+                    f"the technique '{slug}' doesn't exist in the db."
+                )
         return v
 
     @field_validator("tech")
@@ -1009,7 +1064,7 @@ class MonsterEvolutionItemModel(BaseModel):
             for taste_value in v.values():
                 if not has.db_entry("taste", taste_value):
                     raise ValueError(
-                        f"The taste '{taste_value}' does not exist in the database."
+                        f"the taste '{taste_value}' does not exist in the database."
                     )
         return v
 
@@ -1036,7 +1091,7 @@ class MonsterEvolutionItemModel(BaseModel):
         for item_slug, weight in v.items():
             if not has.db_entry("item", item_slug):
                 raise ValueError(
-                    f"The item '{item_slug}' doesn't exist in the database."
+                    f"The item '{item_slug}' does not exist in the database."
                 )
             if weight < 0.0:
                 raise ValueError(
@@ -1052,6 +1107,7 @@ class MonsterEvolutionItemModel(BaseModel):
         normalized = {
             slug: weight / total_weight for slug, weight in v.items()
         }
+        logger.debug(f"Item weights normalized: {normalized}")
         return normalized
 
     @field_validator("held_item")

--- a/tuxemon/event/eventbus.py
+++ b/tuxemon/event/eventbus.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(order=True)
+@dataclass
 class Listener:
     priority: int
-    callback: Callable[..., None]
+    callback: Callable[..., None] = field(compare=False)
 
 
 class EventBus:

--- a/tuxemon/monster/evolution.py
+++ b/tuxemon/monster/evolution.py
@@ -16,12 +16,12 @@ from tuxemon.monster.evolution_conditions import (
     check_party_conditions,
     check_simple_conditions,
     check_stats,
-    check_steps,
     check_tastes,
     check_variables,
 )
 
 if TYPE_CHECKING:
+    from tuxemon.entity.npc import NPC
     from tuxemon.item.item import Item
     from tuxemon.monster.evolution_registry import EvolutionRegistry
     from tuxemon.monster.monster import Monster
@@ -41,25 +41,22 @@ class Evolution:
             return None
 
         ctx = context or {"use_item": False}
-        registry = self.monster.get_owner().evolution_registry
+        owner = self.monster.get_owner()
+        registry = owner.evolution_registry
         monster_id = self.monster.instance_id
 
-        # Check Held Item (Everstone) - Bypass if using an evolution item
         if not ctx.get("use_item"):
             held = self.monster.held_item
             if held and held.behaviors.block_evolution:
                 return None
 
-        # Check Registry (Blocked list)
         blocked = registry.get_blocked(monster_id)
 
-        # Scan evolution paths
         for evolution_item in self.monster.evolutions:
             slug = evolution_item.monster_slug
             if slug in blocked:
                 continue
-
-            if self.can_evolve(evolution_item, ctx):
+            if self.can_evolve(evolution_item, ctx, owner):
                 return slug
 
         return None
@@ -90,9 +87,7 @@ class Evolution:
     def confirm_pending_evolution(
         self, registry: EvolutionRegistry, evolution_slug: str
     ) -> None:
-        """
-        Handles all monster-side and registry cleanup when a pending evolution is confirmed.
-        """
+        """Confirms a pending evolution and cleans up registry state."""
         registry.clear_missed(self.monster.instance_id, evolution_slug)
         registry.clear_pending(self.monster.instance_id)
         self.monster.experience_handler.reset_status_flags()
@@ -104,10 +99,7 @@ class Evolution:
     def deny_pending_evolution(
         self, registry: EvolutionRegistry, evolution_slug: str
     ) -> None:
-        """
-        Handles all monster-side and registry cleanup when a pending evolution is denied.
-        It logs the evolution as 'missed' and resets the monster's temporary status flags.
-        """
+        """Logs a missed evolution, cleans up registry state."""
         self.monster.experience_handler.reset_status_flags()
         registry.log_missed(
             self.monster.instance_id, evolution_slug, self.monster.level
@@ -117,8 +109,17 @@ class Evolution:
             f"Denied evolution of {self.monster.name}. Missed evolution logged at level {self.monster.level}."
         )
 
+    def is_eligible_for_evolution(self) -> bool:
+        return (
+            self.monster.owner is not None
+            and self.monster in self.monster.owner.monsters
+        )
+
     def evolve_monster(self, new_monster: Monster) -> None:
         if not self.is_eligible_for_evolution():
+            logger.warning(
+                f"evolve_monster called on {self.monster} but it is not eligible for evolution."
+            )
             return
 
         owner = self.monster.get_owner()
@@ -138,35 +139,20 @@ class Evolution:
         else:
             logger.warning(f"Failed to evolve {self.monster}")
 
-    def is_eligible_for_evolution(self) -> bool:
-        return (
-            self.monster.owner is not None
-            and self.monster in self.monster.owner.monsters
-        )
-
     def can_evolve(
         self,
         evolution_item: MonsterEvolutionItemModel,
         context: dict[str, bool],
+        owner: NPC | None = None,
     ) -> bool:
-        """
-        Checks if a monster can evolve based on conditions.
-
-        Parameters:
-            evolution_item: The evolution item to apply.
-            context: A dictionary containing the current context
-                (e.g., location, item usage).
-
-        Returns:
-            bool: True if the monster can evolve, False otherwise.
-        """
+        """Checks if a monster can evolve based on conditions."""
         if self.monster.owner is None:
             return False
 
         if evolution_item.monster_slug == self.monster.slug:
             return False
 
-        owner = self.monster.get_owner()
+        owner = owner or self.monster.get_owner()
         conditions: list[bool] = []
 
         check_simple_conditions(self.monster, evolution_item, conditions)
@@ -176,7 +162,6 @@ class Evolution:
         check_tastes(self.monster, evolution_item, conditions)
         check_stats(self.monster, evolution_item, conditions)
         check_variables(self.monster, evolution_item, conditions)
-        check_steps(self.monster, evolution_item, conditions)
         check_bond(self.monster, evolution_item, conditions)
 
         if evolution_item.party_conditions is not None:
@@ -186,25 +171,19 @@ class Evolution:
                 )
             )
 
-        # If the evolution requires an item, do not evolve unless it's being used
         if evolution_item.item is not None and not context.get(
             "use_item", False
         ):
             return False
 
-        # No conditions, only probability
         if not conditions and evolution_item.probability is not None:
             return random.random() <= evolution_item.probability
 
-        # Conditions must all be met
         if all(conditions):
-            # If probability is set, roll for it
             if evolution_item.probability is not None:
                 return random.random() <= evolution_item.probability
-            # Otherwise, guaranteed evolution
             return True
 
-        # Conditions not met
         return False
 
     def get_possible_item_evolutions(
@@ -231,8 +210,10 @@ class Evolution:
         self,
         possible_evolutions: list[tuple[MonsterEvolutionItemModel, float]],
     ) -> MonsterEvolutionItemModel:
+        if not possible_evolutions:
+            raise ValueError("No possible evolutions to choose from.")
         if len(possible_evolutions) == 1:
             return possible_evolutions[0][0]
-        evolution_choices, weights = zip(*possible_evolutions)
-        choices: list[MonsterEvolutionItemModel] = list(evolution_choices)
-        return random.choices(choices, weights=list(weights), k=1)[0]
+        models = [e[0] for e in possible_evolutions]
+        weights = [e[1] for e in possible_evolutions]
+        return random.choices(models, weights=weights, k=1)[0]

--- a/tuxemon/monster/evolution_conditions.py
+++ b/tuxemon/monster/evolution_conditions.py
@@ -45,11 +45,8 @@ def check_party_conditions(
     if conditions_model.monster_types is not None:
         type_counts: dict[str, int] = {}
         for mon in party_handler.monsters:
-            types = mon.types.current
-            for t in types:
-                slug = t.slug
-                type_counts[slug] = type_counts.get(slug, 0) + 1
-
+            for t in mon.types.current:
+                type_counts[t.slug] = type_counts.get(t.slug, 0) + 1
         for type_, required_count in conditions_model.monster_types.items():
             conditions.append(type_counts.get(type_, 0) >= required_count)
 
@@ -57,11 +54,31 @@ def check_party_conditions(
     if conditions_model.genders is not None:
         gender_counts: dict[GenderType, int] = {}
         for mon in party_handler.monsters:
-            gender = mon.gender
-            gender_counts[gender] = gender_counts.get(gender, 0) + 1
-
+            gender_counts[mon.gender] = gender_counts.get(mon.gender, 0) + 1
         for gender, required_count in conditions_model.genders.items():
             conditions.append(gender_counts.get(gender, 0) >= required_count)
+
+    # Check party size
+    if conditions_model.party_size is not None:
+        conditions.append(
+            party_handler.party_size >= conditions_model.party_size
+        )
+
+    # Check party level
+    if conditions_model.party_level is not None:
+        average = party_handler.level_average
+        conditions.append(
+            average is not None and average >= conditions_model.party_level
+        )
+
+    # Check party stages
+    if conditions_model.party_stages is not None:
+        stage_counts: dict[str, int] = {}
+        for mon in party_handler.monsters:
+            stage = mon.stage.value
+            stage_counts[stage] = stage_counts.get(stage, 0) + 1
+        for stage, required_count in conditions_model.party_stages.items():
+            conditions.append(stage_counts.get(stage, 0) >= required_count)
 
     return all(conditions)
 
@@ -113,9 +130,7 @@ def check_location_items_moves(
     # Moves check
     if evolution_item.moves:
         moves_slugs = {mov.slug for mov in monster.moves.get_moves()}
-        conditions.extend(
-            monster in moves_slugs for monster in evolution_item.moves
-        )
+        conditions.extend(move in moves_slugs for move in evolution_item.moves)
 
     if evolution_item.held_item is not None:
         held_item = monster.held_item
@@ -177,21 +192,6 @@ def check_variables(
     conditions.append(
         owner.variable_manager.check_conditions(evolution_item.variables)
     )
-
-
-def check_steps(
-    monster: Monster,
-    evolution_item: MonsterEvolutionItemModel,
-    conditions: list[bool],
-) -> None:
-    """Append a check for required steps taken and trigger experience flags."""
-    if evolution_item.steps is None:
-        return
-
-    result = evolution_item.steps - int(monster.steps)
-    conditions.append(result == 0)
-    monster.steps += 1
-    monster.experience_handler.trigger_experience_flags()
 
 
 def check_bond(

--- a/tuxemon/monster/experience.py
+++ b/tuxemon/monster/experience.py
@@ -209,11 +209,6 @@ class MonsterExperience:
             return 0
         return self._total_experience - self.experience_required()
 
-    def trigger_experience_flags(self) -> None:
-        """Sets the flags to indicate experience gain and level-up activity."""
-        self.got_experience = True
-        self.levelling_up = True
-
     def reset_status_flags(self) -> None:
         """Resets the temporary flags used to signal experience/level activity."""
         self.got_experience = False

--- a/tuxemon/monster/listener.py
+++ b/tuxemon/monster/listener.py
@@ -22,3 +22,9 @@ def monster_update_listener(
             results = monster.status.tick_statuses_on_steps(session, steps)
             for r in results:
                 logger.info(f"{monster.name} affected by {r.name}")
+        if not monster.waiting_to_evolve:
+            for evolution_item in monster.evolutions:
+                if evolution_item.steps is not None:
+                    if int(monster.steps) >= evolution_item.steps:
+                        monster.waiting_to_evolve = True
+                        break

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -77,6 +77,8 @@ class Monster:
         "steps": float,
     }
 
+    _persist_include_falsy = {"current_hp", "steps"}
+
     def __init__(
         self,
         slug: str,
@@ -163,6 +165,21 @@ class Monster:
         self.individual_values = randomize_ivs()
 
         self.body = Body()
+
+    def __repr__(self) -> str:
+        return (
+            f"<Monster {self.slug!r} lv{self.level}"
+            f" hp={self.current_hp}/{self.hp}"
+            f" id={self.instance_id.hex[:8]}>"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Monster):
+            return NotImplemented
+        return self.instance_id == other.instance_id
+
+    def __hash__(self) -> int:
+        return hash(self.instance_id)
 
     def _init_assets(self, db_data: MonsterModel) -> None:
         """Store only metadata for assets. No loading, no SpriteLoader."""
@@ -512,7 +529,7 @@ class Monster:
             return
 
         new_val = current_stat_val + points_to_add
-        setattr(self.training_points, stat_name, new_val)
+        self.training_points.set_stat(stat_name, new_val)
         self.training_points.validate()
         logger.debug(
             f"Added {points_to_add} TP to '{stat_name}'. New total: {new_val}"
@@ -583,7 +600,6 @@ class Monster:
             self.item_handler.held_item.temporary_stat_boosts = BasicStats()
 
     def set_level(self, new_level: int, old_level: int) -> int:
-
         if new_level > old_level and self._levelup_start_stats is None:
             self._levelup_start_stats = self.base_stats.copy()
             self._levelup_start_level = old_level
@@ -647,7 +663,8 @@ class Monster:
         """Gets the experience requirement for the given level."""
         return self.experience_handler.experience_required(level_delta)
 
-    def assign_gender(self, weights: dict[GenderType, float]) -> GenderType:
+    @staticmethod
+    def assign_gender(weights: dict[GenderType, float]) -> GenderType:
         """Randomly selects a gender based on weighted probabilities."""
         return random.choices(
             population=list(weights.keys()),
@@ -657,7 +674,10 @@ class Monster:
 
     def transfer_properties_from(self, old_monster: Monster) -> None:
         """Copies essential state and identity properties from the pre-evolved monster."""
-        self.set_level(old_monster.level, old_monster.level)
+        self.experience_handler.set_level(old_monster.level)
+        self.taste_cold = old_monster.taste_cold
+        self.taste_warm = old_monster.taste_warm
+        self.set_stats()
         self.current_hp = min(old_monster.current_hp, self.hp)
         self.moves = old_monster.moves
         self.status = old_monster.status
@@ -665,7 +685,7 @@ class Monster:
 
         if old_monster.gender in self.gender_weights:
             self.gender = old_monster.gender
-        else:  # Re-roll if incompatible
+        else:
             self.gender = self.assign_gender(self.gender_weights)
             logger.info(
                 f"{self.name} changed gender from {old_monster.gender} to {self.gender} upon evolution."
@@ -674,8 +694,6 @@ class Monster:
         self.birthdate = old_monster.birthdate
         self.capture_date = old_monster.capture_date
         self.capture_device = old_monster.capture_device
-        self.taste_cold = old_monster.taste_cold
-        self.taste_warm = old_monster.taste_warm
         self.plague = old_monster.plague
         self.steps = old_monster.steps
         self.bond_handler = old_monster.bond_handler
@@ -683,7 +701,7 @@ class Monster:
         if old_monster.name != T.translate(old_monster.slug):
             self.name = old_monster.name
 
-        for flair_category, new_flair in self.flairs.items():
+        for flair_category in self.flairs:
             if flair_category in old_monster.flairs:
                 self.flairs[flair_category] = old_monster.flairs[
                     flair_category
@@ -695,7 +713,8 @@ class Monster:
         save_data: dict[str, Any] = {
             attr: getattr(self, attr)
             for attr, _type in self._persist_simple.items()
-            if getattr(self, attr)
+            if getattr(self, attr) is not None
+            or attr in self._persist_include_falsy
         }
 
         save_data["instance_id"] = self.instance_id.hex

--- a/tuxemon/monster/stats.py
+++ b/tuxemon/monster/stats.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import random
 from collections.abc import Mapping
-from dataclasses import astuple, dataclass, fields
+from dataclasses import astuple, dataclass, fields, replace
 from typing import TYPE_CHECKING, Any
 
 from tuxemon.database.rules import config_monster
@@ -35,6 +35,19 @@ class BasicStats:
     def sum(self) -> int:
         return sum(astuple(self))
 
+    def to_dict(self) -> Mapping[str, int]:
+        return {
+            field.name: getattr(self, field.name) for field in fields(self)
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, int]) -> BasicStats:
+        valid_fields = {field.name for field in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in valid_fields})
+
+    def copy(self) -> BasicStats:
+        return replace(self)
+
     def __add__(self, other: BasicStats) -> BasicStats:
         if not isinstance(other, BasicStats):
             return NotImplemented
@@ -42,15 +55,14 @@ class BasicStats:
             *[s + o for s, o in zip(astuple(self), astuple(other))]
         )
 
-    def copy(self) -> BasicStats:
-        return BasicStats(
-            armour=self.armour,
-            dodge=self.dodge,
-            hp=self.hp,
-            melee=self.melee,
-            ranged=self.ranged,
-            speed=self.speed,
-        )
+    def __iadd__(self, other: BasicStats) -> BasicStats:
+        if not isinstance(other, BasicStats):
+            return NotImplemented
+        for f in fields(self):
+            setattr(
+                self, f.name, getattr(self, f.name) + getattr(other, f.name)
+            )
+        return self
 
 
 @dataclass
@@ -83,6 +95,7 @@ def randomize_ivs() -> IndividualValues:
     return IndividualValues(**random_data)
 
 
+@dataclass
 class CustomStatBoosts(BasicStats):
     """
     Persistent, user- or modder-defined additive boosts to a monster's base
@@ -129,6 +142,11 @@ class TrainingPoints(BasicStats):
             setattr(contribution, name, int(raw_tp * level_scale))
         return contribution
 
+    def set_stat(self, stat_name: str, value: int) -> None:
+        if not hasattr(self, stat_name):
+            raise ValueError(f"Invalid stat name: {stat_name}")
+        setattr(self, stat_name, value)
+
     def validate(self) -> None:
         """Clamps individual stats and the total to configuration limits."""
         max_stat = config_monster.max_tps
@@ -145,8 +163,7 @@ class TrainingPoints(BasicStats):
         if current_total > max_total:
             ratio = max_total / current_total
             for name in self.names():
-                val = getattr(self, name)
-                setattr(self, name, int(val * ratio))
+                setattr(self, name, int(getattr(self, name) * ratio))
             logger.warning(f"TPs exceeded {max_total} and were scaled down.")
 
 
@@ -181,11 +198,7 @@ class StatCalculator:
         final_stats = self.apply_stat_updates(raw_stats, cold, warm)
 
         if temporary_boosts:
-            for stat in BasicStats.names():
-                boosted = getattr(final_stats, stat) + getattr(
-                    temporary_boosts, stat
-                )
-                setattr(final_stats, stat, boosted)
+            final_stats += temporary_boosts
 
         return final_stats
 
@@ -367,16 +380,15 @@ def randomize_training_points(total_points: int) -> TrainingPoints:
 
     stats = TrainingPoints()
     stat_names = BasicStats.names()
-    num_stats = len(stat_names)
-    remaining_points = total_points
-
-    for i in range(num_stats - 1):
-        max_possible = remaining_points // (num_stats - i)
-        points = random.randint(0, max_possible)
-        setattr(stats, stat_names[i], points)
-        remaining_points -= points
-
-    setattr(stats, stat_names[-1], remaining_points)
+    max_per_stat = config_monster.max_tps
+    remaining = total_points
+    for name in stat_names[:-1]:
+        cap = min(max_per_stat, remaining // len(stat_names))
+        points = random.randint(0, cap)
+        setattr(stats, name, points)
+        remaining -= points
+    setattr(stats, stat_names[-1], min(remaining, max_per_stat))
+    stats.validate()
     return stats
 
 


### PR DESCRIPTION
Bugfix:
- fix variable shadowing in `check_location_items_moves` moves check (`monster` → `move`)
- fix `check_steps` to use `>=` instead of exact match
- remove state mutation (`monster.steps += 1`, `trigger_experience_flags`) from `check_steps`
- fix `choose_evolution_model` to raise `ValueError` on empty input instead of `IndexError`
- fix `can_evolve` receiving `owner` to avoid redundant `get_owner()` calls
- fix `PartyConditionsModel` count validators to reject `0` (`>= 1` instead of `>= 0`)
- fix `variables` field `min_length=1` contradicting empty default in `MonsterEvolutionItemModel`
- fix duplicate `@field_validator("moves")` in `MonsterEvolutionItemModel`

Changes:
- add `party_size`, `party_level`, `party_stages` condition to `PartyConditionsModel`
- add `monster_types`, `alignment`  db validation to `PartyConditionsModel`
- add `at_least_one_condition` model validator to `PartyConditionsModel`
- add `party_stages` validator against valid `EvolutionStage` values
- add `probability` range validation (`0.0` to `1.0`) to `MonsterEvolutionItemModel`
- add `steps` lower bound validation (`ge=1`) to `MonsterEvolutionItemModel`
- add `at_level` lower bound correction (`ge=1` instead of `ge=0`) to `MonsterEvolutionItemModel`
- move steps-based evolution check from `can_evolve` to `monster_update_listener`
- add `check_party_conditions` support for `party_size`, `party_level`, and `party_stages`