### PR TITLE
Fix event engine: behavior double-expansion, cancelled global events, action state invariants, process loop safety

### DIFF
--- a/tests/tuxemon/test_event_action.py
+++ b/tests/tuxemon/test_event_action.py
@@ -20,26 +20,49 @@ def mock_session():
     return MagicMock(spec=Session)
 
 
-def test_context_manager_enter(mock_action, mock_session):
-    with ActionContextManager(mock_action, mock_session):
-        mock_action.on_start.assert_called_once()
+class TestActionContextManager:
+    def test_enter_calls_on_start(self, mock_action, mock_session):
+        with ActionContextManager(mock_action, mock_session):
+            mock_action.on_start.assert_called_once_with(mock_session)
 
-
-def test_context_manager_exit(mock_action, mock_session):
-    with ActionContextManager(mock_action, mock_session):
-        pass
-    mock_action.cleanup.assert_called_once()
-
-
-def test_cancelled_action(mock_action, mock_session):
-    mock_action.cancelled = True
-    with ActionContextManager(mock_action, mock_session):
-        mock_action.start.assert_not_called()
-    mock_action.cleanup.assert_not_called()
-
-
-def test_exception_handling(mock_action, mock_session):
-    mock_action.cleanup = MagicMock(side_effect=Exception("Cleanup error"))
-    with pytest.raises(Exception):
+    def test_exit_calls_cleanup(self, mock_action, mock_session):
         with ActionContextManager(mock_action, mock_session):
             pass
+        mock_action.cleanup.assert_called_once_with(mock_session)
+
+    def test_cancelled_action_skips_on_start(self, mock_action, mock_session):
+        mock_action.cancelled = True
+        with ActionContextManager(mock_action, mock_session):
+            mock_action.on_start.assert_not_called()
+        mock_action.cleanup.assert_called_once_with(mock_session)
+
+    def test_cleanup_always_called_even_when_cancelled(
+        self, mock_action, mock_session
+    ):
+        mock_action.cancelled = True
+        with ActionContextManager(mock_action, mock_session):
+            pass
+        assert mock_action.cleanup.call_count == 1
+
+    def test_cleanup_called_on_exception(self, mock_action, mock_session):
+        with pytest.raises(ValueError):
+            with ActionContextManager(mock_action, mock_session):
+                raise ValueError("body error")
+        mock_action.cleanup.assert_called_once_with(mock_session)
+
+    def test_cleanup_exception_propagates(self, mock_action, mock_session):
+        mock_action.cleanup.side_effect = RuntimeError("cleanup error")
+        with pytest.raises(RuntimeError, match="cleanup error"):
+            with ActionContextManager(mock_action, mock_session):
+                pass
+
+    def test_body_exception_not_swallowed_when_cleanup_is_clean(
+        self, mock_action, mock_session
+    ):
+        with pytest.raises(ValueError, match="body error"):
+            with ActionContextManager(mock_action, mock_session):
+                raise ValueError("body error")
+
+    def test_enter_returns_action(self, mock_action, mock_session):
+        with ActionContextManager(mock_action, mock_session) as action:
+            assert action is mock_action

--- a/tests/tuxemon/test_event_behavior_manager.py
+++ b/tests/tuxemon/test_event_behavior_manager.py
@@ -15,8 +15,7 @@ from tuxemon.db import (
 from tuxemon.event.eventbehavior import (
     BehaviorManager,
     EventBehavior,
-    expand_behavior_actions,
-    expand_behavior_conditions,
+    expand_behavior,
 )
 
 
@@ -73,86 +72,178 @@ class DummyBehavior(EventBehavior):
         return [cond], [act]
 
 
-def test_get_behavior_success(patch_behavior_plugins):
-    patch_behavior_plugins({"dummy": DummyBehavior})
-    mgr = BehaviorManager(root_path=None)
-    beh = mgr.get_behavior("dummy")
-    assert isinstance(beh, DummyBehavior)
+class EmptyBehavior(EventBehavior):
+    name = "empty"
+
+    def expand(self, event, behavior):
+        return [], []
 
 
-def test_get_behavior_missing(patch_behavior_plugins, caplog):
-    patch_behavior_plugins({})
-    mgr = BehaviorManager(root_path=None)
-    beh = mgr.get_behavior("unknown")
-    assert beh is None
-    assert "not implemented" in caplog.text.lower()
+class ExplodingBehavior(EventBehavior):
+    name = "explode"
+
+    def expand(self, event, behavior):
+        raise RuntimeError("boom")
 
 
-def test_get_behavior_instantiation_error(patch_behavior_plugins, caplog):
+class TestBehaviorManager:
+    def test_get_behavior_success(self, patch_behavior_plugins):
+        patch_behavior_plugins({"dummy": DummyBehavior})
+        mgr = BehaviorManager(root_path=None)
+        beh = mgr.get_behavior("dummy")
+        assert isinstance(beh, DummyBehavior)
 
-    class BadBehavior(EventBehavior):
-        name = "bad"
+    def test_get_behavior_returns_new_instance_each_call(
+        self, patch_behavior_plugins
+    ):
+        patch_behavior_plugins({"dummy": DummyBehavior})
+        mgr = BehaviorManager(root_path=None)
+        a = mgr.get_behavior("dummy")
+        b = mgr.get_behavior("dummy")
+        assert a is not b
 
-        def __init__(self):
-            raise RuntimeError("boom")
+    def test_get_behavior_missing(self, patch_behavior_plugins, caplog):
+        patch_behavior_plugins({})
+        mgr = BehaviorManager(root_path=None)
+        beh = mgr.get_behavior("unknown")
+        assert beh is None
+        assert "not implemented" in caplog.text.lower()
 
-        def expand(self, event, behavior):
-            return [], []
+    def test_get_behavior_instantiation_error(
+        self, patch_behavior_plugins, caplog
+    ):
+        class BadBehavior(EventBehavior):
+            name = "bad"
 
-    patch_behavior_plugins({"bad": BadBehavior})
-    mgr = BehaviorManager(root_path=None)
-    beh = mgr.get_behavior("bad")
-    assert beh is None
-    assert "error instantiating behavior" in caplog.text.lower()
+            def __init__(self):
+                raise RuntimeError("boom")
 
+            def expand(self, event, behavior):
+                return [], []
 
-def test_expand_behavior_conditions(patch_behavior_plugins, dummy_event):
-    dummy_event.behavs = [Behavior(type="dummy", args=[], name="b1")]
-    patch_behavior_plugins({"dummy": DummyBehavior})
-    mgr = BehaviorManager(root_path=None)
-    conds = expand_behavior_conditions(dummy_event, mgr)
-    assert len(conds) == 1
-    assert isinstance(conds[0], SpatialCondition)
-    assert conds[0].type == "dummy_cond"
+        patch_behavior_plugins({"bad": BadBehavior})
+        mgr = BehaviorManager(root_path=None)
+        beh = mgr.get_behavior("bad")
+        assert beh is None
+        assert "error instantiating behavior" in caplog.text.lower()
 
-
-def test_expand_behavior_actions(patch_behavior_plugins, dummy_event):
-    dummy_event.behavs = [Behavior(type="dummy", args=[], name="b1")]
-    patch_behavior_plugins({"dummy": DummyBehavior})
-    mgr = BehaviorManager(root_path=None)
-    acts = expand_behavior_actions(dummy_event, mgr)
-    assert len(acts) == 1
-    assert isinstance(acts[0], ParameterizableRule)
-    assert acts[0].type == "dummy_act"
-
-
-def test_expand_behavior_skips_missing_plugin(
-    patch_behavior_plugins, dummy_event
-):
-    dummy_event.behavs = [Behavior(type="missing", args=[], name="b1")]
-    patch_behavior_plugins({})
-    mgr = BehaviorManager(root_path=None)
-    conds = expand_behavior_conditions(dummy_event, mgr)
-    acts = expand_behavior_actions(dummy_event, mgr)
-    assert conds == []
-    assert acts == []
+    def test_get_behaviors_returns_all(self, patch_behavior_plugins):
+        patch_behavior_plugins(
+            {"dummy": DummyBehavior, "empty": EmptyBehavior}
+        )
+        mgr = BehaviorManager(root_path=None)
+        result = mgr.get_behaviors()
+        assert set(result) == {DummyBehavior, EmptyBehavior}
 
 
-def test_expand_behavior_logs_error_on_plugin_failure(
-    patch_behavior_plugins, dummy_event, caplog
-):
+class TestExpandBehavior:
+    def test_returns_both_conditions_and_actions(
+        self, patch_behavior_plugins, dummy_event
+    ):
+        dummy_event.behavs = [Behavior(type="dummy", args=[], name="b1")]
+        patch_behavior_plugins({"dummy": DummyBehavior})
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert len(conds) == 1
+        assert len(acts) == 1
+        assert isinstance(conds[0], SpatialCondition)
+        assert isinstance(acts[0], ParameterizableRule)
+        assert conds[0].type == "dummy_cond"
+        assert acts[0].type == "dummy_act"
 
-    class ExplodingBehavior(EventBehavior):
-        name = "explode"
+    def test_conditions_and_actions_come_from_same_expand_call(
+        self, patch_behavior_plugins, dummy_event
+    ):
+        call_count = {"n": 0}
+        outer_self = self
 
-        def expand(self, event, behavior):
-            raise RuntimeError("boom")
+        class CountingBehavior(EventBehavior):
+            name = "counting"
 
-    dummy_event.behavs = [Behavior(type="explode", args=[], name="b1")]
-    patch_behavior_plugins({"explode": ExplodingBehavior})
-    mgr = BehaviorManager(root_path=None)
-    conds = expand_behavior_conditions(dummy_event, mgr)
-    acts = expand_behavior_actions(dummy_event, mgr)
-    assert conds == []
-    assert acts == []
-    assert "error expanding behavior" in caplog.text.lower()
+            def expand(self, event, behavior):
+                call_count["n"] += 1
+                cond = SpatialCondition(
+                    type="c",
+                    parameters=[],
+                    box=event.box,
+                    operator=Operator.IS,
+                    name="c",
+                )
+                act = ParameterizableRule(type="a", parameters=[], name="a")
+                return [cond], [act]
+
+        dummy_event.behavs = [Behavior(type="counting", args=[], name="b1")]
+        patch_behavior_plugins({"counting": CountingBehavior})
+        mgr = BehaviorManager(root_path=None)
+        expand_behavior(dummy_event, mgr)
+        assert call_count["n"] == 1, (
+            f"expand() was called {call_count['n']} times — expected exactly 1"
+        )
+
+    def test_no_behavs_returns_empty(
+        self, patch_behavior_plugins, dummy_event
+    ):
+        patch_behavior_plugins({})
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert conds == []
+        assert acts == []
+
+    def test_skips_missing_plugin(self, patch_behavior_plugins, dummy_event):
+        dummy_event.behavs = [Behavior(type="missing", args=[], name="b1")]
+        patch_behavior_plugins({})
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert conds == []
+        assert acts == []
+
+    def test_multiple_behaviors_accumulated(
+        self, patch_behavior_plugins, dummy_event
+    ):
+        dummy_event.behavs = [
+            Behavior(type="dummy", args=[], name="b1"),
+            Behavior(type="dummy", args=[], name="b2"),
+        ]
+        patch_behavior_plugins({"dummy": DummyBehavior})
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert len(conds) == 2
+        assert len(acts) == 2
+
+    def test_empty_behavior_contributes_nothing(
+        self, patch_behavior_plugins, dummy_event
+    ):
+        dummy_event.behavs = [Behavior(type="empty", args=[], name="b1")]
+        patch_behavior_plugins({"empty": EmptyBehavior})
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert conds == []
+        assert acts == []
+
+    def test_exploding_behavior_skipped_entirely(
+        self, patch_behavior_plugins, dummy_event, caplog
+    ):
+        dummy_event.behavs = [Behavior(type="explode", args=[], name="b1")]
+        patch_behavior_plugins({"explode": ExplodingBehavior})
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert conds == []
+        assert acts == []
+        assert "failed to expand" in caplog.text.lower()
+
+    def test_exploding_behavior_does_not_affect_others(
+        self, patch_behavior_plugins, dummy_event, caplog
+    ):
+        dummy_event.behavs = [
+            Behavior(type="explode", args=[], name="b1"),
+            Behavior(type="dummy", args=[], name="b2"),
+        ]
+        patch_behavior_plugins(
+            {"explode": ExplodingBehavior, "dummy": DummyBehavior}
+        )
+        mgr = BehaviorManager(root_path=None)
+        conds, acts = expand_behavior(dummy_event, mgr)
+        assert len(conds) == 1
+        assert len(acts) == 1
+        assert conds[0].type == "dummy_cond"
+        assert acts[0].type == "dummy_act"

--- a/tests/tuxemon/test_event_engine.py
+++ b/tests/tuxemon/test_event_engine.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,7 +26,7 @@ def event_engine():
     return eng
 
 
-def make_event(event_id, box):
+def make_event(event_id, box, behavs=None):
     return EventObject(
         id=event_id,
         name="",
@@ -33,150 +34,267 @@ def make_event(event_id, box):
         box=box,
         conds=[],
         acts=[],
+        behavs=behavs or [],
     )
 
 
-def test_init(event_engine):
-    assert event_engine.current_map is None
-    assert event_engine.running_events == {}
-    assert event_engine.partial_events == []
-
-
-def test_reset(event_engine):
-    event_engine.running_events = {1: "event1", 2: "event2"}
-    event_engine.current_map = "map1"
-    event_engine.reset()
-    assert event_engine.current_map is None
-    assert event_engine.running_events == {}
-
-
-def test_start_event(event_engine):
-    event = make_event(1, event_engine._test_box)
+def _mock_session(event_engine, inits=None):
     event_engine.session = MagicMock(spec=Session)
     event_engine.session.client = MagicMock(spec=LocalPygameClient)
     event_engine.session.client.map_manager = MagicMock(spec=MapManager)
-    event_engine.session.client.map_manager.inits = []
-    event_engine.start_event(event)
-    assert 1 in event_engine.running_events
+    event_engine.session.client.map_manager.inits = inits or []
 
 
-@pytest.mark.parametrize(
-    "event_id",
-    [
-        pytest.param(99, id="id_99"),
-        pytest.param(303, id="id_303"),
-    ],
-)
-def test_register_global_event_prevents_duplicates(event_engine, event_id):
-    event = make_event(event_id, event_engine._test_box)
-    event_engine.global_events = [event]
-    result = event_engine.register_global_event(event)
-    assert result is False
-    assert len(event_engine.global_events) == 1
+class TestInit:
+    def test_initial_state(self, event_engine):
+        assert event_engine.current_map is None
+        assert event_engine.running_events == {}
+        assert event_engine.partial_events == []
+        assert event_engine._behavior_cache == {}
+        assert event_engine.global_events == []
+        assert event_engine.triggered_global_events == set()
 
 
-@pytest.mark.parametrize(
-    "event_id",
-    [
-        pytest.param(77, id="id_77"),
-        pytest.param(404, id="id_404"),
-    ],
-)
-def test_unregister_global_event(event_engine, event_id):
-    event = make_event(event_id, event_engine._test_box)
-    event_engine.global_events = [event]
-    event_engine.triggered_global_events = {event_id}
-    result = event_engine.unregister_global_event(event_id)
-    assert result is True
-    assert event not in event_engine.global_events
-    assert event_id not in event_engine.triggered_global_events
+class TestReset:
+    def test_clears_running_events_and_map(self, event_engine):
+        event_engine.running_events = {1: "event1", 2: "event2"}
+        event_engine.current_map = "map1"
+        event_engine.reset()
+        assert event_engine.current_map is None
+        assert event_engine.running_events == {}
+
+    def test_clears_behavior_cache(self, event_engine):
+        event_engine._behavior_cache = {1: ([], [])}
+        event_engine.reset()
+        assert event_engine._behavior_cache == {}
+
+    def test_clears_triggered_global_events(self, event_engine):
+        event_engine.triggered_global_events = {1, 2, 3}
+        event_engine.reset()
+        assert event_engine.triggered_global_events == set()
 
 
-def test_start_event_expands_behavior_actions(event_engine):
-    event = make_event(1, event_engine._test_box)
-    event_engine.behavior_manager = MagicMock()
-    event_engine.session = MagicMock()
-    event_engine.session.client = MagicMock()
-    event_engine.session.client.map_manager = MagicMock()
-    event_engine.session.client.map_manager.inits = []
-
-    with patch("tuxemon.event.eventengine.expand_behavior_actions") as expand:
-        expand.return_value = []
+class TestStartEvent:
+    def test_event_added_to_running(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        _mock_session(event_engine)
         event_engine.start_event(event)
-        expand.assert_called_once_with(event, event_engine.behavior_manager)
+        assert 1 in event_engine.running_events
+
+    def test_duplicate_start_ignored(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        _mock_session(event_engine)
+        event_engine.start_event(event)
+        event_engine.start_event(event)
+        assert len(event_engine.running_events) == 1
+
+    def test_uses_expand_behavior_not_split_functions(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        _mock_session(event_engine)
+
+        with patch("tuxemon.event.eventengine.expand_behavior") as expand:
+            expand.return_value = ([], [])
+            event_engine.start_event(event)
+            expand.assert_called_once_with(
+                event, event_engine.behavior_manager
+            )
+
+    def test_behavior_expansion_cached(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        _mock_session(event_engine)
+
+        with patch("tuxemon.event.eventengine.expand_behavior") as expand:
+            expand.return_value = ([], [])
+            event_engine._get_behavior_expansion(event)
+            event_engine._get_behavior_expansion(event)
+            assert expand.call_count == 1
+
+    def test_behavior_cache_cleared_each_update(self, event_engine):
+        event_engine.check_global_conditions = MagicMock()
+        event_engine.check_conditions = MagicMock()
+        event_engine.update_running_events = MagicMock()
+        event_engine._behavior_cache = {99: ([], [])}
+        event_engine.update(0.1)
+        assert event_engine._behavior_cache == {}
 
 
-def test_event_starts_only_when_conditions_met(event_engine):
-    event = make_event(1, event_engine._test_box)
-    cond = MagicMock()
-    cond.check.return_value = True
-    event.conds = [cond]
-    event_engine.evaluator = MagicMock()
-    event_engine.start_event = MagicMock()
-    event_engine._evaluate_and_queue_event(event)
+class TestGlobalEvents:
+    def test_register_prevents_duplicates(self, event_engine):
+        event = make_event(99, event_engine._test_box)
+        event_engine.global_events = [event]
+        result = event_engine.register_global_event(event)
+        assert result is False
+        assert len(event_engine.global_events) == 1
 
-    event_engine.start_event.assert_called_once_with(event)
+    def test_register_sorts_by_priority(self, event_engine):
+        low = make_event(1, event_engine._test_box)
+        low.priority = 0
+        high = make_event(2, event_engine._test_box)
+        high.priority = 10
+        event_engine.register_global_event(low)
+        event_engine.register_global_event(high)
+        assert event_engine.global_events[0].id == 2
 
+    def test_unregister_removes_event(self, event_engine):
+        event = make_event(77, event_engine._test_box)
+        event_engine.global_events = [event]
+        event_engine.triggered_global_events = {77}
+        result = event_engine.unregister_global_event(77)
+        assert result is True
+        assert event not in event_engine.global_events
+        assert 77 not in event_engine.triggered_global_events
 
-def test_event_does_not_start_when_conditions_fail(event_engine):
-    event = make_event(1, event_engine._test_box)
-    cond = MagicMock()
-    event.conds = [cond]
-    event_engine.evaluator.evaluate.return_value = False
-    event_engine.start_event = MagicMock()
-    event_engine._evaluate_and_queue_event(event)
-    event_engine.start_event.assert_not_called()
+    def test_unregister_missing_returns_false(self, event_engine):
+        result = event_engine.unregister_global_event(999)
+        assert result is False
 
+    def test_global_event_triggers_only_once(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        event.conds = [MagicMock()]
+        event.conds[0].check.return_value = True
+        event_engine.global_events = [event]
+        event_engine.start_event = MagicMock()
+        event_engine.check_global_conditions()
+        event_engine.start_event.assert_called_once_with(event)
+        event_engine.start_event.reset_mock()
+        event_engine.check_global_conditions()
+        event_engine.start_event.assert_not_called()
 
-def test_global_event_triggers_only_once(event_engine):
-    event = make_event(1, event_engine._test_box)
-    event.conds = [MagicMock()]
-    event.conds[0].check.return_value = True
-    event_engine.global_events = [event]
-    event_engine.start_event = MagicMock()
-    event_engine.check_global_conditions()
-    event_engine.start_event.assert_called_once_with(event)
-    event_engine.start_event.reset_mock()
-    event_engine.check_global_conditions()
-    event_engine.start_event.assert_not_called()
+    def test_cancel_event_clears_triggered_global(self, event_engine):
+        running = MagicMock()
+        event_engine.running_events = {1: running}
+        event_engine.triggered_global_events = {1}
+        event_engine.cancel_event(1)
+        assert 1 not in event_engine.triggered_global_events
 
-
-def test_completed_events_are_removed(event_engine):
-    running = MagicMock()
-    running.is_running.return_value = True
-    running.process.return_value = False
-    running.state = EventState.COMPLETED
-    event_engine.running_events = {1: running}
-    event_engine.update_running_events(0.1)
-    assert event_engine.running_events == {}
-
-
-def test_map_change_aborts_event_processing(event_engine):
-    running = MagicMock()
-    running.is_running.return_value = True
-
-    def change_map(*args, **kwargs):
-        event_engine.current_map = "mapB"
-        return True
-
-    running.process.side_effect = change_map
-    event_engine.running_events = {1: running}
-    event_engine.current_map = "mapA"
-    event_engine.update_running_events(0.1)
-    running.step.assert_called_once()
+    def test_cancel_all_events_clears_triggered_globals(self, event_engine):
+        r1, r2 = MagicMock(), MagicMock()
+        event_engine.running_events = {1: r1, 2: r2}
+        event_engine.triggered_global_events = {1, 2}
+        event_engine.cancel_all_events()
+        assert event_engine.triggered_global_events == set()
 
 
-def test_cancel_event(event_engine):
-    running = MagicMock()
-    event_engine.running_events = {1: running}
-    event_engine.cancel_event(1)
-    running.cancel.assert_called_once()
+class TestConditionEvaluation:
+    def test_event_starts_when_conditions_met(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        cond = MagicMock()
+        cond.check.return_value = True
+        event.conds = [cond]
+        event_engine.evaluator = MagicMock()
+        event_engine.start_event = MagicMock()
+        event_engine._evaluate_and_queue_event(event)
+        event_engine.start_event.assert_called_once_with(event)
+
+    def test_event_does_not_start_when_conditions_fail(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        cond = MagicMock()
+        event.conds = [cond]
+        event_engine.evaluator.evaluate.return_value = False
+        event_engine.start_event = MagicMock()
+        event_engine._evaluate_and_queue_event(event)
+        event_engine.start_event.assert_not_called()
+
+    def test_event_with_no_conditions_not_started(self, event_engine):
+        event = make_event(1, event_engine._test_box)
+        event_engine.start_event = MagicMock()
+        event_engine._evaluate_and_queue_event(event)
+        event_engine.start_event.assert_not_called()
 
 
-def test_cancel_all_events(event_engine):
-    r1 = MagicMock()
-    r2 = MagicMock()
-    event_engine.running_events = {1: r1, 2: r2}
-    event_engine.cancel_all_events()
-    r1.cancel.assert_called_once()
-    r2.cancel.assert_called_once()
+class TestUpdateRunningEvents:
+    def test_completed_events_removed(self, event_engine):
+        running = MagicMock()
+        running.is_running.return_value = True
+        running.step.return_value = False
+        running.state = EventState.COMPLETED
+        event_engine.running_events = {1: running}
+        event_engine.update_running_events(0.1)
+        assert event_engine.running_events == {}
+
+    def test_cancelled_events_removed(self, event_engine):
+        running = MagicMock()
+        running.is_running.return_value = True
+        running.step.return_value = False
+        running.state = EventState.CANCELLED
+        event_engine.running_events = {1: running}
+        event_engine.update_running_events(0.1)
+        assert event_engine.running_events == {}
+
+    def test_active_events_kept(self, event_engine):
+        running = MagicMock()
+        running.is_running.return_value = True
+        running.step.return_value = True
+        running.state = EventState.RUNNING
+        event_engine.running_events = {1: running}
+        event_engine.update_running_events(0.1)
+        assert 1 in event_engine.running_events
+
+    def test_map_change_aborts_processing(self, event_engine):
+        running = MagicMock()
+        running.is_running.return_value = True
+
+        def change_map(*args, **kwargs):
+            event_engine.current_map = "mapB"
+            return True
+
+        running.step.side_effect = change_map
+        event_engine.running_events = {1: running}
+        event_engine.current_map = "mapA"
+        event_engine.update_running_events(0.1)
+        running.step.assert_called_once()
+
+    def test_not_running_events_skipped(self, event_engine):
+        running = MagicMock()
+        running.is_running.return_value = False
+        event_engine.running_events = {1: running}
+        event_engine.update_running_events(0.1)
+        running.step.assert_not_called()
+
+
+class TestCancelEvents:
+    def test_cancel_event_calls_cancel(self, event_engine):
+        running = MagicMock()
+        event_engine.running_events = {1: running}
+        event_engine.cancel_event(1)
+        running.cancel.assert_called_once()
+
+    def test_cancel_event_missing_id_safe(self, event_engine):
+        event_engine.cancel_event(999)
+
+    def test_cancel_all_events(self, event_engine):
+        r1, r2 = MagicMock(), MagicMock()
+        event_engine.running_events = {1: r1, 2: r2}
+        event_engine.cancel_all_events()
+        r1.cancel.assert_called_once()
+        r2.cancel.assert_called_once()
+
+
+class TestSuspendResume:
+    def test_suspended_engine_skips_update(self, event_engine):
+        event_engine.suspend()
+        event_engine.check_conditions = MagicMock()
+        event_engine.update(0.1)
+        event_engine.check_conditions.assert_not_called()
+
+    def test_resumed_engine_processes_update(self, event_engine):
+        event_engine.suspend()
+        event_engine.resume()
+        event_engine.check_conditions = MagicMock()
+        event_engine.check_global_conditions = MagicMock()
+        event_engine.update_running_events = MagicMock()
+        event_engine.update(0.1)
+        event_engine.check_conditions.assert_called_once()
+
+    def test_double_suspend_does_not_log_twice(self, event_engine, caplog):
+        with caplog.at_level(logging.INFO, logger="tuxemon.event.eventengine"):
+            event_engine.suspend()
+            event_engine.suspend()
+        assert caplog.text.count("suspended") == 1
+
+    def test_double_resume_does_not_log_twice(self, event_engine, caplog):
+        with caplog.at_level(logging.INFO, logger="tuxemon.event.eventengine"):
+            event_engine.suspend()
+            event_engine.resume()
+            event_engine.resume()
+        assert caplog.text.count("resumed") == 1

--- a/tests/tuxemon/test_map_transition.py
+++ b/tests/tuxemon/test_map_transition.py
@@ -43,8 +43,7 @@ def test_change_map(deps, transition):
     deps["map_loader"].load_map_data.return_value = map_data
     transition.change_map("test_map")
     deps["map_loader"].load_map_data.assert_called_once_with("test_map")
-    deps["event_engine"].reset.assert_called_once()
-    deps["event_engine"].set_current_map.assert_called_once_with(map_data)
+    deps["event_engine"].reset.assert_called_once_with(map_data)
     deps["map_manager"].load_map.assert_called_once_with(map_data)
     deps["npc_manager"].clear_npcs.assert_called_once()
     deps["boundary"].set_rectangular_boundary.assert_called_once()
@@ -69,8 +68,7 @@ def test_update_boundaries_parametrized(deps, transition, size):
 def test_reset_events(deps, transition):
     map_data = MagicMock()
     transition._reset_events(map_data)
-    deps["event_engine"].reset.assert_called_once()
-    deps["event_engine"].set_current_map.assert_called_once_with(map_data)
+    deps["event_engine"].reset.assert_called_once_with(map_data)
 
 
 def test_update_map_state(deps, transition):

--- a/tests/tuxemon/test_running_condition.py
+++ b/tests/tuxemon/test_running_condition.py
@@ -60,69 +60,170 @@ def running_condition(spatial_condition, evaluator):
     return RunningCondition(spatial_condition, evaluator)
 
 
-def test_initial_state(running_condition):
-    assert running_condition.state == ConditionState.WAITING
-    assert running_condition.result is None
+class TestConditionState:
+    def test_has_met(self):
+        assert hasattr(ConditionState, "MET")
+
+    def test_has_failed(self):
+        assert hasattr(ConditionState, "FAILED")
+
+    def test_has_cancelled(self):
+        assert hasattr(ConditionState, "CANCELLED")
+
+    def test_no_waiting(self):
+        assert not hasattr(ConditionState, "WAITING")
+
+    def test_no_checking(self):
+        assert not hasattr(ConditionState, "CHECKING")
 
 
-def test_start_check_sets_state_to_checking(running_condition):
-    running_condition.start_check()
-    assert running_condition.state == ConditionState.CHECKING
+class TestRunningConditionInit:
+    def test_initial_state_is_failed(self, running_condition):
+        assert running_condition.state == ConditionState.FAILED
+
+    def test_initial_result_is_none(self, running_condition):
+        assert running_condition.result is None
+
+    def test_no_start_check_method(self, running_condition):
+        assert not hasattr(running_condition, "start_check")
 
 
-def test_cancel_sets_state_to_cancelled(running_condition):
-    running_condition.cancel()
-    assert running_condition.is_cancelled()
-    assert running_condition.state == ConditionState.CANCELLED
+class TestRunningConditionCheck:
+    def test_check_condition_met(self, running_condition):
+        result = running_condition.check()
+        assert result is True
+        assert running_condition.is_met()
+        assert running_condition.result is True
+
+    def test_check_condition_failed(self, running_condition, mock_condition):
+        mock_condition.test.return_value = False
+        result = running_condition.check()
+        assert result is False
+        assert running_condition.is_failed()
+        assert running_condition.result is False
+
+    def test_check_is_expected_false(self, running_condition, mock_condition):
+        mock_condition.test.return_value = False
+        mock_condition.is_expected = False
+        result = running_condition.check()
+        assert result is True
+        assert running_condition.is_met()
+
+    def test_check_condition_type_not_found(
+        self, running_condition, mock_condition_manager
+    ):
+        mock_condition_manager.get_condition.return_value = None
+        result = running_condition.check()
+        assert result is False
+        assert running_condition.is_failed()
+        assert running_condition.result is False
+
+    def test_check_condition_exception(
+        self, running_condition, mock_condition, caplog
+    ):
+        mock_condition.test.side_effect = Exception("test error")
+        result = running_condition.check()
+        assert result is False
+        assert running_condition.is_failed()
+        assert running_condition.result is False
+        assert "error checking condition" in caplog.text.lower()
+
+    def test_check_cancelled_returns_false_immediately(
+        self, running_condition
+    ):
+        running_condition.cancel()
+        result = running_condition.check()
+        assert result is False
+        assert running_condition.is_cancelled()
+        assert running_condition.result is False
+
+    def test_check_cancelled_does_not_call_evaluator(
+        self, running_condition, mock_condition_manager
+    ):
+        running_condition.cancel()
+        running_condition.check()
+        mock_condition_manager.get_condition.assert_not_called()
+
+    def test_check_sets_result_on_success(self, running_condition):
+        running_condition.check()
+        assert running_condition.result is True
+
+    def test_check_sets_result_on_failure(
+        self, running_condition, mock_condition
+    ):
+        mock_condition.test.return_value = False
+        running_condition.check()
+        assert running_condition.result is False
 
 
-def test_check_condition_met(running_condition):
-    result = running_condition.check()
-    assert result is True
-    assert running_condition.is_met()
-    assert running_condition.result is True
+class TestRunningConditionCancel:
+    def test_cancel_sets_state(self, running_condition):
+        running_condition.cancel()
+        assert running_condition.state == ConditionState.CANCELLED
+
+    def test_is_cancelled_true_after_cancel(self, running_condition):
+        running_condition.cancel()
+        assert running_condition.is_cancelled()
+
+    def test_cancel_after_met_overrides_state(self, running_condition):
+        running_condition.check()
+        assert running_condition.is_met()
+        running_condition.cancel()
+        assert running_condition.is_cancelled()
 
 
-def test_check_condition_failed(running_condition, mock_condition):
-    mock_condition.test.return_value = False
-    result = running_condition.check()
-    assert result is False
-    assert running_condition.is_failed()
-    assert running_condition.result is False
+class TestRunningConditionFlags:
+    def test_is_met(self, running_condition):
+        running_condition.state = ConditionState.MET
+        assert running_condition.is_met()
+        assert not running_condition.is_failed()
+        assert not running_condition.is_cancelled()
+
+    def test_is_failed(self, running_condition):
+        running_condition.state = ConditionState.FAILED
+        assert running_condition.is_failed()
+        assert not running_condition.is_met()
+        assert not running_condition.is_cancelled()
+
+    def test_is_cancelled(self, running_condition):
+        running_condition.state = ConditionState.CANCELLED
+        assert running_condition.is_cancelled()
+        assert not running_condition.is_met()
+        assert not running_condition.is_failed()
 
 
-def test_check_condition_type_not_found(
-    running_condition, mock_condition_manager
-):
-    mock_condition_manager.get_condition.return_value = None
-    result = running_condition.check()
-    assert result is False
-    assert running_condition.is_failed()
-    assert running_condition.result is False
+class TestConditionEvaluator:
+    def test_evaluate_passes_when_expected(
+        self, evaluator, spatial_condition, mock_condition
+    ):
+        mock_condition.test.return_value = True
+        mock_condition.is_expected = True
+        assert evaluator.evaluate(spatial_condition) is True
 
+    def test_evaluate_fails_when_unexpected(
+        self, evaluator, spatial_condition, mock_condition
+    ):
+        mock_condition.test.return_value = True
+        mock_condition.is_expected = False
+        assert evaluator.evaluate(spatial_condition) is False
 
-def test_check_condition_exception(running_condition, mock_condition):
-    mock_condition.test.side_effect = Exception("Test error")
-    result = running_condition.check()
-    assert result is False
-    assert running_condition.is_failed()
-    assert running_condition.result is False
+    def test_evaluate_raises_when_condition_not_found(
+        self, evaluator, spatial_condition, mock_condition_manager
+    ):
+        mock_condition_manager.get_condition.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            evaluator.evaluate(spatial_condition)
 
+    def test_evaluate_clears_condition_box_on_success(
+        self, evaluator, spatial_condition, mock_session
+    ):
+        evaluator.evaluate(spatial_condition)
+        assert mock_session.current_condition_box is None
 
-def test_check_cancelled_condition(running_condition):
-    running_condition.cancel()
-    result = running_condition.check()
-    assert result is False
-    assert running_condition.is_cancelled()
-    assert running_condition.result is False
-
-
-def test_state_flag_helpers(running_condition):
-    running_condition.state = ConditionState.MET
-    assert running_condition.is_met()
-
-    running_condition.state = ConditionState.FAILED
-    assert running_condition.is_failed()
-
-    running_condition.state = ConditionState.CANCELLED
-    assert running_condition.is_cancelled()
+    def test_evaluate_clears_condition_box_on_exception(
+        self, evaluator, spatial_condition, mock_condition, mock_session
+    ):
+        mock_condition.test.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            evaluator.evaluate(spatial_condition)
+        assert mock_session.current_condition_box is None

--- a/tests/tuxemon/test_running_event.py
+++ b/tests/tuxemon/test_running_event.py
@@ -341,3 +341,118 @@ def test_running_event_reset(simple_event):
     assert running.elapsed_time == 0.0
     assert running.state == EventState.WAITING
     assert running.context == {}
+
+
+def test_advance_does_not_complete_prematurely(simple_event, expanded_actions):
+    event = RunningEvent(simple_event, expanded_actions)
+    event.running()
+    event.advance()
+    event.advance()
+    event.advance()
+    assert event.state == EventState.RUNNING
+    assert event.action_index == 3
+
+
+def test_get_next_action_returns_none_when_index_exhausted(
+    simple_event, expanded_actions
+):
+    event = RunningEvent(simple_event, expanded_actions)
+    event.action_index = len(expanded_actions)
+    assert event.get_next_action() is None
+    assert event.state != EventState.COMPLETED
+
+
+def test_step_returns_false_when_completed(simple_event, expanded_actions):
+    event = RunningEvent(simple_event, expanded_actions)
+    event.complete()
+    result = event.step(Mock(), Mock(), 0.1)
+    assert result is False
+
+
+def test_step_returns_false_when_cancelled(simple_event, expanded_actions):
+    event = RunningEvent(simple_event, expanded_actions)
+    event.cancel()
+    result = event.step(Mock(), Mock(), 0.1)
+    assert result is False
+
+
+def test_step_delegates_to_process_when_running(simple_event):
+    simple_event.delay = None
+    simple_event.timeout = None
+    running = RunningEvent(simple_event, [Mock()])
+    session = Mock()
+    action_manager = Mock()
+    long_action = Mock(done=False, cancelled=False)
+    action_manager.get_action.return_value = long_action
+    running.running()
+    result = running.step(session, action_manager, 0.1)
+    assert result is True
+
+
+def test_is_alive(simple_event, expanded_actions):
+    event = RunningEvent(simple_event, expanded_actions)
+    assert event.is_alive()
+    event.complete()
+    assert not event.is_alive()
+
+
+def test_is_alive_false_when_cancelled(simple_event, expanded_actions):
+    event = RunningEvent(simple_event, expanded_actions)
+    event.cancel()
+    assert not event.is_alive()
+
+
+def test_action_budget_yields_instead_of_spinning(simple_event):
+    simple_event.delay = None
+    simple_event.timeout = None
+
+    n = 5
+    rules = [Mock() for _ in range(n)]
+    running = RunningEvent(simple_event, rules)
+    session = Mock()
+    action_manager = Mock()
+
+    def self_cancelling(*args, **kwargs):
+        return Mock(done=False, cancelled=True)
+
+    action_manager.get_action.side_effect = self_cancelling
+
+    result = running.process(session, action_manager, 0.1)
+
+    assert result is False
+    assert running.state == EventState.COMPLETED
+    assert running.action_index == n
+
+
+def test_cancel_mid_sequence_continues_to_next_action(simple_event):
+    simple_event.delay = None
+    simple_event.timeout = None
+    rule1 = Mock()
+    rule2 = Mock()
+    running = RunningEvent(simple_event, [rule1, rule2])
+    session = Mock()
+    action_manager = Mock()
+
+    cancelled_action = Mock(done=False, cancelled=False)
+    long_action = Mock(done=False, cancelled=False)
+    action_manager.get_action.side_effect = [cancelled_action, long_action]
+
+    result = running.process(session, action_manager, 0.1)
+    assert result is True
+    assert running.current_action is cancelled_action
+
+    cancelled_action.cancelled = True
+
+    result = running.process(session, action_manager, 0.1)
+    assert result is True
+    assert running.current_action is long_action
+    assert running.state != EventState.COMPLETED
+
+
+def test_repr(simple_event, expanded_actions):
+    event = RunningEvent(simple_event, expanded_actions)
+    event.running()
+    r = repr(event)
+    assert "RunningEvent" in r
+    assert str(simple_event.id) in r
+    assert "RUNNING" in r

--- a/tuxemon/base_client.py
+++ b/tuxemon/base_client.py
@@ -335,6 +335,12 @@ class BaseClient(ABC):
         """
         return self.state_manager.get_queued_state_by_name(state_name)
 
+    def has_queued_state(self, state_name: str) -> bool:
+        return any(
+            s.name == state_name
+            for s in self.state_manager.state_queue.queued_states
+        )
+
     def queue_state(self, state_name: str, **kwargs: Any) -> None:
         """Queue a state"""
         self.state_manager.queue_state(state_name, **kwargs)

--- a/tuxemon/event/actions/access_pc.py
+++ b/tuxemon/event/actions/access_pc.py
@@ -60,6 +60,7 @@ class AccessPCAction(EventAction):
 
         character = self.session.get_npc(self.character_slug)
         if not character:
+            self.stop()
             return
 
         tag_list = [
@@ -85,7 +86,5 @@ class AccessPCAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("PCState")
-        except ValueError:
+        if "PCState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/add_combo.py
+++ b/tuxemon/event/actions/add_combo.py
@@ -83,9 +83,10 @@ class AddComboAction(EventAction):
 
                 def make_callback(
                     event_name: str | None,
+                    combo_name: str,
                 ) -> Callable[[], None]:
                     def callback() -> None:
-                        logger.info(f"Combo '{combo['name']}' triggered!")
+                        logger.info(f"Combo '{combo_name}' triggered!")
                         if event_name:
                             session.client.event_engine.execute_action(
                                 "call_event", [event_name]
@@ -96,7 +97,9 @@ class AddComboAction(EventAction):
                 profile = ComboProfile(
                     name=combo["name"],
                     buttons=button_sequence,
-                    callback=make_callback(combo.get("event_name")),
+                    callback=make_callback(
+                        combo.get("event_name"), combo["name"]
+                    ),
                     delays_s=delays_s,
                     description=combo.get(
                         "description",

--- a/tuxemon/event/actions/add_contacts.py
+++ b/tuxemon/event/actions/add_contacts.py
@@ -51,6 +51,7 @@ class AddContactsAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         if self.relation is not None:
@@ -60,6 +61,7 @@ class AddContactsAction(EventAction):
                 logger.error(
                     f"Add msgid 'relation_{self.relation}' in the 'en_US' base.po"
                 )
+                self.stop()
                 return
 
         if self.strength is not None:
@@ -83,4 +85,5 @@ class AddContactsAction(EventAction):
         else:
             contact.apply_decay(character.steps)
             logger.error(f"{self.npc_slug} already exist")
+            self.stop()
             return

--- a/tuxemon/event/actions/add_held_item.py
+++ b/tuxemon/event/actions/add_held_item.py
@@ -42,19 +42,23 @@ class AddHeldItemAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         held = monster.held_item
         if held is not None:
             logger.error(f"{monster.name} held already {held.name}")
+            self.stop()
             return
 
         item = Item.create(self.item)
         output = monster.equip_item(item)
         if not output:
+            self.stop()
             return

--- a/tuxemon/event/actions/add_item.py
+++ b/tuxemon/event/actions/add_item.py
@@ -64,6 +64,7 @@ class AddItemAction(EventAction):
             elif qty < 0:
                 bag.remove_item(existing, abs(qty))
             # qty == 0 → do nothing
+            self.stop()
             return
 
         # No existing item

--- a/tuxemon/event/actions/add_step_tracker.py
+++ b/tuxemon/event/actions/add_step_tracker.py
@@ -47,6 +47,7 @@ class AddStepTrackerAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         steps = round(character.steps)

--- a/tuxemon/event/actions/add_tech.py
+++ b/tuxemon/event/actions/add_tech.py
@@ -57,11 +57,13 @@ class AddTechAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         tech = Technique.create(self.technique)

--- a/tuxemon/event/actions/add_tracker.py
+++ b/tuxemon/event/actions/add_tracker.py
@@ -45,10 +45,12 @@ class AddTrackerAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         if not T.has_translation("en_US", f"{self.location.lower()}"):
             logger.error(f"Add msgid '{self.location}' in the 'en_US' base.po")
+            self.stop()
             return
 
         visited = True if self.visited is None else parse_flag(self.visited)

--- a/tuxemon/event/actions/adjust_bill_penalty.py
+++ b/tuxemon/event/actions/adjust_bill_penalty.py
@@ -42,6 +42,7 @@ class AdjustBillPenaltyAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"Character '{self.character}' not found")
+            self.stop()
             return
 
         money_manager = character.money_controller.money_manager
@@ -51,6 +52,7 @@ class AdjustBillPenaltyAction(EventAction):
             logger.error(
                 f"Bill '{self.bill_slug}' not found for character '{self.character}'"
             )
+            self.stop()
             return
 
         try:
@@ -64,12 +66,14 @@ class AdjustBillPenaltyAction(EventAction):
                 logger.error(
                     f"Invalid method '{self.method}': must be 'interest' or 'fee'"
                 )
+                self.stop()
                 return
         except Exception as e:
             logger.error(
                 f"Failed to apply {self.method} to bill '{self.bill_slug}' "
                 f"for '{self.character}': {e}"
             )
+            self.stop()
             return
 
         updated_bill = money_manager.get_bill(self.bill_slug)

--- a/tuxemon/event/actions/afk_threshold.py
+++ b/tuxemon/event/actions/afk_threshold.py
@@ -41,6 +41,7 @@ class AFKThresholdAction(EventAction):
         if self.action == "add":
             if self.duration is None:
                 logger.error("Add threshold requires a duration")
+                self.stop()
                 return
             afk.add_threshold(self.level, self.duration)
             logger.info(
@@ -53,6 +54,7 @@ class AFKThresholdAction(EventAction):
         elif self.action == "modify":
             if self.duration is None:
                 logger.error("Modify threshold requires a duration")
+                self.stop()
                 return
             success = afk.modify_threshold(self.level, self.duration)
             if success:

--- a/tuxemon/event/actions/boundary_move.py
+++ b/tuxemon/event/actions/boundary_move.py
@@ -41,6 +41,7 @@ class BoundaryMoveAction(EventAction):
             logger.error(
                 f"Boundary '{self.boundary_name}' not found. Cannot move."
             )
+            self.stop()
             return
 
         parts = self.values.split(":")
@@ -48,6 +49,7 @@ class BoundaryMoveAction(EventAction):
             logger.warning(
                 f"BoundaryMoveAction requires 2 values (dx:dy), got {len(parts)}."
             )
+            self.stop()
             return
 
         try:
@@ -56,6 +58,7 @@ class BoundaryMoveAction(EventAction):
             logger.warning(
                 f"Invalid numeric values in boundary_move: {self.values}"
             )
+            self.stop()
             return
 
         try:

--- a/tuxemon/event/actions/boundary_resize.py
+++ b/tuxemon/event/actions/boundary_resize.py
@@ -44,6 +44,7 @@ class BoundaryResizeAction(EventAction):
             logger.error(
                 f"Boundary '{self.boundary_name}' not found. Cannot move."
             )
+            self.stop()
             return
 
         parts = self.values.split(":")
@@ -53,6 +54,7 @@ class BoundaryResizeAction(EventAction):
             logger.warning(
                 f"Invalid numeric values in boundary_resize: {self.values}"
             )
+            self.stop()
             return
 
         if isinstance(boundary, RectangularBoundary):

--- a/tuxemon/event/actions/boundary_set.py
+++ b/tuxemon/event/actions/boundary_set.py
@@ -44,12 +44,14 @@ class BoundarySetAction(EventAction):
         if not self.shape and not self.values:
             checker.reset_to_default()
             logger.debug("Boundary reset to default.")
+            self.stop()
             return
 
         if not self.shape or not self.values:
             logger.warning(
                 "BoundarySetAction requires both shape and values, or neither."
             )
+            self.stop()
             return
 
         parts = self.values.split(":")
@@ -59,6 +61,7 @@ class BoundarySetAction(EventAction):
             logger.warning(
                 f"Invalid numeric values in boundary_set: {self.values}"
             )
+            self.stop()
             return
 
         if self.shape == "rectangle" and len(nums) == 4:

--- a/tuxemon/event/actions/breeding.py
+++ b/tuxemon/event/actions/breeding.py
@@ -40,6 +40,7 @@ class BreedingAction(EventAction):
     def set_var(self, menu_item: MenuItem[Monster | None]) -> None:
         monster = menu_item.game_object
         if monster is None:
+            self.stop()
             return
 
         parent = (
@@ -54,6 +55,7 @@ class BreedingAction(EventAction):
 
         if not char:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         self.char = char
@@ -82,7 +84,5 @@ class BreedingAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("MonsterMenuState")
-        except ValueError:
+        if "MonsterMenuState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/camera_manage.py
+++ b/tuxemon/event/actions/camera_manage.py
@@ -48,6 +48,7 @@ class CameraManageAction(EventAction):
                 logger.error(
                     f"Cannot add camera '{self.camera_name}': NPC '{self.npc_slug}' not found."
                 )
+                self.stop()
                 return
             camera = Camera(
                 entity, session.client.boundary, session.client.context
@@ -70,6 +71,7 @@ class CameraManageAction(EventAction):
             follow = manager.cameras.get(self.camera_name)
             if not follow:
                 logger.error(f"Camera '{self.camera_name}' not found.")
+                self.stop()
                 return
             entity = session.get_npc(self.npc_slug or "player")
             if entity is None:

--- a/tuxemon/event/actions/camera_mode.py
+++ b/tuxemon/event/actions/camera_mode.py
@@ -40,6 +40,7 @@ class CameraModeAction(EventAction):
         camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
+            self.stop()
             return
         mode = CameraMode(self.mode)
         if mode == CameraMode.FREE_ROAMING:

--- a/tuxemon/event/actions/camera_move.py
+++ b/tuxemon/event/actions/camera_move.py
@@ -38,6 +38,7 @@ class CameraMoveAction(EventAction):
         self.camera = session.client.camera_manager.get_active_camera()
         if self.camera is None:
             logger.error("No active camera found.")
+            self.stop()
             return
         if self.x is not None and self.y is not None:
             if not session.client.boundary.is_within_boundaries(
@@ -47,6 +48,7 @@ class CameraMoveAction(EventAction):
                 logger.error(
                     f"({self.x, self.y}) is outside the map bounds {map_size}"
                 )
+                self.stop()
                 return
             self._move_camera(self.camera, self.x, self.y)
         else:

--- a/tuxemon/event/actions/camera_position.py
+++ b/tuxemon/event/actions/camera_position.py
@@ -36,6 +36,7 @@ class CameraPositionAction(EventAction):
         camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
+            self.stop()
             return
         if self.x is not None and self.y is not None:
             map_size = session.client.map_manager.map_size
@@ -45,6 +46,7 @@ class CameraPositionAction(EventAction):
                 logger.error(
                     f"({self.x, self.y}) is outside the map bounds {map_size}"
                 )
+                self.stop()
                 return
             self._move_camera(camera, self.x, self.y)
         else:

--- a/tuxemon/event/actions/camera_shake.py
+++ b/tuxemon/event/actions/camera_shake.py
@@ -46,6 +46,7 @@ class CameraShakeAction(EventAction):
         camera = session.client.camera_manager.get_active_camera()
         if camera is None:
             logger.error("No active camera found.")
+            self.stop()
             return
         camera.shake(self.intensity, self.duration)
         logger.info("Camera is shaking!")

--- a/tuxemon/event/actions/change_bg.py
+++ b/tuxemon/event/actions/change_bg.py
@@ -63,6 +63,7 @@ class ChangeBgAction(EventAction):
         if self.image and self.category:
             if self.category not in CATEGORIES:
                 logger.error(f"{self.category} must be among {CATEGORIES}")
+                self.stop()
                 return
             if self.category == "image":
                 self.image = CATEGORY_PATHS[self.category].format(self.image)
@@ -72,12 +73,14 @@ class ChangeBgAction(EventAction):
                 logger.error(
                     f"Image {self.image} not found in category {self.category}"
                 )
+                self.stop()
                 return
 
         if client.current_state.name != "ImageState":
             if self.background is None:
                 if client.has_extra_states():
                     client.pop_state()
+                    self.stop()
                     return
             else:
                 _background = self.background.split(":")

--- a/tuxemon/event/actions/change_faction_membership.py
+++ b/tuxemon/event/actions/change_faction_membership.py
@@ -41,6 +41,7 @@ class ChangeFactionMembershipAction(EventAction):
         char = session.get_npc(self.character)
         if not char:
             logger.error(f"[Membership] NPC '{self.character}' not found.")
+            self.stop()
             return
 
         faction_manager = session.world.faction_manager
@@ -49,6 +50,7 @@ class ChangeFactionMembershipAction(EventAction):
             logger.error(
                 f"[Membership] Faction '{self.faction_slug}' not found."
             )
+            self.stop()
             return
 
         if self.status == "join":

--- a/tuxemon/event/actions/change_state.py
+++ b/tuxemon/event/actions/change_state.py
@@ -44,12 +44,11 @@ class ChangeStateAction(EventAction):
             logger.error(
                 f"The state '{self.state_name}' is already active. No action taken."
             )
+            self.stop()
             return
 
         self.client.push_state(self.state_name)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name(self.state_name)
-        except ValueError:
+        if self.state_name not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/change_taste.py
+++ b/tuxemon/event/actions/change_taste.py
@@ -52,15 +52,18 @@ class ChangeTasteAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         if self.new_taste == "tasteless":
             logger.error("Cannot assign 'tasteless' explicitly.")
+            self.stop()
             return
 
         if self.type_taste not in ("warm", "cold"):
@@ -80,11 +83,13 @@ class ChangeTasteAction(EventAction):
                 logger.warning(
                     f"No alternate {self.type_taste} taste found for {monster.name}."
                 )
+                self.stop()
                 return
         else:
             taste_obj = Taste.get(self.new_taste)
             if not taste_obj:
                 logger.error(f"Taste '{self.new_taste}' not found.")
+                self.stop()
                 return
 
             if taste_obj.taste_type != self.type_taste:
@@ -92,6 +97,7 @@ class ChangeTasteAction(EventAction):
                     f"Taste '{self.new_taste}' is of type '{taste_obj.taste_type}', "
                     f"expected '{self.type_taste}'."
                 )
+                self.stop()
                 return
 
             new_taste = self.new_taste

--- a/tuxemon/event/actions/char_face.py
+++ b/tuxemon/event/actions/char_face.py
@@ -39,6 +39,7 @@ class CharFaceAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         # "player" isn't among the Directions (map_loader.py)
@@ -46,6 +47,7 @@ class CharFaceAction(EventAction):
             target = session.get_npc(self.direction)
             if target is None:
                 logger.error(f"{self.direction} not found")
+                self.stop()
                 return
             direction = get_direction(character.tile_pos, target.tile_pos)
         else:

--- a/tuxemon/event/actions/char_face_char.py
+++ b/tuxemon/event/actions/char_face_char.py
@@ -38,6 +38,7 @@ class CharFaceCharAction(EventAction):
 
     def update(self, session: Session, dt: float) -> None:
         if not self.npc or not self.target_char:
+            self.stop()
             return
 
         dist = tile_distance(self.npc.tile_pos, self.target_char.tile_pos)

--- a/tuxemon/event/actions/char_look.py
+++ b/tuxemon/event/actions/char_look.py
@@ -51,6 +51,7 @@ class CharLookAction(EventAction):
 
         if not character:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         self.limit_direction: list[Direction] = []
@@ -65,6 +66,7 @@ class CharLookAction(EventAction):
                 state_name in ("WorldMenuState", "DialogState", "ChoiceState")
                 for state_name in session.client.active_state_names
             ):
+                self.stop()
                 return
 
             # Choose a random direction

--- a/tuxemon/event/actions/char_move.py
+++ b/tuxemon/event/actions/char_move.py
@@ -50,6 +50,7 @@ class CharMoveAction(EventAction):
     def start(self, session: Session) -> None:
         if len(self.raw_parameters) < 2:
             logger.error("Insufficient parameters")
+            self.stop()
             return
 
         character_name = self.raw_parameters[0]
@@ -57,6 +58,7 @@ class CharMoveAction(EventAction):
 
         if self.character is None:
             logger.error(f"Character '{character_name}' not found")
+            self.stop()
             return
 
         path_parameters = self.raw_parameters[1:]
@@ -68,6 +70,7 @@ class CharMoveAction(EventAction):
             logger.error(
                 f"Failed to parse path parameters due to invalid input: {e}"
             )
+            self.stop()
             return
 
         if path:

--- a/tuxemon/event/actions/char_patrol.py
+++ b/tuxemon/event/actions/char_patrol.py
@@ -54,6 +54,7 @@ class CharPatrolAction(EventAction):
             logger.error(
                 "Insufficient parameters: requires NPC and patrol path"
             )
+            self.stop()
             return
 
         npc_name = self.raw_parameters[0]
@@ -62,12 +63,14 @@ class CharPatrolAction(EventAction):
 
         if not npc:
             logger.error(f"NPC '{npc_name}' not found")
+            self.stop()
             return
 
         try:
             route = list(parse_path_parameters(npc.tile_pos, move_list))
         except Exception as e:
             logger.error(f"Failed to parse patrol path: {e}")
+            self.stop()
             return
 
         # Assign PatrolBehavior

--- a/tuxemon/event/actions/char_plague.py
+++ b/tuxemon/event/actions/char_plague.py
@@ -49,6 +49,7 @@ class CharPlagueAction(EventAction):
 
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         enforce = parse_flag(self.enforced_check)

--- a/tuxemon/event/actions/char_position.py
+++ b/tuxemon/event/actions/char_position.py
@@ -36,6 +36,7 @@ class CharPositionAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         position = (self.tile_pos_x, self.tile_pos_y)

--- a/tuxemon/event/actions/char_run.py
+++ b/tuxemon/event/actions/char_run.py
@@ -34,5 +34,6 @@ class CharRunAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         character.mover.running()

--- a/tuxemon/event/actions/char_speed.py
+++ b/tuxemon/event/actions/char_speed.py
@@ -37,6 +37,7 @@ class CharSpeedAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         if MOVERATE_RANGE[0] < self.speed < MOVERATE_RANGE[1]:
             logger.info(f"{character.name}'s moverate is {self.speed}")

--- a/tuxemon/event/actions/char_stop.py
+++ b/tuxemon/event/actions/char_stop.py
@@ -34,5 +34,6 @@ class CharStopAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         session.client.movement_manager.stop_char(character)

--- a/tuxemon/event/actions/char_talk.py
+++ b/tuxemon/event/actions/char_talk.py
@@ -62,6 +62,7 @@ class CharTalkAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         dialogue = DialogueProfileManager()
@@ -72,13 +73,12 @@ class CharTalkAction(EventAction):
 
         if line is None:
             logger.error(f"{self.character} line {self.field} doesn't exist.")
+            self.stop()
             return
 
         text = TextFormatter.replace_text(session, line, T)
         open_dialog(client=session.client, text=[T.translate(text)])
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("DialogState")
-        except ValueError:
+        if "DialogState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/char_walk.py
+++ b/tuxemon/event/actions/char_walk.py
@@ -34,5 +34,6 @@ class CharWalkAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         character.mover.walking()

--- a/tuxemon/event/actions/char_wander.py
+++ b/tuxemon/event/actions/char_wander.py
@@ -50,6 +50,7 @@ class CharWanderAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         # Compute bounds if provided

--- a/tuxemon/event/actions/choice_item.py
+++ b/tuxemon/event/actions/choice_item.py
@@ -63,7 +63,5 @@ class ChoiceItemAction(EventAction):
         session.client.push_state("ChoiceItem", menu=MenuOptions(options))
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("ChoiceItem")
-        except ValueError:
+        if "ChoiceItem" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/choice_monster.py
+++ b/tuxemon/event/actions/choice_monster.py
@@ -63,7 +63,5 @@ class ChoiceMonsterAction(EventAction):
         session.client.push_state("ChoiceMonster", menu=MenuOptions(options))
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("ChoiceMonster")
-        except ValueError:
+        if "ChoiceMonster" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/choice_npc.py
+++ b/tuxemon/event/actions/choice_npc.py
@@ -63,7 +63,5 @@ class ChoiceNpcAction(EventAction):
         session.client.push_state("ChoiceNpc", menu=MenuOptions(options))
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("ChoiceNpc")
-        except ValueError:
+        if "ChoiceNpc" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/cipher_dialog.py
+++ b/tuxemon/event/actions/cipher_dialog.py
@@ -114,9 +114,7 @@ class CipherDialogAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("DialogState")
-        except ValueError:
+        if "DialogState" not in session.client.active_state_names:
             self.stop()
 
 

--- a/tuxemon/event/actions/clear_kennel.py
+++ b/tuxemon/event/actions/clear_kennel.py
@@ -46,6 +46,7 @@ class ClearKennelAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         kennel = self.kennel
@@ -63,4 +64,5 @@ class ClearKennelAction(EventAction):
                     character.monster_boxes.merge_boxes(kennel, transfer)
                     character.monster_boxes.remove_box(kennel)
             else:
+                self.stop()
                 return

--- a/tuxemon/event/actions/crafting_station.py
+++ b/tuxemon/event/actions/crafting_station.py
@@ -45,6 +45,7 @@ class CraftingStationAction(EventAction):
             logger.error(
                 f"The state 'CraftMenuState' is already active. No action taken."
             )
+            self.stop()
             return
 
         character = session.get_npc(self.character_slug)
@@ -52,6 +53,7 @@ class CraftingStationAction(EventAction):
             logger.error(
                 f"Character '{self.character_slug}' not found for CraftMenuState."
             )
+            self.stop()
             return
 
         file_yaml = self.file_yaml or "recipes.yaml"
@@ -63,7 +65,5 @@ class CraftingStationAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("CraftMenuState")
-        except ValueError:
+        if "CraftMenuState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/create_kennel.py
+++ b/tuxemon/event/actions/create_kennel.py
@@ -54,6 +54,7 @@ class CreateKennelAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         if not character.monster_boxes.has_box(self.kennel, "monster"):

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -56,6 +56,7 @@ class CreateNpcAction(EventAction):
         slug = self.npc_slug
 
         if session.client.npc_manager.npc_exists(slug):
+            self.stop()
             return
 
         npc = NPC.create(session, slug)

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -63,17 +63,20 @@ class DojoMethodAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable_name}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.debug(f"Monster {monster_id} not found.")
+            self.stop()
             return
 
         self.monster = monster
 
         if self.option not in ["monster", "technique"]:
             logger.error(f"{self.option} must be 'monster' or 'technique'")
+            self.stop()
             return
 
         if self.option == "technique":
@@ -86,6 +89,7 @@ class DojoMethodAction(EventAction):
 
             if not learnable_moves:
                 session.player.game_variables.set("dojo_notech", "on")
+                self.stop()
                 return
 
             forget = session.client.push_state(
@@ -121,9 +125,7 @@ class DojoMethodAction(EventAction):
             open_choice_dialog(session.client, MenuOptions(menu_options))
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("DialogState")
-        except ValueError:
+        if "DialogState" not in session.client.active_state_names:
             self.stop()
 
     def devolve(self, slug: str) -> None:
@@ -156,6 +158,7 @@ class DojoMethodAction(EventAction):
         ]
         if not learnable_moves:
             self.player.game_variables.set("dojo_notech", "on")
+            self.stop()
             return
 
         if len(learnable_moves) == 1:
@@ -165,6 +168,7 @@ class DojoMethodAction(EventAction):
             )
             logger.info(f"{tech.name} learned!")
             self.client.sound_manager.play_sound("sound_confirm")
+            self.stop()
             return
 
         relearn = self.client.push_state(

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -47,11 +47,13 @@ class EvolutionAction(EventAction):
 
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         self.char = character
 
         if self.client.has_extra_states():
+            self.stop()
             return
 
         self._pending_map: dict[UUID, str] = {}
@@ -70,18 +72,21 @@ class EvolutionAction(EventAction):
         monster_id = get_valid_uuid(self.char.game_variables, variable)
         if monster_id is None:
             logger.info(f"No valid monster selected for variable '{variable}'")
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = self.client.get_monster_by_iid(monster_id)
 
         if monster is None:
             logger.error(f"Monster '{monster_id}' doesn't exist.")
+            self.stop()
             return
 
         if not monster.evolution_handler.is_valid_evolution_target(evolution):
             logger.error(
                 f"Monster '{evolution}' isn't in the evolutionary path."
             )
+            self.stop()
             return
 
         evolved = Monster.spawn_base(evolution, monster.level)
@@ -94,6 +99,7 @@ class EvolutionAction(EventAction):
         """Process pending evolutions for the character."""
         candidates = [m for m in self.char.monsters if m.waiting_to_evolve]
         if not candidates:
+            self.stop()
             return
 
         monster = candidates[0]
@@ -102,6 +108,7 @@ class EvolutionAction(EventAction):
 
         if not slug:
             monster.waiting_to_evolve = False
+            self.stop()
             return
 
         registry = self.char.evolution_registry
@@ -118,7 +125,5 @@ class EvolutionAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("EvolutionState")
-        except ValueError:
+        if "EvolutionState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/format_variable.py
+++ b/tuxemon/event/actions/format_variable.py
@@ -42,6 +42,7 @@ class FormatVariableAction(EventAction):
         value = player.game_variables.get(key, None)
         if value is None:
             logger.error(f"Game variable {key} doesn't exist")
+            self.stop()
             return
         _formats = ["int", "float", "-int", "-float"]
         if type_format not in _formats:

--- a/tuxemon/event/actions/get_pending_moves.py
+++ b/tuxemon/event/actions/get_pending_moves.py
@@ -72,6 +72,7 @@ class GetPendingMovesAction(EventAction):
         )
         if not monsters:
             logger.warning("No monsters found in event_data['check_max_tech']")
+            self.stop()
             return
 
         for mon in monsters:
@@ -90,7 +91,5 @@ class GetPendingMovesAction(EventAction):
         session.client.event_data.pop("check_max_tech", None)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("TechniqueMenuState")
-        except ValueError:
+        if "TechniqueMenuState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/get_player_monster.py
+++ b/tuxemon/event/actions/get_player_monster.py
@@ -166,14 +166,10 @@ class GetPlayerMonsterAction(EventAction):
             menu.escape_key_exits = False
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("MonsterMenuState")
-        except ValueError:
+        if "MonsterMenuState" not in session.client.active_state_names:
             player = session.player
             if self.result and not self.choose:
-                # the player can choose, but returns
                 player.game_variables.set(self.variable_name, "no_choice")
             if not self.result:
-                # the player can't choose (eg no females in the party)
                 player.game_variables.set(self.variable_name, "no_options")
             self.stop()

--- a/tuxemon/event/actions/give_experience.py
+++ b/tuxemon/event/actions/give_experience.py
@@ -61,6 +61,7 @@ class GiveExperienceAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
 
             monster = session.client.get_monster_by_iid(monster_id)
@@ -68,10 +69,12 @@ class GiveExperienceAction(EventAction):
                 monster = player.monster_boxes.get_monsters_by_iid(monster_id)
                 if monster is None:
                     logger.error("Monster not found")
+                    self.stop()
                     return
             monsters = [monster]
 
         if not monsters:
+            self.stop()
             return
 
         for mon in monsters:
@@ -91,7 +94,5 @@ class GiveExperienceAction(EventAction):
     def update(self, session: Session, dt: float) -> None:
         trigger_ui = parse_flag(self.trigger_ui)
         if trigger_ui:
-            try:
-                session.client.get_state_by_name("LevelUpSummaryState")
-            except ValueError:
+            if "LevelUpSummaryState" not in session.client.active_state_names:
                 self.stop()

--- a/tuxemon/event/actions/info.py
+++ b/tuxemon/event/actions/info.py
@@ -57,17 +57,20 @@ class InfoAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             monster = player.monster_boxes.get_monsters_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
 
         character = session.client.get_monster_owner(monster)
         if character is None:
             logger.error(f"{monster.name}'s owner not found")
+            self.stop()
             return
 
         attr = None

--- a/tuxemon/event/actions/input_variable.py
+++ b/tuxemon/event/actions/input_variable.py
@@ -72,7 +72,5 @@ class InputVariableAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("InputMenu")
-        except ValueError:
+        if "InputMenu" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/learn_tech_by_method.py
+++ b/tuxemon/event/actions/learn_tech_by_method.py
@@ -48,18 +48,21 @@ class LearnTechByMethodAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.monster_var}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = session.client.get_monster_by_iid(monster_id)
 
         if monster is None:
             logger.error(f"Monster with ID '{monster_id}' not found")
+            self.stop()
             return
 
         try:
             method_enum = LearningMethod[self.method.upper()]
         except KeyError:
             logger.error(f"Invalid learning method: {self.method}")
+            self.stop()
             return
 
         technique_obj = monster.moves.learn_by_method(

--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -49,6 +49,7 @@ class LoadGameAction(EventAction):
 
         save_data = SaveManager.load(slot)
         if not save_data:
+            self.stop()
             return
 
         try:
@@ -63,6 +64,7 @@ class LoadGameAction(EventAction):
         npc_state = save_data.npc_state
         if npc_state is None:
             logger.error("Save data missing NPC state.")
+            self.stop()
             return
 
         slug = npc_state.player_slug or PLAYER_NPC
@@ -71,6 +73,7 @@ class LoadGameAction(EventAction):
 
         if npc_state.current_map is None:
             logger.error("Save data missing current map.")
+            self.stop()
             return
 
         map_path = fetch_asset("maps", npc_state.current_map)
@@ -80,6 +83,7 @@ class LoadGameAction(EventAction):
 
         if npc_state.tile_pos is None:
             logger.error("Save data missing tile position.")
+            self.stop()
             return
 
         tele_x, tele_y = npc_state.tile_pos

--- a/tuxemon/event/actions/menu.py
+++ b/tuxemon/event/actions/menu.py
@@ -48,6 +48,7 @@ class MenuAction(EventAction):
             flags.reset_flags()
             flags.apply_preset("raw")
             session.world.menu_manager.update_menu_display()
+            self.stop()
             return
 
         if self.act in presets:

--- a/tuxemon/event/actions/modify_bill.py
+++ b/tuxemon/event/actions/modify_bill.py
@@ -45,6 +45,7 @@ class ModifyBillAction(EventAction):
 
         if character is None:
             logger.error(f"Character '{self.character}' not found")
+            self.stop()
             return
 
         player = session.player
@@ -61,6 +62,7 @@ class ModifyBillAction(EventAction):
                     bill = money_manager.get_bill(self.bill_slug)
                     if bill is None:
                         logger.error(f"Bill '{self.bill_slug}' not found")
+                        self.stop()
                         return
                     amount = int(bill.amount * raw_value)
 
@@ -84,6 +86,7 @@ class ModifyBillAction(EventAction):
                 money_manager.remove_bill(self.bill_slug, -amount)
         except KeyError as e:
             logger.error(str(e))
+            self.stop()
             return
 
         bill = money_manager.get_bill(self.bill_slug)

--- a/tuxemon/event/actions/modify_char_attribute.py
+++ b/tuxemon/event/actions/modify_char_attribute.py
@@ -42,6 +42,7 @@ class ModifyCharAttributeAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         CommonAction.modify_entity_attribute(
             character, self.attribute, self.value

--- a/tuxemon/event/actions/modify_contacts.py
+++ b/tuxemon/event/actions/modify_contacts.py
@@ -40,11 +40,13 @@ class ModifyContactsAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         contact = character.relationships.get_connection(self.npc_slug)
         if contact is None:
             logger.error(f"Contact '{self.npc_slug}' does not exist")
+            self.stop()
             return
 
         session.client.event_bus.publish(

--- a/tuxemon/event/actions/modify_faction_reputation.py
+++ b/tuxemon/event/actions/modify_faction_reputation.py
@@ -39,6 +39,7 @@ class ModifyFactionReputationAction(EventAction):
         char = session.get_npc(self.character)
         if not char:
             logger.error(f"[Reputation] NPC '{self.character}' not found.")
+            self.stop()
             return
 
         faction_manager = session.world.faction_manager
@@ -47,6 +48,7 @@ class ModifyFactionReputationAction(EventAction):
             logger.error(
                 f"[Reputation] Faction '{self.faction_slug}' not found."
             )
+            self.stop()
             return
 
         faction.modify_reputation(char.slug, self.amount)

--- a/tuxemon/event/actions/modify_money.py
+++ b/tuxemon/event/actions/modify_money.py
@@ -42,6 +42,7 @@ class ModifyMoneyAction(EventAction):
 
         if character is None:
             logger.error(f"Character '{self.character}' not found")
+            self.stop()
             return
 
         player = session.player

--- a/tuxemon/event/actions/modify_monster_bond.py
+++ b/tuxemon/event/actions/modify_monster_bond.py
@@ -48,6 +48,7 @@ class ModifyMonsterBondAction(EventAction):
     def start(self, session: Session) -> None:
         player = session.player
         if not player.monsters:
+            self.stop()
             return
 
         amount_bond = self.amount if self.amount else 1
@@ -67,10 +68,12 @@ class ModifyMonsterBondAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
             monster = session.client.get_monster_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
             else:
                 monster.bond_handler.change_bond(amount_bond)

--- a/tuxemon/event/actions/modify_monster_health.py
+++ b/tuxemon/event/actions/modify_monster_health.py
@@ -41,6 +41,7 @@ class ModifyMonsterHealthAction(EventAction):
     def start(self, session: Session) -> None:
         player = session.player
         if not player.monsters:
+            self.stop()
             return
 
         monster_health = 1.0 if self.health is None else self.health
@@ -56,10 +57,12 @@ class ModifyMonsterHealthAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
             monster = session.client.get_monster_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
             set_health(monster, monster_health, True)
             if monster.is_fainted:

--- a/tuxemon/event/actions/modify_monster_stats.py
+++ b/tuxemon/event/actions/modify_monster_stats.py
@@ -55,6 +55,7 @@ class ModifyMonsterStatsAction(EventAction):
     def start(self, session: Session) -> None:
         player = session.player
         if not player.monsters:
+            self.stop()
             return
         if self.stat and self.stat not in list(StatType):
             raise ValueError(f"{self.stat} isn't among {list(StatType)}")
@@ -85,10 +86,12 @@ class ModifyMonsterStatsAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
             monster = session.client.get_monster_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
 
             for stat in monster_stats:

--- a/tuxemon/event/actions/open_journal.py
+++ b/tuxemon/event/actions/open_journal.py
@@ -47,6 +47,7 @@ class OpenJournalAction(EventAction):
             logger.error(
                 f"The state 'JournalInfoState' is already active. No action taken."
             )
+            self.stop()
             return
 
         journal = MonsterModel.lookup(self.monster_slug, db)
@@ -54,6 +55,7 @@ class OpenJournalAction(EventAction):
             logger.error(
                 f"Monster with slug '{self.monster_slug}' not found for JournalInfoState."
             )
+            self.stop()
             return
 
         self.client.push_state(
@@ -65,7 +67,5 @@ class OpenJournalAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("JournalInfoState")
-        except ValueError:
+        if "JournalInfoState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/open_shop.py
+++ b/tuxemon/event/actions/open_shop.py
@@ -66,6 +66,7 @@ class OpenShopAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"NPC '{self.npc_slug}' not found.")
+            self.stop()
             return
 
         # Only item/monster shops require an economy
@@ -95,6 +96,7 @@ class OpenShopAction(EventAction):
                 npc=character,
                 mode="item",
             )
+            self.stop()
             return
 
         if self.menu == "both_monster":
@@ -104,6 +106,7 @@ class OpenShopAction(EventAction):
                 npc=character,
                 mode="monster",
             )
+            self.stop()
             return
 
         if self.menu == "buy_item":

--- a/tuxemon/event/actions/overwrite_tech.py
+++ b/tuxemon/event/actions/overwrite_tech.py
@@ -51,12 +51,14 @@ class OverwriteTechAction(EventAction):
             logger.error(
                 f"{removed.slug} not found in current moves of {monster.name}"
             )
+            self.stop()
             return
 
         if monster.moves.has_move(self.added):
             logger.warning(
                 f"{monster.name} already knows {self.added}. Overwrite skipped."
             )
+            self.stop()
             return
 
         added_tech = Technique.create(self.added)
@@ -72,6 +74,7 @@ class OverwriteTechAction(EventAction):
             logger.info(
                 f"No valid tech selected for variable '{self.removed}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         for monster in player.monsters:

--- a/tuxemon/event/actions/park_experience.py
+++ b/tuxemon/event/actions/park_experience.py
@@ -50,10 +50,7 @@ class ParkExperienceAction(EventAction):
 
     def update(self, session: Session, dt: float) -> None:
         if self.option == "stop":
-            try:
-                session.client.get_state_by_name("ParkState")
-            except ValueError:
-                session.client.park_session.reset_session()
+            if "ParkState" not in session.client.active_state_names:
                 self.stop()
         else:
             self.stop()

--- a/tuxemon/event/actions/pathfind_to_char.py
+++ b/tuxemon/event/actions/pathfind_to_char.py
@@ -77,6 +77,7 @@ class PathfindToCharAction(EventAction):
                 self.moving_entity.tile_pos, final_destination
             )
             self.moving_entity.set_facing(direction)
+            self.stop()
             return
 
         self.moving_entity.pathfind(final_destination)

--- a/tuxemon/event/actions/play_map_animation.py
+++ b/tuxemon/event/actions/play_map_animation.py
@@ -46,6 +46,7 @@ class PlayMapAnimationAction(EventAction):
 
         if character is None:
             logger.error(f"Character '{self.character}' not found")
+            self.stop()
             return
 
         if self.loop == "loop":

--- a/tuxemon/event/actions/quarantine.py
+++ b/tuxemon/event/actions/quarantine.py
@@ -76,6 +76,7 @@ class QuarantineAction(EventAction):
 
         if not boxes.has_box(self.name, "monster"):
             logger.info(f"Box {self.name} does not exist")
+            self.stop()
             return
 
         box_monsters = [
@@ -86,6 +87,7 @@ class QuarantineAction(EventAction):
 
         if not box_monsters:
             logger.info(f"Box {self.name} is empty")
+            self.stop()
             return
 
         if self.amount is None or self.amount >= len(box_monsters):
@@ -107,6 +109,7 @@ class QuarantineAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         if self.action_type == "in":

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -85,6 +85,7 @@ class RandomBattleAction(EventAction):
         npc = session.get_npc(self.opponent.slug)
         if npc is None:
             logger.error(f"{self.opponent.slug} not found after creation.")
+            self.stop()
             return
 
         monster_filters = list(lookup_cache_mon.values())
@@ -105,6 +106,7 @@ class RandomBattleAction(EventAction):
         player = session.player
         if not (check_battle_legal(player) and check_battle_legal(npc)):
             logger.warning("Battle is not legal, won't start.")
+            self.stop()
             return
 
         environment = session.client.environment_manager
@@ -113,6 +115,7 @@ class RandomBattleAction(EventAction):
             logger.error(
                 "No environment defined. Use 'set_environment' before starting combat."
             )
+            self.stop()
             return
 
         logger.info(f"Starting battle with '{npc.name}'!")
@@ -128,9 +131,11 @@ class RandomBattleAction(EventAction):
             session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("CombatState")
-        except ValueError:
+        client = session.client
+        if (
+            "CombatState" not in client.active_state_names
+            and not client.has_queued_state("CombatState")
+        ):
             self.stop()
 
     def cleanup(self, session: Session) -> None:

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -59,19 +59,23 @@ class RandomEncounterAction(EventAction):
 
         if not check_battle_legal(player):
             logger.error("Battle is not legal, won't start")
+            self.stop()
             return
 
         if check_repellent(player):
             logger.info(f"Repellent active, skipping encounter.")
+            self.stop()
             return
 
         if not encounter.load_zone(self.encounter_slug):
+            self.stop()
             return
 
         total_prob = self.total_prob if self.total_prob else 1.0
         results = encounter.attempt_single_encounter(player, total_prob)
 
         if results is None:
+            self.stop()
             return
 
         logger.info("Starting random encounter!")
@@ -85,6 +89,7 @@ class RandomEncounterAction(EventAction):
             item = Item.create(results.held_item)
             output = current_monster.equip_item(item)
             if not output:
+                self.stop()
                 return
 
         current_monster.wild = True
@@ -97,6 +102,7 @@ class RandomEncounterAction(EventAction):
         npc = session.get_npc("wild_encounter")
         if npc is None:
             logger.error("'wild_encounter' not found")
+            self.stop()
             return
 
         npc.party.insert_monster_to_party(current_monster, len(npc.monsters))
@@ -108,6 +114,7 @@ class RandomEncounterAction(EventAction):
             logger.error(
                 "No environment defined. Use 'set_environment' before starting combat."
             )
+            self.stop()
             return
 
         context = CombatContext(
@@ -130,14 +137,12 @@ class RandomEncounterAction(EventAction):
             session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_queued_state_by_name("CombatState")
-        except ValueError:
-            try:
-                session.client.get_state_by_name("CombatState")
-            except ValueError:
-                self.stop()
+        client = session.client
+        if (
+            "CombatState" not in client.active_state_names
+            and not client.has_queued_state("CombatState")
+        ):
+            self.stop()
 
     def cleanup(self, session: Session) -> None:
-        npc = None
         session.client.npc_manager.remove_npc("wild_encounter")

--- a/tuxemon/event/actions/random_horde.py
+++ b/tuxemon/event/actions/random_horde.py
@@ -58,10 +58,12 @@ class RandomHordeAction(EventAction):
 
         if not check_battle_legal(player):
             logger.error("Battle is not legal, won't start")
+            self.stop()
             return
 
         if check_repellent(player):
             logger.info(f"Repellent active, skipping encounter.")
+            self.stop()
             return
 
         if self.total_prob is not None:
@@ -69,14 +71,17 @@ class RandomHordeAction(EventAction):
                 logger.error(
                     f"Invalid total_prob: {self.total_prob}. Must be between 0 and 100."
                 )
+                self.stop()
                 return
 
         if not encounter.load_zone(self.encounter_slug):
+            self.stop()
             return
 
         results = encounter.attempt_horde_encounter(player, self.total_prob)
 
         if not results:
+            self.stop()
             return
 
         logger.info("Starting random horde!")
@@ -96,6 +101,7 @@ class RandomHordeAction(EventAction):
                 item = Item.create(result.held_item)
                 output = current_monster.equip_item(item)
                 if not output:
+                    self.stop()
                     return
 
                 current_monster.wild = True
@@ -103,6 +109,7 @@ class RandomHordeAction(EventAction):
             horde.append(current_monster)
 
         if not horde:
+            self.stop()
             return
 
         event_engine = session.client.event_engine
@@ -113,6 +120,7 @@ class RandomHordeAction(EventAction):
         npc = session.get_npc("wild_encounter")
         if npc is None:
             logger.error("'wild_encounter' not found")
+            self.stop()
             return
 
         npc.party.replace_party(
@@ -128,6 +136,7 @@ class RandomHordeAction(EventAction):
             logger.error(
                 "No environment defined. Use 'set_environment' before starting combat."
             )
+            self.stop()
             return
 
         context = CombatContext(
@@ -150,14 +159,12 @@ class RandomHordeAction(EventAction):
             session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_queued_state_by_name("CombatState")
-        except ValueError:
-            try:
-                session.client.get_state_by_name("CombatState")
-            except ValueError:
-                self.stop()
+        client = session.client
+        if (
+            "CombatState" not in client.active_state_names
+            and not client.has_queued_state("CombatState")
+        ):
+            self.stop()
 
     def cleanup(self, session: Session) -> None:
-        npc = None
         session.client.npc_manager.remove_npc("wild_encounter")

--- a/tuxemon/event/actions/random_integer.py
+++ b/tuxemon/event/actions/random_integer.py
@@ -46,6 +46,7 @@ class RandomIntegerAction(EventAction):
                 f"Invalid range for 'random_integer'. Lower bound ({self.lower_bound}) "
                 f"cannot be greater than the upper bound ({self.upper_bound})."
             )
+            self.stop()
             return
 
         player = session.player

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -65,6 +65,7 @@ class RandomMonsterAction(EventAction):
 
         if not filters:
             logger.error("No valid monsters found for the given criteria.")
+            self.stop()
             return
 
         monster_slug = random.choice(filters)

--- a/tuxemon/event/actions/remove_combo.py
+++ b/tuxemon/event/actions/remove_combo.py
@@ -63,12 +63,15 @@ class RemoveComboAction(EventAction):
             ]
             if not button_sequence:
                 logger.warning(f"Combo '{self.combo_name}' has no buttons.")
+                self.stop()
                 return
         except KeyError as e:
             logger.warning(f"Unknown button name in combo: {e}")
+            self.stop()
             return
         except Exception as e:
             logger.warning(f"Invalid combo definition: {self.values} — {e}")
+            self.stop()
             return
 
         try:

--- a/tuxemon/event/actions/remove_contacts.py
+++ b/tuxemon/event/actions/remove_contacts.py
@@ -36,12 +36,14 @@ class RemoveContactsAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         relationships = character.relationships
         contact = relationships.get_connection(self.slug)
         if contact is None:
             logger.error("Nothing to remove")
+            self.stop()
             return
         else:
             relationships.remove_connection(self.slug)

--- a/tuxemon/event/actions/remove_flair.py
+++ b/tuxemon/event/actions/remove_flair.py
@@ -40,10 +40,12 @@ class RemoveFlairAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         category = self.category.strip().lower() if self.category else None

--- a/tuxemon/event/actions/remove_held_item.py
+++ b/tuxemon/event/actions/remove_held_item.py
@@ -38,10 +38,12 @@ class RemoveHeldItemAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         item = monster.unequip_item()

--- a/tuxemon/event/actions/remove_monster.py
+++ b/tuxemon/event/actions/remove_monster.py
@@ -42,15 +42,18 @@ class RemoveMonsterAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         character = session.client.get_monster_owner(monster)
         if character is None:
             logger.error(f"{monster.name}'s owner not found")
+            self.stop()
             return
 
         logger.info(f"{monster.name} removed from {character.name} party!")

--- a/tuxemon/event/actions/remove_state.py
+++ b/tuxemon/event/actions/remove_state.py
@@ -54,6 +54,7 @@ class RemoveStateAction(EventAction):
         else:
             if state_name not in client.active_state_names:
                 logger.error(f"{state_name} isn't active.")
+                self.stop()
                 return
             client.remove_state_by_name(state_name)
             logger.info(f"{state_name} is removed.")

--- a/tuxemon/event/actions/remove_step_tracker.py
+++ b/tuxemon/event/actions/remove_step_tracker.py
@@ -36,10 +36,12 @@ class RemoveStepTrackerAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         if not character.step_tracker.get_tracker(self.tracker_id):
             logger.warning(f"StepTracker '{self.tracker_id}' doesn't exist.")
+            self.stop()
             return
 
         character.step_tracker.remove_tracker(self.tracker_id)

--- a/tuxemon/event/actions/remove_tech.py
+++ b/tuxemon/event/actions/remove_tech.py
@@ -48,6 +48,7 @@ class RemoveTechAction(EventAction):
             logger.info(
                 f"No valid tech selected for variable '{self.tech_id}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         force_remove = parse_flag(self.force_remove)
 

--- a/tuxemon/event/actions/remove_tracker.py
+++ b/tuxemon/event/actions/remove_tracker.py
@@ -36,6 +36,7 @@ class RemoveTrackerAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         character.tracker.remove_location(self.location)

--- a/tuxemon/event/actions/rename_monster.py
+++ b/tuxemon/event/actions/rename_monster.py
@@ -44,10 +44,12 @@ class RenameMonsterAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         self.monster = monster
@@ -62,7 +64,5 @@ class RenameMonsterAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("InputMenu")
-        except ValueError:
+        if "InputMenu" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/rename_player.py
+++ b/tuxemon/event/actions/rename_player.py
@@ -46,6 +46,7 @@ class RenamePlayerAction(EventAction):
 
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         session.client.push_state(
@@ -59,7 +60,5 @@ class RenamePlayerAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("InputMenu")
-        except ValueError:
+        if "InputMenu" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/replace_party_from_yaml.py
+++ b/tuxemon/event/actions/replace_party_from_yaml.py
@@ -74,6 +74,7 @@ class ReplacePartyFromYamlAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error("'wild_encounter' not found")
+            self.stop()
             return
 
         parties = Loader.get_config_monsters(f"{self.yaml_file}.yaml")
@@ -83,6 +84,7 @@ class ReplacePartyFromYamlAction(EventAction):
             logger.error(
                 f"Party '{self.set_name}' not found in '{self.yaml_file}'"
             )
+            self.stop()
             return
 
         monster_defs = party.monsters

--- a/tuxemon/event/actions/replace_techs_from_yaml.py
+++ b/tuxemon/event/actions/replace_techs_from_yaml.py
@@ -73,10 +73,12 @@ class ReplaceTechsFromYamlAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         movesets = Loader.get_config_moves(f"{self.yaml_file}.yaml")
@@ -86,6 +88,7 @@ class ReplaceTechsFromYamlAction(EventAction):
             logger.error(
                 f"Moveset '{self.set_name}' not found in '{self.yaml_file}'"
             )
+            self.stop()
             return
 
         move_slugs = [

--- a/tuxemon/event/actions/set_appearance_layer.py
+++ b/tuxemon/event/actions/set_appearance_layer.py
@@ -46,6 +46,7 @@ class SetAppearanceLayerAction(EventAction):
         target = session.get_npc(self.character)
         if not target:
             logger.error(f"NPC {self.character} not found")
+            self.stop()
             return
 
         if self.layer not in (
@@ -55,6 +56,7 @@ class SetAppearanceLayerAction(EventAction):
             "combat_sheet",
         ):
             logger.error(f"Invalid appearance layer '{self.layer}'")
+            self.stop()
             return
 
         setattr(target.appearance_manager.state, self.layer, self.value)

--- a/tuxemon/event/actions/set_battle.py
+++ b/tuxemon/event/actions/set_battle.py
@@ -48,6 +48,7 @@ class SetBattleAction(EventAction):
         character = session.get_npc(self.fighter_slug)
         if character is None:
             logger.error(f"Character '{self.fighter_slug}' not found")
+            self.stop()
             return
 
         character.battle_handler.record_battle(

--- a/tuxemon/event/actions/set_bill.py
+++ b/tuxemon/event/actions/set_bill.py
@@ -57,6 +57,7 @@ class SetBillAction(EventAction):
 
         if character is None:
             logger.error(f"Character '{self.character}' not found.")
+            self.stop()
             return
 
         if not T.has_translation("en_US", self.bill_slug):

--- a/tuxemon/event/actions/set_char_birthday.py
+++ b/tuxemon/event/actions/set_char_birthday.py
@@ -47,11 +47,13 @@ class SetPlayerBirthdayAction(EventAction):
 
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         if self.random is not None:
             birthdate = random_month_day()
             self.set_birthday(character, birthdate)
+            self.stop()
             self.stop()
             return
 
@@ -62,7 +64,5 @@ class SetPlayerBirthdayAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("DatePickerState")
-        except ValueError:
+        if "DatePickerState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/set_economy.py
+++ b/tuxemon/event/actions/set_economy.py
@@ -42,6 +42,7 @@ class SetEconomyAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         try:
@@ -51,6 +52,7 @@ class SetEconomyAction(EventAction):
             )
         except RuntimeError as e:
             logger.error(f"Error loading economy '{self.economy_slug}': {e}")
+            self.stop()
             return
 
         applier = EconomyApplier()

--- a/tuxemon/event/actions/set_environment.py
+++ b/tuxemon/event/actions/set_environment.py
@@ -41,6 +41,7 @@ class SetEnvironmentAction(EventAction):
         if self.slug is None:
             session.client.environment_manager.unload_environment()
             logger.info("Environment unloaded via event action.")
+            self.stop()
             return
 
         success = session.client.environment_manager.load_environment(
@@ -50,5 +51,6 @@ class SetEnvironmentAction(EventAction):
             logger.info(f"Environment '{self.slug}' successfully loaded.")
         else:
             if session.client.environment_manager.is_locked():
+                self.stop()
                 return
             logger.error(f"Failed to load environment '{self.slug}'.")

--- a/tuxemon/event/actions/set_facing_mode.py
+++ b/tuxemon/event/actions/set_facing_mode.py
@@ -44,6 +44,7 @@ class SetFacingModeAction(EventAction):
     def start(self, session: Session) -> None:
         npc = session.get_npc(self.npc_slug)
         if not npc:
+            self.stop()
             return
 
         mode_str = self.mode.strip().lower()

--- a/tuxemon/event/actions/set_kennel_visible.py
+++ b/tuxemon/event/actions/set_kennel_visible.py
@@ -50,6 +50,7 @@ class SetKennelVisibleAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         kennel = self.kennel
@@ -58,6 +59,7 @@ class SetKennelVisibleAction(EventAction):
         if kennel == KENNEL:
             raise ValueError(f"{kennel} cannot be made invisible.")
         if not character.monster_boxes.has_box(kennel, "monster"):
+            self.stop()
             return
 
         try:

--- a/tuxemon/event/actions/set_mission.py
+++ b/tuxemon/event/actions/set_mission.py
@@ -35,6 +35,7 @@ class SetMissionAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"Character '{self.character}' not found.")
+            self.stop()
             return
 
         missions = (
@@ -42,6 +43,7 @@ class SetMissionAction(EventAction):
         )
         if not missions:
             logger.info(f"No missions met prerequisites for {self.character}.")
+            self.stop()
             return
 
         for mission in missions:

--- a/tuxemon/event/actions/set_money.py
+++ b/tuxemon/event/actions/set_money.py
@@ -37,6 +37,7 @@ class SetMoneyAction(EventAction):
 
         if character is None:
             logger.error(f"Character '{self.character}' not found")
+            self.stop()
             return
 
         amount = 0 if self.amount is None else self.amount

--- a/tuxemon/event/actions/set_monster_attribute.py
+++ b/tuxemon/event/actions/set_monster_attribute.py
@@ -43,12 +43,14 @@ class SetMonsterAttributeAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             monster = player.monster_boxes.get_monsters_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
 
         CommonAction.set_entity_attribute(monster, self.attribute, self.value)

--- a/tuxemon/event/actions/set_monster_flair.py
+++ b/tuxemon/event/actions/set_monster_flair.py
@@ -54,17 +54,20 @@ class SetMonsterFlairAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return
 
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         try:
             flair_model = FlairModel.lookup(self.flair, db)
         except RuntimeError as e:
             logger.error(str(e))
+            self.stop()
             return
 
         sprite_types = (

--- a/tuxemon/event/actions/set_monster_health.py
+++ b/tuxemon/event/actions/set_monster_health.py
@@ -41,6 +41,7 @@ class SetMonsterHealthAction(EventAction):
     def start(self, session: Session) -> None:
         player = session.player
         if not player.monsters:
+            self.stop()
             return
 
         monster_health = 1.0 if self.health is None else self.health
@@ -56,10 +57,12 @@ class SetMonsterHealthAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
             monster = session.client.get_monster_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
             set_health(monster, monster_health)
             if monster.is_fainted:

--- a/tuxemon/event/actions/set_monster_level.py
+++ b/tuxemon/event/actions/set_monster_level.py
@@ -43,6 +43,7 @@ class SetMonsterLevelAction(EventAction):
         player = session.player
         trigger_ui = parse_flag(self.trigger_ui)
         if not player.monsters:
+            self.stop()
             return
 
         if self.levels_added is None:
@@ -56,10 +57,12 @@ class SetMonsterLevelAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return
             monster = session.client.get_monster_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
             monsters_to_update.append(monster)
         else:
@@ -84,7 +87,5 @@ class SetMonsterLevelAction(EventAction):
     def update(self, session: Session, dt: float) -> None:
         trigger_ui = parse_flag(self.trigger_ui)
         if trigger_ui:
-            try:
-                session.client.get_state_by_name("LevelUpSummaryState")
-            except ValueError:
+            if "LevelUpSummaryState" not in session.client.active_state_names:
                 self.stop()

--- a/tuxemon/event/actions/set_monster_plague.py
+++ b/tuxemon/event/actions/set_monster_plague.py
@@ -50,10 +50,12 @@ class SetMonsterPlagueAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         enforce = parse_flag(self.enforced_check)

--- a/tuxemon/event/actions/set_monster_status.py
+++ b/tuxemon/event/actions/set_monster_status.py
@@ -51,6 +51,7 @@ class SetMonsterStatusAction(EventAction):
         player = session.player
         steps = player.steps
         if not player.monsters:
+            self.stop()
             return
 
         if self.variable is None:
@@ -62,9 +63,11 @@ class SetMonsterStatusAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.variable}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
             monster = session.client.get_monster_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
             self.set_status(session, monster, self.status, steps)

--- a/tuxemon/event/actions/set_party_status.py
+++ b/tuxemon/event/actions/set_party_status.py
@@ -34,9 +34,11 @@ class SetPartyStatusAction(EventAction):
         char = session.get_npc(self.character)
         if char is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         if not char.monsters:
             logger.error(f"{char.name} has no monsters!")
+            self.stop()
             return
 
         _healthy = sum(

--- a/tuxemon/event/actions/set_price_policy.py
+++ b/tuxemon/event/actions/set_price_policy.py
@@ -37,15 +37,18 @@ class SetPricePolicyAction(EventAction):
         character = session.get_npc(self.npc_slug)
         if character is None:
             logger.error(f"{self.npc_slug} not found")
+            self.stop()
             return
 
         if not character.economy:
             logger.error(f"NPC '{self.npc_slug}' has no economy set yet.")
+            self.stop()
             return
 
         data = load_policy(self.policy_slug)
         if not data:
             logger.error(f"Unknown PricePolicy slug: '{self.policy_slug}'")
+            self.stop()
             return
 
         policy = StaticYamlPolicy(data)

--- a/tuxemon/event/actions/set_step_tracker_milestone_shown.py
+++ b/tuxemon/event/actions/set_step_tracker_milestone_shown.py
@@ -38,6 +38,7 @@ class SetStepTrackerMilestoneShownAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"Character '{self.character}' not found.")
+            self.stop()
             return
 
         tracker = character.step_tracker.get_tracker(self.tracker_id)
@@ -45,12 +46,14 @@ class SetStepTrackerMilestoneShownAction(EventAction):
             logger.warning(
                 f"StepTracker '{self.tracker_id}' not found for character '{self.character}'."
             )
+            self.stop()
             return
 
         if tracker.has_shown_milestone(self.milestone):
             logger.info(
                 f"Milestone {self.milestone} already marked as shown for '{self.character}'."
             )
+            self.stop()
             return
 
         tracker.show_milestone_dialogue(self.milestone)

--- a/tuxemon/event/actions/set_teleport_faint.py
+++ b/tuxemon/event/actions/set_teleport_faint.py
@@ -41,6 +41,7 @@ class SetTeleportFaintAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         character.teleport_faint = TeleportFaint(self.map_name, self.x, self.y)

--- a/tuxemon/event/actions/set_template.py
+++ b/tuxemon/event/actions/set_template.py
@@ -58,6 +58,7 @@ class SetTemplateAction(EventAction):
         target = session.get_npc(self.character)
         if not target:
             logger.error(f"NPC {self.character} not found")
+            self.stop()
             return
 
         if self.sprite == "default":

--- a/tuxemon/event/actions/set_tuxepedia.py
+++ b/tuxemon/event/actions/set_tuxepedia.py
@@ -41,6 +41,7 @@ class SetTuxepediaAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         # start tuxepedia operations
         if self.label not in list(SeenStatus):

--- a/tuxemon/event/actions/show_monster.py
+++ b/tuxemon/event/actions/show_monster.py
@@ -46,20 +46,20 @@ class ShowMonsterAction(EventAction):
             logger.error(
                 f"The state 'MonsterInfoState' is already active. No action taken."
             )
+            self.stop()
             return
 
         monster = self._retrieve_monster(session)
         if monster is None:
             logger.error("Monster not found for MonsterInfoState.")
+            self.stop()
             return
 
         params = {"monster": monster, "source": self.name}
         self.client.push_state("MonsterInfoState", **params)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("MonsterInfoState")
-        except ValueError:
+        if "MonsterInfoState" not in session.client.active_state_names:
             self.stop()
 
     def _retrieve_monster(self, session: Session) -> Monster | None:

--- a/tuxemon/event/actions/spawn_monster.py
+++ b/tuxemon/event/actions/spawn_monster.py
@@ -64,6 +64,7 @@ class SpawnMonsterAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable(s): {', '.join(missing)}"
             )
+            self.stop()
             return  # Exit early if either UUID is invalid
 
         mother = session.client.get_monster_by_iid(
@@ -71,6 +72,7 @@ class SpawnMonsterAction(EventAction):
         ) or player.monster_boxes.get_monsters_by_iid(mother_id)
         if mother is None:
             logger.error(f"Mother {mother_id} not found.")
+            self.stop()
             return
 
         father = session.client.get_monster_by_iid(
@@ -78,6 +80,7 @@ class SpawnMonsterAction(EventAction):
         ) or player.monster_boxes.get_monsters_by_iid(father_id)
         if father is None:
             logger.error(f"Father {father_id} not found.")
+            self.stop()
             return
 
         # Determine the seed monster based on the types of the mother and father
@@ -128,6 +131,7 @@ class SpawnMonsterAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
         character.party.add_monster(child, len(character.monsters))
 
@@ -136,9 +140,7 @@ class SpawnMonsterAction(EventAction):
         open_dialog(session.client, [msg], dialog_speed="max")
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("DialogState")
-        except ValueError:
+        if "DialogState" not in session.client.active_state_names:
             self.stop()
 
 

--- a/tuxemon/event/actions/start_battle.py
+++ b/tuxemon/event/actions/start_battle.py
@@ -49,12 +49,14 @@ class StartBattleAction(EventAction):
         if not character1 or not character2:
             _char = self.character1 if not character1 else self.character2
             logger.error(f"Character not found in map: {_char}")
+            self.stop()
             return
 
         if not (
             check_battle_legal(character1) and check_battle_legal(character2)
         ):
             logger.warning("Battle is not legal, won't start")
+            self.stop()
             return
 
         environment = session.client.environment_manager
@@ -63,6 +65,7 @@ class StartBattleAction(EventAction):
             logger.error(
                 "No environment defined. Use 'set_environment' before starting combat."
             )
+            self.stop()
             return
 
         fighters = sorted(
@@ -86,7 +89,5 @@ class StartBattleAction(EventAction):
             session.client.current_music.play(filename, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("CombatState")
-        except ValueError:
+        if "CombatState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/start_double_battle.py
+++ b/tuxemon/event/actions/start_double_battle.py
@@ -50,12 +50,14 @@ class StartDoubleBattleAction(EventAction):
         if not character1 or not character2:
             _char = self.character1 if not character1 else self.character2
             logger.error(f"Character not found in map: {_char}")
+            self.stop()
             return
 
         if not (
             check_battle_legal(character1) and check_battle_legal(character2)
         ):
             logger.warning("Battle is not legal, won't start")
+            self.stop()
             return
 
         environment = session.client.environment_manager
@@ -64,6 +66,7 @@ class StartDoubleBattleAction(EventAction):
             logger.error(
                 "No environment defined. Use 'set_environment' before starting combat."
             )
+            self.stop()
             return
 
         fighters = sorted(
@@ -75,6 +78,7 @@ class StartDoubleBattleAction(EventAction):
             logger.error(
                 f"{total_monsters} monsters aren't enough to trigger a double battle ({MONSTERS_DOUBLE})"
             )
+            self.stop()
             return
 
         logger.info(
@@ -94,7 +98,5 @@ class StartDoubleBattleAction(EventAction):
             session.client.current_music.play(filename, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("CombatState")
-        except ValueError:
+        if "CombatState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/store_monster.py
+++ b/tuxemon/event/actions/store_monster.py
@@ -44,21 +44,25 @@ class StoreMonsterAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = session.client.get_monster_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         character = session.client.get_monster_owner(monster)
         if character is None:
             logger.error(f"{monster.name}'s owner not found")
+            self.stop()
             return
 
         box = self.box or KENNEL
 
         if not player.monster_boxes.has_box(box, "monster"):
             logger.error(f"No box found with name {box}")
+            self.stop()
             return
 
         if character.party.transfer_monster_to_box(monster, box):

--- a/tuxemon/event/actions/store_party.py
+++ b/tuxemon/event/actions/store_party.py
@@ -41,11 +41,13 @@ class StorePartyAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"Character '{self.character}' not found.")
+            self.stop()
             return
 
         store = self.box or KENNEL
         if self.box and not character.monster_boxes.has_box(store, "monster"):
             logger.error(f"No box found with name '{store}'.")
+            self.stop()
             return
 
         success = character.monster_boxes.store_party_in_box(

--- a/tuxemon/event/actions/teleport.py
+++ b/tuxemon/event/actions/teleport.py
@@ -48,6 +48,7 @@ class TeleportAction(EventAction):
             logger.error(
                 f"TeleportAction: Character '{self.character}' not found."
             )
+            self.stop()
             return
 
         request = TeleportRequest(

--- a/tuxemon/event/actions/teleport_faint.py
+++ b/tuxemon/event/actions/teleport_faint.py
@@ -47,6 +47,7 @@ class TeleportFaintAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         healing = parse_flag(self.healing)
@@ -60,6 +61,7 @@ class TeleportFaintAction(EventAction):
             logger.error(
                 "The teleport_faint variable has not been set, use 'set_teleport_faint'."
             )
+            self.stop()
             return
         else:
             teleport = character.teleport_faint

--- a/tuxemon/event/actions/toggle_evolution_block.py
+++ b/tuxemon/event/actions/toggle_evolution_block.py
@@ -45,6 +45,7 @@ class ToggleEvolutionBlockAction(EventAction):
 
         if character is None:
             logger.error(f"Character '{self.npc_slug}' not found.")
+            self.stop()
             return
 
         registry = character.evolution_registry
@@ -56,6 +57,7 @@ class ToggleEvolutionBlockAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.monster_variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         monster = session.client.get_monster_by_iid(monster_id)
@@ -63,6 +65,7 @@ class ToggleEvolutionBlockAction(EventAction):
             logger.warning(
                 f"Monster with ID '{monster_id}' not found. Cannot toggle evolution block."
             )
+            self.stop()
             return
 
         if self.action == "block":

--- a/tuxemon/event/actions/trading.py
+++ b/tuxemon/event/actions/trading.py
@@ -51,11 +51,13 @@ class TradingAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
 
         player_monster = session.client.get_monster_by_iid(player_monster_id)
         if player_monster is None:
             logger.error("Player's monster not found.")
+            self.stop()
             return
 
         if self.added in db.database["monster"]:
@@ -82,11 +84,13 @@ class TradingAction(EventAction):
                 logger.info(
                     f"No valid monster selected for variable '{self.added}'"
                 )
+                self.stop()
                 return  # Exit early if no valid UUID
 
             other_monster = session.client.get_monster_by_iid(other_monster_id)
             if other_monster is None:
                 logger.error("Other monster not found.")
+                self.stop()
                 return
 
             result = session.client.trade_manager.execute_trade(

--- a/tuxemon/event/actions/transfer_money.py
+++ b/tuxemon/event/actions/transfer_money.py
@@ -43,6 +43,7 @@ class TransferMoneyAction(EventAction):
         if not character1 or not character2:
             _char = self.slug1 if not character1 else self.slug2
             logger.error(f"Character not found in map: {_char}")
+            self.stop()
             return
 
         try:
@@ -51,6 +52,7 @@ class TransferMoneyAction(EventAction):
             )
         except ValueError as e:
             logger.error(str(e))
+            self.stop()
             return
 
         logger.debug(

--- a/tuxemon/event/actions/transition_teleport.py
+++ b/tuxemon/event/actions/transition_teleport.py
@@ -49,6 +49,7 @@ class TransitionTeleportAction(EventAction):
 
         char = session.get_npc(self.character)
         if char is None:
+            self.stop()
             return
 
         teleport_queue = session.client.teleporter.teleport_queue

--- a/tuxemon/event/actions/transition_teleport_return.py
+++ b/tuxemon/event/actions/transition_teleport_return.py
@@ -56,11 +56,13 @@ class TransitionTeleportReturnAction(EventAction):
         char = session.get_npc(self.character)
         if char is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         request = session.client.teleporter.last_teleport_request
         if not request:
             logger.error("No previous teleport request found.")
+            self.stop()
             return
 
         if (
@@ -71,12 +73,14 @@ class TransitionTeleportReturnAction(EventAction):
             logger.error(
                 "Last teleport request is missing source location data."
             )
+            self.stop()
             return
 
         try:
             facing_dir = Direction(self.facing.lower())
         except ValueError:
             logger.warning(f"Invalid facing direction: {self.facing}")
+            self.stop()
             return
 
         char.set_facing(facing_dir)

--- a/tuxemon/event/actions/translated_dialog.py
+++ b/tuxemon/event/actions/translated_dialog.py
@@ -107,7 +107,5 @@ class TranslatedDialogAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("DialogState")
-        except ValueError:
+        if "DialogState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/translated_dialog_choice.py
+++ b/tuxemon/event/actions/translated_dialog_choice.py
@@ -64,7 +64,5 @@ class TranslatedDialogChoiceAction(EventAction):
         )
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_state_by_name("ChoiceState")
-        except ValueError:
+        if "ChoiceState" not in session.client.active_state_names:
             self.stop()

--- a/tuxemon/event/actions/trigger_status.py
+++ b/tuxemon/event/actions/trigger_status.py
@@ -49,6 +49,7 @@ class TriggerStatusAction(EventAction):
         if self.variable is not None:
             variable = self.variable
             if not player.game_variables.has(variable):
+                self.stop()
                 return
 
             monster_id = UUID(player.game_variables.get(variable))
@@ -57,18 +58,21 @@ class TriggerStatusAction(EventAction):
             ) or player.monster_boxes.get_monsters_by_iid(monster_id)
             if monster is None:
                 logger.error("Monster not found")
+                self.stop()
                 return
             monsters = [monster]
         else:
             monsters = player.monsters
 
         if not monsters:
+            self.stop()
             return
 
         monsters_with_status = [
             m for m in monsters if m.status.current_status is not None
         ]
         if not monsters_with_status:
+            self.stop()
             return
 
         for monster in monsters_with_status:

--- a/tuxemon/event/actions/tune_radio.py
+++ b/tuxemon/event/actions/tune_radio.py
@@ -61,6 +61,7 @@ class TuneRadioAction(EventAction):
             logger.error(
                 f"The state '{self.client.current_state.name}' is already active. No action taken."
             )
+            self.stop()
             return
 
         character = self.session.get_npc(self.character_slug)
@@ -68,6 +69,7 @@ class TuneRadioAction(EventAction):
             logger.error(
                 f"Character '{self.character_slug}' not found for radio tuning."
             )
+            self.stop()
             return
 
         if self.frequency is not None:
@@ -75,6 +77,7 @@ class TuneRadioAction(EventAction):
                 logger.error(
                     f"Frequency {self.frequency} is out of FM range {MIN_FREQ}-{MAX_FREQ}."
                 )
+                self.stop()
                 return
 
             self.client.push_state(

--- a/tuxemon/event/actions/update_cipher.py
+++ b/tuxemon/event/actions/update_cipher.py
@@ -43,6 +43,7 @@ class UpdateCipherAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         if self.letters:
@@ -57,5 +58,6 @@ class UpdateCipherAction(EventAction):
         cipher_processor = session.client.cipher_processor
         if cipher_processor is None:
             logger.error(f"Cipher processor isn't enabled")
+            self.stop()
             return
         cipher_processor.set_unlocked_letters(character.unlocked_letters)

--- a/tuxemon/event/actions/update_time.py
+++ b/tuxemon/event/actions/update_time.py
@@ -36,6 +36,7 @@ class UpdateTimeAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         time_vars = session.time.get_time_variables()

--- a/tuxemon/event/actions/wild_encounter.py
+++ b/tuxemon/event/actions/wild_encounter.py
@@ -58,6 +58,7 @@ class WildEncounterAction(EventAction):
 
         if not check_battle_legal(player):
             logger.warning("battle is not legal, won't start")
+            self.stop()
             return
 
         logger.info("Starting wild encounter!")
@@ -73,6 +74,7 @@ class WildEncounterAction(EventAction):
             item = Item.create(self.held_item)
             output = current_monster.equip_item(item)
             if not output:
+                self.stop()
                 return
         current_monster.wild = True
 
@@ -82,6 +84,7 @@ class WildEncounterAction(EventAction):
         npc = session.get_npc(self.name)
         if npc is None:
             logger.error(f"{self.name} not found")
+            self.stop()
             return
 
         npc.party.insert_monster_to_party(current_monster, len(npc.monsters))
@@ -93,6 +96,7 @@ class WildEncounterAction(EventAction):
             logger.error(
                 "No environment defined. Use 'set_environment' before starting combat."
             )
+            self.stop()
             return
 
         context = CombatContext(
@@ -114,14 +118,12 @@ class WildEncounterAction(EventAction):
             session.client.current_music.play(sound.music, sound.volume)
 
     def update(self, session: Session, dt: float) -> None:
-        try:
-            session.client.get_queued_state_by_name("CombatState")
-        except ValueError:
-            try:
-                session.client.get_state_by_name("CombatState")
-            except ValueError:
-                self.stop()
+        client = session.client
+        if (
+            "CombatState" not in client.active_state_names
+            and not client.has_queued_state("CombatState")
+        ):
+            self.stop()
 
     def cleanup(self, session: Session) -> None:
-        npc = None
         session.client.npc_manager.remove_npc(self.name)

--- a/tuxemon/event/actions/withdraw_monster.py
+++ b/tuxemon/event/actions/withdraw_monster.py
@@ -46,10 +46,12 @@ class WithdrawMonsterAction(EventAction):
             logger.info(
                 f"No valid monster selected for variable '{self.variable}'"
             )
+            self.stop()
             return  # Exit early if no valid UUID
         monster = player.monster_boxes.get_monsters_by_iid(monster_id)
         if monster is None:
             logger.error("Monster not found")
+            self.stop()
             return
 
         player.monster_boxes.remove_from_box("monster", None, monster)
@@ -57,6 +59,7 @@ class WithdrawMonsterAction(EventAction):
         character = session.get_npc(self.character)
         if character is None:
             logger.error(f"{self.character} not found")
+            self.stop()
             return
 
         if character.party.transfer_monster_to_party(monster):

--- a/tuxemon/event/eventaction.py
+++ b/tuxemon/event/eventaction.py
@@ -52,9 +52,6 @@ class ActionContextManager:
         Ensures the action is properly cleaned up, unless it is marked as cancelled.
         Logs a warning if the action is cancelled.
         """
-        if self.action.cancelled:
-            logger.warning("Event is cancelled, not cleaning up")
-            return
         self.action.cleanup(self.session)
 
 
@@ -175,6 +172,7 @@ class EventAction(ABC):
             last_time = time.perf_counter()
             while not self.done and not self.cancelled:
                 if self._skip:
+                    self.stop()
                     return
 
                 now = time.perf_counter()
@@ -209,8 +207,7 @@ class EventAction(ABC):
         method for subclass logic.
         """
         if self.cancelled:
-            logger.debug(f"Action is cancelled, not starting")
-            self.stop()
+            logger.debug("Action is cancelled, not starting")
             return
         try:
             self.start(session)
@@ -234,12 +231,7 @@ class EventAction(ABC):
         """
         if self.cancelled:
             logger.debug("Action is cancelled, not updating")
-            return
-        try:
-            self.stop()
-        except Exception as e:
-            logger.error(f"Error updating action: {e}")
-            raise
+        self.stop()
 
     def cancel(self) -> None:
         """
@@ -260,12 +252,6 @@ class EventAction(ABC):
         if self.cancelled:
             logger.debug("Action is cancelled, not cleaning up")
             return
-        try:
-            # clean up the action
-            pass
-        except Exception as e:
-            logger.error(f"Error cleaning up action: {e}")
-            raise
 
 
 class ActionManager:

--- a/tuxemon/event/eventbehavior.py
+++ b/tuxemon/event/eventbehavior.py
@@ -73,33 +73,28 @@ class BehaviorManager:
         return list(self.behaviors.values())
 
 
-def expand_behavior_conditions(
+def expand_behavior(
     event: EventObject, behavior_manager: BehaviorManager
-) -> list[SpatialCondition]:
-    conds = []
+) -> tuple[list[SpatialCondition], list[ParameterizableRule]]:
+    """
+    Expand all behaviors for an event in a single pass.
+    Returns (all_conditions, all_actions) from a single expand() call per behavior.
+    """
+    all_conds: list[SpatialCondition] = []
+    all_acts: list[ParameterizableRule] = []
+
     for beh in event.behavs:
         plugin = behavior_manager.get_behavior(beh.type)
         if not plugin:
             continue
         try:
-            c, _ = plugin.expand(event, beh)
-            conds.extend(c)
+            conds, acts = plugin.expand(event, beh)
+            all_conds.extend(conds)
+            all_acts.extend(acts)
         except Exception as e:
-            logger.error(f"Error expanding behavior {beh.type}: {e}")
-    return conds
+            logger.error(
+                f"Behavior '{beh.type}' on event {event.id} failed to expand: {e}. "
+                f"Skipping entire behavior."
+            )
 
-
-def expand_behavior_actions(
-    event: EventObject, behavior_manager: BehaviorManager
-) -> list[ParameterizableRule]:
-    acts = []
-    for beh in event.behavs:
-        plugin = behavior_manager.get_behavior(beh.type)
-        if not plugin:
-            continue
-        try:
-            _, a = plugin.expand(event, beh)
-            acts.extend(a)
-        except Exception as e:
-            logger.error(f"Error expanding behavior {beh.type}: {e}")
-    return acts
+    return all_conds, all_acts

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -6,15 +6,12 @@ import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from tuxemon.event.eventbehavior import (
-    expand_behavior_actions,
-    expand_behavior_conditions,
-)
+from tuxemon.event.eventbehavior import expand_behavior
 from tuxemon.event.running import EventState, RunningCondition, RunningEvent
 from tuxemon.user_config import CONFIG
 
 if TYPE_CHECKING:
-    from tuxemon.db import EventObject, SpatialCondition
+    from tuxemon.db import EventObject, ParameterizableRule, SpatialCondition
     from tuxemon.event.eventaction import ActionManager
     from tuxemon.event.eventbehavior import BehaviorManager
     from tuxemon.event.running import ConditionEvaluator
@@ -60,6 +57,9 @@ class EventEngine:
 
         self.global_events: list[EventObject] = []
         self.triggered_global_events: set[int] = set()
+        self._behavior_cache: dict[
+            int, tuple[list[SpatialCondition], list[ParameterizableRule]]
+        ] = {}
 
         # debug
         self.partial_events: list[Sequence[tuple[bool, SpatialCondition]]] = (
@@ -73,9 +73,10 @@ class EventEngine:
 
     def reset(self) -> None:
         """Clear out running events.  Use when changing maps."""
-        self.running_events = dict()
+        self.running_events = {}
         self.set_current_map(None)
         self.triggered_global_events = set()
+        self._behavior_cache = {}
 
     def suspend(self) -> None:
         """
@@ -141,7 +142,7 @@ class EventEngine:
         if map_event.id in self.running_events:
             return
 
-        behav_acts = expand_behavior_actions(map_event, self.behavior_manager)
+        _, behav_acts = self._get_behavior_expansion(map_event)
         combined_actions = behav_acts + list(map_event.acts)
         logger.debug(f"Starting map event: {map_event.id}")
 
@@ -175,6 +176,7 @@ class EventEngine:
         if self._suspended:
             return
 
+        self._behavior_cache = {}
         self.partial_events = []
         self.check_global_conditions()
         self.check_conditions()
@@ -230,7 +232,7 @@ class EventEngine:
     def _evaluate_and_queue_event(
         self, event: EventObject, is_global: bool = False
     ) -> None:
-        behav_conds = expand_behavior_conditions(event, self.behavior_manager)
+        behav_conds, _ = self._get_behavior_expansion(event)
         all_conditions = list(event.conds) + behav_conds
 
         if not all_conditions:
@@ -258,11 +260,13 @@ class EventEngine:
         """Cancels the event with the given ID."""
         if event_id in self.running_events:
             self.running_events[event_id].cancel()
+            self.triggered_global_events.discard(event_id)
 
     def cancel_all_events(self) -> None:
         """Cancels all currently running events."""
         for event in self.running_events.values():
             event.cancel()
+        self.triggered_global_events.clear()
 
     def update_running_events(self, dt: float) -> None:
         """
@@ -290,3 +294,16 @@ class EventEngine:
                 EventState.CANCELLED,
             ):
                 self.running_events.pop(event_id, None)
+
+    def _get_behavior_expansion(
+        self, event: EventObject
+    ) -> tuple[list[SpatialCondition], list[ParameterizableRule]]:
+        """
+        Returns cached behavior expansion for an event within the current update cycle.
+        Prevents expand() from being called twice (once for conditions, once for actions).
+        """
+        if event.id not in self._behavior_cache:
+            self._behavior_cache[event.id] = expand_behavior(
+                event, self.behavior_manager
+            )
+        return self._behavior_cache[event.id]

--- a/tuxemon/event/eventengine.py
+++ b/tuxemon/event/eventengine.py
@@ -71,12 +71,12 @@ class EventEngine:
         if self.current_map != new_map:
             self.current_map = new_map
 
-    def reset(self) -> None:
+    def reset(self, new_map: AbstractMap | None = None) -> None:
         """Clear out running events.  Use when changing maps."""
         self.running_events = {}
-        self.set_current_map(None)
         self.triggered_global_events = set()
         self._behavior_cache = {}
+        self.set_current_map(new_map)
 
     def suspend(self) -> None:
         """
@@ -188,10 +188,13 @@ class EventEngine:
 
         Actions may be started during this function.
         """
-        for event in self.session.client.map_manager.inits:
+        inits = list(self.session.client.map_manager.inits)
+        events = list(self.session.client.map_manager.events)
+
+        for event in inits:
             self.process_map_event(event)
 
-        for event in self.session.client.map_manager.events:
+        for event in events:
             self.process_map_event(event)
 
     def register_global_event(self, event: EventObject) -> bool:

--- a/tuxemon/event/running.py
+++ b/tuxemon/event/running.py
@@ -117,10 +117,12 @@ class RunningEvent:
             True - event is still alive (delay, long-running action)
             False - event is finished or cancelled
         """
-
         # Delay / timeout
         if not self.tick(dt):
             return self.is_alive()
+
+        max_actions_per_frame = len(self.actions) + 1
+        actions_this_frame = 0
 
         while True:
             if self.is_cancelled():
@@ -129,6 +131,13 @@ class RunningEvent:
 
             # If no action is active, try to load the next one
             if self.current_action is None:
+                if actions_this_frame >= max_actions_per_frame:
+                    logger.warning(
+                        f"Event {self.map_event.id} exhausted action budget "
+                        f"in a single frame — yielding."
+                    )
+                    return True
+
                 next_data = self.get_next_action()
                 if next_data is None:
                     self.complete()
@@ -146,6 +155,7 @@ class RunningEvent:
 
                 action.on_start(session)
                 self.current_action = action
+                actions_this_frame += 1
 
                 # Edge case: action cancelled itself during on_start()
                 if self.current_action.cancelled:
@@ -182,9 +192,6 @@ class RunningEvent:
 
     def get_next_action(self) -> ParameterizableRule | None:
         """Return the next action, or None if the event is completed."""
-        if self.state == EventState.COMPLETED:
-            return None
-
         if self.action_index >= len(self.actions):
             return None
 
@@ -199,8 +206,6 @@ class RunningEvent:
 
     def advance(self) -> None:
         self.action_index += 1
-        if self.action_index >= len(self.actions):
-            self.complete()
 
     def cancel(self) -> None:
         self.state = EventState.CANCELLED
@@ -231,8 +236,6 @@ class RunningEvent:
 
 
 class ConditionState(Enum):
-    WAITING = auto()
-    CHECKING = auto()
     MET = auto()
     FAILED = auto()
     CANCELLED = auto()
@@ -251,11 +254,8 @@ class RunningCondition:
     ) -> None:
         self.map_condition = map_condition
         self.evaluator = evaluator
-        self.state = ConditionState.WAITING
+        self.state = ConditionState.FAILED
         self.result: bool | None = None
-
-    def start_check(self) -> None:
-        self.state = ConditionState.CHECKING
 
     def cancel(self) -> None:
         self.state = ConditionState.CANCELLED
@@ -274,7 +274,6 @@ class RunningCondition:
             self.result = False
             return False
 
-        self.start_check()
         try:
             passed = self.evaluator.evaluate(self.map_condition)
             self.result = passed

--- a/tuxemon/map/loader.py
+++ b/tuxemon/map/loader.py
@@ -215,10 +215,8 @@ class MapLoader:
             yaml_collision: Collision event data.
             events: Dictionary containing events and init sequences.
         """
-        # Debugging before merging
         logger.debug(f"TMX events before merging: {len(txmn_map.events)}")
         logger.debug(f"TMX inits before merging: {len(txmn_map.inits)}")
-
         txmn_map.collision_map.update(yaml_collision)
         txmn_map.add_events(events["event"])
         txmn_map.add_inits(events["init"])
@@ -303,7 +301,6 @@ class YAMLEventLoader:
                 y = int(collision_data.get("y", 0))
                 w = int(collision_data.get("width", 1))
                 h = int(collision_data.get("height", 1))
-                event_type = str(collision_data.get("type"))
                 coords = [(x + i, y + j) for i in range(w) for j in range(h)]
                 for coord in coords:
                     collision_dict[coord] = None
@@ -329,7 +326,14 @@ class YAMLEventLoader:
         """
         event_parser = EventParser()
         yaml_data: dict[str, dict[str, dict[str, Any]]] = load_yaml(path)
+
         events_dict: dict[str, list[EventObject]] = {"event": [], "init": []}
+
+        if source not in ("event", "init"):
+            logger.warning(
+                f"Unknown event source '{source}', returning empty."
+            )
+            return events_dict
 
         for name, event_data in yaml_data["events"].items():
             _event_type = event_data.get("type")
@@ -342,7 +346,13 @@ class YAMLEventLoader:
                 delay = float(_delay) if _delay is not None else None
                 x, y = event_data.get("x", 0), event_data.get("y", 0)
                 w, h = event_data.get("width", 1), event_data.get("height", 1)
-                box = BoundingBox(x=x, y=y, width=w, height=h)
+                try:
+                    box = BoundingBox(x=x, y=y, width=w, height=h)
+                except Exception as e:
+                    logger.error(
+                        f"Invalid bounding box for event '{name}': {e}"
+                    )
+                    continue
                 event = event_parser.create_event_object(
                     event_data, name, box, priority, timeout, delay
                 )
@@ -496,10 +506,13 @@ class TMXMapLoader:
         inits: list[EventObject] = []
 
         for obj in data.objects:
-            if obj.type == "event":
-                events.append(self.load_event(obj, tile_size))
-            elif obj.type == "init":
-                inits.append(self.load_event(obj, tile_size))
+            try:
+                if obj.type == "event":
+                    events.append(self.load_event(obj, tile_size))
+                elif obj.type == "init":
+                    inits.append(self.load_event(obj, tile_size))
+            except ValueError as e:
+                logger.error(f"Skipping event '{obj.name}': {e}")
 
         return events, inits
 
@@ -651,5 +664,11 @@ class TMXMapLoader:
             elif key.startswith("behav"):
                 event_data["behav"].append(value)
 
-        box = BoundingBox(x=x, y=y, width=w, height=h)
+        try:
+            box = BoundingBox(x=x, y=y, width=w, height=h)
+        except Exception as e:
+            raise ValueError(
+                f"Invalid bounding box for event '{obj.name}': {e}"
+            ) from e
+
         return event_parser.create_event_object(event_data, obj.name, box)

--- a/tuxemon/map/manager.py
+++ b/tuxemon/map/manager.py
@@ -154,10 +154,6 @@ class MapManager:
         self.current_map = map_data
         self.maps = map_data.maps
         self._map_type_slug = map_data.map_type
-
-        map_data.add_events([])
-        map_data.add_inits([])
-
         if map_data.map_type not in MAP_TYPES:
             logger.warning(
                 f"Invalid map type '{map_data.map_type}', defaulting to 'notype'."
@@ -168,6 +164,7 @@ class MapManager:
             sorted_events = sorted(
                 new_events, key=lambda e: e.priority, reverse=True
             )
+            self.current_map.clear_events()
             self.current_map.add_events(sorted_events)
 
     def set_inits(self, new_inits: Sequence[EventObject]) -> None:
@@ -175,6 +172,7 @@ class MapManager:
             sorted_inits = sorted(
                 new_inits, key=lambda e: e.priority, reverse=True
             )
+            self.current_map.clear_inits()
             self.current_map.add_inits(sorted_inits)
 
     def clear_events(self) -> None:
@@ -190,17 +188,13 @@ class MapManager:
         self.maps = {}
         self._map_type_slug = None
 
-    def remove_event(self, event: EventObject) -> None:
-        if self.current_map:
-            updated = list(self.current_map.events)
-            updated.remove(event)
-            self.current_map.add_events(updated)
-
     def remove_init(self, event: EventObject) -> None:
         if self.current_map:
-            updated = list(self.current_map.inits)
-            updated.remove(event)
-            self.current_map.add_inits(updated)
+            self.current_map.remove_init(event)
+
+    def remove_event(self, event: EventObject) -> None:
+        if self.current_map:
+            self.current_map.remove_event(event)
 
     def get_map_filepath(self) -> str | None:
         """Returns the filepath of the current map."""

--- a/tuxemon/map/transition.py
+++ b/tuxemon/map/transition.py
@@ -41,7 +41,6 @@ class MapTransition:
         """Loads the new map or a NullMap and updates relevant game components."""
         current = self.map_manager.current_map
         self._clear_npcs()
-
         if map_name:
             if current is None or map_name != current.filename:
                 map_data = self.map_loader.load_map_data(map_name)
@@ -49,9 +48,8 @@ class MapTransition:
                 map_data = current
         else:
             map_data = self.map_loader.load_null_map(yaml_path)
-
-        self._reset_events(map_data)
         self._update_map_state(map_data)
+        self._reset_events(map_data)
         self._update_boundaries()
 
     def validate_coordinates(self, x: int, y: int) -> None:
@@ -62,8 +60,7 @@ class MapTransition:
 
     def _reset_events(self, map_data: AbstractMap) -> None:
         """Resets and updates event engine for the new map."""
-        self.event_engine.reset()
-        self.event_engine.set_current_map(map_data)
+        self.event_engine.reset(map_data)
 
     def _update_map_state(self, map_data: AbstractMap) -> None:
         """Updates the map manager with new map data."""

--- a/tuxemon/map/tuxemon.py
+++ b/tuxemon/map/tuxemon.py
@@ -143,6 +143,11 @@ class AbstractMap(ABC):
         """Append new init events to the existing inits list."""
 
     @abstractmethod
+    def remove_init(self, event: EventObject) -> None: ...
+
+    @abstractmethod
+    def remove_event(self, event: EventObject) -> None: ...
+    @abstractmethod
     def clear_events(self) -> None: ...
 
     @abstractmethod
@@ -317,6 +322,12 @@ class TuxemonMap(AbstractMap):
     def add_inits(self, new_inits: Sequence[EventObject]) -> None:
         self._inits.extend(new_inits)
 
+    def remove_init(self, event: EventObject) -> None:
+        self._inits.remove(event)
+
+    def remove_event(self, event: EventObject) -> None:
+        self._events.remove(event)
+
     def clear_events(self) -> None:
         self._events.clear()
 
@@ -443,8 +454,14 @@ class NullMap(AbstractMap):
     def add_inits(self, new_inits: Sequence[EventObject]) -> None:
         self._inits.extend(new_inits)
 
+    def remove_init(self, event: EventObject) -> None:
+        self._inits.remove(event)
+
+    def remove_event(self, event: EventObject) -> None:
+        self._events.remove(event)
+
     def clear_events(self) -> None:
-        self._events = []
+        self._events.clear()
 
     def clear_inits(self) -> None:
-        self._inits = []
+        self._inits.clear()


### PR DESCRIPTION
Each behavior's `expand()` was called twice per event cycle, once for conditions, once for actions. Replaced the two split functions with a single `expand_behavior()` and added a per-frame cache in `EventEngine` so each behavior expands exactly once. `reset()` now clears the cache on map change.

`cancel_event()` and `cancel_all_events()` never cleaned up `triggered_global_events`, so cancelled global events could never re-trigger. Fixed.

`EventAction` had several broken invariants: `on_start()` set `done=True` on cancelled actions, `update()` could leave `_done=False` on cancelled single-frame actions, `run()` returned early on `_skip` without calling `stop()`, and `ActionContextManager.__exit__()` blocked subclass `cleanup()` from running on cancellation.

`advance()` in `RunningEvent` was setting `COMPLETED` speculatively, moved that responsibility exclusively to `process()`. Added a per-frame action budget to `process()` to prevent spinning on pathological self-cancelling action chains. Removed dead `WAITING`/`CHECKING` states from `ConditionState`.

Tests updated and expanded.