### PR TITLE
Refactor Party, Box, and RoutingPolicy Systems

### DIFF
--- a/mods/routing_policies.yaml
+++ b/mods/routing_policies.yaml
@@ -32,9 +32,19 @@
 default:
   force_to_box: false     # If true, all monsters go directly to the box instead of the party.
   kennel_override: null   # Optional: override the default box name (KENNEL). Use null to disable.
+  locker_override: null
+  max_party_size: null
+  allow_party_addition: true
+  auto_release_if_box_full: false
+  auto_discard_if_box_full: false
+  overflow_kennel: null
+  overflow_locker: null
+  max_box_capacity: null
+  nickname_rules: {}
   kennel_name_rules:
     prefix: "_"
     suffix: ""
+  locker_name_rules: {}
 
 example_policy:
   # ── Routing Behavior ───────────────────────

--- a/tests/tuxemon/test_boxes.py
+++ b/tests/tuxemon/test_boxes.py
@@ -137,7 +137,7 @@ def test_move_monster(boxes, monster1):
 def test_merge_boxes(boxes, monster1, monster2):
     boxes.add_monster("box1", monster1)
     boxes.add_monster("box1", monster2)
-    boxes.merge_boxes("box1", "box2")
+    boxes.merge_and_remove_boxes("box1", "box2")
 
     assert boxes.get_monsters("box1") == []
     assert boxes.get_monsters("box2") == [monster1, monster2]
@@ -376,3 +376,60 @@ def test_is_box_full_respects_metadata_capacity(boxes, monster1):
 
     policy = RoutingPolicy("default", max_box_capacity=10)
     assert boxes.is_box_full("box1", "monster", policy)
+
+
+def test_store_party_in_box_success(boxes, monster1, monster2):
+    party = [monster1, monster2]
+    result = boxes.store_party_in_box("box1", party)
+    assert result is True
+    assert monster1 in boxes.get_monsters("box1")
+    assert monster2 in boxes.get_monsters("box1")
+    assert len(party) == 2
+
+
+def test_store_party_in_box_creates_box_if_missing(boxes, monster1):
+    assert not boxes.has_box("box1", "monster")
+    boxes.store_party_in_box("box1", [monster1])
+    assert boxes.has_box("box1", "monster")
+
+
+def test_store_party_in_box_creates_metadata(boxes, monster1):
+    boxes.store_party_in_box("box1", [monster1], max_size=5)
+    meta = boxes.metadata_manager.get("box1", "monster")
+    assert meta is not None
+    assert meta.max_capacity == 5
+
+
+def test_store_party_in_box_fails_if_not_enough_space(
+    boxes, monster1, monster2
+):
+    boxes.create_box("box1", BoxMetadata(max_capacity=1, is_hidden=False))
+    boxes.add_monster("box1", monster1)
+    result = boxes.store_party_in_box("box1", [monster2], max_size=1)
+    assert result is False
+    assert monster2 not in boxes.get_monsters("box1")
+
+
+def test_store_party_in_box_does_not_clear_party_on_failure(
+    boxes, monster1, monster2
+):
+    boxes.create_box("box1", BoxMetadata(max_capacity=1, is_hidden=False))
+    boxes.add_monster("box1", monster1)
+    party = [monster2]
+    boxes.store_party_in_box("box1", party, max_size=1)
+    assert len(party) == 1
+
+
+def test_store_party_in_box_existing_box_accumulates(
+    boxes, monster1, monster2
+):
+    boxes.create_box("box1", BoxMetadata(max_capacity=5, is_hidden=False))
+    boxes.add_monster("box1", monster1)
+    boxes.store_party_in_box("box1", [monster2], max_size=5)
+    assert boxes.get_box_size("box1", "monster") == 2
+
+
+def test_store_party_in_box_empty_party(boxes):
+    result = boxes.store_party_in_box("box1", [])
+    assert result is True
+    assert boxes.get_box_size("box1", "monster") == 0

--- a/tests/tuxemon/test_party_handler.py
+++ b/tests/tuxemon/test_party_handler.py
@@ -48,6 +48,9 @@ class FakeBoxes:
         self.received.append((monster, kennel))
         return True
 
+    def remove_from_box(self, box_type, box_id, obj):
+        self.received = [(m, k) for m, k in self.received if m is not obj]
+
 
 class FakeNPC:
     pass

--- a/tests/tuxemon/test_routing_policy.py
+++ b/tests/tuxemon/test_routing_policy.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tuxemon.entity.routing import RoutingPolicy, RoutingPolicyRegistry
+from tuxemon.platform.const.sizes import KENNEL, LOCKER
+
+
+def _register(name: str, overrides: dict[str, Any] | None = None) -> None:
+    base: dict[str, Any] = {
+        "force_to_box": False,
+        "kennel_override": None,
+        "locker_override": None,
+        "max_party_size": None,
+        "allow_party_addition": True,
+        "auto_release_if_box_full": False,
+        "auto_discard_if_box_full": False,
+        "overflow_kennel": None,
+        "overflow_locker": None,
+        "max_box_capacity": None,
+        "nickname_rules": {},
+        "kennel_name_rules": {},
+        "locker_name_rules": {},
+    }
+    if overrides:
+        base.update(overrides)
+    RoutingPolicyRegistry._policies[name] = base
+
+
+@dataclass
+class FakeNPCState:
+    routing_policy: Any = "default"
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Isolate each test — clear and repopulate with a known default."""
+    RoutingPolicyRegistry._policies = {}
+    _register("default")
+    yield
+    RoutingPolicyRegistry._policies = {}
+
+
+class TestRegistryHas:
+    def test_known_policy_returns_true(self):
+        assert RoutingPolicyRegistry.has("default") is True
+
+    def test_unknown_policy_returns_false(self):
+        assert RoutingPolicyRegistry.has("nonexistent") is False
+
+
+class TestRegistryGet:
+    def test_returns_routing_policy_instance(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert isinstance(policy, RoutingPolicy)
+
+    def test_returned_policy_has_correct_name(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.name == "default"
+
+    def test_unknown_policy_raises_key_error(self):
+        with pytest.raises(KeyError, match="nonexistent"):
+            RoutingPolicyRegistry.get("nonexistent")
+
+
+class TestRegistryGetRaw:
+    def test_returns_dict(self):
+        raw = RoutingPolicyRegistry.get_raw("default")
+        assert isinstance(raw, dict)
+
+    def test_missing_key_raises(self):
+        with pytest.raises(KeyError):
+            RoutingPolicyRegistry.get_raw("missing")
+
+
+class TestRegistryLazyLoad:
+    def test_empty_registry_triggers_load_on_get(self, monkeypatch):
+        RoutingPolicyRegistry._policies = {}
+        monkeypatch.setattr(
+            RoutingPolicyRegistry,
+            "load_from_file",
+            lambda cls=None: _register("default"),
+        )
+        assert RoutingPolicyRegistry.has("default")
+
+    def test_empty_registry_triggers_load_on_has(self, monkeypatch):
+        RoutingPolicyRegistry._policies = {}
+        called = []
+        original = RoutingPolicyRegistry.load_from_file
+
+        def fake_load(cls=None):
+            called.append(True)
+            _register("default")
+
+        monkeypatch.setattr(RoutingPolicyRegistry, "load_from_file", fake_load)
+        RoutingPolicyRegistry.has("default")
+        assert called
+
+    def test_populated_registry_does_not_reload(self, monkeypatch):
+        called = []
+
+        def fake_load(cls=None):
+            called.append(True)
+
+        monkeypatch.setattr(RoutingPolicyRegistry, "load_from_file", fake_load)
+        RoutingPolicyRegistry.get("default")
+        assert not called
+
+
+class TestFromRegistry:
+    def test_defaults_are_applied_for_missing_keys(self):
+        RoutingPolicyRegistry._policies["sparse"] = {}
+        policy = RoutingPolicyRegistry.get("sparse")
+        assert policy.force_to_box is False
+        assert policy.allow_party_addition is True
+        assert policy.auto_release_if_box_full is False
+        assert policy.auto_discard_if_box_full is False
+        assert policy.nickname_rules == {}
+        assert policy.kennel_name_rules == {}
+        assert policy.locker_name_rules == {}
+
+    def test_overrides_are_applied(self):
+        _register("custom", {"force_to_box": True, "max_party_size": 3})
+        policy = RoutingPolicyRegistry.get("custom")
+        assert policy.force_to_box is True
+        assert policy.max_party_size == 3
+
+    @pytest.mark.parametrize(
+        "raw_value, expected",
+        [
+            pytest.param(1, True, id="int-truthy-becomes-true"),
+            pytest.param(0, False, id="int-falsy-becomes-false"),
+            pytest.param("yes", True, id="nonempty-string-becomes-true"),
+            pytest.param("", False, id="empty-string-becomes-false"),
+        ],
+    )
+    def test_bool_coercion_on_force_to_box(self, raw_value, expected):
+        _register("coerce", {"force_to_box": raw_value})
+        policy = RoutingPolicyRegistry.get("coerce")
+        assert policy.force_to_box is expected
+
+    @pytest.mark.parametrize(
+        "raw_value, expected",
+        [
+            pytest.param(1, True, id="int-1"),
+            pytest.param(0, False, id="int-0"),
+        ],
+    )
+    def test_bool_coercion_on_allow_party_addition(self, raw_value, expected):
+        _register("coerce", {"allow_party_addition": raw_value})
+        policy = RoutingPolicyRegistry.get("coerce")
+        assert policy.allow_party_addition is expected
+
+    def test_none_overrides_are_preserved(self):
+        _register("nulls", {"kennel_override": None, "locker_override": None})
+        policy = RoutingPolicyRegistry.get("nulls")
+        assert policy.kennel_override is None
+        assert policy.locker_override is None
+
+    def test_string_overrides_are_preserved(self):
+        _register(
+            "overrides",
+            {
+                "kennel_override": "my_kennel",
+                "locker_override": "my_locker",
+            },
+        )
+        policy = RoutingPolicyRegistry.get("overrides")
+        assert policy.kennel_override == "my_kennel"
+        assert policy.locker_override == "my_locker"
+
+    def test_nickname_rules_preserved(self):
+        _register("nick", {"nickname_rules": {"prefix": "S-", "suffix": "!"}})
+        policy = RoutingPolicyRegistry.get("nick")
+        assert policy.nickname_rules == {"prefix": "S-", "suffix": "!"}
+
+    def test_max_party_size_negative_one(self):
+        _register("unlimited", {"max_party_size": -1})
+        policy = RoutingPolicyRegistry.get("unlimited")
+        assert policy.max_party_size == -1
+
+    def test_max_box_capacity_preserved(self):
+        _register("capped", {"max_box_capacity": 20})
+        policy = RoutingPolicyRegistry.get("capped")
+        assert policy.max_box_capacity == 20
+
+
+class TestShouldForceToBox:
+    def test_returns_true_when_force_to_box_true(self):
+        _register("forced", {"force_to_box": True})
+        policy = RoutingPolicyRegistry.get("forced")
+        assert policy.should_force_to_box() is True
+
+    def test_returns_false_when_force_to_box_false(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.should_force_to_box() is False
+
+
+class TestGetKennel:
+    def test_returns_kennel_constant_when_no_override(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.get_kennel() == KENNEL
+
+    def test_returns_override_when_set(self):
+        _register("k_override", {"kennel_override": "special_box"})
+        policy = RoutingPolicyRegistry.get("k_override")
+        assert policy.get_kennel() == "special_box"
+
+    def test_returns_kennel_constant_when_override_is_none(self):
+        _register("k_none", {"kennel_override": None})
+        policy = RoutingPolicyRegistry.get("k_none")
+        assert policy.get_kennel() == KENNEL
+
+
+class TestGetLocker:
+    def test_returns_locker_constant_when_no_override(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.get_locker() == LOCKER
+
+    def test_returns_override_when_set(self):
+        _register("l_override", {"locker_override": "special_locker"})
+        policy = RoutingPolicyRegistry.get("l_override")
+        assert policy.get_locker() == "special_locker"
+
+    def test_returns_locker_constant_when_override_is_none(self):
+        _register("l_none", {"locker_override": None})
+        policy = RoutingPolicyRegistry.get("l_none")
+        assert policy.get_locker() == LOCKER
+
+
+class TestSerialize:
+    def test_returns_policy_name(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.serialize() == "default"
+
+    def test_returns_custom_policy_name(self):
+        _register("custom_name")
+        policy = RoutingPolicyRegistry.get("custom_name")
+        assert policy.serialize() == "custom_name"
+
+
+class TestDeserialize:
+    def test_valid_policy_name_is_returned(self):
+        state = FakeNPCState(routing_policy="default")
+        result = RoutingPolicy.deserialize(state)
+        assert result == "default"
+
+    def test_missing_policy_falls_back_to_default(self):
+        state = FakeNPCState(routing_policy="nonexistent")
+        result = RoutingPolicy.deserialize(state)
+        assert result == "default"
+
+    def test_none_routing_policy_falls_back_to_default(self):
+        state = FakeNPCState(routing_policy=None)
+        result = RoutingPolicy.deserialize(state)
+        assert result == "default"
+
+    def test_empty_string_falls_back_to_default(self):
+        state = FakeNPCState(routing_policy="")
+        result = RoutingPolicy.deserialize(state)
+        assert result == "default"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            pytest.param(123, id="integer"),
+            pytest.param([], id="list"),
+            pytest.param({}, id="dict"),
+            pytest.param(False, id="bool-false"),
+        ],
+    )
+    def test_non_string_values_fall_back_to_default(self, bad_value):
+        state = FakeNPCState(routing_policy=bad_value)
+        result = RoutingPolicy.deserialize(state)
+        assert result == "default"
+
+    def test_valid_non_default_policy_is_returned(self):
+        _register("special")
+        state = FakeNPCState(routing_policy="special")
+        result = RoutingPolicy.deserialize(state)
+        assert result == "special"
+
+    def test_deserialize_logs_warning_for_missing_policy(self, caplog):
+        import logging
+
+        state = FakeNPCState(routing_policy="ghost")
+        with caplog.at_level(logging.WARNING, logger="tuxemon.entity.routing"):
+            RoutingPolicy.deserialize(state)
+        assert "ghost" in caplog.text
+
+    def test_deserialize_logs_warning_for_none(self, caplog):
+        import logging
+
+        state = FakeNPCState(routing_policy=None)
+        with caplog.at_level(logging.WARNING, logger="tuxemon.entity.routing"):
+            RoutingPolicy.deserialize(state)
+        assert "default" in caplog.text
+
+
+class TestRoundTrip:
+    def test_serialize_then_deserialize_returns_same_name(self):
+        _register("round_trip")
+        policy = RoutingPolicyRegistry.get("round_trip")
+        name = policy.serialize()
+        state = FakeNPCState(routing_policy=name)
+        result = RoutingPolicy.deserialize(state)
+        assert result == policy.name
+
+    @pytest.mark.parametrize(
+        "policy_name",
+        [
+            pytest.param("default", id="default"),
+            pytest.param("unlimited", id="unlimited-party"),
+        ],
+    )
+    def test_round_trip_for_known_policies(self, policy_name):
+        _register("unlimited", {"max_party_size": -1})
+        policy = RoutingPolicyRegistry.get(policy_name)
+        state = FakeNPCState(routing_policy=policy.serialize())
+        assert RoutingPolicy.deserialize(state) == policy_name
+
+
+class TestEdgeCases:
+    def test_multiple_policies_coexist(self):
+        _register("a", {"force_to_box": True})
+        _register("b", {"max_party_size": 6})
+        assert RoutingPolicyRegistry.get("a").force_to_box is True
+        assert RoutingPolicyRegistry.get("b").max_party_size == 6
+
+    def test_get_returns_new_instance_each_call(self):
+        p1 = RoutingPolicyRegistry.get("default")
+        p2 = RoutingPolicyRegistry.get("default")
+        assert p1 is not p2
+
+    def test_mutating_returned_policy_does_not_affect_registry(self):
+        policy = RoutingPolicyRegistry.get("default")
+        policy.force_to_box = True
+        fresh = RoutingPolicyRegistry.get("default")
+        assert fresh.force_to_box is False
+
+    def test_nickname_rules_empty_dict_by_default(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.nickname_rules == {}
+
+    def test_overflow_fields_none_by_default(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.overflow_kennel is None
+        assert policy.overflow_locker is None
+
+    def test_max_party_size_none_by_default(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.max_party_size is None
+
+    def test_kennel_name_rules_empty_dict_by_default(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.kennel_name_rules == {}
+
+    def test_locker_name_rules_empty_dict_by_default(self):
+        policy = RoutingPolicyRegistry.get("default")
+        assert policy.locker_name_rules == {}

--- a/tuxemon/boxes.py
+++ b/tuxemon/boxes.py
@@ -53,6 +53,9 @@ class BoxMetadataManager:
     def get(self, box_id: str, box_type: str) -> BoxMetadata | None:
         return self._get_dict(box_type).get(box_id)
 
+    def get_all(self, box_type: str) -> dict[str, BoxMetadata]:
+        return dict(self._get_dict(box_type))
+
     def delete(self, box_id: str, box_type: str) -> None:
         metadata_dict = self._get_dict(box_type)
         if box_id not in metadata_dict:
@@ -91,6 +94,66 @@ class BoxCollection:
         self.item_boxes: dict[str, list[Item]] = {}
         self.monster_boxes: dict[str, list[Monster]] = {}
         self.metadata_manager = BoxMetadataManager()
+
+    def _get_boxes(self, box_type: str) -> dict[str, list[Any]]:
+        if box_type == "item":
+            return self.item_boxes
+        elif box_type == "monster":
+            return self.monster_boxes
+        raise ValueError(f"Invalid box_type: {box_type}")
+
+    def _create_box(
+        self,
+        box_id: str,
+        box_type: str,
+        default_capacity: int,
+        box_metadata: BoxMetadata | None = None,
+    ) -> None:
+        boxes = self._get_boxes(box_type)
+        if box_id in boxes:
+            raise ValueError(
+                f"{box_type.capitalize()} box '{box_id}' already exists."
+            )
+        boxes[box_id] = []
+        metadata = box_metadata or BoxMetadata(
+            max_capacity=default_capacity, is_hidden=False
+        )
+        self.metadata_manager.create(box_id, box_type, metadata)
+
+    def _remove_box(
+        self, box_id: str, box_type: str, force: bool = False
+    ) -> None:
+        boxes = self._get_boxes(box_type)
+        if box_id not in boxes:
+            raise ValueError(
+                f"{box_type.capitalize()} box '{box_id}' doesn't exist."
+            )
+        if not force and boxes[box_id]:
+            raise ValueError(f"Cannot remove a non-empty {box_type} box.")
+        del boxes[box_id]
+        self.metadata_manager.delete(box_id, box_type)
+
+    def _merge_and_remove_boxes(
+        self,
+        source_box_id: str,
+        target_box_id: str,
+        box_type: str,
+        default_capacity: int,
+    ) -> None:
+        boxes = self._get_boxes(box_type)
+        if target_box_id not in boxes:
+            self._create_box(target_box_id, box_type, default_capacity)
+        if source_box_id in boxes:
+            boxes[target_box_id].extend(boxes[source_box_id])
+            del boxes[source_box_id]
+            source_meta = self.metadata_manager.get(source_box_id, box_type)
+            target_meta = self.metadata_manager.get(target_box_id, box_type)
+            if source_meta and target_meta:
+                target_meta.max_capacity = max(
+                    source_meta.max_capacity, target_meta.max_capacity
+                )
+            if self.metadata_manager.get(source_box_id, box_type) is not None:
+                self.metadata_manager.delete(source_box_id, box_type)
 
     def add_item(self, box_id: str, item: Item) -> None:
         """
@@ -146,6 +209,11 @@ class BoxCollection:
         """
         if box_id not in self.monster_boxes:
             self.monster_boxes[box_id] = []
+            self.metadata_manager.create(
+                box_id,
+                "monster",
+                BoxMetadata(max_capacity=max_size, is_hidden=False),
+            )
 
         current_size = len(self.monster_boxes[box_id])
         required_space = len(party)
@@ -160,7 +228,6 @@ class BoxCollection:
 
         self.monster_boxes[box_id].extend(party)
         logger.info(f"Stored {required_space} monsters in box '{box_id}'.")
-        party.clear()
         return True
 
     def remove_from_box(
@@ -376,11 +443,12 @@ class BoxCollection:
             item: The item to move.
         """
         if (
-            source_box_id in self.item_boxes
-            and item in self.item_boxes[source_box_id]
+            source_box_id not in self.item_boxes
+            or item not in self.item_boxes[source_box_id]
         ):
-            self.remove_from_box("item", source_box_id, item)
-            self.add_item(target_box_id, item)
+            raise ValueError(f"Item not found in box '{source_box_id}'.")
+        self.remove_from_box("item", source_box_id, item)
+        self.add_item(target_box_id, item)
 
     def move_monster(
         self, source_box_id: str, target_box_id: str, monster: Monster
@@ -460,46 +528,19 @@ class ItemBoxes(BoxCollection):
         self, box_id: str, box_metadata: BoxMetadata | None = None
     ) -> None:
         """Create a new item box with optional metadata."""
-        if box_id in self.item_boxes:
-            raise ValueError(f"Item box '{box_id}' already exists.")
-        self.item_boxes[box_id] = []
-        metadata = box_metadata or BoxMetadata(
-            max_capacity=MAX_LOCKER, is_hidden=False
-        )
-        self.metadata_manager.create(box_id, "item", metadata)
+        super()._create_box(box_id, "item", MAX_LOCKER, box_metadata)
 
     def remove_box(self, box_id: str, force: bool = False) -> None:
         """Remove an item box, optionally forcing removal if non-empty."""
-        if box_id not in self.item_boxes:
-            raise ValueError(f"Item box '{box_id}' doesn't exist.")
-        if not force and self.item_boxes[box_id]:
-            logger.error(
-                f"Cannot remove non-empty item box '{box_id}'. Use force=True to override."
-            )
-            raise ValueError("Cannot remove a non-empty item box.")
-        del self.item_boxes[box_id]
-        self.metadata_manager.delete(box_id, "item")
+        super()._remove_box(box_id, "item", force)
 
-    def merge_boxes(self, source_box_id: str, target_box_id: str) -> None:
+    def merge_and_remove_boxes(
+        self, source_box_id: str, target_box_id: str
+    ) -> None:
         """Merge contents and metadata from one item box into another."""
-        if target_box_id not in self.item_boxes:
-            self.create_box(target_box_id)
-        if source_box_id in self.item_boxes:
-            self.item_boxes[target_box_id].extend(
-                self.item_boxes[source_box_id]
-            )
-            del self.item_boxes[source_box_id]
-
-            source_metadata = self.metadata_manager.get(source_box_id, "item")
-            if source_metadata:
-                target_metadata = self.metadata_manager.get(
-                    target_box_id, "item"
-                )
-                if target_metadata is None:
-                    self.metadata_manager.create(
-                        target_box_id, "item", source_metadata
-                    )
-                self.metadata_manager.delete(source_box_id, "item")
+        super()._merge_and_remove_boxes(
+            source_box_id, target_box_id, "item", MAX_LOCKER
+        )
 
     def attempt_add_item(
         self,
@@ -569,14 +610,14 @@ class ItemBoxes(BoxCollection):
                 break
             i += 1
         self.create_box(new_box_id)
-        self.merge_boxes(box_id, new_box_id)
+        self.merge_and_remove_boxes(box_id, new_box_id)
         return new_box_id
 
     def get_state(self) -> dict[str, Any]:
         """Return a serializable state of all item boxes and metadata."""
         return self.get_state_generic(
             self.item_boxes,
-            self.metadata_manager._get_dict("item"),
+            self.metadata_manager.get_all("item"),
             encode_items,
             "item_boxes",
             "item_box_metadata",
@@ -602,13 +643,7 @@ class MonsterBoxes(BoxCollection):
         self, box_id: str, box_metadata: BoxMetadata | None = None
     ) -> None:
         """Create a new monster box with optional metadata."""
-        if box_id in self.monster_boxes:
-            raise ValueError(f"Monster box '{box_id}' already exists.")
-        self.monster_boxes[box_id] = []
-        metadata = box_metadata or BoxMetadata(
-            max_capacity=MAX_KENNEL, is_hidden=False
-        )
-        self.metadata_manager.create(box_id, "monster", metadata)
+        super()._create_box(box_id, "monster", MAX_KENNEL, box_metadata)
 
     def get_total_monster_count(self) -> int:
         """Return the total number of monsters across all boxes."""
@@ -631,15 +666,7 @@ class MonsterBoxes(BoxCollection):
 
     def remove_box(self, box_id: str, force: bool = False) -> None:
         """Remove a monster box, optionally forcing removal if non-empty."""
-        if box_id not in self.monster_boxes:
-            raise ValueError(f"Monster box '{box_id}' doesn't exist.")
-        if not force and self.monster_boxes[box_id]:
-            logger.error(
-                f"Cannot remove non-empty monster box '{box_id}'. Use force=True to override."
-            )
-            raise ValueError("Cannot remove a non-empty monster box.")
-        del self.monster_boxes[box_id]
-        self.metadata_manager.delete(box_id, "monster")
+        super()._remove_box(box_id, "monster", force)
 
     def get_box_name(self, instance_id: UUID) -> str | None:
         """Return the box ID containing the monster with the given instance ID."""
@@ -653,28 +680,13 @@ class MonsterBoxes(BoxCollection):
             None,
         )
 
-    def merge_boxes(self, source_box_id: str, target_box_id: str) -> None:
+    def merge_and_remove_boxes(
+        self, source_box_id: str, target_box_id: str
+    ) -> None:
         """Merge contents and metadata from one box into another."""
-        if target_box_id not in self.monster_boxes:
-            self.create_box(target_box_id)
-        if source_box_id in self.monster_boxes:
-            self.monster_boxes[target_box_id].extend(
-                self.monster_boxes[source_box_id]
-            )
-            del self.monster_boxes[source_box_id]
-
-            source_metadata = self.metadata_manager.get(
-                source_box_id, "monster"
-            )
-            if source_metadata:
-                target_metadata = self.metadata_manager.get(
-                    target_box_id, "monster"
-                )
-                if target_metadata is None:
-                    self.metadata_manager.create(
-                        target_box_id, "monster", source_metadata
-                    )
-                self.metadata_manager.delete(source_box_id, "monster")
+        super()._merge_and_remove_boxes(
+            source_box_id, target_box_id, "monster", MAX_KENNEL
+        )
 
     def create_and_merge_box(
         self, box_id: str, kennel_name_rules: dict[str, Any]
@@ -690,7 +702,7 @@ class MonsterBoxes(BoxCollection):
                 break
             i += 1
         self.create_box(new_box_id)
-        self.merge_boxes(box_id, new_box_id)
+        self.merge_and_remove_boxes(box_id, new_box_id)
         return new_box_id
 
     def attempt_add_monster(
@@ -764,20 +776,19 @@ class MonsterBoxes(BoxCollection):
         self, instance_id: UUID, external_monster: Monster
     ) -> Monster:
         """Swap a monster by instance ID with an external monster."""
-        monster = self.get_monsters_by_iid(instance_id)
-        box_id = self.get_box_name(instance_id)
-        if monster is not None and box_id is not None:
-            return self.swap_with_external_monster(
-                box_id, monster, external_monster
-            )
-        else:
-            raise ValueError("Monster not found in box.")
+        for box_id, monsters in self.monster_boxes.items():
+            for monster in monsters:
+                if monster.instance_id == instance_id:
+                    return self.swap_with_external_monster(
+                        box_id, monster, external_monster
+                    )
+        raise ValueError("Monster not found in box.")
 
     def get_state(self) -> dict[str, Any]:
         """Return a serializable state of all monster boxes and metadata."""
         return self.get_state_generic(
             self.monster_boxes,
-            self.metadata_manager._get_dict("monster"),
+            self.metadata_manager.get_all("monster"),
             encode_monsters,
             "monster_boxes",
             "monster_box_metadata",

--- a/tuxemon/entity/npc.py
+++ b/tuxemon/entity/npc.py
@@ -249,7 +249,7 @@ class NPC(Entity):
         base.step_tracker = encode_steps(self.step_tracker)
         base.unlocked_letters = encode_cipher(self.unlocked_letters)
         base.evolution_registry = self.evolution_registry.encode_registry()
-        base.routing_policy = self.party.routing_policy.to_dict()
+        base.routing_policy = self.party.routing_policy.serialize()
 
         return base
 
@@ -288,7 +288,7 @@ class NPC(Entity):
 
         self.tracker = decode_tracking(save_data.tracker)
         self.step_tracker = decode_steps(save_data.step_tracker)
-        self.party.routing_policy_name = RoutingPolicy.from_dict(save_data)
+        self.party.routing_policy_name = RoutingPolicy.deserialize(save_data)
 
         if save_data.appearance:
             self.appearance_manager.load_state(save_data.appearance)

--- a/tuxemon/entity/party.py
+++ b/tuxemon/entity/party.py
@@ -162,21 +162,12 @@ class PartyHandler:
 
     def should_send_to_box(self, policy: RoutingPolicy | None = None) -> bool:
         policy = policy or self.routing_policy
-
-        is_unlimited = (
-            policy.max_party_size is not None and policy.max_party_size == -1
-        )
-        party_limit = (
-            policy.max_party_size
-            if policy.max_party_size is not None
-            else self._party_limit
-        )
-
-        return (
-            policy.should_force_to_box()
-            or not policy.allow_party_addition
-            or (not is_unlimited and self.party_size >= party_limit)
-        )
+        if policy.should_force_to_box() or not policy.allow_party_addition:
+            return True
+        if policy.max_party_size == -1:
+            return False
+        limit = policy.max_party_size or self._party_limit
+        return self.party_size >= limit
 
     def send_monster_to_box(
         self, monster: Monster, kennel: str | None = None
@@ -230,12 +221,12 @@ class PartyHandler:
             return False
 
         self.remove_monster(monster)
-        monster.owner = None
         return True
 
     def remove_monster(self, monster: Monster) -> None:
         if monster in self._monsters:
             self._monsters.remove(monster)
+            monster.owner = None
 
     def switch_monsters(self, index_1: int, index_2: int) -> None:
         self._validate_index(index_1)
@@ -254,6 +245,7 @@ class PartyHandler:
         if old_monster not in self._monsters:
             return False
         index = self._monsters.index(old_monster)
+        old_monster.owner = None
         self._monsters[index] = new_monster
         self._assign_owner(new_monster)
         return True
@@ -306,14 +298,18 @@ class PartyHandler:
         return True
 
     def transfer_monster_to_party(
-        self, monster: Monster, slot: int | None = None
+        self,
+        monster: Monster,
+        slot: int | None = None,
+        source_kennel: str | None = None,
     ) -> bool:
         if self.should_send_to_box():
             logger.warning(
                 f"Cannot transfer monster '{monster}' to party: policy or limit prevents it."
             )
-            return False
+            return False  # monster stays in box, nothing mutated yet
 
+        self._monster_boxes.remove_from_box("monster", source_kennel, monster)
         self.insert_monster_to_party(monster, slot)
         logger.info(f"Monster '{monster}' transferred from box to party.")
         return True
@@ -322,6 +318,8 @@ class PartyHandler:
         return encode_monsters(self._monsters)
 
     def decode_party(self, json_data: NPCState | None) -> None:
+        # Bypasses add_monster intentionally: save/load restores state directly
+        # without applying routing policy, nickname rules, or capacity checks.
         self.clear_party()
         if not json_data or not json_data.monsters:
             return

--- a/tuxemon/entity/routing.py
+++ b/tuxemon/entity/routing.py
@@ -27,16 +27,22 @@ class RoutingPolicyRegistry:
 
     @classmethod
     def get(cls, name: str) -> RoutingPolicy:
+        if not cls._policies:
+            cls.load_from_file()
         if name not in cls._policies:
             raise KeyError(f"Routing policy '{name}' not found.")
         return RoutingPolicy.from_registry(name)
 
     @classmethod
     def get_raw(cls, name: str) -> dict[str, Any]:
+        if not cls._policies:
+            cls.load_from_file()
         return cls._policies[name]
 
     @classmethod
     def has(cls, name: str) -> bool:
+        if not cls._policies:
+            cls.load_from_file()
         return name in cls._policies
 
 
@@ -90,11 +96,11 @@ class RoutingPolicy:
     def get_locker(self) -> str:
         return self.locker_override or LOCKER
 
-    def to_dict(self) -> str:
+    def serialize(self) -> str:
         return self.name
 
     @classmethod
-    def from_dict(cls, data: NPCState) -> str:
+    def deserialize(cls, data: NPCState) -> str:
         name = data.routing_policy
 
         if not isinstance(name, str) or not name:
@@ -110,6 +116,3 @@ class RoutingPolicy:
             return "default"
 
         return name
-
-
-RoutingPolicyRegistry.load_from_file()

--- a/tuxemon/event/actions/clear_kennel.py
+++ b/tuxemon/event/actions/clear_kennel.py
@@ -60,7 +60,8 @@ class ClearKennelAction(EventAction):
                 if transfer is None:
                     character.monster_boxes.remove_box(kennel)
                 else:
-                    character.monster_boxes.merge_boxes(kennel, transfer)
-                    character.monster_boxes.remove_box(kennel)
+                    character.monster_boxes.merge_and_remove_boxes(
+                        kennel, transfer
+                    )
             else:
                 return

--- a/tuxemon/event/actions/quarantine.py
+++ b/tuxemon/event/actions/quarantine.py
@@ -97,8 +97,9 @@ class QuarantineAction(EventAction):
             # Inoculates the monster before releasing it.
             monster.plague.inoculate(self.plague_slug)
 
-            if party.transfer_monster_to_party(monster):
-                boxes.remove_from_box("monster", self.name, monster)
+            if party.transfer_monster_to_party(
+                monster, source_kennel=self.name
+            ):
                 logger.info(f"{monster} has been inoculated and released")
             else:
                 logger.warning(f"Failed to release {monster} to party")

--- a/tuxemon/event/actions/replace_party_from_yaml.py
+++ b/tuxemon/event/actions/replace_party_from_yaml.py
@@ -115,6 +115,13 @@ class ReplacePartyFromYamlAction(EventAction):
 
             new_monsters.append(monster)
 
+        if not new_monsters:
+            logger.error(
+                f"No valid monsters built for set '{self.set_name}', party unchanged."
+            )
+            self.stop()
+            return
+
         character.party.replace_party(new_monsters, False)
         logger.info(
             f"Replaced all monsters for {character.name} using set '{self.set_name}' from {self.yaml_file}"

--- a/tuxemon/states/pc_kennel.py
+++ b/tuxemon/states/pc_kennel.py
@@ -61,10 +61,7 @@ class MonsterActionHandler:
 
     def pick(self, monster: Monster) -> None:
         self._clear_states("ChoiceState", "MonsterTakeState")
-        self.monster_boxes.remove_from_box("monster", None, monster)
-        self.char.party.insert_monster_to_party(
-            monster, len(self.char.monsters)
-        )
+        self.char.party.transfer_monster_to_party(monster)
         open_dialog(
             self.client,
             [T.format("menu_storage_take_monster", {"name": monster.name})],
@@ -290,8 +287,6 @@ class MonsterTakeState(PygameMenuState):
         )
 
     def add_menu_items(self, menu: Menu, items: Sequence[Monster]) -> None:
-        self.monster_boxes = self.char.monster_boxes
-        self.box = self.monster_boxes.get_monsters(self.box_name)
         handler = MonsterActionHandler(
             self.client, self.char, self.box_name, self.name
         )
@@ -429,8 +424,7 @@ class MonsterStorageState(MonsterBoxState):
         menu_items_map = []
         monster_boxes = self.char.monster_boxes
         for box_name, monsters in monster_boxes.monster_boxes.items():
-            metadata = monster_boxes.metadata_manager.get(box_name, "monster")
-            if metadata is None or not metadata.is_hidden:
+            if not monster_boxes.is_box_hidden(box_name, "monster"):
                 if not monsters:
                     menu_callback = partial(
                         open_dialog,
@@ -459,8 +453,7 @@ class MonsterDropOffState(MonsterBoxState):
         menu_items_map = []
         monster_boxes = self.char.monster_boxes
         for box_name, monsters in monster_boxes.monster_boxes.items():
-            metadata = monster_boxes.metadata_manager.get(box_name, "monster")
-            if metadata is None or not metadata.is_hidden:
+            if not monster_boxes.is_box_hidden(box_name, "monster"):
                 if len(monsters) < MAX_BOX:
                     menu_callback = self.change_state(
                         "MonsterDropOff",
@@ -523,6 +516,5 @@ class MonsterDropOff(MonsterMenuState):
             self.on_selection(monster)
             self.client.state_manager.pop_state(self)
         else:
-            self.char.monster_boxes.add_monster(self.box_name, monster)
-            self.char.party.remove_monster(monster)
+            self.char.party.transfer_monster_to_box(monster, self.box_name)
             self.client.state_manager.pop_state(self)

--- a/tuxemon/states/pc_locker.py
+++ b/tuxemon/states/pc_locker.py
@@ -126,8 +126,8 @@ class ItemTakeState(PygameMenuState):
     ) -> None:
         self.box_name = box_name
         self.char = character
-        self.box = self.char.item_boxes.get_items(self.box_name)
-
+        self.item_boxes = self.char.item_boxes
+        self.box = self.item_boxes.get_items(self.box_name)
         width, height = client.context.resolution
 
         columns = 3
@@ -232,8 +232,6 @@ class ItemTakeState(PygameMenuState):
         )
 
     def add_menu_items(self, menu: Menu, items: Sequence[Item]) -> None:
-        self.item_boxes = self.char.item_boxes
-        self.box = self.item_boxes.get_items(self.box_name)
         handler = ItemActionHandler(
             self.client, self.char, self.box_name, self.name
         )
@@ -351,8 +349,7 @@ class ItemStorageState(ItemBoxState):
         item_boxes = self.char.item_boxes
         menu_items_map = []
         for box_name, items in item_boxes.item_boxes.items():
-            metadata = item_boxes.metadata_manager.get(box_name, "item")
-            if metadata is None or not metadata.is_hidden:
+            if not item_boxes.is_box_hidden(box_name, "item"):
                 if not items:
                     menu_callback = partial(
                         open_dialog,
@@ -380,9 +377,8 @@ class ItemDropOffState(ItemBoxState):
     def get_menu_items_map(self) -> Sequence[tuple[str, MenuGameObj]]:
         item_boxes = self.char.item_boxes
         menu_items_map = []
-        for box_name, items in item_boxes.item_boxes.items():
-            metadata = item_boxes.metadata_manager.get(box_name, "item")
-            if metadata is None or not metadata.is_hidden:
+        for box_name in item_boxes.item_boxes:
+            if not item_boxes.is_box_hidden(box_name, "item"):
                 menu_callback = self.change_state(
                     "ItemDropOff", box_name=box_name, character=self.char
                 )
@@ -430,13 +426,7 @@ class ItemDropOff(ItemMenuState):
             item_boxes = self.char.item_boxes
             box = item_boxes.get_items(self.box_name)
 
-            new_item = Item.create(itm.slug)
-            new_item.set_quantity(quantity)
-
-            def find_item_in_box(slug: str, items: list[Item]) -> Item | None:
-                return next((i for i in items if i.slug == slug), None)
-
-            retrieve = find_item_in_box(itm.slug, box) if box else None
+            retrieve = next((i for i in box if i.slug == itm.slug), None)
             stored = (
                 item_boxes.get_items_by_iid(retrieve.instance_id)
                 if retrieve
@@ -446,6 +436,8 @@ class ItemDropOff(ItemMenuState):
             if stored:
                 stored.increase_quantity(quantity)
             else:
+                new_item = Item.create(itm.slug)
+                new_item.set_quantity(quantity)
                 item_boxes.add_item(self.box_name, new_item)
 
             self.char.bag.remove_item(itm, quantity)


### PR DESCRIPTION
PR improves consistency, correctness, and naming across the party handler, box collections, and routing policy registry. Party operations now maintain ownership state reliably, avoid redundant resets, and handle transfers and replacements in a predictable order. Box management gains clearer method names, corrected item‑specific constants, safer metadata handling, and explicit destructive merge behaviour. Movement operations now raise errors instead of failing silently, and test doubles match the real interface. Routing policies now load lazily, serialize and deserialize through clearer method names, and validate stored values without relying on module‑level side effects.