### PR TITLE
Unified Lookup Cache

### DIFF
--- a/tests/tuxemon/test_event_action_random_monster.py
+++ b/tests/tuxemon/test_event_action_random_monster.py
@@ -4,10 +4,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tuxemon.event.actions.random_monster import (
-    RandomMonsterAction,
-    lookup_cache,
-)
+from tuxemon.db import MonsterModel
+from tuxemon.event.actions.random_monster import RandomMonsterAction
 from tuxemon.event.eventaction import ActionManager
 from tuxemon.event.eventbehavior import BehaviorManager
 from tuxemon.event.eventengine import EventEngine
@@ -44,9 +42,18 @@ def engine():
     return engine
 
 
-def test_random_monster_basic(engine):
-    lookup_cache.clear()
-    lookup_cache.update(
+@pytest.fixture
+def set_monster_cache():
+    def _set(data):
+        MonsterModel._lookup_cache.clear()
+        MonsterModel._lookup_cache.update(data)
+
+    yield _set
+    MonsterModel._lookup_cache.clear()
+
+
+def test_random_monster_basic(engine, set_monster_cache):
+    set_monster_cache(
         {
             "a": make_mock_monster("a"),
             "b": make_mock_monster("b"),
@@ -61,9 +68,8 @@ def test_random_monster_basic(engine):
     assert slug in {"a", "b"}
 
 
-def test_excludes_monsters_that_would_evolve(engine):
-    lookup_cache.clear()
-    lookup_cache.update(
+def test_excludes_monsters_that_would_evolve(engine, set_monster_cache):
+    set_monster_cache(
         {
             "evo": make_mock_monster("evo", evolves=True),
             "ok": make_mock_monster("ok"),
@@ -77,9 +83,8 @@ def test_excludes_monsters_that_would_evolve(engine):
     assert slug == "ok"
 
 
-def test_excludes_underleveled_forms(engine):
-    lookup_cache.clear()
-    lookup_cache.update(
+def test_excludes_underleveled_forms(engine, set_monster_cache):
+    set_monster_cache(
         {
             "bad": make_mock_monster("bad", underleveled=True),
             "ok": make_mock_monster("ok"),
@@ -93,9 +98,8 @@ def test_excludes_underleveled_forms(engine):
     assert slug == "ok"
 
 
-def test_excludes_non_random_monsters(engine):
-    lookup_cache.clear()
-    lookup_cache.update(
+def test_excludes_non_random_monsters(engine, set_monster_cache):
+    set_monster_cache(
         {
             "bad": make_mock_monster("bad", randomly=False),
             "ok": make_mock_monster("ok"),
@@ -109,9 +113,8 @@ def test_excludes_non_random_monsters(engine):
     assert slug == "ok"
 
 
-def test_no_valid_monsters_logs_error(engine, caplog):
-    lookup_cache.clear()
-    lookup_cache.update(
+def test_no_valid_monsters_logs_error(engine, set_monster_cache, caplog):
+    set_monster_cache(
         {
             "bad": make_mock_monster("bad", randomly=False),
         }

--- a/tuxemon/core/effects/fishing.py
+++ b/tuxemon/core/effects/fishing.py
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-lookup_cache: dict[str, MonsterModel] = {}
-
 
 @dataclass
 class ActionConfig:
@@ -103,8 +101,8 @@ class FishingEffect(CoreEffect):
     _trigger_next_frame: bool = False
 
     def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        self.cache = MonsterModel.get_cache()
 
         fishing_configs = Loader.get_config_fishing(f"{self.name}.yaml")
 
@@ -217,7 +215,7 @@ class FishingEffect(CoreEffect):
                 )
             )
 
-        filtered = [mon for mon in lookup_cache.values() if matches(mon)]
+        filtered = [mon for mon in self.cache.values() if matches(mon)]
 
         if not filtered:
             logger.error(
@@ -249,12 +247,3 @@ class FishingEffect(CoreEffect):
         """Prepare a fishing encounter (store slug + level only)."""
         self._pending_encounter = (mon_slug, level)
         self._trigger_next_frame = True
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }

--- a/tuxemon/core/effects/learn_mm.py
+++ b/tuxemon/core/effects/learn_mm.py
@@ -17,9 +17,6 @@ if TYPE_CHECKING:
     from tuxemon.session import Session
 
 
-lookup_cache: dict[str, TechniqueModel] = {}
-
-
 @dataclass
 class LearnMmEffect(CoreEffect):
     """
@@ -49,11 +46,19 @@ class LearnMmEffect(CoreEffect):
     def apply_item_target(
         self, session: Session, item: Item, target: Monster
     ) -> ItemEffectResult:
-        if not lookup_cache:
-            _lookup_techniques(self.element)
+        TechniqueModel.load_cache(db)
+        cache = TechniqueModel.get_cache()
+
+        # Filter AFTER cache load
+        filtered = {
+            slug: tech
+            for slug, tech in cache.items()
+            if tech.category != TechCategory.reserved
+            and self.element in tech.types
+        }
 
         known_moves = [tech.slug for tech in target.moves.get_moves()]
-        available = list(set(lookup_cache.keys()) - set(known_moves))
+        available = list(set(filtered.keys()) - set(known_moves))
 
         if available:
             tech_slug = random.choice(available)
@@ -69,14 +74,3 @@ class LearnMmEffect(CoreEffect):
             return ItemEffectResult(name=item.name, success=True)
 
         return ItemEffectResult(name=item.name)
-
-
-def _lookup_techniques(element: str) -> None:
-    global lookup_cache
-    lookup_cache = {
-        tech_name: result
-        for tech_name in db.database["technique"]
-        if (result := TechniqueModel.lookup(tech_name, db)).category
-        != TechCategory.reserved
-        and element in result.types
-    }

--- a/tuxemon/core/effects/trap.py
+++ b/tuxemon/core/effects/trap.py
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-lookup_cache: dict[str, MonsterModel] = {}
-
 
 @dataclass
 class TrapConfig:
@@ -60,15 +58,6 @@ class TrapConfig:
                 raise ValueError(
                     "Lower weight bound cannot exceed upper bound."
                 )
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
 
 
 class Loader:
@@ -141,8 +130,8 @@ class TrapEffect(CoreEffect):
     _pending_encounter: tuple[str, int] | None = None
 
     def apply_item(self, session: Session, item: Item) -> ItemEffectResult:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        self.cache = MonsterModel.get_cache()
         trap_configs = Loader.get_config_trap("trap.yaml")
         self._trap: TrapConfig = trap_configs[item.slug]
         self._trap.validate_parameters()
@@ -254,7 +243,7 @@ class TrapEffect(CoreEffect):
                 )
             )
 
-        filtered = [mon for mon in lookup_cache.values() if matches(mon)]
+        filtered = [mon for mon in self.cache.values() if matches(mon)]
         if not filtered:
             logger.error("No monsters matched trap filters")
             return []

--- a/tuxemon/db.py
+++ b/tuxemon/db.py
@@ -698,6 +698,7 @@ class DynamicMenuEntry(BaseModel):
 
 class ItemModel(DataModel, BaseLookupModel):
     table_name: ClassVar[str] = "item"
+    _lookup_cache: ClassVar[dict[str, ItemModel]] = {}
     model_config = ConfigDict(title="Item")
     slug: str = Field(..., description="The slug of the item")
     use_item: str = Field(
@@ -802,6 +803,21 @@ class ItemModel(DataModel, BaseLookupModel):
             return cast(ItemModel, db.lookup(slug, table=cls.table_name))
         except EntryNotFoundError:
             raise RuntimeError(f"Item {slug} not found")
+
+    @classmethod
+    def load_cache(cls, db: ModData) -> None:
+        """Populate the internal cache if it hasn't been populated yet."""
+        if not cls._lookup_cache:
+            cls._lookup_cache = {
+                tech_name: result
+                for tech_name in db.database[cls.table_name]
+                if (result := cls.lookup(tech_name, db))
+            }
+
+    @classmethod
+    def get_cache(cls) -> dict[str, ItemModel]:
+        """Returns the current cache."""
+        return cls._lookup_cache
 
     @field_validator("use_item", "use_success", "use_failure")
     def translation_exists(cls, v: str) -> str:
@@ -1214,6 +1230,7 @@ class MonsterSoundsModel(BaseModel):
 
 class MonsterModel(DataModel, BaseLookupModel, validate_assignment=True):
     table_name: ClassVar[str] = "monster"
+    _lookup_cache: ClassVar[dict[str, MonsterModel]] = {}
     slug: str = Field(..., description="The slug of the monster")
     species: str = Field(..., description="The species of monster")
     txmn_id: int = Field(..., description="The id of the monster")
@@ -1290,17 +1307,51 @@ class MonsterModel(DataModel, BaseLookupModel, validate_assignment=True):
         except EntryNotFoundError:
             raise RuntimeError(f"Monster {slug} not found")
 
+    @classmethod
+    def load_cache(cls, db: ModData) -> None:
+        """Populates the internal cache if it hasn't been populated yet."""
+        if not cls._lookup_cache:
+            cls._lookup_cache = {
+                mon_name: result
+                for mon_name in db.database[cls.table_name]
+                if (result := cls.lookup(mon_name, db)).txmn_id > 0
+            }
+
+    @classmethod
+    def get_cache(cls) -> dict[str, MonsterModel]:
+        """Returns the current cache."""
+        return cls._lookup_cache
+
     def can_evolve_at_level(self, level: int) -> bool:
         return any(
             evo.at_level is not None and evo.at_level <= level
             for evo in self.evolutions
         )
 
-    def is_underleveled_for_form(self, level: int) -> bool:
-        return any(
-            hist.at_level is not None and hist.at_level > level
-            for hist in self.evolutions
+    def is_underleveled_for_form(self, level: int, db: ModData) -> bool:
+        """
+        Checks if this monster's current form is only possible at a
+        higher level than the one provided by checking its ancestors.
+        """
+        current_history = next(
+            (h for h in self.history if h.slug == self.slug), None
         )
+
+        if not current_history or not current_history.evolves_from:
+            return False
+
+        for parent_slug in current_history.evolves_from:
+            try:
+                parent_mon = MonsterModel.lookup(parent_slug, db)
+            except RuntimeError:
+                continue  # Skip if parent data is missing
+
+            for evo in parent_mon.evolutions:
+                if evo.monster_slug == self.slug:
+                    if evo.at_level is not None and level < evo.at_level:
+                        return True
+
+        return False
 
     @field_validator("sprites")
     def set_default_sprites(
@@ -1587,6 +1638,7 @@ class TargetModel(BaseModel):
 
 class TechniqueModel(DataModel, BaseLookupModel):
     table_name: ClassVar[str] = "technique"
+    _lookup_cache: ClassVar[dict[str, TechniqueModel]] = {}
     slug: str = Field(..., description="The slug of the technique")
     sort: TechSort = Field(..., description="The sort of technique this is")
     behaviors: TechBehaviors
@@ -1709,6 +1761,21 @@ class TechniqueModel(DataModel, BaseLookupModel):
             return cast(TechniqueModel, db.lookup(slug, table=cls.table_name))
         except EntryNotFoundError:
             raise RuntimeError(f"Technique {slug} not found")
+
+    @classmethod
+    def load_cache(cls, db: ModData) -> None:
+        """Populate the internal cache if it hasn't been populated yet."""
+        if not cls._lookup_cache:
+            cls._lookup_cache = {
+                tech_name: result
+                for tech_name in db.database[cls.table_name]
+                if (result := cls.lookup(tech_name, db))
+            }
+
+    @classmethod
+    def get_cache(cls) -> dict[str, TechniqueModel]:
+        """Returns the current cache."""
+        return cls._lookup_cache
 
     @field_validator("use_tech", "use_success", "use_failure")
     def translation_exists(cls, v: str | None) -> str | None:
@@ -2068,6 +2135,7 @@ class NpcAudioModel(BaseModel):
 
 class NpcModel(DataModel, BaseLookupModel):
     table_name: ClassVar[str] = "npc"
+    _lookup_cache: ClassVar[dict[str, NpcModel]] = {}
     slug: str = Field(..., description="Slug of the name of the NPC")
     birthdate: tuple[int, int] | None = Field(
         None, description="The NPC's birthday represented as (month, day)."
@@ -2100,6 +2168,21 @@ class NpcModel(DataModel, BaseLookupModel):
             return cast(NpcModel, db.lookup(slug, table=cls.table_name))
         except EntryNotFoundError:
             raise RuntimeError(f"NPC {slug} not found")
+
+    @classmethod
+    def load_cache(cls, db: ModData) -> None:
+        """Populate the internal cache if it hasn't been populated yet."""
+        if not cls._lookup_cache:
+            cls._lookup_cache = {
+                npc_slug: result
+                for npc_slug in db.database[cls.table_name]
+                if (result := cls.lookup(npc_slug, db))
+            }
+
+    @classmethod
+    def get_cache(cls) -> dict[str, NpcModel]:
+        """Returns the current cache."""
+        return cls._lookup_cache
 
 
 class BattleHudModel(BaseModel):
@@ -2638,6 +2721,7 @@ class EncounterModel(DataModel, BaseLookupModel):
 
 class DialogueModel(DataModel, BaseLookupModel):
     table_name: ClassVar[str] = "dialogue"
+    _lookup_cache: ClassVar[dict[str, DialogueModel]] = {}
     slug: str = Field(
         ..., description="Slug to uniquely identify this dialogue"
     )
@@ -2655,6 +2739,21 @@ class DialogueModel(DataModel, BaseLookupModel):
             return cast(DialogueModel, db.lookup(slug, table=cls.table_name))
         except EntryNotFoundError:
             raise RuntimeError(f"Dialogue {slug} not found")
+
+    @classmethod
+    def load_cache(cls, db: ModData) -> None:
+        """Populate the internal cache if it hasn't been populated yet."""
+        if not cls._lookup_cache:
+            cls._lookup_cache = {
+                slug: result
+                for slug in db.database[cls.table_name]
+                if (result := cls.lookup(slug, db))
+            }
+
+    @classmethod
+    def get_cache(cls) -> dict[str, DialogueModel]:
+        """Returns the current cache."""
+        return cls._lookup_cache
 
     @field_validator("border_slug")
     def file_exists(cls, v: str) -> str:
@@ -2716,6 +2815,7 @@ class ElementModel(DataModel, BaseLookupModel):
 
 class TasteModel(DataModel, BaseLookupModel):
     table_name: ClassVar[str] = "taste"
+    _lookup_cache: ClassVar[dict[str, TasteModel]] = {}
     slug: str = Field(..., description="Slug of the taste")
     name: str = Field(..., description="Name of the taste")
     taste_type: Literal["warm", "cold"] = Field(
@@ -2738,6 +2838,21 @@ class TasteModel(DataModel, BaseLookupModel):
             return cast(TasteModel, db.lookup(slug, table=cls.table_name))
         except EntryNotFoundError:
             raise RuntimeError(f"Taste {slug} not found")
+
+    @classmethod
+    def load_cache(cls, db: ModData) -> None:
+        """Populate the internal cache if it hasn't been populated yet."""
+        if not cls._lookup_cache:
+            cls._lookup_cache = {
+                taste_name: result
+                for taste_name in db.database[cls.table_name]
+                if (result := cls.lookup(taste_name, db)).slug
+            }
+
+    @classmethod
+    def get_cache(cls) -> dict[str, TasteModel]:
+        """Returns the current cache."""
+        return cls._lookup_cache
 
     @field_validator("name")
     def translation_exists_taste(cls, v: str) -> str:

--- a/tuxemon/event/actions/cipher_dialog.py
+++ b/tuxemon/event/actions/cipher_dialog.py
@@ -14,6 +14,7 @@ from tuxemon.locale.locale import T
 from tuxemon.monster.avatar import get_avatar
 from tuxemon.session import Session
 from tuxemon.tools import open_dialog, safe_enum_value
+from tuxemon.ui.dialogue import DialogueStyleCache
 from tuxemon.ui.text_alignment import (
     DialogPosition,
     HorizontalAlignment,
@@ -23,7 +24,7 @@ from tuxemon.ui.text_formatter import TextFormatter
 
 logger = logging.getLogger(__name__)
 
-style_cache: dict[str, DialogueModel] = {}
+style_cache = DialogueStyleCache()
 
 
 @final
@@ -83,7 +84,7 @@ class CipherDialogAction(EventAction):
         )
 
         dialogue = self.style or session.client.config.dialog_box_style
-        style = _get_style(dialogue)
+        style = style_cache.get(dialogue)
         h_alignment = safe_enum_value(
             HorizontalAlignment, self.h_alignment, HorizontalAlignment.LEFT
         )
@@ -116,15 +117,3 @@ class CipherDialogAction(EventAction):
     def update(self, session: Session, dt: float) -> None:
         if "DialogState" not in session.client.active_state_names:
             self.stop()
-
-
-def _get_style(cache_key: str) -> DialogueModel:
-    if cache_key in style_cache:
-        return style_cache[cache_key]
-    else:
-        try:
-            style = DialogueModel.lookup(cache_key, db)
-            style_cache[cache_key] = style
-            return style
-        except KeyError:
-            raise RuntimeError(f"Dialogue {cache_key} not found")

--- a/tuxemon/event/actions/create_npc.py
+++ b/tuxemon/event/actions/create_npc.py
@@ -88,16 +88,17 @@ class CreateNpcAction(EventAction):
         npc.dialogue = merge_dialogue(npc_details.speech.profile, None)
 
 
-lookup_cache: dict[str, NpcModel] = {}
-
-
 def load_party(slug: str) -> NpcModel:
-    if slug in lookup_cache:
-        return lookup_cache[slug]
-    else:
-        npc_details = NpcModel.lookup(slug, db)
-        lookup_cache[slug] = npc_details
-        return npc_details
+    NpcModel.load_cache(db)
+    cache = NpcModel.get_cache()
+
+    try:
+        return cache[slug]
+    except KeyError:
+        # fallback to direct lookup (should not happen if DB is consistent)
+        npc = NpcModel.lookup(slug, db)
+        cache[slug] = npc
+        return npc
 
 
 def load_party_monsters(

--- a/tuxemon/event/actions/random_battle.py
+++ b/tuxemon/event/actions/random_battle.py
@@ -23,9 +23,6 @@ from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
-lookup_cache_mon: dict[str, MonsterModel] = {}
-lookup_cache_npc: dict[str, NpcModel] = {}
-
 
 @final
 @dataclass
@@ -51,6 +48,12 @@ class RandomBattleAction(EventAction):
     max_level: int
 
     def start(self, session: Session) -> None:
+        MonsterModel.load_cache(db)
+        self.monster_cache = MonsterModel.get_cache()
+
+        NpcModel.load_cache(db)
+        self.npc_cache = NpcModel.get_cache()
+
         self._validate_parameters()
         self._prepare_opponent(session)
         self._start_battle(session)
@@ -66,12 +69,16 @@ class RandomBattleAction(EventAction):
             )
 
     def _prepare_opponent(self, session: Session) -> None:
-        if not lookup_cache_npc or not lookup_cache_mon:
-            _lookup()
+
+        lookup_cache_npc = {
+            slug: npc
+            for slug, npc in self.npc_cache.items()
+            if not npc.monsters
+        }
 
         if not lookup_cache_npc:
             raise ValueError("No valid NPCs found to start a random battle.")
-        if not lookup_cache_mon:
+        if not self.monster_cache:
             raise ValueError(
                 "No valid monsters found to start a random battle."
             )
@@ -88,7 +95,7 @@ class RandomBattleAction(EventAction):
             self.stop()
             return
 
-        monster_filters = list(lookup_cache_mon.values())
+        monster_filters = list(self.monster_cache.values())
 
         if self.nr_txmns > len(monster_filters):
             logger.error(
@@ -141,20 +148,3 @@ class RandomBattleAction(EventAction):
     def cleanup(self, session: Session) -> None:
         if self.opponent:
             session.client.npc_manager.remove_npc(self.opponent.slug)
-
-
-def _lookup() -> None:
-    global lookup_cache_mon, lookup_cache_npc
-
-    lookup_cache_mon = {
-        mon_slug: mon_model
-        for mon_slug in db.database["monster"]
-        if (mon_model := MonsterModel.lookup(mon_slug, db)).txmn_id > 0
-        and mon_model.randomly
-    }
-
-    lookup_cache_npc = {
-        npc_slug: npc_model
-        for npc_slug in db.database["npc"]
-        if not (npc_model := NpcModel.lookup(npc_slug, db)).monsters
-    }

--- a/tuxemon/event/actions/random_item.py
+++ b/tuxemon/event/actions/random_item.py
@@ -2,12 +2,17 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 import random
 from dataclasses import dataclass
 from typing import final
 
+from tuxemon.database.runtime import db
+from tuxemon.db import ItemModel
 from tuxemon.event.eventaction import EventAction
 from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
 
 
 @final
@@ -22,20 +27,40 @@ class RandomItemAction(EventAction):
             random_item <item_slugs>[,quantity][,trainer_slug]
 
     Script parameters:
-        item_slugs: A colon-separated string of item names to choose from.
+        item_slugs:
+            A colon-separated string of item slugs to choose from.
             Example: 'potion:super-potion:hyper-potion'.
-        quantity: The number of the item to add. Defaults to 1.
-        trainer_slug: The slug of the trainer to receive the item.
+
+            If omitted or empty, the action will load the full item cache
+            and randomly select from *all available items* in the database.
+
+        quantity:
+            The number of the chosen item to add. Defaults to 1.
+
+        trainer_slug:
+            The slug of the trainer who will receive the item.
             Defaults to the current player.
     """
 
     name = "random_item"
-    item_slug: str
+    item_slug: str | None = None
     quantity: int | None = None
     trainer_slug: str | None = None
 
     def start(self, session: Session) -> None:
-        items = self.item_slug.split(":")
+
+        if self.item_slug is None:
+            ItemModel.load_cache(db)
+            cache = ItemModel.get_cache()
+            items = [item.slug for item in cache.values()]
+        else:
+            items = self.item_slug.split(":")
+
+        if not items:
+            logger.error("No valid items found for the given criteria.")
+            self.stop()
+            return
+
         chosen_item = random.choice(items)
 
         params: list[str | int] = [chosen_item]

--- a/tuxemon/event/actions/random_monster.py
+++ b/tuxemon/event/actions/random_monster.py
@@ -14,8 +14,6 @@ from tuxemon.session import Session
 
 logger = logging.getLogger(__name__)
 
-lookup_cache: dict[str, MonsterModel] = {}
-
 
 @final
 @dataclass
@@ -51,16 +49,16 @@ class RandomMonsterAction(EventAction):
     money: float | None = None
 
     def start(self, session: Session) -> None:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        cache = MonsterModel.get_cache()
 
         filters = [
             monster.slug
-            for monster in lookup_cache.values()
+            for monster in cache.values()
             if monster.txmn_id > 0
             and monster.randomly
             and not monster.can_evolve_at_level(self.monster_level)
-            and not monster.is_underleveled_for_form(self.monster_level)
+            and not monster.is_underleveled_for_form(self.monster_level, db)
         ]
 
         if not filters:
@@ -81,12 +79,3 @@ class RandomMonsterAction(EventAction):
             ],
             True,
         )
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }

--- a/tuxemon/event/conditions/tuxepedia.py
+++ b/tuxemon/event/conditions/tuxepedia.py
@@ -12,8 +12,6 @@ from tuxemon.session import Session
 from tuxemon.tools import compare
 from tuxemon.tuxepedia.reporter import TuxepediaReporter
 
-lookup_cache: dict[str, MonsterModel] = {}
-
 
 @dataclass
 class TuxepediaCondition(EventCondition):
@@ -39,15 +37,15 @@ class TuxepediaCondition(EventCondition):
     total: int | None = None
 
     def test(self, session: Session) -> bool:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        cache = MonsterModel.get_cache()
 
         player = session.player
 
         if self.total:
             total = self.total
         else:
-            total = len(lookup_cache)
+            total = len(cache)
 
         reporter = TuxepediaReporter(player.tuxepedia.data)
         completeness = reporter.get_completeness_report(total)
@@ -59,12 +57,3 @@ class TuxepediaCondition(EventCondition):
             )
 
         return compare(self.operator, float(registered), self.percentage)
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }

--- a/tuxemon/states/character.py
+++ b/tuxemon/states/character.py
@@ -26,17 +26,6 @@ if TYPE_CHECKING:
     from tuxemon.base_client import BaseClient
     from tuxemon.platform.events import PlayerInput
 
-lookup_cache: dict[str, MonsterModel] = {}
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
-
 
 class CharacterState(PygameMenuState):
     """
@@ -67,7 +56,7 @@ class CharacterState(PygameMenuState):
         )
 
         # tuxepedia data
-        filters = list(lookup_cache.values())
+        filters = list(self.cache.values())
         reporter = TuxepediaReporter(self.char.tuxepedia.data)
         completeness = reporter.get_completeness_report(len(filters))
         percentage = round(completeness["registered_percent"] * 100, 1)
@@ -210,8 +199,8 @@ class CharacterState(PygameMenuState):
         character: NPC,
         **kwargs: Any,
     ) -> None:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        self.cache = MonsterModel.get_cache()
 
         width, height = client.context.resolution
         self.char = character

--- a/tuxemon/states/journal_choice.py
+++ b/tuxemon/states/journal_choice.py
@@ -25,16 +25,6 @@ MAX_PAGE = 20
 
 
 MenuGameObj = Callable[[], object]
-lookup_cache: dict[str, MonsterModel] = {}
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
 
 
 class JournalChoice(PygameMenuState):
@@ -96,14 +86,14 @@ class JournalChoice(PygameMenuState):
     ) -> None:
         self.char = character
 
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        cache = MonsterModel.get_cache()
 
         width, height = client.context.resolution
 
         columns = 2
 
-        box = list(lookup_cache.values())
+        box = list(cache.values())
         diff = round(len(box) / MAX_PAGE) + 1
         rows = int(diff / columns) + 1
 

--- a/tuxemon/states/journal_info.py
+++ b/tuxemon/states/journal_info.py
@@ -24,17 +24,6 @@ if TYPE_CHECKING:
     from tuxemon.entity.npc import NPC
     from tuxemon.platform.events import PlayerInput
 
-lookup_cache: dict[str, MonsterModel] = {}
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
-
 
 class JournalInfoState(PygameMenuState):
     """Shows journal (screen 3/3)."""
@@ -257,9 +246,9 @@ class JournalInfoState(PygameMenuState):
         reveal: bool = False,
         **kwargs: Any,
     ) -> None:
+        MonsterModel.load_cache(db)
+        self.cache = MonsterModel.get_cache()
 
-        if not lookup_cache:
-            _lookup_monsters()
         if monster is None:
             raise ValueError("No monster")
 
@@ -285,7 +274,7 @@ class JournalInfoState(PygameMenuState):
     def process_event(self, event: PlayerInput) -> PlayerInput | None:
         client = self.client
         monsters = self.char.tuxepedia.get_monsters()
-        models = list(lookup_cache.values())
+        models = list(self.cache.values())
         model_dict = {model.slug: model for model in models}
         monster_models = sorted(
             [model_dict[mov] for mov in monsters if mov in model_dict],

--- a/tuxemon/states/journal_state.py
+++ b/tuxemon/states/journal_state.py
@@ -25,16 +25,6 @@ if TYPE_CHECKING:
 MAX_PAGE = 20
 
 MenuGameObj = Callable[[], object]
-lookup_cache: dict[str, MonsterModel] = {}
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
 
 
 class JournalState(PygameMenuState):
@@ -99,8 +89,8 @@ class JournalState(PygameMenuState):
         page: int,
         **kwargs: Any,
     ) -> None:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        self.cache = MonsterModel.get_cache()
 
         self.char = character
         self._page = page
@@ -153,7 +143,7 @@ class JournalState(PygameMenuState):
 
     def process_event(self, event: PlayerInput) -> PlayerInput | None:
         client = self.client
-        box = list(lookup_cache.values())
+        box = list(self.cache.values())
         max_page = (len(box) + MAX_PAGE - 1) // MAX_PAGE
 
         # LEFT / RIGHT → page navigation (with repeat)

--- a/tuxemon/states/minigame.py
+++ b/tuxemon/states/minigame.py
@@ -21,17 +21,6 @@ from tuxemon.tools import fix_measure, open_dialog
 if TYPE_CHECKING:
     from tuxemon.base_client import BaseClient
 
-lookup_cache: dict[str, MonsterModel] = {}
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
-
 
 class MinigameState(PygameMenuState):
     """Minigame where player guesses a monster using image or description."""
@@ -46,8 +35,8 @@ class MinigameState(PygameMenuState):
         score: int = 0,
         **kwargs: Any,
     ) -> None:
-        if not lookup_cache:
-            _lookup_monsters()
+        MonsterModel.load_cache(db)
+        self.cache = MonsterModel.get_cache()
 
         width, height = client.context.resolution
         self.difficulty = difficulty
@@ -74,7 +63,7 @@ class MinigameState(PygameMenuState):
             underline=True,
         )
 
-        data = list(lookup_cache.values())
+        data = list(self.cache.values())
         tuxemon = random.choice(data)
         self.tuxemon = tuxemon
 

--- a/tuxemon/states/monster_info.py
+++ b/tuxemon/states/monster_info.py
@@ -25,27 +25,6 @@ if TYPE_CHECKING:
     from tuxemon.base_client import BaseClient
     from tuxemon.platform.events import PlayerInput
 
-lookup_cache: dict[str, MonsterModel] = {}
-lookup_tastes: dict[str, TasteModel] = {}
-
-
-def _lookup_tastes() -> None:
-    global lookup_tastes
-    lookup_tastes = {
-        taste_name: result
-        for taste_name in db.database["taste"]
-        if (result := TasteModel.lookup(taste_name, db)).slug
-    }
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
-
 
 class MonsterInfoState(PygameMenuState):
     """
@@ -76,7 +55,7 @@ class MonsterInfoState(PygameMenuState):
         background_widget.translate(fxw(0 / 256), fxh(0 / 144))
 
         # weight and height
-        models = list(lookup_cache.values())
+        models = list(self.monster_cache.values())
         results = next(
             (model for model in models if model.slug == monster.slug), None
         )
@@ -383,7 +362,7 @@ class MonsterInfoState(PygameMenuState):
 
         # Helper: find which stat a taste affects
         def get_stat_for_taste(slug: str) -> str | None:
-            taste = lookup_tastes.get(slug.lower())
+            taste = self.taste_cache.get(slug.lower())
             if not taste or not taste.modifiers:
                 return None
 
@@ -444,10 +423,9 @@ class MonsterInfoState(PygameMenuState):
         monsters: list[Monster] | None,
         **kwargs: Any,
     ) -> None:
-        if not lookup_cache:
-            _lookup_monsters()
-        if not lookup_tastes:
-            _lookup_tastes()
+        MonsterModel.load_cache(db)
+        self.monster_cache = MonsterModel.get_cache()
+        self.taste_cache = TasteModel.get_cache()
 
         width, height = client.context.resolution
 

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -26,17 +26,6 @@ if TYPE_CHECKING:
     from tuxemon.monster.monster import Monster
     from tuxemon.platform.events import PlayerInput
 
-lookup_cache: dict[str, MonsterModel] = {}
-
-
-def _lookup_monsters() -> None:
-    global lookup_cache
-    lookup_cache = {
-        mon_name: result
-        for mon_name in db.database["monster"]
-        if (result := MonsterModel.lookup(mon_name, db)).txmn_id > 0
-    }
-
 
 class MonsterMovesState(PygameMenuState):
     """
@@ -346,8 +335,6 @@ class MonsterMovesState(PygameMenuState):
         monsters: list[Monster] | None,
         **kwargs: Any,
     ) -> None:
-        if not lookup_cache:
-            _lookup_monsters()
 
         width, height = client.context.resolution
 

--- a/tuxemon/ui/dialogue.py
+++ b/tuxemon/ui/dialogue.py
@@ -105,31 +105,17 @@ def calc_dialog_rect(
 class DialogueStyleCache:
     """
     Handles lookup and caching of DialogueModel styles.
-
-    Usage:
-        style_cache = DialogueStyleCache()
-        style = style_cache.get("default")
     """
 
     def __init__(self) -> None:
-        self._cache: dict[str, DialogueModel] = {}
+        DialogueModel.load_cache(db)
+        self._cache = DialogueModel.get_cache()
 
     def get(self, style_key: str) -> DialogueModel:
-        """
-        Retrieves a DialogueModel by key, caching the result.
-
-        Raises:
-            RuntimeError if style is not found in the DB.
-        """
-        if style_key in self._cache:
-            return self._cache[style_key]
-
+        """Retrieve the DialogueModel for the given style key from cache."""
         try:
-            style = DialogueModel.lookup(style_key, db)
-            self._cache[style_key] = style
-            return style
+            return self._cache[style_key]
         except KeyError:
-            logger.warning(f"Dialogue style '{style_key}' not found in DB.")
             raise RuntimeError(f"Dialogue style '{style_key}' not found")
 
     def clear(self) -> None:
@@ -137,7 +123,7 @@ class DialogueStyleCache:
         self._cache.clear()
 
     def preload(self, keys: list[str]) -> None:
-        """Preloads multiple styles into cache, useful during scene setup."""
+        """Preloads multiple styles into cache."""
         for key in keys:
             if key not in self._cache:
                 try:


### PR DESCRIPTION
PR standardizes lookup caching across all data models and removes local caches and ad‑hoc lookup functions.

Key changes:
- added `_lookup_cache`, `load_cache()`, and `get_cache()` to: `MonsterModel`, `TasteModel`, `TechniqueModel`, `NpcModel` and `DialogueModel`
- removed all standalone `_lookup_*` helpers and module‑level cache dictionaries
- all caches now load raw entries only; filtering happens in the caller
- actions and systems now rely on model‑level caches instead of custom lookup logic