### PR TITLE
Extract Layout Engine

### DIFF
--- a/tests/tuxemon/test_interface_menu_item.py
+++ b/tests/tuxemon/test_interface_menu_item.py
@@ -19,58 +19,75 @@ def game_object():
 
 
 def test_init_default(image, game_object):
-    menu_item = MenuItem(image, "Test Label", "Test Description", game_object)
-    assert menu_item.label == "Test Label"
-    assert menu_item.description == "Test Description"
-    assert menu_item.enabled is True
+    item = MenuItem(image, "Label", "Desc", game_object)
+    assert item.label == "Label"
+    assert item.description == "Desc"
+    assert item.enabled is True
+    assert item.in_focus is False
+    assert isinstance(item.metadata, dict)
 
 
 def test_init_custom(image, game_object):
-    menu_item = MenuItem(
+    item = MenuItem(
         image,
-        "Test Label",
-        "Test Description",
+        "Label",
+        "Desc",
         game_object,
         enabled=False,
-        position=(100, 100),
+        position=(50, 60),
     )
-    assert menu_item.label == "Test Label"
-    assert menu_item.description == "Test Description"
-    assert menu_item.enabled is False
+    assert item.enabled is False
+    assert item.rect.topleft == (50, 60)
 
 
-def test_update_image_focus(image, game_object):
-    menu_item = MenuItem(image, "Test Label", "Test Description", game_object)
-    menu_item._in_focus = True
-    menu_item.update_image = MagicMock()
-    menu_item.update_image()
-    menu_item.update_image.assert_called_once()
+def test_trigger_calls_game_object(image, game_object):
+    item = MenuItem(image, "Label", "Desc", game_object)
+    item.trigger()
+    game_object.assert_called_once()
 
 
-def test_update_image_enabled(image, game_object):
-    menu_item = MenuItem(image, "Test Label", "Test Description", game_object)
-    menu_item.enabled = False
-    menu_item.update_image = MagicMock()
-    menu_item.update_image()
-    menu_item.update_image.assert_called_once()
+def test_trigger_does_not_call_when_disabled(image, game_object):
+    item = MenuItem(image, "Label", "Desc", game_object, enabled=False)
+    item.trigger()
+    game_object.assert_not_called()
 
 
 def test_enabled_property(image, game_object):
-    menu_item = MenuItem(image, "Test Label", "Test Description", game_object)
-    assert menu_item.enabled is True
-    menu_item.enabled = False
-    assert menu_item.enabled is False
+    item = MenuItem(image, "Label", "Desc", game_object)
+    assert item.enabled is True
+    item.enabled = False
+    assert item.enabled is False
 
 
 def test_in_focus_property(image, game_object):
-    menu_item = MenuItem(image, "Test Label", "Test Description", game_object)
-    assert menu_item.in_focus is False
-    menu_item.in_focus = True
-    assert menu_item.in_focus is True
+    item = MenuItem(image, "Label", "Desc", game_object)
+    assert item.in_focus is False
+    item.in_focus = True
+    assert item.in_focus is True
 
 
-def test_repr(image, game_object):
-    menu_item = MenuItem(image, "Test Label", "Test Description", game_object)
-    rep = str(menu_item)
-    assert "Test Label" in rep
+def test_update_image_runs_without_error(image, game_object):
+    item = MenuItem(image, "Label", "Desc", game_object)
+    item.update_image()  # Should not raise
+
+
+def test_repr_contains_label_and_enabled(image, game_object):
+    item = MenuItem(image, "Label", "Desc", game_object)
+    rep = repr(item)
+    assert "Label" in rep
     assert "enabled=True" in rep
+
+
+def test_trigger_ignores_non_callable_non_command(image):
+    data_object = {"foo": "bar"}  # no execute(), not callable
+    item = MenuItem(image, "Label", "Desc", data_object)
+    item.trigger()  # Should not raise
+
+
+def test_trigger_calls_callable_if_not_command(image):
+    fn = MagicMock()
+    item = MenuItem(image, "Label", "Desc", fn)
+
+    item.trigger()
+
+    fn.assert_called_once()

--- a/tests/tuxemon/test_menu_layout_adjacent.py
+++ b/tests/tuxemon/test_menu_layout_adjacent.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+from pygame import Rect
+
+from tuxemon.menu.layout_engine import MenuLayoutEngine
+
+
+class FakeScaling:
+    def scale_int(self, value: int) -> int:
+        return value
+
+
+class FakeContext:
+    def __init__(self):
+        self.scaling = FakeScaling()
+
+
+class FakeClient:
+    def __init__(self):
+        self.context = FakeContext()
+
+
+class FakeSpriteContainer:
+    def __init__(self, rect: Rect):
+        self._rect = rect
+        self.calc_bounding_rect_called = 0
+
+    def calc_bounding_rect(self) -> Rect:
+        self.calc_bounding_rect_called += 1
+        return self._rect.copy()
+
+
+class FakeMenu:
+    def __init__(
+        self,
+        rect: Rect,
+        shrink_to_items: bool,
+        items_rect: Rect,
+        sprites_rect: Rect,
+        cursor_margin=(0, 0),
+        anchors=None,
+    ):
+        self.rect = rect
+        self.shrink_to_items = shrink_to_items
+        self._anchors = anchors or []
+
+        self._items = FakeSpriteContainer(items_rect)
+        self._sprites = FakeSpriteContainer(sprites_rect)
+
+        self.cursor_margin = cursor_margin
+
+        self.arrange_items_called = 0
+        self.update_cursor_visibility_called = 0
+        self.position_rect_called = 0
+
+        self._client = FakeClient()
+
+    def arrange_items(self) -> None:
+        self.arrange_items_called += 1
+
+    def update_cursor_visibility(self) -> None:
+        self.update_cursor_visibility_called += 1
+
+    def calc_internal_rect(self) -> Rect:
+        return self.rect.copy()
+
+    def position_rect(self) -> None:
+        self.position_rect_called += 1
+        for attr, value in self._anchors:
+            setattr(self.rect, attr, value)
+
+    @property
+    def menu_items(self):
+        return self._items
+
+    @property
+    def menu_sprites(self):
+        return self._sprites
+
+    @property
+    def client(self):
+        return self._client
+
+    def calc_menu_items_rect(self) -> Rect:
+        inner = self.calc_internal_rect()
+        inflated = inner.inflate(*self.cursor_margin)
+        inflated.bottomright = inner.bottomright
+        return inflated
+
+
+def test_calc_menu_items_rect_applies_cursor_margin():
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=False,
+        items_rect=Rect(0, 0, 10, 10),
+        sprites_rect=Rect(0, 0, 10, 10),
+        cursor_margin=(20, 10),
+    )
+
+    r = menu.calc_menu_items_rect()
+
+    assert r.width == 100 + 20
+    assert r.height == 50 + 10
+    assert r.bottomright == menu.rect.bottomright
+
+
+@pytest.mark.parametrize(
+    "anchors, expected_center",
+    [
+        pytest.param(
+            [("center", (200, 200))],
+            (200, 200),
+            id="center_anchor",
+        ),
+        pytest.param(
+            [("topleft", (10, 10))],
+            None,  # computed dynamically
+            id="topleft_anchor",
+        ),
+        pytest.param(
+            [("bottomright", (300, 300))],
+            None,
+            id="bottomright_anchor",
+        ),
+    ],
+)
+def test_anchor_application_order(anchors, expected_center):
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=Rect(0, 0, 40, 20),
+        sprites_rect=Rect(0, 0, 10, 10),
+        anchors=anchors,
+    )
+
+    result = engine.compute(menu, mutate=True)
+
+    if expected_center is not None:
+        assert result.center == expected_center
+        return
+
+    attr, value = anchors[0]
+
+    expected = Rect(0, 0, result.width, result.height)
+    setattr(expected, attr, value)
+
+    assert result.center == expected.center
+
+
+def test_shrink_to_items_preserves_center_before_anchor():
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(100, 100, 100, 50),
+        shrink_to_items=True,
+        items_rect=Rect(0, 0, 40, 20),
+        sprites_rect=Rect(0, 0, 10, 10),
+        anchors=[],  # no override
+    )
+
+    original_center = menu.rect.center
+    result = engine.compute(menu, mutate=True)
+
+    assert result.center == original_center
+
+
+@pytest.mark.parametrize(
+    "items_rect, sprites_rect",
+    [
+        pytest.param(Rect(0, 0, 0, 0), Rect(0, 0, 0, 0), id="zero_rects"),
+        pytest.param(Rect(0, 0, 1, 1), Rect(0, 0, 0, 0), id="one_pixel_item"),
+        pytest.param(
+            Rect(0, 0, 0, 0), Rect(0, 0, 1, 1), id="one_pixel_sprite"
+        ),
+    ],
+)
+def test_union_edge_cases(items_rect, sprites_rect):
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=items_rect,
+        sprites_rect=sprites_rect,
+    )
+
+    result = engine.compute(menu, mutate=True)
+
+    # Must be >= padding
+    assert result.width >= 18
+    assert result.height >= 19
+
+
+def test_padding_constants_are_applied():
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=Rect(0, 0, 40, 20),
+        sprites_rect=Rect(0, 0, 40, 20),
+    )
+
+    result = engine.compute(menu, mutate=True)
+
+    assert result.width == 40 + 18
+    assert result.height == 20 + 19

--- a/tests/tuxemon/test_menu_layout_engine.py
+++ b/tests/tuxemon/test_menu_layout_engine.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+from pygame import Rect
+
+from tuxemon.menu.layout_engine import MenuLayoutEngine
+
+
+class FakeScaling:
+    def scale_int(self, value: int) -> int:
+        return value
+
+
+class FakeContext:
+    def __init__(self):
+        self.scaling = FakeScaling()
+
+
+class FakeClient:
+    def __init__(self):
+        self.context = FakeContext()
+
+
+class FakeSpriteContainer:
+    def __init__(self, rect: Rect):
+        self._rect = rect
+        self.calc_bounding_rect_called = 0
+
+    def calc_bounding_rect(self) -> Rect:
+        self.calc_bounding_rect_called += 1
+        return self._rect.copy()
+
+
+class FakeMenu:
+    def __init__(
+        self,
+        rect: Rect,
+        shrink_to_items: bool,
+        items_rect: Rect,
+        sprites_rect: Rect,
+        anchors=None,
+    ):
+        self.rect = rect
+        self.shrink_to_items = shrink_to_items
+        self._anchors = anchors or []
+
+        self._items = FakeSpriteContainer(items_rect)
+        self._sprites = FakeSpriteContainer(sprites_rect)
+
+        self.arrange_items_called = 0
+        self.update_cursor_visibility_called = 0
+        self.position_rect_called = 0
+
+        self._client = FakeClient()
+
+    def arrange_items(self) -> None:
+        self.arrange_items_called += 1
+
+    def update_cursor_visibility(self) -> None:
+        self.update_cursor_visibility_called += 1
+
+    def calc_internal_rect(self) -> Rect:
+        return self.rect.copy()
+
+    def position_rect(self) -> None:
+        self.position_rect_called += 1
+
+    @property
+    def menu_items(self):
+        return self._items
+
+    @property
+    def menu_sprites(self):
+        return self._sprites
+
+    @property
+    def client(self):
+        return self._client
+
+
+def test_pure_layout_does_not_mutate_rect():
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=False,
+        items_rect=Rect(0, 0, 10, 10),
+        sprites_rect=Rect(0, 0, 10, 10),
+    )
+
+    original = menu.rect.copy()
+    result = engine.compute(menu, mutate=False)
+
+    assert result == original
+    assert menu.rect == original
+    assert menu.arrange_items_called == 1
+    assert menu.update_cursor_visibility_called == 1
+
+
+def test_mutating_layout_changes_rect_when_shrink_to_items():
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=Rect(0, 0, 40, 20),
+        sprites_rect=Rect(0, 0, 30, 10),
+    )
+
+    result = engine.compute(menu, mutate=True)
+
+    assert result.width == 40 + 18
+    assert result.height == 20 + 19
+    assert menu.position_rect_called == 1
+
+
+@pytest.mark.parametrize(
+    "items_rect, sprites_rect, expected",
+    [
+        pytest.param(
+            Rect(0, 0, 10, 10),
+            Rect(0, 0, 20, 5),
+            (20, 10),
+            id="wider_sprites",
+        ),
+        pytest.param(
+            Rect(0, 0, 50, 10),
+            Rect(0, 0, 10, 40),
+            (50, 40),
+            id="taller_sprites",
+        ),
+        pytest.param(
+            Rect(0, 0, 30, 30),
+            Rect(0, 0, 30, 30),
+            (30, 30),
+            id="equal_size",
+        ),
+    ],
+)
+def test_union_of_items_and_sprites(items_rect, sprites_rect, expected):
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=items_rect,
+        sprites_rect=sprites_rect,
+    )
+
+    result = engine.compute(menu, mutate=True)
+
+    expected_w = expected[0] + 18
+    expected_h = expected[1] + 19
+
+    assert result.width == expected_w
+    assert result.height == expected_h
+
+
+def test_anchors_are_restored_in_pure_mode():
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=Rect(0, 0, 20, 20),
+        sprites_rect=Rect(0, 0, 20, 20),
+        anchors=[("center", (200, 200))],
+    )
+
+    original_anchors = list(menu._anchors)
+    engine.compute(menu, mutate=False)
+
+    assert menu._anchors == original_anchors
+
+
+def test_position_rect_called_only_when_shrink_to_items():
+    engine = MenuLayoutEngine()
+
+    # shrink_to_items = False
+    menu1 = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=False,
+        items_rect=Rect(0, 0, 10, 10),
+        sprites_rect=Rect(0, 0, 10, 10),
+    )
+    engine.compute(menu1, mutate=True)
+    assert menu1.position_rect_called == 0
+
+    # shrink_to_items = True
+    menu2 = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=True,
+        items_rect=Rect(0, 0, 10, 10),
+        sprites_rect=Rect(0, 0, 10, 10),
+    )
+    engine.compute(menu2, mutate=True)
+    assert menu2.position_rect_called == 1
+
+
+def test_cursor_visibility_and_arrange_items_always_called():
+    engine = MenuLayoutEngine()
+    menu = FakeMenu(
+        rect=Rect(0, 0, 100, 50),
+        shrink_to_items=False,
+        items_rect=Rect(0, 0, 10, 10),
+        sprites_rect=Rect(0, 0, 10, 10),
+    )
+
+    engine.compute(menu, mutate=True)
+
+    assert menu.arrange_items_called == 1
+    assert menu.update_cursor_visibility_called == 1

--- a/tuxemon/menu/interface.py
+++ b/tuxemon/menu/interface.py
@@ -190,21 +190,6 @@ class MenuItem(Generic[T], Sprite):
     A MenuItem is a visual component used to represent an option in a menu.
     It can display an image, label, and description, and is associated with
     a callable game object or behavior that is triggered when selected.
-
-    Inherits from:
-        Sprite: Provides rendering, animation, and position management.
-
-    Type Parameters:
-        T: The type of the game object or callable associated with this item.
-
-    Parameters:
-        image: The visual surface to represent the item.
-        label: A short label or name for the menu item.
-        description: A longer description or tooltip text.
-        game_object: A callable or linked object triggered on selection.
-        enabled: Whether the menu item is interactable. Defaults to True.
-        position: Initial (x, y) position of the item.
-            If None, position must be set later. Defaults to None.
     """
 
     def __init__(
@@ -217,17 +202,31 @@ class MenuItem(Generic[T], Sprite):
         position: tuple[int, int] | None = None,
     ):
         super().__init__(image=image)
+
         self.label = label
         self.description = description
         self.game_object = game_object
+
         self._enabled = enabled
         self._in_focus = False
+
         self.metadata: dict[str, Any] = {}
 
         if position is not None:
             self.set_position(*position)
 
         self.update_image()
+
+    def trigger(self) -> None:
+        """Triggers the associated action for this menu item."""
+        if not self._enabled:
+            return
+
+        action = self.game_object
+
+        # Legacy callable
+        if callable(action):
+            action()
 
     def update_image(self, source: Surface | None = None) -> None:
         """
@@ -239,12 +238,10 @@ class MenuItem(Generic[T], Sprite):
             return
 
         if self._in_focus:
-            # Add visual effect for focus here
-            pass
+            pass  # Add highlight, tint, outline, etc.
 
         if not self._enabled:
-            # Add visual effect for not enabled here
-            pass
+            pass  # Add dimming, greyscale, alpha reduction, etc.
 
     @property
     def enabled(self) -> bool:
@@ -254,6 +251,7 @@ class MenuItem(Generic[T], Sprite):
     def enabled(self, value: bool) -> None:
         if self._enabled != value:
             self._enabled = value
+            self.update_image()
 
     @property
     def in_focus(self) -> bool:
@@ -261,7 +259,9 @@ class MenuItem(Generic[T], Sprite):
 
     @in_focus.setter
     def in_focus(self, value: bool) -> None:
-        self._in_focus = bool(value)
+        if self._in_focus != value:
+            self._in_focus = value
+            self.update_image()
 
     def __repr__(self) -> str:
         return (

--- a/tuxemon/menu/layout_engine.py
+++ b/tuxemon/menu/layout_engine.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pygame.rect import Rect
+
+if TYPE_CHECKING:
+    from tuxemon.base_client import BaseClient
+
+
+class LayoutContext(Protocol):
+    """
+    Minimal interface the layout engine needs from Menu.
+    """
+
+    rect: Rect
+    shrink_to_items: bool
+    _anchors: list[tuple[str, int | tuple[int, int]]]
+
+    def arrange_items(self) -> None: ...
+    def update_cursor_visibility(self) -> None: ...
+    def calc_internal_rect(self) -> Rect: ...
+    def position_rect(self) -> None: ...
+
+    @property
+    def menu_items(self) -> Any: ...
+    @property
+    def menu_sprites(self) -> Any: ...
+    @property
+    def client(self) -> BaseClient: ...
+
+
+class MenuLayoutEngine:
+    """
+    Pure layout engine for Menu.
+
+    Computes the final rect and performs all layout steps without mutating
+    the caller unless explicitly requested.
+    """
+
+    def compute(self, menu: LayoutContext, *, mutate: bool = False) -> Rect:
+        """
+        Compute the layout rect for the menu.
+
+        If mutate=True, modifies menu.rect and related state.
+        If mutate=False, returns the computed rect without side effects.
+        """
+        if mutate:
+            return self._compute_mutating(menu)
+
+        return self._compute_pure(menu)
+
+    def _compute_mutating(self, menu: LayoutContext) -> Rect:
+        """
+        Perform layout exactly as Menu.refresh_layout() does today.
+        This is the mutating path.
+        """
+        menu.arrange_items()
+        menu.update_cursor_visibility()
+        self._update_border(menu)
+        return menu.rect
+
+    def _compute_pure(self, menu: LayoutContext) -> Rect:
+        """
+        Pure version: compute final rect without mutating menu.
+        """
+        original_rect = menu.rect.copy()
+        original_anchors = list(menu._anchors)
+
+        # Perform layout
+        menu.arrange_items()
+        menu.update_cursor_visibility()
+        self._update_border(menu)
+
+        result = menu.rect.copy()
+
+        # Restore state
+        menu.rect = original_rect
+        menu._anchors = original_anchors
+
+        return result
+
+    def _update_border(self, menu: LayoutContext) -> None:
+        if not menu.shrink_to_items:
+            return
+
+        center = menu.rect.center
+
+        rect1 = menu.menu_items.calc_bounding_rect()
+        rect2 = menu.menu_sprites.calc_bounding_rect()
+        rect1 = rect1.union(rect2)
+
+        # TODO: remove hardcoded padding
+        rect1.width += menu.client.context.scaling.scale_int(18)
+        rect1.height += menu.client.context.scaling.scale_int(19)
+        rect1.topleft = (0, 0)
+
+        menu.rect = rect1
+        menu.rect.center = center
+        menu.position_rect()

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -7,7 +7,7 @@ import tempfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import IntFlag
-from functools import partial
+from functools import cached_property, partial
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
 from pygame import SRCALPHA, image
@@ -70,15 +70,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class LayoutFlag(IntFlag):
-    NONE = 0
-    ITEMS = 1 << 0
-    FONT = 1 << 1
-    BORDER = 1 << 2
-    CURSOR = 1 << 3
-    POSITION = 1 << 4
-
-
 @dataclass(frozen=True)
 class FontSettings:
     smaller: int
@@ -99,19 +90,6 @@ class FontSettings:
             bigger=s(FONT_SIZE_BIGGER),
             biggest=s(FONT_SIZE_BIGGEST),
         )
-
-
-T = TypeVar("T", covariant=True)
-
-
-class MenuConfig(TypedDict):
-    width: int
-    height: int
-    theme: Theme | None
-    sound_engine: Sound | None
-    menu_kwargs: dict[str, Any]
-    columns: int | None
-    rows: int | None
 
 
 class PygameMenuState(State):
@@ -348,6 +326,18 @@ class PygameMenuState(State):
         return None
 
 
+class LayoutFlag(IntFlag):
+    NONE = 0
+    ITEMS = 1 << 0
+    FONT = 1 << 1
+    BORDER = 1 << 2
+    CURSOR = 1 << 3
+    POSITION = 1 << 4
+
+
+T = TypeVar("T")
+
+BORDER_PADDING = (18, 19)
 ALLOWED_KWARGS = {
     "rect",
     "columns",
@@ -417,21 +407,35 @@ class Menu(Generic[T], State):
 
         self.rect = self.rect.copy()  # do not remove!
         self.selected_index = selected_index
-        # state: closed, opening, normal, disabled, closing
+
+        # Core controllers
         self.state_controller = MenuController()
         self.layout_engine = MenuLayoutEngine()
-        self._show_contents: bool = False
-        self._layout_flags: LayoutFlag = LayoutFlag.NONE
-        self._layout_passes: int = 0
+
+        # State tracking
+        self._show_contents = False
+        # Prevent layout recalculation during animations
+        self._layout_locked = False
+        self._layout_flags = LayoutFlag.NONE
         self._anchors: list[tuple[str, int | tuple[int, int]]] = []
 
         for key, value in kwargs.items():
-            if key not in ALLOWED_KWARGS:
+            if key in ALLOWED_KWARGS:
+                setattr(self, key, value)
+            else:
                 raise TypeError(f"Unexpected Menu argument: {key!r}")
-            setattr(self, key, value)
 
-        # holds sprites representing menu items
+        # Sprite groups
         self.create_new_menu_items_group()
+
+        # Resources
+        self.setup_resources()
+
+        # Input
+        self._input_handler = MenuInputHandler(self)
+
+        # Cursor controller
+        self.cursor_controller = self._setup_cursor_controller()
 
         # callbacks
         self.on_close_callback: Callable[[], None] | None = None
@@ -440,12 +444,13 @@ class Menu(Generic[T], State):
         )
         self.on_selection_callback: Callable[[MenuItem[T]], None] | None = None
 
-        self.font_filename = fetch_asset("font", self.font_filename)
-        self.font = self.set_font()  # load default font
-        self.load_graphics()  # load default graphics
-        self.reload_sounds()  # load default sounds
-        self._input_handler = MenuInputHandler(self)
-        self._text_renderer = TextRenderer(
+    @property
+    def dialog(self) -> AlertManager:
+        return self.client.alert_manager
+
+    @cached_property
+    def text_renderer(self) -> TextRenderer:
+        return TextRenderer(
             scaling=self.client.context.scaling,
             font=self.font,
             font_filename=self.font_filename,
@@ -453,7 +458,15 @@ class Menu(Generic[T], State):
             font_shadow_color=self.font_shadow_color,
         )
 
-        self.cursor_controller: MenuCursorController[T] = MenuCursorController(
+    def setup_resources(self) -> None:
+        """Centralized asset loading."""
+        self.font_filename = fetch_asset("font", self.font_filename)
+        self.set_font()
+        self.load_graphics()
+        self.reload_sounds()
+
+    def _setup_cursor_controller(self) -> MenuCursorController[T]:
+        return MenuCursorController(
             cursor_filename=self.cursor_filename,
             menu_sprites=self.menu_sprites,
             get_selected_item=self.get_selected_item,
@@ -463,9 +476,11 @@ class Menu(Generic[T], State):
             remove_animations=self.remove_animations_of,
         )
 
-    @property
-    def dialog(self) -> AlertManager:
-        return self.client.alert_manager
+    def ensure_layout(self) -> None:
+        """Trigger layout calculation only if flags are dirty."""
+        if self._layout_flags != LayoutFlag.NONE:
+            self.layout_engine.compute(self, mutate=True)
+            self._layout_flags = LayoutFlag.NONE
 
     def create_new_menu_items_group(self) -> None:
         """
@@ -497,8 +512,15 @@ class Menu(Generic[T], State):
         del self.menu_sprites
         del self.cursor_controller
 
+    def lock_layout(self) -> None:
+        self._layout_locked = True
+
+    def unlock_layout(self) -> None:
+        self._layout_locked = False
+
     def invalidate_layout(self, reason: str = "") -> None:
-        self._layout_flags |= LayoutFlag.ITEMS
+        if not self._layout_locked:
+            self._layout_flags |= LayoutFlag.ITEMS
         logger.debug(reason)
 
     def validate_layout(self, reason: str = "") -> None:
@@ -574,24 +596,6 @@ class Menu(Generic[T], State):
         self._populate_items(items)
         self._recover_selection(previous_index)
 
-    def build_item(
-        self: Menu[Callable[[], object]],
-        label: str,
-        callback: Callable[[], object],
-        icon: Surface | None = None,
-    ) -> None:
-        """
-        Create a menu item and add it to the menu.
-
-        Parameters:
-            label: Some text.
-            callback: Callback to use when selected.
-            icon: Image of the item (not used yet).
-        """
-        image = self.shadow_text(label)
-        item = MenuItem(image, label, None, callback)
-        self.add(item)
-
     def add(self, menu_item: MenuItem[T]) -> None:
         """
         Add a menu item.
@@ -609,24 +613,18 @@ class Menu(Generic[T], State):
 
     def fit_border(self) -> None:
         """Resize the window border to fit the contents of the menu."""
-        # get bounding box of menu items and the cursor
         center = self.rect.center
         rect1 = self.menu_items.calc_bounding_rect()
         rect2 = self.menu_sprites.calc_bounding_rect()
         rect1 = rect1.union(rect2)
 
-        # expand the bounding box by the border and some padding
-        # TODO: do not hardcode these values
-        # border is 12, padding is the rest
-        rect1.width += self.client.context.scaling.scale_int(18)
-        rect1.height += self.client.context.scaling.scale_int(19)
+        pad_x, pad_y = BORDER_PADDING
+        rect1.width += self.client.context.scaling.scale_int(pad_x)
+        rect1.height += self.client.context.scaling.scale_int(pad_y)
         rect1.topleft = 0, 0
 
-        # set our rect and adjust the centers to match
         self.rect = rect1
         self.rect.center = center
-
-        # move the bounding box taking account the anchors
         self.position_rect()
 
     def reload_sounds(self) -> None:
@@ -638,12 +636,17 @@ class Menu(Generic[T], State):
     def shadow_text(
         self,
         text: str,
-        bg: ColorLike = font_shadow_color,
+        bg: ColorLike | None = None,
         fg: ColorLike | None = None,
         offset: tuple[float, float] = (0.5, 0.5),
     ) -> Surface:
         """Renders text with a drop shadow using the configured text renderer."""
-        return self._text_renderer.shadow_text(text, bg, fg, offset)
+        return self.text_renderer.shadow_text(
+            text,
+            bg or self.font_shadow_color,
+            fg,
+            offset,
+        )
 
     def load_graphics(self) -> None:
         """
@@ -712,9 +715,7 @@ class Menu(Generic[T], State):
         Parameters:
             surface: Surface to draw on.
         """
-        if self._layout_flags is not LayoutFlag.NONE:
-            self.layout_engine.compute(self, mutate=True)
-            self._layout_flags = LayoutFlag.NONE
+        self.ensure_layout()
 
         if not self.transparent:
             self.window.draw(surface, self.rect)
@@ -880,6 +881,8 @@ class Menu(Generic[T], State):
     def close(self) -> None:
         if self.state_controller.is_interactive():
             self.state_controller.close()
+            self._show_contents = False
+            self.set_transparent(True)
             ani = self.animate_close()
             self.on_close()
             if ani:
@@ -972,16 +975,10 @@ class Menu(Generic[T], State):
         Override in subclass, if you want to.
         """
         if self.on_selection_callback:
-            return self.on_selection_callback(selected_item)
+            self.on_selection_callback(selected_item)
+            return
 
-        if selected_item.enabled:
-            if selected_item.game_object is None:
-                raise ValueError("Selected menu item has no game object")
-            if not callable(selected_item.game_object):
-                raise ValueError(
-                    "Selected menu item's game object is not callable"
-                )
-            selected_item.game_object()
+        selected_item.trigger()
 
     def on_menu_selection_change(self) -> None:
         """
@@ -1049,26 +1046,26 @@ class PopUpMenu(Menu[T]):
         return initial_rect
 
     def animate_open(self) -> Animation:
-        # anchor the center of the popup
         final_rect = self.calc_final_rect()
         self.anchor("center", self.client.context.rect.center)
 
-        # set rect to a small size for the initial values of the animation
         self.rect = self._calculate_initial_rect(final_rect)
 
-        # if this statement were removed, then the menu would
-        # refresh and the size animation would be lost
+        self.lock_layout()
         self.validate_layout("animate_open")
 
-        # create animation to open window with
         ani = self.animate(
             self.rect,
             height=final_rect.height,
             width=final_rect.width,
             duration=self.ANIMATION_DURATION,
         )
+
         ani.schedule(
             lambda: setattr(self.rect, "center", final_rect.center),
             ScheduleType.ON_UPDATE,
         )
+
+        ani.schedule(self.unlock_layout, ScheduleType.ON_FINISH)
+
         return ani

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -35,6 +35,7 @@ from tuxemon.menu.input_handler import (
     PygameMenuInputHandler,
 )
 from tuxemon.menu.interface import MenuItem
+from tuxemon.menu.layout_engine import MenuLayoutEngine
 from tuxemon.menu.theme import get_sound_engine, get_theme
 from tuxemon.platform.const.graphics import (
     BACKGROUND_COLOR,
@@ -418,6 +419,7 @@ class Menu(Generic[T], State):
         self.selected_index = selected_index
         # state: closed, opening, normal, disabled, closing
         self.state_controller = MenuController()
+        self.layout_engine = MenuLayoutEngine()
         self._show_contents: bool = False
         self._layout_flags: LayoutFlag = LayoutFlag.NONE
         self._layout_passes: int = 0
@@ -686,30 +688,7 @@ class Menu(Generic[T], State):
         Compute layout. If mutate=False, return the computed rect
         without modifying menu state.
         """
-        if mutate:
-            self._layout_passes += 1
-            logger.debug(
-                f"[{self.name}] layout pass #{self._layout_passes} "
-                f"(layout_flags={self._layout_flags!s})"
-            )
-            self.arrange_items()
-            self.update_cursor_visibility()
-            self.update_border()
-            return self.rect
-
-        original_rect = self.rect.copy()
-        original_flags = self._layout_flags
-
-        self.arrange_items()
-        self.update_cursor_visibility()
-        self.update_border()
-
-        result = self.rect.copy()
-
-        self.rect = original_rect
-        self._layout_flags = original_flags
-
-        return result
+        return self.layout_engine.compute(self, mutate=mutate)
 
     def arrange_items(self) -> None:
         self.menu_items.expand = not self.shrink_to_items
@@ -734,7 +713,7 @@ class Menu(Generic[T], State):
             surface: Surface to draw on.
         """
         if self._layout_flags is not LayoutFlag.NONE:
-            self.refresh_layout()
+            self.layout_engine.compute(self, mutate=True)
             self._layout_flags = LayoutFlag.NONE
 
         if not self.transparent:
@@ -876,7 +855,7 @@ class Menu(Generic[T], State):
 
             self.state_controller.open()
             self.reload_items()
-            self.refresh_layout()
+            self.layout_engine.compute(self, mutate=True)
 
             ani = self.animate_open()
             if ani:
@@ -958,15 +937,7 @@ class Menu(Generic[T], State):
         Pure layout computation: returns the rect the menu *would* have
         after layout, without mutating any state.
         """
-        original_rect = self.rect.copy()
-        original_flags = self._layout_flags
-
-        result = self.refresh_layout(mutate=False).copy()
-
-        self.rect = original_rect
-        self._layout_flags = original_flags
-
-        return result
+        return self.layout_engine.compute(self, mutate=False)
 
     def calc_final_rect(self) -> Rect:
         """

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -6,6 +6,7 @@ import logging
 import tempfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from enum import IntFlag
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
 
@@ -66,6 +67,15 @@ if TYPE_CHECKING:
     from tuxemon.prepare import DisplayContext
 
 logger = logging.getLogger(__name__)
+
+
+class LayoutFlag(IntFlag):
+    NONE = 0
+    ITEMS = 1 << 0
+    FONT = 1 << 1
+    BORDER = 1 << 2
+    CURSOR = 1 << 3
+    POSITION = 1 << 4
 
 
 @dataclass(frozen=True)
@@ -337,6 +347,27 @@ class PygameMenuState(State):
         return None
 
 
+ALLOWED_KWARGS = {
+    "rect",
+    "columns",
+    "background_filename",
+    "background_color",
+    "font_color",
+    "font_shadow_color",
+    "unavailable_color",
+    "unavailable_color_shop",
+    "menu_select_sound_filename",
+    "font_filename",
+    "borders_filename",
+    "cursor_filename",
+    "cursor_move_duration",
+    "shrink_to_items",
+    "escape_key_exits",
+    "animate_contents",
+    "touch_aware",
+}
+
+
 class Menu(Generic[T], State):
     """
     A class to create menu objects.
@@ -388,10 +419,14 @@ class Menu(Generic[T], State):
         # state: closed, opening, normal, disabled, closing
         self.state_controller = MenuController()
         self._show_contents: bool = False
-        self._needs_refresh: bool = False
+        self._layout_flags: LayoutFlag = LayoutFlag.NONE
         self._layout_passes: int = 0
         self._anchors: list[tuple[str, int | tuple[int, int]]] = []
-        self.__dict__.update(kwargs)
+
+        for key, value in kwargs.items():
+            if key not in ALLOWED_KWARGS:
+                raise TypeError(f"Unexpected Menu argument: {key!r}")
+            setattr(self, key, value)
 
         # holds sprites representing menu items
         self.create_new_menu_items_group()
@@ -461,11 +496,11 @@ class Menu(Generic[T], State):
         del self.cursor_controller
 
     def invalidate_layout(self, reason: str = "") -> None:
-        self._needs_refresh = True
+        self._layout_flags |= LayoutFlag.ITEMS
         logger.debug(reason)
 
     def validate_layout(self, reason: str = "") -> None:
-        self._needs_refresh = False
+        self._layout_flags = LayoutFlag.NONE
         logger.debug(reason)
 
     def initialize_items(self) -> Iterable[MenuItem[T]] | None:
@@ -492,18 +527,12 @@ class Menu(Generic[T], State):
         """
         return True
 
-    def reload_items(self) -> None:
-        """
-        Empty all items in the menu and re-add them.
-        Only works if initialize_items is used.
-        """
-        self.invalidate_layout("items changed")
-        items = self.initialize_items()
+    def _load_items(self) -> Iterable[MenuItem[T]] | None:
+        """Return freshly initialized items or None if unchanged."""
+        return self.initialize_items()
 
-        if items is None:
-            # No change requested
-            return
-
+    def _populate_items(self, items: Iterable[MenuItem[T]]) -> None:
+        """Replace menu_items with new items and validate them."""
         self.menu_items.empty()
 
         for item in items:
@@ -513,20 +542,35 @@ class Menu(Generic[T], State):
 
         self.menu_items.arrange_menu_items()
 
+    def _recover_selection(self, previous_index: int) -> None:
+        """Pick the closest enabled item to the previous index."""
         selected_item = self.get_selected_item()
         if selected_item and selected_item.enabled:
             return
 
-        # Choose new cursor position. We can't use the prev position, so we
-        # will use the closest valid option.
-        score = None
-        prev_index = self.selected_index
+        best_score = None
         for index, item in enumerate(self.menu_items):
             if item.enabled:
-                new_score = abs(prev_index - index)
-                if score is None or new_score < score:
+                score = abs(previous_index - index)
+                if best_score is None or score < best_score:
                     self.selected_index = index
-                    score = new_score
+                    best_score = score
+
+    def reload_items(self) -> None:
+        """
+        Empty all items in the menu and re-add them.
+        Only works if initialize_items is used.
+        """
+        self.invalidate_layout("items changed")
+
+        items = self._load_items()
+        if items is None:
+            return
+
+        previous_index = self.selected_index
+
+        self._populate_items(items)
+        self._recover_selection(previous_index)
 
     def build_item(
         self: Menu[Callable[[], object]],
@@ -637,15 +681,35 @@ class Menu(Generic[T], State):
         """Hide the cursor that indicates the selected object."""
         self.cursor_controller.hide_cursor()
 
-    def refresh_layout(self) -> None:
-        """Fit border to contents and hide/show cursor."""
-        self._layout_passes += 1
-        logger.debug(
-            f"[{self.name}] layout pass #{self._layout_passes} (needs_refresh={self._needs_refresh})"
-        )
+    def refresh_layout(self, *, mutate: bool = True) -> Rect:
+        """
+        Compute layout. If mutate=False, return the computed rect
+        without modifying menu state.
+        """
+        if mutate:
+            self._layout_passes += 1
+            logger.debug(
+                f"[{self.name}] layout pass #{self._layout_passes} "
+                f"(layout_flags={self._layout_flags!s})"
+            )
+            self.arrange_items()
+            self.update_cursor_visibility()
+            self.update_border()
+            return self.rect
+
+        original_rect = self.rect.copy()
+        original_flags = self._layout_flags
+
         self.arrange_items()
         self.update_cursor_visibility()
         self.update_border()
+
+        result = self.rect.copy()
+
+        self.rect = original_rect
+        self._layout_flags = original_flags
+
+        return result
 
     def arrange_items(self) -> None:
         self.menu_items.expand = not self.shrink_to_items
@@ -669,9 +733,9 @@ class Menu(Generic[T], State):
         Parameters:
             surface: Surface to draw on.
         """
-        if self._needs_refresh:
+        if self._layout_flags is not LayoutFlag.NONE:
             self.refresh_layout()
-            self.validate_layout("refresh layout")
+            self._layout_flags = LayoutFlag.NONE
 
         if not self.transparent:
             self.window.draw(surface, self.rect)
@@ -889,6 +953,21 @@ class Menu(Generic[T], State):
         menu_rect.bottomright = inner.bottomright
         return menu_rect
 
+    def compute_layout_rect(self) -> Rect:
+        """
+        Pure layout computation: returns the rect the menu *would* have
+        after layout, without mutating any state.
+        """
+        original_rect = self.rect.copy()
+        original_flags = self._layout_flags
+
+        result = self.refresh_layout(mutate=False).copy()
+
+        self.rect = original_rect
+        self._layout_flags = original_flags
+
+        return result
+
     def calc_final_rect(self) -> Rect:
         """
         Calculate the area in the game window where menu is shown.
@@ -902,11 +981,7 @@ class Menu(Generic[T], State):
         Returns:
             Rectangle with the size of the menu.
         """
-        original = self.rect.copy()  # store the original rect
-        self.refresh_layout()  # arrange the menu
-        rect = self.rect.copy()  # store the final rect
-        self.rect = original  # set the original back
-        return rect
+        return self.compute_layout_rect()
 
     def on_open(self) -> None:
         """Hook is called after opening animation has finished."""

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -729,10 +729,10 @@ class CombatTargetMenuState(Menu[Monster]):
                         )
                         return
 
-    def refresh_layout(self) -> None:
+    def refresh_layout(self, *, mutate: bool = True) -> Rect:
         """Updates layout after determining the target."""
         self.determine_target()
-        super().refresh_layout()
+        return super().refresh_layout(mutate=mutate)
 
     def _update_borders(self) -> None:
         """Draws borders around the currently selected monster in 2vs2/1vs2 combat."""


### PR DESCRIPTION
PR moves all layout work out of `Menu` and into a new `MenuLayoutEngine`. The old boolean layout toggle is replaced with a bitmask‑based `LayoutFlag`. The engine can compute layout without touching menu state, which lets the menu calculate its final geometry cleanly. The `Menu` initializer now checks keyword arguments against `ALLOWED_KWARGS` to block accidental attribute injection.

`PopUpMenu` now locks layout during `animate_open` so size changes from the animation aren’t overwritten by layout passes. The covariant `TypeVar` was replaced with an invariant one because menu callbacks take `MenuItem[T]` as an argument, and covariance would break type safety.

I removed `MenuConfig` and the `build_item()` method because nothing in the codebase used them. They added noise without providing value, so cutting them keeps the module straightforward.