### PR TITLE
Fix Music Transitions, Add Explicit Mute State, and Add Audio Test Coverage

### DIFF
--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4787,6 +4787,9 @@ msgstr "Enable"
 msgid "disable"
 msgstr "Disable"
 
+msgid "menu_unmute_music"
+msgstr "Unmute Music"
+
 msgid "menu_mute_music"
 msgstr "Mute Music"
 

--- a/tests/tuxemon/test_music_player_state.py
+++ b/tests/tuxemon/test_music_player_state.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.audio import MusicPlayerState
+from tuxemon.db import MusicStatus
+
+
+class DummyMixer:
+    """Minimal stub for pygame.mixer.music."""
+
+    def __init__(self):
+        self.loaded = None
+        self.volume = 1.0
+        self.play_calls = []
+        self.busy = False
+
+    def load(self, path):
+        self.loaded = path
+
+    def set_volume(self, v):
+        self.volume = v
+
+    def play(self, loops, fade_ms):
+        self.play_calls.append((loops, fade_ms))
+        self.busy = True
+
+    def pause(self):
+        self.busy = False
+
+    def unpause(self):
+        self.busy = True
+
+    def stop(self):
+        self.busy = False
+
+    def fadeout(self, t):
+        self.busy = False
+
+    def get_busy(self):
+        return self.busy
+
+
+@pytest.fixture
+def mixer(monkeypatch):
+    dummy = DummyMixer()
+    monkeypatch.setattr("tuxemon.platform.platform.mixer.music", dummy)
+    return dummy
+
+
+@pytest.fixture(autouse=True)
+def mock_music_db(monkeypatch):
+    monkeypatch.setattr(
+        "tuxemon.audio.db.get_entry", lambda table, slug: "dummy.ogg"
+    )
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    monkeypatch.setattr(
+        "tuxemon.audio.fetch_asset", lambda category, filename: "dummy.ogg"
+    )
+
+
+@pytest.fixture
+def player():
+    return MusicPlayerState()
+
+
+def test_play_sets_state_and_loads_track(player, mixer):
+    player.play("battle_theme")
+    assert player.status == MusicStatus.PLAYING
+    assert player.current_song == "battle_theme"
+    assert mixer.loaded is not None
+    assert mixer.busy is True
+
+
+def test_play_respects_mute(player, mixer):
+    player.mute()
+    player.play("battle_theme")
+    assert mixer.volume == 0.0
+
+
+def test_unmute_restores_volume(player, mixer):
+    player.mute()
+    player.unmute()
+    assert mixer.volume == player._user_volume
+
+
+def test_toggle_mute(player, mixer):
+    player.toggle_mute()
+    assert player.muted is True
+    player.toggle_mute()
+    assert player.muted is False
+
+
+def test_set_volume_updates_logical_volume(player, mixer):
+    player.set_volume(0.7)
+    assert player._user_volume == 0.7
+
+
+def test_set_volume_zero_triggers_mute(player, mixer):
+    player.set_volume(0.0)
+    assert player.muted is True
+    assert mixer.volume == 0.0
+
+
+def test_play_same_song_no_reload(player, mixer):
+    player.play("track")
+    mixer.loaded = None
+    player.play("track")
+    assert mixer.loaded is None  # no reload
+
+
+def test_pause_and_unpause(player, mixer):
+    player.play("track")
+    player.pause()
+    assert mixer.busy is False
+    player.unpause()
+    assert mixer.busy is True
+
+
+def test_stop_resets_state(player, mixer):
+    player.play("track")
+    player.stop()
+    assert player.status == MusicStatus.STOPPED
+    assert player.current_song is None
+    assert mixer.busy is False

--- a/tests/tuxemon/test_sound_manager.py
+++ b/tests/tuxemon/test_sound_manager.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+import pytest
+
+from tuxemon.audio import SoundManager
+
+
+class DummySound:
+    def __init__(self):
+        self.volume = 1.0
+        self.played = False
+
+    def play(self):
+        self.played = True
+
+    def set_volume(self, v):
+        self.volume = v
+
+
+@pytest.fixture
+def dummy_sound(monkeypatch):
+    def fake_load(path):
+        return DummySound()
+
+    monkeypatch.setattr("pygame.mixer.Sound", fake_load)
+    return fake_load
+
+
+@pytest.fixture(autouse=True)
+def mock_db(monkeypatch):
+    monkeypatch.setattr(
+        "tuxemon.audio.db.get_entry", lambda table, slug: "dummy.wav"
+    )
+    # Pretend the file exists
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+
+
+@pytest.fixture
+def manager():
+    return SoundManager()
+
+
+def test_load_sound_caches(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    s1 = manager.load_sound("hit")
+    s2 = manager.load_sound("hit")
+    assert s1 is s2
+
+
+def test_play_sound_uses_cached_sound(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    wrapper = manager.load_sound("hit")
+    manager.play("hit")
+    assert wrapper.sound.played is True
+
+
+def test_set_volume_updates_all_sounds(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    s1 = manager.load_sound("hit")
+    s2 = manager.load_sound("step")
+
+    manager.set_volume(0.4)
+    assert s1.sound.volume == 0.4
+    assert s2.sound.volume == 0.4
+
+
+def test_mute_sets_all_sounds_to_zero(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    s1 = manager.load_sound("hit")
+    s2 = manager.load_sound("step")
+
+    manager.mute()
+    assert s1.sound.volume == 0.0
+    assert s2.sound.volume == 0.0
+    assert manager.muted is True
+
+
+def test_unmute_restores_volume(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    s1 = manager.load_sound("hit")
+
+    manager.set_volume(0.3)
+    manager.mute()
+    manager.unmute()
+
+    assert s1.sound.volume == 0.3
+    assert manager.muted is False
+
+
+def test_toggle_mute(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    manager.toggle_mute()
+    assert manager.muted is True
+    manager.toggle_mute()
+    assert manager.muted is False
+
+
+def test_unload_sound(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    manager.load_sound("hit")
+    manager.unload_sound("hit")
+    assert "hit" not in manager.sounds
+
+
+def test_unload_all_sounds(manager, dummy_sound, monkeypatch):
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+    manager.load_sound("hit")
+    manager.load_sound("step")
+    manager.unload_all_sounds()
+    assert manager.sounds == {}

--- a/tuxemon/audio.py
+++ b/tuxemon/audio.py
@@ -30,6 +30,9 @@ class MusicPlayerState:
         self.previous_song: str | None = None
         self.cache: dict[str, str] = {}
 
+        self.muted: bool = False
+        self._user_volume = CONFIG.music_volume
+
     def load(
         self, filename: str, volume: float, loop: int, fade_ms: int
     ) -> None:
@@ -47,21 +50,35 @@ class MusicPlayerState:
         volume: float = CONFIG.music_volume,
         loop: int = MUSIC_LOOP,
         fade_ms: int = MUSIC_FADEIN,
+        *,
+        fade_previous: bool = False,
     ) -> None:
         if self.is_playing_same_song(song):
             return
+
+        if fade_previous and self.current_song and self.is_playing():
+            try:
+                platform.mixer.music.fadeout(MUSIC_FADEOUT)
+            except Exception as e:
+                logger.error(f"Error during fadeout: {e}")
+
         self.previous_song = self.current_song
-        self.status = MusicStatus.PLAYING
         self.current_song = song
-        self.load(song, volume, loop, fade_ms)
+        self.status = MusicStatus.PLAYING
+
+        self._user_volume = volume
+
+        physical_volume = 0.0 if self.muted else self._user_volume
+
+        self.load(song, physical_volume, loop, fade_ms)
 
     def get_path(self, filename: str) -> str:
         if filename in self.cache:
             return self.cache[filename]
-        else:
-            path = fetch_asset("music", db.get_entry("music", filename))
-            self.cache[filename] = path
-            return path
+
+        path = fetch_asset("music", db.get_entry("music", filename))
+        self.cache[filename] = path
+        return path
 
     def pause(self) -> None:
         if self.status == MusicStatus.PLAYING:
@@ -103,10 +120,18 @@ class MusicPlayerState:
         return self.status == MusicStatus.PLAYING and self.current_song == song
 
     def set_volume(self, volume: float) -> None:
-        if self.status == MusicStatus.PLAYING:
-            platform.mixer.music.set_volume(volume)
-        else:
-            logger.warning("Music is not playing, set volume not applied.")
+        volume = max(0.0, min(1.0, volume))
+
+        # UI mute button sets volume=0 → treat as mute
+        if volume == 0.0:
+            self.mute()
+            return
+
+        # Otherwise it's a real volume change
+        self._user_volume = volume
+
+        if not self.muted and self.status == MusicStatus.PLAYING:
+            platform.mixer.music.set_volume(self._user_volume)
 
     def decrease_volume(self, amount: float = 0.1) -> None:
         if self.status == MusicStatus.PLAYING:
@@ -128,12 +153,22 @@ class MusicPlayerState:
                 "Music is not playing, volume adjustment not applied."
             )
 
-    def get_volume(self) -> float | None:
-        if self.status == MusicStatus.PLAYING:
-            return float(platform.mixer.music.get_volume())
+    def get_volume(self) -> float:
+        return 0.0 if self.muted else self._user_volume
+
+    def mute(self) -> None:
+        self.muted = True
+        platform.mixer.music.set_volume(0.0)
+
+    def unmute(self) -> None:
+        self.muted = False
+        platform.mixer.music.set_volume(self._user_volume)
+
+    def toggle_mute(self) -> None:
+        if self.muted:
+            self.unmute()
         else:
-            logger.warning("Music is not playing, cannot get volume.")
-            return None
+            self.mute()
 
     def __repr__(self) -> str:
         return f"MusicPlayerState(status={self.status}, current_song={self.current_song}, previous_song={self.previous_song})"
@@ -163,14 +198,15 @@ class SoundWrapper(SoundProtocol):
 class SoundManager:
     def __init__(self) -> None:
         self.sounds: dict[str, SoundProtocol] = {}
+        self._user_volume: float = CONFIG.sound_volume
+        self.muted: bool = False
 
     def get_sound_filename(self, slug: str) -> Path | None:
-        if slug is None or slug == "":
+        if not slug:
             return None
 
         filename = db.get_entry("sounds", slug)
         filename = transform_resource_filename("sounds", filename)
-
         path = Path(filename)
 
         if not path.exists():
@@ -182,11 +218,8 @@ class SoundManager:
 
         return path
 
-    def load_sound(
-        self, slug: str, value: float = CONFIG.sound_volume
-    ) -> SoundProtocol:
+    def load_sound(self, slug: str) -> SoundProtocol:
         if slug in self.sounds:
-            logger.debug(f"Sound '{slug}' loaded from cache.")
             return self.sounds[slug]
 
         filename = self.get_sound_filename(slug)
@@ -195,26 +228,59 @@ class SoundManager:
 
         try:
             sound = pygame.mixer.Sound(filename)
-            sound.set_volume(value)
-            self.sounds[slug] = SoundWrapper(sound)
-            logger.debug(f"Sound '{slug}' loaded and cached successfully.")
-            return self.sounds[slug]
+
+            # Apply physical volume based on mute state
+            physical_volume = 0.0 if self.muted else self._user_volume
+            sound.set_volume(physical_volume)
+
+            wrapper = SoundWrapper(sound)
+            self.sounds[slug] = wrapper
+            return wrapper
+
         except (MemoryError, pygame.error) as e:
             logger.error(f"Failed to load sound '{slug}': {e}")
             return SoundWrapper()
 
-    def play_sound(
-        self, slug: str, value: float = CONFIG.sound_volume
-    ) -> None:
-        sound = self.load_sound(slug, value)
+    def play(self, slug: str) -> None:
+        sound = self.load_sound(slug)
         sound.play()
+
+    def set_volume(self, volume: float) -> None:
+        volume = max(0.0, min(1.0, volume))
+
+        if volume == 0.0:
+            self.mute()
+            return
+
+        self._user_volume = volume
+
+        if not self.muted:
+            for wrapper in self.sounds.values():
+                wrapper.set_volume(self._user_volume)
+
+    def get_volume(self) -> float:
+        return 0.0 if self.muted else self._user_volume
+
+    def mute(self) -> None:
+        self.muted = True
+        for wrapper in self.sounds.values():
+            wrapper.set_volume(0.0)
+
+    def unmute(self) -> None:
+        self.muted = False
+        for wrapper in self.sounds.values():
+            wrapper.set_volume(self._user_volume)
+
+    def toggle_mute(self) -> None:
+        if self.muted:
+            self.unmute()
+        else:
+            self.mute()
 
     def unload_sound(self, slug: str) -> None:
         if slug in self.sounds:
             del self.sounds[slug]
             logger.debug(f"Unloaded sound '{slug}' from cache.")
-        else:
-            logger.debug(f"Attempted to unload non-existent sound '{slug}'.")
 
     def unload_all_sounds(self) -> None:
         self.sounds.clear()

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -132,21 +132,21 @@ class DojoMethodAction(EventAction):
         devolution = Monster.spawn_base(slug, self.monster.level)
         self.monster.evolution_handler.evolve_monster(devolution)
         logger.info(f"{self.monster.name}'s devolved!")
-        self.client.sound_manager.play_sound("sound_confirm")
+        self.client.sound_manager.play("sound_confirm")
         self.client.pop_state()
 
     def set_var(self, menu_technique: MenuItem[Technique]) -> None:
         tech = menu_technique.game_object
         self.monster.moves.learn(self.monster, tech, ignore_eligibility=True)
         logger.info(f"{tech.name} learned!")
-        self.client.sound_manager.play_sound("sound_confirm")
+        self.client.sound_manager.play("sound_confirm")
         self.client.pop_state()
 
     def get_tech(self, menu_technique: MenuItem[Technique]) -> None:
         tech = menu_technique.game_object
         self.monster.moves.remove_forced(tech)
         logger.info(f"{tech.name} forgot!")
-        self.client.sound_manager.play_sound("sound_confirm")
+        self.client.sound_manager.play("sound_confirm")
         self.client.pop_state()
 
         # Now push the learn menu
@@ -167,7 +167,7 @@ class DojoMethodAction(EventAction):
                 self.monster, tech, ignore_eligibility=True
             )
             logger.info(f"{tech.name} learned!")
-            self.client.sound_manager.play_sound("sound_confirm")
+            self.client.sound_manager.play("sound_confirm")
             self.stop()
             return
 

--- a/tuxemon/event/actions/play_music.py
+++ b/tuxemon/event/actions/play_music.py
@@ -62,4 +62,10 @@ class PlayMusicAction(EventAction):
                 )
 
         # Keep track of what song we're currently playing
-        client.current_music.play(self.filename, volume, loop, fade_ms)
+        client.current_music.play(
+            self.filename,
+            volume,
+            loop,
+            fade_ms,
+            fade_previous=True,
+        )

--- a/tuxemon/event/actions/play_sound.py
+++ b/tuxemon/event/actions/play_sound.py
@@ -41,7 +41,8 @@ class PlaySoundAction(EventAction):
 
     def start(self, session: Session) -> None:
         client = session.client
-        sound_volume = client.config.sound_volume
+        sound_manager = client.sound_manager
+        user_volume = client.config.sound_volume
 
         if self.volume is not None:
             lower, upper = SOUND_RANGE
@@ -49,10 +50,12 @@ class PlaySoundAction(EventAction):
                 raise ValueError(
                     f"Volume must be between {lower} and {upper}",
                 )
-        volume = (
-            self.volume * sound_volume
+
+        effective_volume = (
+            self.volume * user_volume
             if self.volume is not None
-            else sound_volume
+            else user_volume
         )
 
-        client.sound_manager.play_sound(self.filename, volume)
+        sound_manager.set_volume(effective_volume)
+        sound_manager.play(self.filename)

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -1193,10 +1193,11 @@ class CombatState(CombatAnimations):
         """Play the sound effect."""
         if sound is None:
             return
-        volume = (
-            value if value is not None else self.client.config.sound_volume
-        )
-        self.client.sound_manager.play_sound(sound, volume)
+
+        user_volume = self.client.config.sound_volume
+        effective_volume = value if value is not None else user_volume
+        self.client.sound_manager.set_volume(effective_volume)
+        self.client.sound_manager.play(sound)
 
     def _on_play_music_combat(self, monster: Monster) -> None:
         """Play the music."""

--- a/tuxemon/states/control_state.py
+++ b/tuxemon/states/control_state.py
@@ -108,19 +108,27 @@ class ControlState(PygameMenuState):
 
         if not self.main_menu:
 
-            def mute_music() -> None:
-                self.client.config.update_attribute(
-                    "gameplay", "music_volume", 0
-                )
-                self.client.current_music.set_volume(0)
+            def toggle_mute() -> None:
+                self.client.current_music.toggle_mute()
 
-            _volume = self.client.current_music.get_volume()
-            if _volume and _volume > 0.0:
-                menu.add.button(
-                    title=T.translate("menu_mute_music").upper(),
-                    action=mute_music,
-                    font_size=self.font_type.small,
+                # Persist logical volume (0 if muted, user volume otherwise)
+                new_vol = self.client.current_music.get_volume()
+                self.client.config.update_attribute(
+                    "gameplay", "music_volume", new_vol
                 )
+
+            is_muted = self.client.current_music.muted
+            title = (
+                T.translate("menu_unmute_music")
+                if is_muted
+                else T.translate("menu_mute_music")
+            )
+
+            menu.add.button(
+                title=title.upper(),
+                action=toggle_mute,
+                font_size=self.font_type.small,
+            )
 
             _music = self.client.config.music_volume
             default_music = int(float(_music) * 100)

--- a/tuxemon/states/splash_screen.py
+++ b/tuxemon/states/splash_screen.py
@@ -57,7 +57,7 @@ class SplashState(State):
             width - splash_border - cc.rect.width,
             height - splash_border - cc.rect.height,
         )
-        self.client.sound_manager.play_sound("sound_ding")
+        self.client.sound_manager.play("sound_ding")
 
     def resume(self) -> None:
         if self.triggered:

--- a/tuxemon/states/transition_evolution.py
+++ b/tuxemon/states/transition_evolution.py
@@ -140,7 +140,7 @@ class EvolutionTransition(State):
         self.evolved_sprite.image.blit(self.evolved_sprite_white, (0, 0))
 
         if self.elapsed_time > self.total_seconds and not self.dialog_opened:
-            self.client.sound_manager.play_sound("sound_confirm")
+            self.client.sound_manager.play("sound_confirm")
             self.on_animation_complete()
 
     def draw(self, surface: Surface) -> None:

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -141,7 +141,7 @@ class TradingTransition(State):
         self.received_sprite.image.blit(self.received_sprite_white, (0, 0))
 
         if self.elapsed_time > self.total_seconds and not self.dialog_opened:
-            self.client.sound_manager.play_sound("sound_confirm")
+            self.client.sound_manager.play("sound_confirm")
             self.on_animation_complete()
 
     def draw(self, surface: Surface) -> None:


### PR DESCRIPTION
PR restores the expected transition behavior when changing rooms, maps, or entering battle. If a previous track is playing, it now fades out before the new track begins. This fixes #3509

PR adds an explicit mute flag to both the music and sound systems. Music and SFX no longer rely on volume‑0 checks to determine mute state.

Battle music previously ignored the mute setting because mute was inferred from mixer volume. With an explicit mute flag and mute‑aware playback, all music—including battle tracks—now follows the user’s mute setting. This fixes #3515

The Options menu now exposes a single toggle that switches between *Mute Music* and *Unmute Music*, based on the actual mute state rather than mixer volume.

Sound effects now use the same model as music: explicit mute state, logical volume tracking, and consistent application of volume across cached sounds.

PR also adds pytest coverage for both `MusicPlayerState` and `SoundManager`, which were previously untested.