### PR TITLE
Bed locks player during healing

### DIFF
--- a/mods/tuxemon/maps/spyder_bedroom.yaml
+++ b/mods/tuxemon/maps/spyder_bedroom.yaml
@@ -33,8 +33,11 @@ events:
     type: event
   Resting in Bed:
     actions:
+    - char_stop player
+    - lock_controls
     - screen_transition 1
     - wait 0.5
+    - unlock_controls
     - translated_dialog spyder_papertown_restinbed
     - set_monster_health
     - set_monster_status


### PR DESCRIPTION
The player "blacks out" to sleep but movement isn't locked, so the player can be away from the bed by the time they wake up. This locks movement for the duration. 