### PR TITLE
Add autosave system with reserved slot 0 and main‑menu entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Features
 - 223 items
 
 
+Documentation
+--------
+
+- [Save System Architecture](docs/save_system.md)
+
+
 Installation
 ------------
 
@@ -230,82 +236,9 @@ Use *Tiled* map editor: https://www.mapeditor.org/
 CLI Interface
 --------------
 
-The CLI interface is a very convenient way to debug and develop your
-maps. After you enable the CLI interface, you can use the terminal to
-enter commands.  You could, for example, give yourself potions to
-battle, or add a monster directly to your party.  It's also possible to
-change game variables directly.  In fact, any action or condition that
-is usable in the map can be used with the CLI interface.
+Complete CLI documentation:
 
-### Setting up
-
-You can enable cli by changing `cli_enabled` to `True` in the
-`tuxemon.yaml` file:
-
-```
-[game]
-cli_enabled = True
-```
-
-### Commands
-
-- `help [command_name]` — Lists all commands, or specific information on a command.
-- `action <action_name> [params]` — Execute EventAction.  Uses same syntax as the map script.
-- `test <condition_name> [params]` — Test EventCondition.  Uses same syntax as the map script.
-- `random_encounter` — Sets you in a wild tuxemon battle, similar to walking in tall grass.
-- `trainer_battle <npc_slug>` — Sets you in a trainer battle with specified npc.
-- `quit` — Quits the game.
-- `whereami` — Prints out the map filename.
-- `shell` — Starts the Python shell, that you can use to modify the game directly. For advanced users.
-
-### CLI Examples
-
-Get Commands
-
-```
-> help
-Available Options
-=================
-action  help  quit  random_encounter  shell  test  trainer_battle  whereami
-
-Enter 'help [command]' for more info.
-```
-
-Get help on an action
-
-```
-> help action teleport
-
-    Teleport the player to a particular map and tile coordinates.
-
-    Script usage:
-        .. code-block::
-
-            teleport <map_name>,<x>,<y>
-
-    Script parameters:
-        map_name: Name of the map to teleport to.
-        x: X coordinate of the map to teleport to.
-        y: Y coordinate of the map to teleport to.
-```
-
-Test and give an item
-```
-> test has_item player,potion
-False
-> action add_item potion,1
-> test has_item player,potion
-True
-```
-
-**NOTE!**  The CLI interface is new and the error messages are not very
-helpful. In general, you should be using the commands when the game is
-playing, and you are on the world map.
-
-
-Check out the
-[scripting reference](https://tuxemon.readthedocs.io/en/latest/handcrafted/scripting.html) 
-for all the available actions and conditions for use with `action` and `test`!
+- [docs/cli.md](docs/cli.md)
 
 
 Building

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,92 @@
+# Tuxemon CLI Interface
+
+This document describes the in‑game command‑line interface used for debugging, development, and direct game manipulation.
+
+---
+
+## Overview
+
+The CLI interface allows direct execution of actions, conditions, and debugging commands while the game is running.  
+It can modify game state, spawn items or monsters, and inspect map data.
+
+Any action or condition available in map scripts is also available in the CLI.
+
+---
+
+## Enabling the CLI
+
+Enable the CLI by setting `cli_enabled = True` in `tuxemon.yaml`:
+
+```
+[game]
+cli_enabled = True
+```
+
+---
+
+## Commands
+
+| Command | Description |
+|--------|-------------|
+| `help [command_name]` | Lists all commands or details for a specific command |
+| `action <action_name> [params]` | Executes an EventAction (same syntax as map scripts) |
+| `test <condition_name> [params]` | Tests an EventCondition |
+| `random_encounter` | Starts a wild tuxemon battle |
+| `trainer_battle <npc_slug>` | Starts a trainer battle |
+| `quit` | Quits the game |
+| `whereami` | Prints the current map filename |
+| `shell` | Opens a Python shell for advanced manipulation |
+
+---
+
+## Examples
+
+### List all commands
+
+```
+> help
+Available Options
+=================
+action  help  quit  random_encounter  shell  test  trainer_battle  whereami
+
+Enter 'help [command]' for more info.
+```
+
+### Get help for a specific action
+
+```
+> help action teleport
+
+    Teleport the player to a particular map and tile coordinates.
+
+    Script usage:
+        .. code-block::
+
+            teleport <map_name>,<x>,<y>
+
+    Script parameters:
+        map_name: Name of the map to teleport to.
+        x: X coordinate of the map to teleport to.
+        y: Y coordinate of the map to teleport to.
+```
+
+### Test a condition and give an item
+
+```
+> test has_item player,potion
+False
+> action add_item potion,1
+> test has_item player,potion
+True
+```
+
+---
+
+## Notes
+
+The CLI interface is new and error messages may be limited.  
+Use commands while the game is running and the player is on the world map.
+
+For a full list of actions and conditions, see the scripting reference:
+
+[https://tuxemon.readthedocs.io/en/latest/handcrafted/scripting.html](https://tuxemon.readthedocs.io/en/latest/handcrafted/scripting.html)

--- a/docs/handcrafted/action_list.rst
+++ b/docs/handcrafted/action_list.rst
@@ -10,6 +10,7 @@
 .. autoscriptinfoclass:: tuxemon.event.actions.add_tracker.AddTrackerAction
 .. autoscriptinfoclass:: tuxemon.event.actions.adjust_bill_penalty.AdjustBillPenaltyAction
 .. autoscriptinfoclass:: tuxemon.event.actions.afk_threshold.AFKThresholdAction
+.. autoscriptinfoclass:: tuxemon.event.actions.autosave.AutosaveAction
 .. autoscriptinfoclass:: tuxemon.event.actions.boundary_move.BoundaryMoveAction
 .. autoscriptinfoclass:: tuxemon.event.actions.boundary_resize.BoundaryResizeAction
 .. autoscriptinfoclass:: tuxemon.event.actions.boundary_set.BoundarySetAction

--- a/docs/save_system.md
+++ b/docs/save_system.md
@@ -1,0 +1,112 @@
+# Tuxemon Save System Architecture
+
+This document defines how save slots, autosave, and UI slot mapping work in Tuxemon.  
+It is the single source of truth for all save/load behavior.
+
+---
+
+## Slot Types
+
+### UI-visible slots (1–3)
+- Shown in SaveMenuState and LoadMenuState
+- Mapped from UI indices 0–2
+- User-controlled: save, overwrite, delete
+
+### Autosave slot (0)
+- Hidden in SaveMenuState
+- Visible in LoadMenuState
+- Never overwritten by user actions
+- Written only by AutosaveAction
+
+---
+
+## Mapping Rules
+
+| Operation | Rule |
+|----------|------|
+| UI index → save slot | `ui_to_save_index(i) = i + 1` |
+| Save slot → UI index | `save_index_to_ui(s) = s - 1` |
+| Event-action index | `resolve_save_index(i)` |
+| UI selection | `slot_from_ui(i, includes_autosave)` |
+
+---
+
+## Menu Behavior
+
+### SaveMenuState
+- Displays slots 1–3
+- Does not display autosave
+- Cannot overwrite autosave
+
+### LoadMenuState
+- Displays autosave (slot 0) and slots 1–3
+- Allows loading autosave
+- Uses raw slot numbers
+
+---
+
+## Safety Guarantees
+
+- Autosave cannot be overwritten by the player
+- UI slots remain simple and predictable
+- Load menu exposes all available save data
+- Event actions always resolve to correct slot numbers
+
+---
+
+## File Layout
+
+```
+save_system/
+    save_slots.py      # pure mapping helpers
+    save_manager.py    # orchestrator for save/load/delete/render
+    save_state.py      # save data model
+    save.py            # serialization and file I/O
+```
+
+---
+
+## Summary
+
+The save system separates UI slots from the autosave slot to prevent accidental overwrites while keeping the UI simple. All slot mapping and safety rules are centralized in SaveManager and save_slots.
+
+---
+
+## Save System Diagram
+
+```mermaid
+flowchart TD
+
+    subgraph UI["UI Layer"]
+        UI0["UI Index 0 → Slot 1"]
+        UI1["UI Index 1 → Slot 2"]
+        UI2["UI Index 2 → Slot 3"]
+    end
+
+    subgraph Engine["Engine Slot Layer"]
+        AS["Autosave Slot 0"]
+        S1["Save Slot 1"]
+        S2["Save Slot 2"]
+        S3["Save Slot 3"]
+    end
+
+    subgraph Menus["Menu Behavior"]
+        SaveMenu["SaveMenuState\nShows Slots 1–3\nNever shows Autosave"]
+        LoadMenu["LoadMenuState\nShows Autosave + Slots 1–3"]
+    end
+
+    UI0 --> S1
+    UI1 --> S2
+    UI2 --> S3
+
+    SaveMenu --> S1
+    SaveMenu --> S2
+    SaveMenu --> S3
+
+    LoadMenu --> AS
+    LoadMenu --> S1
+    LoadMenu --> S2
+    LoadMenu --> S3
+
+    AS -.->|"AutosaveAction writes here"| AS
+```

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -4712,6 +4712,12 @@ msgstr "Doll"
 msgid "menu_save"
 msgstr "Save"
 
+msgid "menu_autosave"
+msgstr "Autosave"
+
+msgid "menu_no_autosave"
+msgstr "No Autosave"
+
 msgid "menu_up_key"
 msgstr "Up Key"
 

--- a/tests/tuxemon/test_save_manager.py
+++ b/tests/tuxemon/test_save_manager.py
@@ -7,6 +7,7 @@ from pygame.rect import Rect
 from pygame.surface import Surface
 
 from tuxemon.save_system.save_manager import SaveManager
+from tuxemon.save_system.save_slots import AUTOSAVE_SLOT
 
 
 @pytest.fixture
@@ -15,7 +16,8 @@ def fake_save_path(monkeypatch, tmp_path):
         return str(tmp_path / f"slot{slot}.save")
 
     monkeypatch.setattr(
-        "tuxemon.save_system.save_manager.get_save_path", _fake_get_save_path
+        "tuxemon.save_system.save_manager.get_save_path",
+        _fake_get_save_path,
     )
     return tmp_path
 
@@ -35,38 +37,36 @@ def fake_session():
 @pytest.mark.parametrize(
     "slot, create_file, expected",
     [
-        pytest.param(1, True, True, id="file_exists"),
-        pytest.param(2, False, False, id="file_missing"),
+        pytest.param(1, True, True, id="exists-file"),
+        pytest.param(2, False, False, id="exists-missing"),
     ],
 )
 def test_exists(fake_save_path, slot, create_file, expected):
     path = fake_save_path / f"slot{slot}.save"
     if create_file:
-        path.write_text("dummy")
-
+        path.write_text("x")
     assert SaveManager.exists(slot) is expected
 
 
 @pytest.mark.parametrize(
     "content, expected_type",
     [
-        pytest.param("{}", dict, id="valid_json"),
-        pytest.param("", type(None), id="empty_file_returns_none"),
+        pytest.param("{}", dict, id="load-valid"),
+        pytest.param("", type(None), id="load-empty"),
     ],
 )
 def test_load(monkeypatch, fake_save_path, content, expected_type):
     def fake_load(path):
         if not content:
             return None
-        return {"data": True}
+        return {"ok": True}
 
     monkeypatch.setattr(
-        "tuxemon.save_system.save_manager.save.load", fake_load
+        "tuxemon.save_system.save_manager.save.load",
+        fake_load,
     )
-
     path = fake_save_path / "slot1.save"
     path.write_text(content)
-
     result = SaveManager.load(1)
     assert isinstance(result, expected_type)
 
@@ -74,41 +74,35 @@ def test_load(monkeypatch, fake_save_path, content, expected_type):
 @pytest.mark.parametrize(
     "create_file, expected",
     [
-        pytest.param(True, True, id="delete_existing"),
-        pytest.param(False, False, id="delete_missing"),
+        pytest.param(True, True, id="delete-existing"),
+        pytest.param(False, False, id="delete-missing"),
     ],
 )
 def test_delete(fake_save_path, create_file, expected):
     slot = 1
     path = fake_save_path / "slot1.save"
-
     if create_file:
-        path.write_text("dummy")
-
+        path.write_text("x")
     result = SaveManager.delete(slot)
     assert result is expected
-    assert path.exists() is False
+    assert not path.exists()
 
 
 def test_save_calls_session_save_state(fake_session, fake_save_path):
-    slot = 3
-    SaveManager.save(fake_session, slot)
-
-    assert fake_session.calls == [(slot, slot)]
+    SaveManager.save(fake_session, 3)
+    assert fake_session.calls == [(3, 3)]
 
 
 def test_delete_oserror(monkeypatch, fake_save_path):
     slot = 1
     path = fake_save_path / "slot1.save"
-    path.write_text("dummy")
+    path.write_text("x")
 
     def fake_unlink():
-        raise OSError("permission denied")
+        raise OSError("denied")
 
     monkeypatch.setattr(Path, "unlink", lambda self: fake_unlink())
-
-    result = SaveManager.delete(slot)
-    assert result is False
+    assert SaveManager.delete(slot) is False
 
 
 def test_save_raises(monkeypatch, fake_session, fake_save_path):
@@ -116,51 +110,43 @@ def test_save_raises(monkeypatch, fake_session, fake_save_path):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(fake_session, "save_state", fake_save_state)
-
     with pytest.raises(RuntimeError):
         SaveManager.save(fake_session, 1)
 
 
-def test_exists_mutation(monkeypatch, fake_save_path):
+def test_exists_mutation(monkeypatch):
     monkeypatch.setattr(Path, "exists", lambda self: True)
     assert SaveManager.exists(1) is True
 
 
 def test_load_mutation(monkeypatch, fake_save_path):
     monkeypatch.setattr(
-        "tuxemon.save_system.save_manager.save.load", lambda path: "not-a-save"
+        "tuxemon.save_system.save_manager.save.load",
+        lambda path: "x",
     )
-
     path = fake_save_path / "slot1.save"
-    path.write_text("dummy")
-
-    result = SaveManager.load(1)
-    assert result == "not-a-save"
+    path.write_text("x")
+    assert SaveManager.load(1) == "x"
 
 
 def test_delete_mutation(monkeypatch, fake_save_path):
     slot = 1
     path = fake_save_path / "slot1.save"
-    path.write_text("dummy")
-
+    path.write_text("x")
     monkeypatch.setattr(Path, "unlink", lambda self: None)
-
-    result = SaveManager.delete(slot)
-    assert result is True
+    assert SaveManager.delete(slot) is True
 
 
 def test_save_mutation(monkeypatch, fake_session, fake_save_path):
     def fake_save_state(index, slot):
-        fake_session.calls.append(("wrong", "wrong"))
+        fake_session.calls.append(("bad", "bad"))
 
     monkeypatch.setattr(fake_session, "save_state", fake_save_state)
-
     SaveManager.save(fake_session, 3)
+    assert fake_session.calls == [("bad", "bad")]
 
-    assert fake_session.calls == [("wrong", "wrong")]
 
-
-def test_all_slots(monkeypatch):
+def test_all_slots_offset(monkeypatch):
     monkeypatch.setattr(
         "tuxemon.save_system.save_manager.ui_to_save_index",
         lambda i: i + 10,
@@ -168,7 +154,7 @@ def test_all_slots(monkeypatch):
     assert SaveManager.all_slots(3) == [10, 11, 12]
 
 
-def test_slot_from_ui(monkeypatch):
+def test_slot_from_ui_offset(monkeypatch):
     monkeypatch.setattr(
         "tuxemon.save_system.save_manager.ui_to_save_index",
         lambda i: i * 2,
@@ -179,7 +165,7 @@ def test_slot_from_ui(monkeypatch):
 def test_render_empty(monkeypatch):
     called = {}
 
-    def fake_render(rect, scaling, font):
+    def fake_render(rect, scaling, font, slot):
         called["ok"] = True
         return "surface"
 
@@ -187,8 +173,7 @@ def test_render_empty(monkeypatch):
         "tuxemon.save_system.save_manager.render_empty_slot",
         fake_render,
     )
-
-    result = SaveManager.render_empty("rect", "scaling", "font")
+    result = SaveManager.render_empty("rect", 1, "scaling", "font")
     assert result == "surface"
     assert called["ok"] is True
 
@@ -196,7 +181,7 @@ def test_render_empty(monkeypatch):
 def test_render_slot(monkeypatch):
     monkeypatch.setattr(
         "tuxemon.save_system.save_manager.SaveManager.load",
-        lambda slot: {"dummy": True},
+        lambda slot: {"x": True},
     )
     monkeypatch.setattr(
         "tuxemon.save_system.save_manager.render_thumbnail",
@@ -206,11 +191,11 @@ def test_render_slot(monkeypatch):
         "tuxemon.save_system.save_manager.render_slot_text",
         lambda *args, **kwargs: None,
     )
-
     rect = Rect(0, 0, 200, 100)
-    result = SaveManager.render_slot(rect, 1, "scaling", "font")
-
-    assert isinstance(result, Surface)
+    assert isinstance(
+        SaveManager.render_slot(rect, 1, "scaling", "font"),
+        Surface,
+    )
 
 
 def test_render_slot_missing_data(monkeypatch):
@@ -218,17 +203,96 @@ def test_render_slot_missing_data(monkeypatch):
         "tuxemon.save_system.save_manager.SaveManager.load",
         lambda slot: None,
     )
-
     rect = Rect(0, 0, 200, 100)
-
     with pytest.raises(RuntimeError):
         SaveManager.render_slot(rect, 1, "scaling", "font")
 
 
 def test_delete_logs_warning(monkeypatch, caplog):
     monkeypatch.setattr(Path, "exists", lambda self: False)
-
     caplog.set_level("WARNING", logger="tuxemon.save_system.save_manager")
-
     SaveManager.delete(1)
     assert "does not exist" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "exists, expected",
+    [
+        pytest.param(True, True, id="autosave-exists"),
+        pytest.param(False, False, id="autosave-missing"),
+    ],
+)
+def test_has_autosave(monkeypatch, exists, expected):
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.SaveManager.exists",
+        lambda slot: exists if slot == AUTOSAVE_SLOT else False,
+    )
+    assert SaveManager.has_autosave() is expected
+
+
+@pytest.mark.parametrize(
+    "max_slots, include_autosave, expected",
+    [
+        pytest.param(3, False, [1, 2, 3], id="slots-no-autosave"),
+        pytest.param(3, True, [0, 1, 2, 3], id="slots-with-autosave"),
+    ],
+)
+def test_all_slots_autosave(
+    monkeypatch, max_slots, include_autosave, expected
+):
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.ui_to_save_index",
+        lambda i: i + 1,
+    )
+    assert SaveManager.all_slots(max_slots, include_autosave) == expected
+
+
+@pytest.mark.parametrize(
+    "ui_index, includes_autosave, expected",
+    [
+        pytest.param(0, False, 1, id="ui0-no-autosave"),
+        pytest.param(1, False, 2, id="ui1-no-autosave"),
+        pytest.param(0, True, 0, id="ui0-autosave"),
+        pytest.param(1, True, 1, id="ui1-autosave"),
+    ],
+)
+def test_slot_from_ui(monkeypatch, ui_index, includes_autosave, expected):
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.ui_to_save_index",
+        lambda i: i + 1,
+    )
+    assert SaveManager.slot_from_ui(ui_index, includes_autosave) == expected
+
+
+@pytest.mark.parametrize(
+    "slot, expected_label",
+    [
+        pytest.param(0, "menu_autosave", id="label-autosave"),
+        pytest.param(2, "slot", id="label-normal"),
+    ],
+)
+def test_render_slot_label(monkeypatch, slot, expected_label):
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.SaveManager.load",
+        lambda s: {"x": True},
+    )
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.render_thumbnail",
+        lambda data, rect: Surface((10, 10)),
+    )
+    captured = {}
+
+    def fake_render_slot_text(surface, rect, label, save_data, scaling, font):
+        captured["label"] = label
+
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.render_slot_text",
+        fake_render_slot_text,
+    )
+    monkeypatch.setattr(
+        "tuxemon.save_system.save_manager.T.translate",
+        lambda key: key,
+    )
+    rect = Rect(0, 0, 200, 100)
+    SaveManager.render_slot(rect, slot, "scaling", "font")
+    assert expected_label in captured["label"]

--- a/tests/tuxemon/test_save_slots.py
+++ b/tests/tuxemon/test_save_slots.py
@@ -4,6 +4,7 @@ import pytest
 
 from tuxemon.save_system.save_slots import (
     resolve_save_index,
+    save_index_to_ui,
     ui_to_save_index,
 )
 
@@ -35,3 +36,32 @@ def test_resolve_save_index_none():
 )
 def test_ui_to_save_index(ui_index, expected):
     assert ui_to_save_index(ui_index) == expected
+
+
+@pytest.mark.parametrize(
+    "save_index, expected",
+    [
+        pytest.param(1, 0, id="slot1->ui0"),
+        pytest.param(2, 1, id="slot2->ui1"),
+        pytest.param(3, 2, id="slot3->ui2"),
+    ],
+)
+def test_save_index_to_ui(save_index, expected):
+    assert save_index_to_ui(save_index) == expected
+
+
+def test_save_index_to_ui_autosave():
+    assert save_index_to_ui(0) == -1
+
+
+@pytest.mark.parametrize(
+    "ui_index",
+    [
+        pytest.param(0, id="roundtrip-ui0"),
+        pytest.param(1, id="roundtrip-ui1"),
+        pytest.param(2, id="roundtrip-ui2"),
+    ],
+)
+def test_ui_round_trip(ui_index):
+    save_index = ui_to_save_index(ui_index)
+    assert save_index_to_ui(save_index) == ui_index

--- a/tuxemon/event/actions/autosave.py
+++ b/tuxemon/event/actions/autosave.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import final
+
+from tuxemon.event.eventaction import EventAction
+from tuxemon.save_system.save_manager import SaveManager
+from tuxemon.save_system.save_slots import AUTOSAVE_SLOT
+from tuxemon.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@final
+@dataclass
+class AutosaveAction(EventAction):
+    """
+    Performs an automatic save using the engine's autosave slot.
+
+    This action triggers a write to the predefined `AUTOSAVE_SLOT`,
+    which is managed internally by the save system. It requires no
+    parameters and is typically invoked by scripted events that want
+    to persist progress without user interaction.
+
+    Script usage:
+        .. code-block::
+
+            autosave
+
+    Script parameters:
+        (none)
+    """
+
+    name = "autosave"
+
+    def start(self, session: Session) -> None:
+        try:
+            SaveManager.save(session, AUTOSAVE_SLOT)
+            logger.info("Autosave complete.")
+        except Exception as e:
+            logger.error(f"Autosave failed: {e}")

--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -24,9 +24,14 @@ class LoadGameAction(EventAction):
     """
     Loads a game from a specific save slot.
 
-    The `index` parameter refers to the UI slot index (0-2).
-    Slot resolution is handled by `resolve_save_index()`, which converts
-    the UI index (0-based) into a save slot number (1-based).
+    The `index` parameter normally refers to the UI slot index (0-2).
+    When `is_raw_slot` is False (default), the index is interpreted as a
+    UI-facing slot and converted to an actual save slot number using
+    `resolve_save_index()`.
+
+    When `is_raw_slot` is True, the index is treated as a *raw* save slot
+    number and used directly. This is primarily intended for internal or
+    system-driven loads (e.g., autosave recovery).
 
     Script usage:
         .. code-block::
@@ -34,15 +39,19 @@ class LoadGameAction(EventAction):
             load_game <index>
 
     Script parameters:
-        index: UI slot index (0-2). Must always be provided.
+        index: UI slot index (0-2) unless `is_raw_slot=True`.
+        is_raw_slot: If True, bypasses UI-to-slot conversion.
     """
 
     name = "load_game"
     index: int
+    is_raw_slot: bool = False
 
     def start(self, session: Session) -> None:
         client = session.client
-        slot = resolve_save_index(self.index)
+        slot = (
+            self.index if self.is_raw_slot else resolve_save_index(self.index)
+        )
 
         client.map_loader.clear_cache()
         logger.info("Loading!")

--- a/tuxemon/save_system/save_manager.py
+++ b/tuxemon/save_system/save_manager.py
@@ -11,9 +11,10 @@ from pygame.font import Font
 from pygame.rect import Rect
 from pygame.surface import Surface
 
+from tuxemon.locale.locale import T
 from tuxemon.save_system import save
 from tuxemon.save_system.save import get_save_path
-from tuxemon.save_system.save_slots import ui_to_save_index
+from tuxemon.save_system.save_slots import AUTOSAVE_SLOT, ui_to_save_index
 from tuxemon.ui.save_slot_renderer import (
     render_empty_slot,
     render_slot_text,
@@ -60,18 +61,29 @@ class SaveManager:
         session.save_state(index=slot, slot=slot)
 
     @staticmethod
-    def all_slots(max_slots: int) -> list[int]:
-        return [ui_to_save_index(i) for i in range(max_slots)]
+    def has_autosave() -> bool:
+        """Helper to specifically check for the autosave slot."""
+        return SaveManager.exists(AUTOSAVE_SLOT)
 
     @staticmethod
-    def slot_from_ui(ui_index: int) -> int:
-        return ui_to_save_index(ui_index)
+    def all_slots(max_slots: int, include_autosave: bool = False) -> list[int]:
+        slots = [ui_to_save_index(i) for i in range(max_slots)]
+        return ([AUTOSAVE_SLOT] + slots) if include_autosave else slots
+
+    @staticmethod
+    def slot_from_ui(ui_index: int, includes_autosave: bool = False) -> int:
+        return ui_index if includes_autosave else ui_to_save_index(ui_index)
 
     @staticmethod
     def render_empty(
-        rect: Rect, scaling: ScalingStrategy, font: Font
+        rect: Rect, slot: int, scaling: ScalingStrategy, font: Font
     ) -> Surface:
-        return render_empty_slot(rect, scaling=scaling, font=font)
+        return render_empty_slot(
+            rect,
+            scaling=scaling,
+            font=font,
+            slot=slot,
+        )
 
     @staticmethod
     def render_slot(
@@ -81,24 +93,27 @@ class SaveManager:
         save_data = SaveManager.load(slot)
 
         if not save_data:
-            logger.critical(f"Save data missing for slot {slot}")
-            raise RuntimeError(
-                f"Critical error: Save data missing for slot {slot}"
-            )
+            raise RuntimeError(f"Save data missing for slot {slot}")
 
         thumb = render_thumbnail(save_data, rect)
         slot_image.blit(thumb, (rect.width * 0.20, 0))
 
+        slot_label = (
+            T.translate("menu_autosave")
+            if slot == AUTOSAVE_SLOT
+            else f"{T.translate('slot')} {slot}"
+        )
+
         text_rect = Rect(
             0, rect.height // 2 - 10, rect.width, rect.height // 2
         )
+
         render_slot_text(
             slot_image,
             text_rect,
-            slot,
+            slot_label,
             save_data,
             scaling=scaling,
             font=font,
         )
-
         return slot_image

--- a/tuxemon/save_system/save_slots.py
+++ b/tuxemon/save_system/save_slots.py
@@ -2,25 +2,26 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+AUTOSAVE_SLOT: int = 0
+
 
 def ui_to_save_index(global_ui_index: int) -> int:
     """
-    Convert a *global* UI index (0-based) to a save slot number (1-based).
+    Convert a UI slot index (0-2) into a save slot number (1-3); autosave uses slot 0.
     """
     return global_ui_index + 1
 
 
 def save_index_to_ui(save_index: int) -> int:
     """
-    Convert a save slot number (1-based) to a *global* UI index (0-based).
+    Convert a save slot number (1-3) into a UI slot index (0-2); autosave (0) has no UI slot.
     """
     return save_index - 1
 
 
 def resolve_save_index(index: int | None) -> int:
     """
-    Convert event-action index to actual save slot number.
-    index=None → invalid
+    Convert an event-action UI index (0-2) into a save slot number (1-3); autosave is slot 0.
     """
     if index is None:
         raise ValueError("resolve_save_index() called with index=None")

--- a/tuxemon/states/save_and_load.py
+++ b/tuxemon/states/save_and_load.py
@@ -124,7 +124,9 @@ class SaveMenuState(PaginatedMenuState):
             rect.width * SLOT_WIDTH_RATIO,
             rect.height // SLOT_HEIGHT_RATIO,
         )
-        for slot in SaveManager.all_slots(self.max_slots):
+        for slot in SaveManager.all_slots(
+            self.max_slots, include_autosave=False
+        ):
             item = self.create_menu_item(slot_rect, slot)
             self.add(item)
 
@@ -140,6 +142,7 @@ class SaveMenuState(PaginatedMenuState):
         else:
             image = SaveManager.render_empty(
                 slot_rect,
+                slot,
                 scaling=self.client.context.scaling,
                 font=self.font,
             )
@@ -246,7 +249,9 @@ class LoadMenuState(PaginatedMenuState):
             rect.height // SLOT_HEIGHT_RATIO,
         )
 
-        for slot in SaveManager.all_slots(self.max_slots):
+        for slot in SaveManager.all_slots(
+            self.max_slots, include_autosave=False
+        ):
             item = self.create_menu_item(slot_rect, slot)
             self.add(item)
 
@@ -262,6 +267,7 @@ class LoadMenuState(PaginatedMenuState):
         else:
             image = SaveManager.render_empty(
                 slot_rect,
+                slot,
                 scaling=self.client.context.scaling,
                 font=self.font,
             )
@@ -300,13 +306,13 @@ class LoadMenuState(PaginatedMenuState):
             )
 
     def on_menu_selection(self, menuitem: MenuItem[None]) -> None:
-        slot = SaveManager.slot_from_ui(self.selected_index)
-
-        if not SaveManager.exists(slot):
-            return
-
-        self.client.event_engine.execute_action(
-            "load_game",
-            [self.selected_index],
-            True,
+        slot = SaveManager.slot_from_ui(
+            self.selected_index, includes_autosave=False
         )
+
+        if SaveManager.exists(slot):
+            self.client.event_engine.execute_action(
+                "load_game",
+                [slot, True],
+                True,
+            )

--- a/tuxemon/states/start.py
+++ b/tuxemon/states/start.py
@@ -21,6 +21,7 @@ from tuxemon.menu.menu import PygameMenuState
 from tuxemon.platform.const.graphics import BG_START_SCREEN, BLACK_COLOR
 from tuxemon.platform.const.sizes import PLAYER_NPC
 from tuxemon.save_system.save import get_index_of_latest_save
+from tuxemon.save_system.save_manager import SaveManager
 from tuxemon.session import local_session
 from tuxemon.state.state import State
 
@@ -94,6 +95,19 @@ class StartState(PygameMenuState):
                 font_size=self.font_type.big,
                 button_id="menu_load",
             )
+
+            if SaveManager.has_autosave():
+                menu.add.button(
+                    title=T.translate("menu_autosave"),
+                    action=lambda: self.client.event_engine.execute_action(
+                        "load_game",
+                        [0, True],
+                        True,
+                    ),
+                    font_size=self.font_type.big,
+                    button_id="menu_autosave",
+                )
+
         if len(self.client.config.mods) == 1:
             menu.add.button(
                 title=T.translate("menu_new_game"),

--- a/tuxemon/ui/save_slot_renderer.py
+++ b/tuxemon/ui/save_slot_renderer.py
@@ -44,14 +44,21 @@ def render_thumbnail(save_data: SaveData, rect: Rect) -> Surface:
 
 
 def render_empty_slot(
-    rect: Rect, scaling: ScalingStrategy, font: Font
+    rect: Rect, scaling: ScalingStrategy, font: Font, slot: int
 ) -> Surface:
     """Render the 'empty slot' UI block."""
     slot_image = Surface(rect.size, SRCALPHA)
     text_rect = rect.move(0, rect.height // 2 - 10)
+
+    label = (
+        T.translate("menu_no_autosave")
+        if slot == 0
+        else T.translate("empty_slot")
+    )
+
     draw_text(
         slot_image,
-        T.translate("empty_slot"),
+        label,
         text_rect,
         scaling=scaling,
         font=font,
@@ -62,7 +69,7 @@ def render_empty_slot(
 def render_slot_text(
     slot_image: Surface,
     rect: Rect,
-    slot: int,
+    slot_label: str,
     save_data: SaveData,
     scaling: ScalingStrategy,
     font: Font,
@@ -70,7 +77,7 @@ def render_slot_text(
     """Draw slot number, player name, and time."""
     draw_text(
         slot_image,
-        f"{T.translate('slot')} {slot}",
+        slot_label,
         rect,
         scaling=scaling,
         font=font,


### PR DESCRIPTION
Fixes #3490

Key changes:
- add autosave slot `0` as a reserved system slot
- add `SaveManager.has_autosave()` to detect autosave presence
- add unified slot labels: slot `0` → `menu_autosave` or slot `1+` → `slot X`  
- add autosave action (`autosave`) for silent writes to slot `0`
- update Load menu to load slot `0` when requested
- update Start menu to show an Autosave button when slot `0` exists
- keep Save menu limited to manual slots only

Usage:
- maps and events trigger autosave with:  `<property name="act1" value="autosave"/>`  
- optional confirmation text: `<property name="act2" value="translated_dialog menu_autosave"/>`  
- start menu shows “menu_autosave” when autosave exists and loads slot `0` directly