### PR TITLE
Enable Ruff F‑rules and fix all resulting errors

### DIFF
--- a/mods/tuxemon/maps/classic_aerolume_city.tmx
+++ b/mods/tuxemon/maps/classic_aerolume_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYBgF5ISAKBsDgxgQD1ZgBXSb9SB2XzzQbQmD2H2DNV5H3TUaAqMhMBoCoyEwGgLUCAFQG0Z8ENfDoDaMzSB2H6gNkziI3UeNNEJLMwBK+gMN
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Route6" type="event" x="624" y="16" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_6.tmx,0,2,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Route5" type="event" x="0" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_5.tmx,39,17,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_astra.tmx
+++ b/mods/tuxemon/maps/classic_gym_astra.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_stormpeak_city.tmx,35,4,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_bravion.tmx
+++ b/mods/tuxemon/maps/classic_gym_bravion.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_valorhold_city.tmx,27,13,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_ferrum.tmx
+++ b/mods/tuxemon/maps/classic_gym_ferrum.tmx
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">

--- a/mods/tuxemon/maps/classic_gym_granite.tmx
+++ b/mods/tuxemon/maps/classic_gym_granite.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_hearthrock_city.tmx,23,14,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_marin.tmx
+++ b/mods/tuxemon/maps/classic_gym_marin.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_steamshore_city.tmx,31,5,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_mila.tmx
+++ b/mods/tuxemon/maps/classic_gym_mila.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_hearthrock_city.tmx,18,14,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_orion.tmx
+++ b/mods/tuxemon/maps/classic_gym_orion.tmx
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">

--- a/mods/tuxemon/maps/classic_gym_pyra.tmx
+++ b/mods/tuxemon/maps/classic_gym_pyra.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_steamshore_city.tmx,23,15,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_shade.tmx
+++ b/mods/tuxemon/maps/classic_gym_shade.tmx
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">

--- a/mods/tuxemon/maps/classic_gym_sylva.tmx
+++ b/mods/tuxemon/maps/classic_gym_sylva.tmx
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">

--- a/mods/tuxemon/maps/classic_gym_voltessa.tmx
+++ b/mods/tuxemon/maps/classic_gym_voltessa.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="54">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="55">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">
@@ -60,6 +60,14 @@
    <properties>
     <property name="act1" value="set_environment interior"/>
     <property name="cond1" value="not environment_is interior"/>
+   </properties>
+  </object>
+  <object id="54" name="Teleport to City" type="event" x="160" y="304" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_stormpeak_city.tmx,5,4,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_gym_vyre.tmx
+++ b/mods/tuxemon/maps/classic_gym_vyre.tmx
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">

--- a/mods/tuxemon/maps/classic_gym_zephra.tmx
+++ b/mods/tuxemon/maps/classic_gym_zephra.tmx
@@ -16,7 +16,7 @@
  </layer>
  <layer id="2" name="Layer 2" width="20" height="20">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFo2AUjIJRMApIBwAGQAAB
+   eJxjYBgFo2AUjIJRMAogwI2JgcEdiD2YCKsFAChqANw=
   </data>
  </layer>
  <layer id="3" name="Layer 3" width="20" height="20">

--- a/mods/tuxemon/maps/classic_hearthrock_city.tmx
+++ b/mods/tuxemon/maps/classic_hearthrock_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="304">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -18,12 +18,12 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHN1jdvFEEUAOABJISNSQbbiGh+BhiwyT8Du8OYHEWuSBWpIGNiYwMVqSIV5AwNSTIiF6SCHL+VGMk6dq/wWdgjfbrVu517T/N256alOoQnFA8KoScl9KI3fehLP0rpzwDKKKeCgbRl7vSaEBoY1T2EKkYTY8Fo+VtXpXtGMFKeUVQxmjGMpZoaxjGeCUxkEpOZQlvmNsnZzFR11VJHjNWLx7pqXdcxTZ56ptPADGYyi9nMYS7zmM8CFrKIQuaGjBHriuu4VZ5tbGcHO9nFbvbQyF72sZ8DHOQQhczNKO+f/l6Q5yKXuMwVrnKN69zgJre4zR3uco9C5mbVl9vfj/J84jNf+Mo3vvODn/ziN2FwCF3oSjcKmZtVX25/s+7rqHh87uI6dlQdWXljXXEds+7rqHisK65jbh2Li0JY0sGWyh/XsXV9r8VXV4SwhrWsYz3LWM4KVrKKDWxkE5vZQlosbV9vnTPtulEdcR1bf5/Ej8lznBOc5BRNNHOYIxzlNGc4yznOkxZL29db50y7TupI628SfyrPM57zgpfc5wEPecRj3vCWd7znA2mx3H293P9ZBfnGK3Wk9TeJlw50HmAAZZTTgyKK6UkJQxjKMIZTSVosd1+PZ4Ks+uJZIa2/WXMKiefu6/FMkPWb8ayQ1t+sOe0ZT97BfKNM75NnIK2/+ea113fJM55vxHPh/+pvbi3JM55vxHNhvCeuY2f5jO9HrC+uY2f5jO/HH8eMHsE=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYKA/EJNiYBAHYgkgHozAFeguNyB2H6TuG4xhNuqm0RAYDYGhGwIiwLJOFIgHe9kMC+HBWnfA3DfY6aWDvG67Msjdxyw92GN41H2jITD4QwAAWf8EoQ==
   </data>
  </layer>
  <layer id="4" name="Tile Layer 4" width="40" height="20">
@@ -33,14 +33,28 @@
  </layer>
  <layer id="5" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgKjITD4QuCBPQPDQyAeLPTgC6Gh6SIAg+0obw==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="32" y="80" width="48" height="16"/>
+  <object id="286" type="collision" x="16" y="0" width="16" height="288"/>
+  <object id="287" type="collision" x="32" y="288" width="576" height="16"/>
+  <object id="288" type="collision" x="256" y="80" width="256" height="16"/>
+  <object id="289" type="collision" x="496" y="32" width="16" height="48"/>
+  <object id="290" type="collision" x="144" y="208" width="64" height="16"/>
+  <object id="291" type="collision" x="224" y="208" width="64" height="16"/>
+  <object id="292" type="collision" x="304" y="208" width="64" height="16"/>
+  <object id="293" type="collision" x="384" y="208" width="32" height="16"/>
+  <object id="294" type="collision" x="416" y="224" width="48" height="16"/>
+  <object id="295" type="collision" x="480" y="224" width="16" height="16"/>
+  <object id="296" type="collision" x="96" y="208" width="32" height="16"/>
+  <object id="297" type="collision" x="96" y="80" width="64" height="16"/>
+  <object id="298" type="collision" x="176" y="80" width="64" height="16"/>
+  <object id="299" type="collision" x="608" y="32" width="16" height="112"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -53,7 +67,6 @@
    <properties>
     <property name="act1" value="set_environment grass"/>
     <property name="cond1" value="not time_is stage_of_day,equals,night"/>
-    <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is grass"/>
    </properties>
   </object>
@@ -61,8 +74,39 @@
    <properties>
     <property name="act1" value="set_environment night_grass"/>
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
-    <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="300" name="Teleport to Route1" type="event" x="512" y="0" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_1.tmx,33,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="301" name="Teleport to Route8" type="event" x="624" y="240" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_8.tmx,0,16,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+   </properties>
+  </object>
+  <object id="302" name="Teleport to Gym 1" type="event" x="288" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_mila.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="303" name="Teleport to Gym 2" type="event" x="368" y="208" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_granite.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_1.tmx
+++ b/mods/tuxemon/maps/classic_route_1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="295">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHNl0FOAzEMRb1iAWyBbbkGIBGWnIKwbLkDXAGJU7Rdc59yEvBXee1gJZl22pGIZP3G/3/HdVRmWN2bfXlozZLZi8fNidmtx50HOfGrXy1YysEdiqqtNUlm1x5ai2S29HjyvrLHswc58WjBUg7uUFRtrZy8D4+5R2uJRwtOCzm4QzHOv9Ub3L6ej3OcdaxpJml9r2C9wpZBC26Z43/KaX2v4NupWV+gBWv611Arzl2+qIm1Sp6oifshHtWY+Cz0GwRj3dIeLVjSxBxaUHzfHKTJI95Vt4ch58jfN/fSd6x5Slqdscs56CIybzDypT1asKSJObRg5GcP/vzxiPk88v1yXt85C+9tWeivdlfU7SL3t48H/xCPvMwbpF4L0YItLRxakHwJmYO4/E/ut9SnckPmHj1WWY87PEMr1k2aeYMbovEBLSjp51nD0KC+Kz7q5fT3WUqpmk98zYP3mLjrXb13vice9TH1vwkKZjk28k4+T2YX/g586XHloT0cPag/VpzpWPvuO3n3fwn1AcfZP9yafwI=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -33,14 +33,19 @@
  </layer>
  <layer id="5" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgKjITA4Q+CBPQPDQyCmNj04fTsyXAUAJpkYtg==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="240" y="32" width="368" height="16"/>
+  <object id="285" type="collision" x="400" y="80" width="64" height="208"/>
+  <object id="286" type="collision" x="176" y="48" width="64" height="192"/>
+  <object id="287" type="collision" x="16" y="32" width="16" height="256"/>
+  <object id="288" type="collision" x="608" y="48" width="32" height="240"/>
+  <object id="289" type="collision" x="48" y="288" width="352" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -53,7 +58,6 @@
    <properties>
     <property name="act1" value="set_environment grass"/>
     <property name="cond1" value="not time_is stage_of_day,equals,night"/>
-    <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is grass"/>
    </properties>
   </object>
@@ -61,8 +65,47 @@
    <properties>
     <property name="act1" value="set_environment night_grass"/>
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
-    <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="290" name="Random Encounters 1" type="event" x="32" y="80" width="144" height="160">
+   <properties>
+    <property name="act1" value="random_encounter spyder_citypark,11"/>
+    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="291" name="Random Encounters 2" type="event" x="240" y="80" width="160" height="160">
+   <properties>
+    <property name="act1" value="random_encounter spyder_citypark,11"/>
+    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="292" name="Random Encounters 3" type="event" x="464" y="80" width="144" height="160">
+   <properties>
+    <property name="act1" value="random_encounter spyder_citypark,11"/>
+    <property name="act2" value="play_map_animation grass,0.1,noloop,player"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_moved player"/>
+   </properties>
+  </object>
+  <object id="293" name="Teleport to Hearthrock" type="event" x="512" y="304" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_hearthrock_city.tmx,33,0,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
+   </properties>
+  </object>
+  <object id="294" name="Teleport to Steamshore" type="event" x="80" y="0" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_steamshore_city.tmx,6,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_2.tmx
+++ b/mods/tuxemon/maps/classic_route_2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHtlrENACAMwzLxAfAL9Bfg/ydIb2CJUCx1t9wlgHkp0ArQeapMuoWw36bbEfZT/au9XMAFXMAFXODHApWbILeVKoNuua1UWXTLbaXOBY2LAw0=
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -53,7 +53,6 @@
    <properties>
     <property name="act1" value="set_environment grass"/>
     <property name="cond1" value="not time_is stage_of_day,equals,night"/>
-    <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is grass"/>
    </properties>
   </object>
@@ -61,8 +60,23 @@
    <properties>
     <property name="act1" value="set_environment night_grass"/>
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
-    <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Steamshore" type="event" x="0" y="32" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_steamshore_city.tmx,39,3,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Thornwood" type="event" x="624" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_thornwood_city.tmx,0,17,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_3.tmx
+++ b/mods/tuxemon/maps/classic_route_3.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -13,12 +13,12 @@
  <tileset firstgid="16308" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMA7Gi4fpXWxdDAW/gL72k8oABBhhggAEGGGCAAQYeDAxMckTB
+   eAGbxsXAMG0Uj4bBaBoYTQMDkAZ2cTAwqCPh3UA2PcsjZLuxsTWA7hFgQ2A1IJ+WbkQPD2S7iWWD3AjyC7XdCXIbengQ6yZs6mDupIZbqe02dPciu5WQe9HjEKSemuGG7jZsfHT3gtwAw/R2Czb3jYohypTRsBgNi5GaBgCUJhqv
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHtkDEKgDAMRTPVegB1FY+hgpu295+9i1/EoSmhizQOCbzhV9M+PlE6biJqgActKOV0O0+lff49vyE92eF0gAAiKOV0O0+lff49v+E58SP6AtojeQS4RaA9kofkXdtX8pC8a/txD8m3thd/7/Xivvw/rfxXL60+7F1rwBqwBqyBug10jqgHA/jbnBvRDK8FrODOX88FLDAX5A==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -40,7 +40,7 @@
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="32" y="32" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Route4" type="event" x="256" y="0" width="128" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_4.tmx,20,0,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Thornwood" type="event" x="256" y="304" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_thornwood_city.tmx,17,0,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_4.tmx
+++ b/mods/tuxemon/maps/classic_route_4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -13,12 +13,12 @@
  <tileset firstgid="16308" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMA7Gi4fpXWxdDAW/gL72k8oABBhhggAEGGGCAAQYeDAxMckTB
+   eAHt0jENAAAMw7De46/iLYtdPkIgci+pPGCAAQYYYIABBhhggIEHAwOMl/QQ
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHtlt0OgyAMhbly+hZuD4P64maPtbNkJ5JqKQaDvViTE+Sn5ZMSIIS99a8QBqiDHpBW33tuLZYvY24e5V8zmBYoQhOk1XMRLV/GzMWQfd2I9YJa2pk5I9gmqKWVzNmDaYDutBzDDLYFutM0hjP5b8EveUry34KLc0ie95M9vsp0P3pk5H70yMZMrr/cemT0zPZfP65AXek5x2RLz5m6v73e+8vIc+b66HURuX6MwnvPevfKfvprpRxv1sfjNyjvvWi8mWW/xsV2Od6sgy99g34AiKIy8Q==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -40,7 +40,7 @@
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="32" y="32" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Stormpeak" type="event" x="240" y="0" width="112" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_stormpeak_city.tmx,18,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Route3" type="event" x="256" y="304" width="128" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_3.tmx,20,19,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_5.tmx
+++ b/mods/tuxemon/maps/classic_route_5.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHtlrENACAMwzrxAfAL8Avw/xOkTyAPsdTdcpdEsGklouuoTLktsN+R2wX7Uf9qLxdwARdwARdwgf8FqjZLbj8qQ265/ahsueX2o/MAgzoDDQ==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Thornwood" type="event" x="0" y="16" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_thornwood_city.tmx,39,2,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Aerolume" type="event" x="624" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_aerolume_city.tmx,0,17,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_6.tmx
+++ b/mods/tuxemon/maps/classic_route_6.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHtlrENACAMwzrxAfAL8Avw/xOkTyAPsdTdcpdEsGklouuoTLktsN+R2wX7Uf9qLxdwARdwARdwgf8FqjZLbj8qQ265/ahsueX2o/MAgzoDDQ==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Umbrastar" type="event" x="624" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_umbrastar_city.tmx,0,17,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Aerolume" type="event" x="0" y="16" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_aerolume_city.tmx,39,2,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_7.tmx
+++ b/mods/tuxemon/maps/classic_route_7.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYBgc4I49A4MVGwODNRDbADGIP9hAPNBdCUCcCMSjYDQERkNgNARGQ2A0BEZDYDQERkNgZIeAKLBNKAbE4oOwbTiY29YALS0HeQ==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Valorhold" type="event" x="32" y="304" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_valorhold_city.tmx,3,0,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Thornwood" type="event" x="560" y="0" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_thornwood_city.tmx,36,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_route_8.tmx
+++ b/mods/tuxemon/maps/classic_route_8.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="287">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="route"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHtlrENgEAMA12xAdDCGoAEm/C/9xfPJlwKdrBQLFluT6cU6af00G66yyWt1HULbJW6rjJpIA2kgTSQBn5ooPG3OGcapJk6JtztsB2GfCNM4a7Qasi3wRTuXO/vhi3cuebz9gJPelyN
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -40,7 +40,7 @@
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="0" y="32" width="640" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -63,6 +63,22 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Hearthrock" type="event" x="0" y="240" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_hearthrock_city.tmx,39,16,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Valorhold" type="event" x="624" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_valorhold_city.tmx,0,17,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_steamshore_city.tmx
+++ b/mods/tuxemon/maps/classic_steamshore_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="302">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -13,12 +13,12 @@
  <tileset firstgid="16308" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMA7Gi4fpXWxdDAW/gL72k8oABBhhggAEGGGCAAQYeDAxMckTB
+   eAHt1k0KgCAQBWAhiGjVKaoTe5i6XM3iwQiOP4zlLFyIIaWfzxHyq3PeSJsW57Y5bFZs12s7jfokG2XZMz9yHUJuOOe/fTDlXF/7uIMsaLEagyXWa/Pjjvt1YL7YXYytnxvDfLU9XDyPXZGT5CxxwYIzKq0dac2a8ZyPbDyjmrlbvJvy9bbR/iSfBVvK1+r+ac+Y1zx/7llz2j2N78N/rJHHyKNXDTz78deO
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHN1kdOHEEUxvG3ghlgZZIXgEmnwEjMCmbMIYAlsDY5rDCwIl3BBJNWpBVpwQUwGSQQaUW6gf8t80mjUs+IRmqYJ/1UU9VT1JtXRXeb/Y+sarNsRBBFWP3X5QI39eTUgDgSCKvvJTZWbDaOCUxiCp1Rs25HB33VK/APeseESCV7g03y2cI2drALNwqzzIqgernXw+jHyS2BB/J5xBOe8QI3asjtO3TO3Oth9ku+mpWiDN9QDjeayK0ZOmfu9c/uX9aZXeEjz1+Q31weM6vAR56/IPk1k1sLFHtVn3MWtb7ban+Tx3UWM2HPtb/J+enzW/fc757q3mOD9L37sUL7qzrW8z/egDgS+IFGpItUc/yeD73c4/rQjwEMYgi/MIwRjEKhvFTHn+TSgU50oRs9SBep5vg9H+ZZewGLWMIyVrCKNaxjAwrlpTr+JpdpzGAWc/iDdJFqjt/z4YS1T3GGc1zgGje4xR3uoVBequM+ufzFAQ5xhGOki1Rz/J4PEf5WFDnIRR6+IB8FKEQRFMpLddR4prTKS3XMlLyUh/JSHTWeCW1bzKwdXqiOrTEzjevdq5j3B4151/XdsNt51lqAF6qj91njeveqJT+NJX9Xc8JqvbUU/wDTpb3b
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -33,14 +33,26 @@
  </layer>
  <layer id="5" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgKjITA0Q+CBPQPDQyCmNT00Q2dwuhoAD3odNA==
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="528" y="32" width="16" height="32"/>
+  <object id="285" type="collision" x="0" y="192" width="32" height="128"/>
+  <object id="288" type="collision" x="464" y="64" width="32" height="16"/>
+  <object id="289" type="collision" x="512" y="64" width="32" height="16"/>
+  <object id="290" type="collision" x="608" y="80" width="32" height="192"/>
+  <object id="291" type="collision" x="176" y="288" width="416" height="16"/>
+  <object id="292" type="collision" x="240" y="176" width="64" height="64"/>
+  <object id="293" type="collision" x="544" y="176" width="32" height="64"/>
+  <object id="294" type="collision" x="384" y="224" width="64" height="16"/>
+  <object id="295" type="collision" x="320" y="224" width="48" height="16"/>
+  <object id="296" type="collision" x="464" y="224" width="64" height="16"/>
+  <object id="297" type="collision" x="32" y="224" width="64" height="16"/>
+  <object id="298" type="collision" x="112" y="176" width="16" height="64"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -63,6 +75,38 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Route1" type="event" x="80" y="304" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_1.tmx,6,0,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
+   </properties>
+  </object>
+  <object id="287" name="Teleport to Route2" type="event" x="624" y="32" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_2.tmx,0,3,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+   </properties>
+  </object>
+  <object id="300" name="Teleport to Gym 4" type="event" x="368" y="224" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_pyra.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="301" name="Teleport to Gym 3" type="event" x="496" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_marin.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_stormpeak_city.tmx
+++ b/mods/tuxemon/maps/classic_stormpeak_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="295">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -13,12 +13,12 @@
  <tileset firstgid="16308" source="../gfx/tilesets/core_outdoor_nature.tsx"/>
  <layer id="1" name="Tile Layer 1" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0iERAAAMA7Gi4fpXWxdDAW/gL72k8oABBhhggAEGGGCAAQYeDAxMckTB
+   eAHtlMkNQjEMRH3gI6CSDxJQCNAeBUEhUApjiRFRDslEQYGDD6NsjufJWeal2SzqOZlR6p6RcWTzdqSv6hV8fefyi/ot8DZqeuC+ecwEkVG9E71xNTZfJ1/K2Our7m/lI6OaP+L63lTUL+pXugMH/B+uI1SKG7W2f/OQ67wyu0C3bJ7r32bP/VMf79+hE3icy3XdmG3XnzHn2dbY8/y1ce5Pn7Tdgce5FJXY05wt/RZ/hTFitLP8xzq9ADl34do=
   </data>
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHF1DdSw0AUxvGtwAYqcmEbw0mgcYArEE5BThWpIrWEhpwqUkUqYKjJYKAgVaQb8F/DGzQ7suwRI/xmfqBV2PdJu6DUbw2XKTWCUYxhHKmqvkapBjSiCW7Hev5M++6QZxd72McBUtUEmSYxhWm4Hev5M+37Sp43vOMDn/C6QrybXV9ZD91fjgPlSgURQgXC+I+y6yvroftbjzPN08e37ccABjGETnShGz3ohduSfe32+XV6b2ATW9jGEpaxglWswW3Jvnb7/AO9H/GEZ7zgCte4QQK3cFuy59w+X8jeLEIxSlAKH/zIQz4K4FS31UrdQ/+NBCDHd5yTPffXnE79011LkCPCO0QRQxy1qIPsP8mZbi4vrgf5Zs1kaUEr2tCODsj+k5xe9E83p17PGbLMYg7zWMAiZF0lZ7q5vLiu99kJWU5xhnNc4BLmukpeL3KkmlPvP73GOqf+lgGOdenz5rqaeZM3ZvGHdV3NrFmMlWytv6e1rFmt57NxbGbLCSuVi2xXThU5YFYkzP9H+ODHUaX61zqm3yEiZIva5JMwMbLFoUuyyjv5eM4Pc/x9t/1P815zLHPaP+18VrJGft4pxu84zLHTLOa95ljmdJpDX/sCSNSiFg==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -40,7 +40,14 @@
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="48" y="48" width="32" height="16"/>
+  <object id="286" type="collision" x="96" y="0" width="32" height="64"/>
+  <object id="288" type="collision" x="576" y="48" width="32" height="16"/>
+  <object id="289" type="collision" x="528" y="48" width="32" height="16"/>
+  <object id="291" type="collision" x="224" y="64" width="160" height="48"/>
+  <object id="292" type="collision" x="272" y="112" width="64" height="16"/>
+  <object id="293" type="collision" x="352" y="112" width="32" height="16"/>
+  <object id="294" type="collision" x="224" y="112" width="32" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -63,6 +70,30 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Gym 8" type="event" x="80" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_voltessa.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="287" name="Teleport to Gym 7" type="event" x="560" y="48" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_astra.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="290" name="Teleport to Route4" type="event" x="240" y="304" width="112" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_4.tmx,18,0,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_thornwood_city.tmx
+++ b/mods/tuxemon/maps/classic_thornwood_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="289">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYCAf3LFnYLBiY2CwBmIbIAbxqQmoYV480F0JQJwIxNQEokDzxKhsJjXdB4sXappJTbNg8UJNM6ltFjXSH7XdNGreaAiMhsBoCIyGwNAIgcFeh4DaMOKDuB0Da1sO1timRduSXL/C2qTI8TlY0h/IHbA2KXJfAQChKA7x
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -63,6 +63,38 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Route2" type="event" x="0" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_2.tmx,39,17,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Route5" type="event" x="624" y="16" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_5.tmx,0,2,0.3"/>
+    <property name="act2" value="char_face player,right"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,right"/>
+   </properties>
+  </object>
+  <object id="287" name="Teleport to Route7" type="event" x="560" y="304" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_7.tmx,36,0,0.3"/>
+    <property name="act2" value="char_face player,down"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,down"/>
+   </properties>
+  </object>
+  <object id="288" name="Teleport to Route3" type="event" x="256" y="0" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_3.tmx,17,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_umbrastar_city.tmx
+++ b/mods/tuxemon/maps/classic_umbrastar_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="286">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAFjYBgFoyEwGgKjITAaAqMhMBoCoyEwGgIjKQTE2BgYxIF4sAJroNtsBrH7EoBuSxzE7hus8QpzFwCNwgGK
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -63,6 +63,14 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Route6" type="event" x="0" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_6.tmx,39,17,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_valorhold_city.tmx
+++ b/mods/tuxemon/maps/classic_valorhold_city.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="285">
+<map version="1.10" tiledversion="1.12.1-8-g449813058" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="40" height="20" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="299">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="map_type" value="town"/>
@@ -18,7 +18,7 @@
  </layer>
  <layer id="2" name="Tile Layer 2" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHFlldOAzEQhv3EASgJhJflGoDE0uEC9LLcgA4XoMMZ6JyADkfhAUSHS/BZYaXJSLajBBJLX+zf05ydjWJjjHnoMKa1xpg2aAer5XhEP0G5s81Zao5pzpXADOgcUWxMC5Q72/OVmsPGpkPnSGLODeXONn+pOWxsOnSOdD806+eutY3Xe8VqWVvHSJtvHcX+98DGhnxcdllX+0ibb53E/vfAxoZ8XHZZV/tIm2+tn/tQzphhGIFRGINxmIBJmAId49KyrvaRNt86igv7u0b9ddiATdiCbdiBXdgDHePSsq72KdaWcD75Oz+n/gVcwhVcww3cwh3cg45xaXkG7VOsTfrZ9TP1X+AV3uAdPuATvuAbdK9cWud2aR3v8rP7tc3G1EE9NEAGstAITZCDKC58J1zaV0fadLy06XUn9bugG3qgF/qgHwZgEHSvXFrndmkd7/Kz+7PUn4N5WIBFWIJlWIFV0P1waV8dadPx0qbX+9Q/gEM4gmM4gVM4Azt0Pyql89XDn7ofldLhk+U9dD+0znCfykK1Rqif6Z20WucL9vP3Thr6Hv9lL+a52Pt88HvEhf9df+UfOt8Pk0ZaEQ==
   </data>
  </layer>
  <layer id="3" name="Tile Layer 3" width="40" height="20">
@@ -33,14 +33,25 @@
  </layer>
  <layer id="5" name="Above Player" width="40" height="20">
   <data encoding="base64" compression="zlib">
-   eAHt0DEBAAAAwqD1T20LL4hAYcCAAQMGDBgwYMCAgc/AAAyAAAE=
+   eAHt08cNwkAQheFpAxogQwOATeiGDN0QTOiGDB1AF2T4L75Ysjkga5E8T/q0WnulmR3ZIuGlGBMpoQwLNiqoooY6TKZB/SZaaKODLnroYwCTGVJ/hDEmcDDFDHMsYDJL6q+wxgZb7LDHAUeYzIX6V9xwxwNPvPCGxE12J5KgfhIppJFBFjnkUUDUcrJEznDXqN1f76sT+McJuP/jt9Xbu9957znd6wSCJuD3HYX9PKgnfff7BD7eS1nB
   </data>
  </layer>
  <objectgroup color="#ff0000" id="6" name="Collisions">
   <properties>
    <property name="Collision" value=""/>
   </properties>
-  <object id="179" type="collision" x="240" y="0" width="16" height="16"/>
+  <object id="179" type="collision" x="32" y="288" width="480" height="16"/>
+  <object id="287" type="collision" x="0" y="224" width="352" height="32"/>
+  <object id="288" type="collision" x="80" y="16" width="224" height="32"/>
+  <object id="289" type="collision" x="0" y="16" width="32" height="208"/>
+  <object id="290" type="collision" x="80" y="48" width="64" height="112"/>
+  <object id="291" type="collision" x="192" y="128" width="64" height="96"/>
+  <object id="292" type="collision" x="304" y="48" width="64" height="96"/>
+  <object id="293" type="collision" x="512" y="176" width="16" height="112"/>
+  <object id="294" type="collision" x="368" y="144" width="144" height="32"/>
+  <object id="295" type="collision" x="388" y="176" width="108" height="16"/>
+  <object id="296" type="collision" x="416" y="192" width="16" height="16"/>
+  <object id="297" type="collision" x="448" y="192" width="16" height="16"/>
  </objectgroup>
  <objectgroup color="#ffff00" id="7" name="Events">
   <object id="228" name="Play Music" type="event" x="0" y="0" width="16" height="16">
@@ -63,6 +74,30 @@
     <property name="cond1" value="is time_is stage_of_day,equals,night"/>
     <property name="cond2" value="not char_sprite player,swimmer"/>
     <property name="cond3" value="not environment_is night_grass"/>
+   </properties>
+  </object>
+  <object id="285" name="Teleport to Route8" type="event" x="0" y="256" width="16" height="48">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_8.tmx,39,17,0.3"/>
+    <property name="act2" value="char_face player,left"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,left"/>
+   </properties>
+  </object>
+  <object id="286" name="Teleport to Route7" type="event" x="32" y="0" width="48" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_route_7.tmx,3,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
+   </properties>
+  </object>
+  <object id="298" name="Teleport to Gym 13" type="event" x="432" y="192" width="16" height="16">
+   <properties>
+    <property name="act1" value="transition_teleport player,classic_gym_bravion.tmx,10,19,0.3"/>
+    <property name="act2" value="char_face player,up"/>
+    <property name="cond1" value="is char_at player"/>
+    <property name="cond2" value="is char_facing player,up"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/classic_valorhold_city.tmx
+++ b/mods/tuxemon/maps/classic_valorhold_city.tmx
@@ -49,7 +49,7 @@
   <object id="292" type="collision" x="304" y="48" width="64" height="96"/>
   <object id="293" type="collision" x="512" y="176" width="16" height="112"/>
   <object id="294" type="collision" x="368" y="144" width="144" height="32"/>
-  <object id="295" type="collision" x="388" y="176" width="108" height="16"/>
+  <object id="295" type="collision" x="384" y="176" width="112" height="16"/>
   <object id="296" type="collision" x="416" y="192" width="16" height="16"/>
   <object id="297" type="collision" x="448" y="192" width="16" height="16"/>
  </objectgroup>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
     "W",    # pycodestyle warnings
     "UP",   # pyupgrade
     "I",    # import sorting
+    "F",    # enables F401 and all Pyflakes rules
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/tuxemon/test_alert_manager.py
+++ b/tests/tuxemon/test_alert_manager.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import time
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_alignment_offset.py
+++ b/tests/tuxemon/test_alignment_offset.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from pathlib import Path
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_battles_handler.py
+++ b/tests/tuxemon/test_battles_handler.py
@@ -93,7 +93,7 @@ def test_record_battle(handler):
 def test_get_last_battle(handler):
     assert handler.get_last_battle() is None
 
-    b1 = handler.record_battle("npc", OutputBattle.WON)
+    handler.record_battle("npc", OutputBattle.WON)
     b2 = handler.record_battle("npc", OutputBattle.LOST)
 
     assert handler.get_last_battle() == b2

--- a/tests/tuxemon/test_blit_alpha.py
+++ b/tests/tuxemon/test_blit_alpha.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from pathlib import Path
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_break_text_into_lines.py
+++ b/tests/tuxemon/test_break_text_into_lines.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from unittest.mock import patch
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_constrain_width.py
+++ b/tests/tuxemon/test_constrain_width.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from pathlib import Path
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_crafting.py
+++ b/tests/tuxemon/test_crafting.py
@@ -54,7 +54,7 @@ def mock_item_create():
     item_mock.slug = "potion"
     item_mock.quantity = 1
 
-    with patch("tuxemon.item.item.Item.create", return_value=item_mock) as p:
+    with patch("tuxemon.item.item.Item.create", return_value=item_mock):
         yield item_mock
 
 

--- a/tests/tuxemon/test_element_types_handler.py
+++ b/tests/tuxemon/test_element_types_handler.py
@@ -221,7 +221,7 @@ def test_element_cache_clears(elements):
 def test_multiplier_cache_reuse(elements):
     ElementTypesHandler.clear_cache()
 
-    score1 = ElementTypesHandler.calculate_affinity_score(
+    ElementTypesHandler.calculate_affinity_score(
         [elements["fire"]], [elements["metal"]]
     )
     assert ("fire", "metal") in ElementTypesHandler._multiplier_cache

--- a/tests/tuxemon/test_event_behavior_manager.py
+++ b/tests/tuxemon/test_event_behavior_manager.py
@@ -155,7 +155,6 @@ class TestExpandBehavior:
         self, patch_behavior_plugins, dummy_event
     ):
         call_count = {"n": 0}
-        outer_self = self
 
         class CountingBehavior(EventBehavior):
             name = "counting"

--- a/tests/tuxemon/test_event_bus.py
+++ b/tests/tuxemon/test_event_bus.py
@@ -168,14 +168,6 @@ def test_global_events_unregister_nonexistent(state_manager, callbacks):
     state_manager.unregister_global_event("pre_state_update", cb)
 
 
-def test_reset_events(state_manager, callbacks):
-    cb, _, _ = callbacks
-    state_manager.register_global_event("test_event", cb, priority=10)
-    assert state_manager.event_bus._listeners
-    state_manager.event_bus.reset_all_events()
-    assert not state_manager.event_bus._listeners
-
-
 def test_global_events_unregister_correct_callback(state_manager, callbacks):
     cb1, cb2, _ = callbacks
     state_manager.register_global_event("pre_state_update", cb1)

--- a/tests/tuxemon/test_folder_maps_tmx.py
+++ b/tests/tuxemon/test_folder_maps_tmx.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 from tuxemon.constants.asset_loader import fetch_asset
-from tuxemon.database.runtime import db  # initializes asset loader
+from tuxemon.database.runtime import db  # noqa: F401  # side‑effect import
 from tuxemon.map.manager import MAP_TYPES
 from tuxemon.platform.const.sizes import REGION_KEYS
 from tuxemon.script.parser import parse_action_string

--- a/tests/tuxemon/test_folder_maps_yaml.py
+++ b/tests/tuxemon/test_folder_maps_yaml.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from tuxemon.constants.asset_loader import fetch_asset
-from tuxemon.database.runtime import db  # initializes asset loader
+from tuxemon.database.runtime import db  # noqa: F401  # side‑effect import
 from tuxemon.database.yaml_utils import load_yaml
 from tuxemon.script.parser import parse_action_string
 

--- a/tests/tuxemon/test_font_metrics.py
+++ b/tests/tuxemon/test_font_metrics.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from pathlib import Path
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_input_recorder.py
+++ b/tests/tuxemon/test_input_recorder.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import json
 
-import pygame
 import pytest
 
 from tuxemon.platform.events import PlayerInput

--- a/tests/tuxemon/test_item_durability.py
+++ b/tests/tuxemon/test_item_durability.py
@@ -4,9 +4,7 @@ import random
 
 import pytest
 
-from tuxemon.db import ItemBehaviors
 from tuxemon.item.durability import Durability
-from tuxemon.item.item import Item
 
 
 @pytest.mark.parametrize(

--- a/tests/tuxemon/test_iter_render_text.py
+++ b/tests/tuxemon/test_iter_render_text.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from pathlib import Path
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect

--- a/tests/tuxemon/test_map.py
+++ b/tests/tuxemon/test_map.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import unittest
 from math import pi
 from unittest.mock import MagicMock
 

--- a/tests/tuxemon/test_menu_cursor.py
+++ b/tests/tuxemon/test_menu_cursor.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from unittest.mock import MagicMock
 
-import pygame
 import pytest
 
 from tuxemon.menu.cursor import (

--- a/tests/tuxemon/test_monster.py
+++ b/tests/tuxemon/test_monster.py
@@ -6,7 +6,7 @@ import pytest
 
 from tuxemon.database.rules import config_monster
 from tuxemon.database.runtime import db
-from tuxemon.db import GenderType, Modifier
+from tuxemon.db import GenderType
 from tuxemon.monster.monster import Monster
 from tuxemon.monster.stats import IndividualValues
 from tuxemon.shape import ShapeHandler

--- a/tests/tuxemon/test_monster_exp_handler.py
+++ b/tests/tuxemon/test_monster_exp_handler.py
@@ -155,7 +155,7 @@ def test_set_level_below_min():
 
 def test_set_level_resets_progress():
     m = MonsterExperience(level=1)
-    exp4 = m.experience_required(level_delta=3)
+    m.experience_required(level_delta=3)
     exp5 = m.experience_required(level_delta=4)
 
     m._total_experience = exp5 - 1

--- a/tests/tuxemon/test_monster_plague_handler.py
+++ b/tests/tuxemon/test_monster_plague_handler.py
@@ -6,7 +6,6 @@ import pytest
 
 from tuxemon.db import PlagueType
 from tuxemon.monster.plague import (
-    CureData,
     InoculationResult,
     MonsterPlagueHandler,
     PlagueData,

--- a/tests/tuxemon/test_network_websocket_server.py
+++ b/tests/tuxemon/test_network_websocket_server.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/tuxemon/test_npc_manager.py
+++ b/tests/tuxemon/test_npc_manager.py
@@ -143,20 +143,6 @@ def test_load_persistent_mixed_valid_invalid(MockNPC, npc_manager, session):
     assert npc_manager.npcs_off_map == {}
 
 
-@patch("tuxemon.npc_manager.NPC.from_save")
-def test_load_persistent_does_not_clear_existing(
-    MockNPC, npc_manager, session
-):
-    existing = MagicMock(slug="existing")
-    npc_manager.add_npc(existing)
-    state = MagicMock(player_slug="npc_new", current_map="map_a")
-    new_npc = MagicMock(slug="npc_new")
-    MockNPC.return_value = new_npc
-    npc_manager.load_persistent_npc_states(session, [state])
-    assert "existing" in npc_manager.npcs
-    assert "npc_new" in npc_manager.npcs
-
-
 def test_clear_npcs_filters_correctly(npc_manager):
     persistent = MagicMock(slug="p", persistence=True)
     non_persistent = MagicMock(slug="np", persistence=False)

--- a/tests/tuxemon/test_pathfinder.py
+++ b/tests/tuxemon/test_pathfinder.py
@@ -7,7 +7,6 @@ import pytest
 from tuxemon.boundary import BoundaryChecker
 from tuxemon.client import LocalPygameClient
 from tuxemon.db import Direction
-from tuxemon.entity.npc import NPC
 from tuxemon.map.collision_manager import CollisionManager
 from tuxemon.map.manager import MapManager
 from tuxemon.map.map import dirs2

--- a/tests/tuxemon/test_pathfindnode.py
+++ b/tests/tuxemon/test_pathfindnode.py
@@ -122,7 +122,7 @@ def test_reconstruct_path_after_parent_change(child_node):
 
 
 def test_branching_path_reconstruction(root_node):
-    branch1 = PathfindNode((1, 0), root_node)
+    PathfindNode((1, 0), root_node)
     branch2 = PathfindNode((0, 1), root_node)
     leaf = PathfindNode((1, 1), branch2)
     assert leaf.reconstruct_path() == [(1, 1), (0, 1)]

--- a/tests/tuxemon/test_platform.py
+++ b/tests/tuxemon/test_platform.py
@@ -4,7 +4,7 @@ import sys
 import types
 from pathlib import Path
 
-from tuxemon.platform import ASSET_ROOT, DummyMixer, Platform, PlatformError
+from tuxemon.platform import ASSET_ROOT, DummyMixer, Platform
 
 
 def fake_module(name, **attrs):

--- a/tests/tuxemon/test_routing_policy.py
+++ b/tests/tuxemon/test_routing_policy.py
@@ -91,7 +91,6 @@ class TestRegistryLazyLoad:
     def test_empty_registry_triggers_load_on_has(self, monkeypatch):
         RoutingPolicyRegistry._policies = {}
         called = []
-        original = RoutingPolicyRegistry.load_from_file
 
         def fake_load(cls=None):
             called.append(True)

--- a/tests/tuxemon/test_rules.py
+++ b/tests/tuxemon/test_rules.py
@@ -1,18 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import sys
-import types
-
-import pytest
 
 from tuxemon.database.runtime import db
-from tuxemon.startup_rules import StartupRule, load_mod_startup_rules
 from tuxemon.startup_state_machine import (
-    RuleBackground,
-    RuleIntro,
-    RuleLoadSlot,
-    RuleMods,
-    RuleSplash,
     StartupStateMachine,
 )
 

--- a/tests/tuxemon/test_state_draw.py
+++ b/tests/tuxemon/test_state_draw.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from unittest.mock import MagicMock, patch
 
-import pygame
 import pytest
 
 from tuxemon.platform.const.graphics import GREEN_COLOR, RED_COLOR

--- a/tests/tuxemon/test_state_manager.py
+++ b/tests/tuxemon/test_state_manager.py
@@ -384,7 +384,7 @@ def test_push_pop_parametrized(state_manager, register_state, first, second):
 
 
 def test_active_states_order(state_manager, register_state):
-    states = perform_ops(
+    perform_ops(
         state_manager,
         register_state,
         ["push:a", "push:b", "push:c", "update"],
@@ -476,9 +476,9 @@ def test_peek_next_queued_state(state_manager, register_state):
 
 
 def test_remove_state_by_name_middle(state_manager, register_state):
-    a = register_state("a")
+    register_state("a")
     b = register_state("b")
-    c = register_state("c")
+    register_state("c")
 
     state_manager.push_state("a")
     state_manager.push_state("b")
@@ -517,7 +517,7 @@ def test_resume_only_once(state_manager, register_state):
 
 
 def test_resume_after_replace(state_manager, register_state):
-    a = register_state("a")
+    register_state("a")
     b = register_state("b")
 
     state_manager.push_state("a")

--- a/tests/tuxemon/test_state_stack.py
+++ b/tests/tuxemon/test_state_stack.py
@@ -125,8 +125,6 @@ def test_all(stack):
 
 def test_get_states_by_name(stack):
     class StateImpl(State):
-        name = "test_state"
-
         def __init__(self, client, name="test_state"):
             super().__init__(client)
             self._name = name
@@ -148,8 +146,6 @@ def test_get_states_by_name_not_found(stack):
 
 def test_get_states_by_name_multiple_matches(stack):
     class NamedState(State):
-        name = "duplicate"
-
         def __init__(self, client, name="duplicate"):
             super().__init__(client)
             self._name = name

--- a/tests/tuxemon/test_surfanim.py
+++ b/tests/tuxemon/test_surfanim.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import pygame
 import pytest
 from pygame.surface import Surface
 

--- a/tests/tuxemon/test_task.py
+++ b/tests/tuxemon/test_task.py
@@ -155,7 +155,7 @@ def test_large_dt_triggers_multiple_intervals(cb):
 def test_chaining_multiple_tasks(cb, cb2):
     t1 = Task(cb, DEFAULT_INTERVAL)
     t2 = t1.chain(cb2, DEFAULT_INTERVAL)
-    t3 = t2.chain(lambda: None, DEFAULT_INTERVAL)
+    t2.chain(lambda: None, DEFAULT_INTERVAL)
 
     g = Group()
     g.add(t1)

--- a/tests/tuxemon/test_teleporter.py
+++ b/tests/tuxemon/test_teleporter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import pygame
 import pytest
 from pygame import SRCALPHA
 from pygame.color import Color

--- a/tests/tuxemon/test_trade_manager.py
+++ b/tests/tuxemon/test_trade_manager.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 import pytest
 
-from tuxemon.db import SeenStatus
 from tuxemon.trade_manager import TradeManager, TradeRecord, TradeResult
 
 

--- a/tests/tuxemon/test_ui_overflow_handler.py
+++ b/tests/tuxemon/test_ui_overflow_handler.py
@@ -3,11 +3,9 @@
 from pathlib import Path
 from unittest.mock import Mock
 
-import pygame
 import pytest
 from pygame.font import Font
 from pygame.rect import Rect
-from pygame.surface import Surface
 
 from tuxemon.constants.paths import mods_folder
 from tuxemon.platform.const.graphics import FONT_SIZE

--- a/tests/tuxemon/test_ui_text_renderer_multiline.py
+++ b/tests/tuxemon/test_ui_text_renderer_multiline.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import pygame
 import pytest
 from pygame.surface import Surface
 

--- a/tests/tuxemon/test_ui_tile_layout.py
+++ b/tests/tuxemon/test_ui_tile_layout.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
-import random
 
-import pygame
 import pytest
 from pygame.surface import Surface
 
@@ -141,7 +139,7 @@ def test_nineslice_clipping_no_crash():
     img = Surface((30, 30))
     layout = NineSliceLayout(img)
     # draw into a non-multiple-of-tile-size rect
-    surf = Surface((37, 37))
+    Surface((37, 37))
     # Should not crash
     for tile in layout.tiles.values():
         assert tile is not None

--- a/tests/tuxemon/test_world_transition.py
+++ b/tests/tuxemon/test_world_transition.py
@@ -198,7 +198,6 @@ def test_fade_out_call_order(monkeypatch, transition, mock_world):
     color = (0, 0, 0, 255)
     character = mock_world.player
     transition.fade_out(1.0, color, character)
-    mm = mock_world.client.movement_manager
     filtered = [
         c
         for c in mock_world.mock_calls
@@ -254,9 +253,7 @@ def test_fade_and_teleport_call_order(monkeypatch, transition, mock_world):
     mock_world.task.assert_called_with(teleport, interval=1.0)
     chained = mock_world.task.return_value.chain
     chained.assert_called()
-    task_call_index = next(
-        i for i, c in enumerate(mock_world.mock_calls) if c[0] == "task"
-    )
+    next(i for i, c in enumerate(mock_world.mock_calls) if c[0] == "task")
     chain_call_index = next(
         i
         for i, c in enumerate(mock_world.task.return_value.mock_calls)

--- a/tuxemon/ai/ai.py
+++ b/tuxemon/ai/ai.py
@@ -130,7 +130,7 @@ class AIConfigLoader:
             }
 
             if "default" not in rules:
-                raise ValueError(f"'default' is missing")
+                raise ValueError("'default' is missing")
 
             cls._ai_opponent = AIOpponent(rules=rules)
         return cls._ai_opponent

--- a/tuxemon/compat/__init__.py
+++ b/tuxemon/compat/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from tuxemon.compat.rect import ReadOnlyRect
 
-Rect: type[ReadOnlyRect]
+__all__ = ["Rect", "ReadOnlyRect"]
 
 try:
     from pygame.rect import Rect

--- a/tuxemon/core/effects/photogenesis.py
+++ b/tuxemon/core/effects/photogenesis.py
@@ -53,7 +53,6 @@ class PhotogenesisEffect(CoreEffect):
 
         hit = session.client.combat_session.get_tech_hit(user)
         extra: list[str] = []
-        done: bool = False
 
         tech.hit = tech.accuracy >= hit
 

--- a/tuxemon/event/actions/cipher_dialog.py
+++ b/tuxemon/event/actions/cipher_dialog.py
@@ -6,8 +6,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any, final
 
-from tuxemon.database.runtime import db
-from tuxemon.db import DialogueModel
 from tuxemon.event.eventaction import EventAction
 from tuxemon.graphics import string_to_colorlike
 from tuxemon.locale.locale import T

--- a/tuxemon/event/actions/crafting_station.py
+++ b/tuxemon/event/actions/crafting_station.py
@@ -43,7 +43,7 @@ class CraftingStationAction(EventAction):
 
         if self.client.current_state.name == "CraftMenuState":
             logger.error(
-                f"The state 'CraftMenuState' is already active. No action taken."
+                "The state 'CraftMenuState' is already active. No action taken."
             )
             self.stop()
             return

--- a/tuxemon/event/actions/open_journal.py
+++ b/tuxemon/event/actions/open_journal.py
@@ -45,7 +45,7 @@ class OpenJournalAction(EventAction):
 
         if self.client.current_state.name == "JournalInfoState":
             logger.error(
-                f"The state 'JournalInfoState' is already active. No action taken."
+                "The state 'JournalInfoState' is already active. No action taken."
             )
             self.stop()
             return

--- a/tuxemon/event/actions/random_encounter.py
+++ b/tuxemon/event/actions/random_encounter.py
@@ -63,7 +63,7 @@ class RandomEncounterAction(EventAction):
             return
 
         if check_repellent(player):
-            logger.info(f"Repellent active, skipping encounter.")
+            logger.info("Repellent active, skipping encounter.")
             self.stop()
             return
 

--- a/tuxemon/event/actions/random_horde.py
+++ b/tuxemon/event/actions/random_horde.py
@@ -62,7 +62,7 @@ class RandomHordeAction(EventAction):
             return
 
         if check_repellent(player):
-            logger.info(f"Repellent active, skipping encounter.")
+            logger.info("Repellent active, skipping encounter.")
             self.stop()
             return
 

--- a/tuxemon/event/actions/show_monster.py
+++ b/tuxemon/event/actions/show_monster.py
@@ -44,7 +44,7 @@ class ShowMonsterAction(EventAction):
 
         if self.client.current_state.name == "MonsterInfoState":
             logger.error(
-                f"The state 'MonsterInfoState' is already active. No action taken."
+                "The state 'MonsterInfoState' is already active. No action taken."
             )
             self.stop()
             return

--- a/tuxemon/event/actions/update_cipher.py
+++ b/tuxemon/event/actions/update_cipher.py
@@ -57,7 +57,7 @@ class UpdateCipherAction(EventAction):
 
         cipher_processor = session.client.cipher_processor
         if cipher_processor is None:
-            logger.error(f"Cipher processor isn't enabled")
+            logger.error("Cipher processor isn't enabled")
             self.stop()
             return
         cipher_processor.set_unlocked_letters(character.unlocked_letters)

--- a/tuxemon/menu/menu.py
+++ b/tuxemon/menu/menu.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import IntFlag
 from functools import cached_property, partial
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 from pygame import SRCALPHA, image
 from pygame.font import Font

--- a/tuxemon/monster/renderer.py
+++ b/tuxemon/monster/renderer.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 
 from dataclasses import dataclass
 
-from tuxemon.db import SoundProperties
-
 
 @dataclass
 class SoundConfig:

--- a/tuxemon/network/event_dispatcher.py
+++ b/tuxemon/network/event_dispatcher.py
@@ -79,7 +79,7 @@ def handle_push_self(self: EventDispatcher, event_data: EventData) -> None:
         logger.warning("Missing cuuid in PUSH_SELF event")
         return
 
-    entry = self.client.registry.setdefault(cuuid, {})
+    self.client.registry.setdefault(cuuid, {})
     sprite = populate_client(
         cuuid, event_data, self.game, self.client.registry
     )

--- a/tuxemon/rumble/__init__.py
+++ b/tuxemon/rumble/__init__.py
@@ -54,12 +54,6 @@ class RumbleManager:
         """
         Attempts to locate a backend library from the provided locations.
         """
-        try:
-            from ctypes import cdll
-        except ImportError:
-            logger.debug("Ctypes is unavailable.")
-            return None
-
         lib_shake = find_library(locations)
         if lib_shake:
             logger.debug(f"Found library at: {lib_shake}")

--- a/tuxemon/rumble/libshake.py
+++ b/tuxemon/rumble/libshake.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 import logging
 from abc import ABC, abstractmethod
-from ctypes import *
+from ctypes import Structure, Union, c_int, cdll, pointer
 from threading import Lock
 from typing import Any
 

--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -17,7 +17,7 @@ from typing import (
 
 from pygame import SRCALPHA
 from pygame.rect import FRect, Rect
-from pygame.sprite import DirtySprite, Group, LayeredUpdates
+from pygame.sprite import DirtySprite, LayeredUpdates
 from pygame.sprite import Sprite as PySprite
 from pygame.surface import Surface
 from pygame.transform import rotate, rotozoom, scale

--- a/tuxemon/state/manager.py
+++ b/tuxemon/state/manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 

--- a/tuxemon/states/monster_moves.py
+++ b/tuxemon/states/monster_moves.py
@@ -9,8 +9,7 @@ from pygame_menu.menu import Menu
 from pygame_menu.widgets.widget.label import Label
 from pygame_menu.widgets.widget.progressbar import ProgressBar
 
-from tuxemon.database.runtime import db
-from tuxemon.db import MonsterModel, SpeedLabel
+from tuxemon.db import SpeedLabel
 from tuxemon.locale.locale import T
 from tuxemon.menu.menu import PygameMenuState
 from tuxemon.monster.renderer import MonsterRenderer

--- a/tuxemon/states/transition_evolution.py
+++ b/tuxemon/states/transition_evolution.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame
 from pygame.surface import Surface
 
 from tuxemon.database.runtime import db

--- a/tuxemon/states/transition_trading.py
+++ b/tuxemon/states/transition_trading.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import pygame
 from pygame.surface import Surface
 
 from tuxemon import tools

--- a/tuxemon/states/world_state.py
+++ b/tuxemon/states/world_state.py
@@ -257,7 +257,6 @@ class WorldState(State):
             else:
                 if self.wants_duel:
                     if event_data["response"] == "Accept":
-                        world = self.client.current_state
                         pd = self.player.__dict__
                         event_data = {
                             "type": "CLIENT_INTERACTION",


### PR DESCRIPTION
PR enables the `F` rule family in Ruff and updates the codebase to resolve all resulting lint errors. Updated the Classic campaign map definitions; several cities are still missing and will be addressed in a follow‑up.