### PR TITLE
Monsters keep their training and IVs between evolutions

### DIFF
--- a/tests/tuxemon/test_evolution.py
+++ b/tests/tuxemon/test_evolution.py
@@ -108,7 +108,6 @@ def test_evolve_monster_success(evolution_context):
     player.party.replace_monster = MagicMock(return_value=True)
     player.tuxepedia.register_caught = MagicMock()
     evo.evolve_monster(new_mon)
-    new_mon.transfer_properties_from.assert_called_with(mon)
     new_mon.moves.learn_by_method.assert_called_with(
         new_mon, "SpecialBeam", LearningMethod.EVOLUTION
     )

--- a/tuxemon/event/actions/dojo_method.py
+++ b/tuxemon/event/actions/dojo_method.py
@@ -130,6 +130,7 @@ class DojoMethodAction(EventAction):
 
     def devolve(self, slug: str) -> None:
         devolution = Monster.spawn_base(slug, self.monster.level)
+        devolution.transfer_properties_from(self.monster)
         self.monster.evolution_handler.evolve_monster(devolution)
         logger.info(f"{self.monster.name}'s devolved!")
         self.client.sound_manager.play("sound_confirm")

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -116,12 +116,8 @@ class EvolutionAction(EventAction):
             registry.add_pending(monster.instance_id, slug)
 
         evolved = Monster.spawn_base(slug, monster.level)
-        evolved.taste_cold = monster.taste_cold
-        evolved.taste_warm = monster.taste_warm
-        evolved.individual_values = monster.individual_values
-        evolved.training_points = monster.training_points
-        evolved.custom_stats = monster.custom_stats
-        evolved.set_stats()
+        evolved.transfer_properties_from(monster)
+        monster.evolution_handler.evolve_monster(evolved)
 
         self.client.push_state(
             "EvolutionState",

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -90,6 +90,7 @@ class EvolutionAction(EventAction):
             return
 
         evolved = Monster.spawn_base(evolution, monster.level)
+        evolved.transfer_properties_from(monster)
         monster.evolution_handler.evolve_monster(evolved)
         self.client.push_state(
             "EvolutionTransition", original=monster.slug, evolved=evolved.slug
@@ -117,7 +118,6 @@ class EvolutionAction(EventAction):
 
         evolved = Monster.spawn_base(slug, monster.level)
         evolved.transfer_properties_from(monster)
-        monster.evolution_handler.evolve_monster(evolved)
 
         self.client.push_state(
             "EvolutionState",

--- a/tuxemon/event/actions/evolution.py
+++ b/tuxemon/event/actions/evolution.py
@@ -116,6 +116,12 @@ class EvolutionAction(EventAction):
             registry.add_pending(monster.instance_id, slug)
 
         evolved = Monster.spawn_base(slug, monster.level)
+        evolved.taste_cold = monster.taste_cold
+        evolved.taste_warm = monster.taste_warm
+        evolved.individual_values = monster.individual_values
+        evolved.training_points = monster.training_points
+        evolved.custom_stats = monster.custom_stats
+        evolved.set_stats()
 
         self.client.push_state(
             "EvolutionState",

--- a/tuxemon/monster/evolution.py
+++ b/tuxemon/monster/evolution.py
@@ -123,7 +123,6 @@ class Evolution:
             return
 
         owner = self.monster.get_owner()
-        new_monster.transfer_properties_from(self.monster)
 
         for move in new_monster.moves.moveset:
             if move.learning_method == LearningMethod.EVOLUTION:

--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -683,6 +683,9 @@ class Monster:
         self.moves = old_monster.moves
         self.status = old_monster.status
         self.instance_id = old_monster.instance_id
+        self.individual_values = old_monster.individual_values
+        self.training_points = old_monster.training_points
+        self.custom_stats = old_monster.custom_stats
 
         if old_monster.gender in self.gender_weights:
             self.gender = old_monster.gender


### PR DESCRIPTION
Sometimes when a monster evolved, some of their stats went backwards. That shouldn't happen unless the monster's new form has a different body shape to the original. This should fix that. 