### PR TITLE
Player steps iterating once per tile

### DIFF
--- a/tests/tuxemon/test_step_manager.py
+++ b/tests/tuxemon/test_step_manager.py
@@ -30,7 +30,7 @@ def step_tracker_manager():
 
 @pytest.fixture
 def manager(session, step_tracker_manager):
-    return StepManager(session, step_tracker_manager)
+    return StepManager(session, step_tracker_manager, MagicMock())
 
 
 def test_handle_steps_zero(manager, mock_event_bus):

--- a/tuxemon/entity/npc.py
+++ b/tuxemon/entity/npc.py
@@ -107,7 +107,7 @@ class NPC(Entity):
         self.teleport_faint = TeleportFaint()
         self.tracker = TrackingData()
         self.step_tracker = StepTrackerManager()
-        self.step_manager = StepManager(session, self.step_tracker)
+        self.step_manager = StepManager(session, self.step_tracker, self)
         self.unlocked_letters: set[str] = set()
         # Variables for long-term item and monster storage
         # Keeping these separate so other code can safely

--- a/tuxemon/entity/steps.py
+++ b/tuxemon/entity/steps.py
@@ -31,10 +31,14 @@ class StepManager:
     """
 
     def __init__(
-        self, session: Session, step_tracker_manager: StepTrackerManager
+        self,
+        session: Session,
+        step_tracker_manager: StepTrackerManager,
+        owner: NPC,
     ) -> None:
         self.session = session
         self.step_tracker = step_tracker_manager
+        self.owner = owner
         session.client.event_bus.subscribe(
             "entity_moved",
             self._on_entity_moved,
@@ -75,9 +79,7 @@ class StepManager:
         steps: float,
         **kwargs: Any,
     ) -> None:
-        from tuxemon.entity.npc import NPC
-
-        if not isinstance(entity, NPC):
+        if entity is not self.owner:
             return
 
         entity.steps += steps

--- a/tuxemon/entity/steps.py
+++ b/tuxemon/entity/steps.py
@@ -11,6 +11,7 @@ from tuxemon.monster.listener import monster_update_listener
 if TYPE_CHECKING:
     from tuxemon.entity.entity import Entity
     from tuxemon.monster.monster import Monster
+    from tuxemon.entity.npc import NPC
     from tuxemon.session import Session
     from tuxemon.step_tracker import StepTrackerManager
 

--- a/tuxemon/entity/steps.py
+++ b/tuxemon/entity/steps.py
@@ -10,8 +10,8 @@ from tuxemon.monster.listener import monster_update_listener
 
 if TYPE_CHECKING:
     from tuxemon.entity.entity import Entity
-    from tuxemon.monster.monster import Monster
     from tuxemon.entity.npc import NPC
+    from tuxemon.monster.monster import Monster
     from tuxemon.session import Session
     from tuxemon.step_tracker import StepTrackerManager
 


### PR DESCRIPTION
I noticed that when the player moved one tile, their kilometers travelled count sometimes increased by more than 1 meter. I believe this fixes it -- previously other NPCs were counting towards the distance travelled. 