### PR TITLE
Fix TextArea not updating when two consecutive dialog lines are identical

### DIFF
--- a/tests/tuxemon/test_text_area.py
+++ b/tests/tuxemon/test_text_area.py
@@ -132,11 +132,11 @@ def test_next_raises_stopiteration_when_not_animated(text_area):
         next(text_area)
 
 
-def test_text_setter_same_value_does_not_restart_animation(text_area):
+def test_text_setter_same_value_restarts_animation(text_area):
     text_area.text = "abc"
     text_area.drawing_text = False
     text_area.text = "abc"
-    assert text_area.drawing_text is False
+    assert text_area.drawing_text is True
 
 
 def test_empty_string(stress_text_area):

--- a/tuxemon/ui/text.py
+++ b/tuxemon/ui/text.py
@@ -147,8 +147,7 @@ class TextArea(Sprite):
 
     @text.setter
     def text(self, value: str) -> None:
-        if value == self._text:
-            return
+
         self._text = value
 
         if not self._text:


### PR DESCRIPTION
This change removes an early‑return check in `TextArea.text` that skipped updates when the new text matched the previous text. That check caused dialog to break whenever two consecutive lines were identical. The second line never triggered a redraw or animation, so the dialog system treated it as already complete and advanced again. Removing the check forces a proper reset of the text animation every time a new line is shown, even if the content is the same.

fix #3528
fix #3542