### PR TITLE
Fix reroute logic and add complete test suite for NPC obstruction handling

### DIFF
--- a/tests/tuxemon/test_path_reroute.py
+++ b/tests/tuxemon/test_path_reroute.py
@@ -33,7 +33,13 @@ def npc_manager():
 
 
 def test_reroute_policy_immediate_repath_when_npc_blocking(npc, npc_manager):
-    npc_manager.get_entity_pos.return_value = MagicMock()  # NPC blocking
+    # NPC blocks the *target* tile
+    def get_entity_at_pos(pos):
+        if pos == (6, 5):
+            return MagicMock()
+        return None
+
+    npc_manager.get_entity_pos.side_effect = get_entity_at_pos
 
     policy = ReroutePolicy()
     commands = policy.on_obstruction(
@@ -86,8 +92,35 @@ def test_reroute_policy_simple_obstruction_no_pathfinding(npc, npc_manager):
     assert isinstance(commands[0], StopMovementCommand)
 
 
+def test_reroute_policy_prioritizes_npc_over_wall_obstruction(
+    npc, npc_manager
+):
+    # If an NPC is present, it must ALWAYS trigger immediate repath
+    npc_manager.get_entity_pos.return_value = MagicMock()
+
+    policy = ReroutePolicy()
+    commands = policy.on_obstruction(
+        owner=npc,
+        npc_manager=npc_manager,
+        pathfinding=(10, 10),
+        target=(6, 5),
+    )
+
+    assert len(commands) == 1
+    cmd = commands[0]
+    assert isinstance(cmd, RepathCommand)
+    assert cmd.immediate is True
+    assert cmd.cooldown == 0.5
+
+
 def test_ghost_policy_waits_if_destination_blocked(npc, npc_manager):
-    npc_manager.get_entity_pos.return_value = MagicMock()  # NPC blocking
+    # Destination tile blocked, target tile clear
+    def get_entity_at_pos(pos):
+        if pos == (10, 10):
+            return MagicMock()
+        return None
+
+    npc_manager.get_entity_pos.side_effect = get_entity_at_pos
 
     policy = GhostReroutePolicy()
     commands = policy.on_obstruction(
@@ -109,7 +142,7 @@ def test_ghost_policy_waits_if_destination_blocked(npc, npc_manager):
 
 
 def test_ghost_policy_phases_through_walls(npc, npc_manager):
-    npc_manager.get_entity_pos.return_value = None  # No NPC blocking
+    npc_manager.get_entity_pos.return_value = None  # No NPC blocking anything
 
     policy = GhostReroutePolicy()
     commands = policy.on_obstruction(
@@ -124,3 +157,83 @@ def test_ghost_policy_phases_through_walls(npc, npc_manager):
 
     assert isinstance(cmd, ContinueCommand)
     assert cmd.direction == Direction.RIGHT  # (5,5) → (6,5)
+
+
+def test_ghost_policy_ignores_midway_npc_if_destination_clear(
+    npc, npc_manager
+):
+    # NPC blocks the *target* tile, but destination is clear
+    def get_entity_at_pos(pos):
+        if pos == (6, 5):
+            return MagicMock()
+        return None
+
+    npc_manager.get_entity_pos.side_effect = get_entity_at_pos
+
+    policy = GhostReroutePolicy()
+    commands = policy.on_obstruction(
+        owner=npc,
+        npc_manager=npc_manager,
+        pathfinding=(10, 10),
+        target=(6, 5),
+    )
+
+    # Ghost should phase through anyway
+    assert len(commands) == 1
+    assert isinstance(commands[0], ContinueCommand)
+
+
+def test_ghost_policy_zero_distance_movement(npc, npc_manager):
+    npc_manager.get_entity_pos.return_value = None
+
+    policy = GhostReroutePolicy()
+    commands = policy.on_obstruction(
+        owner=npc,
+        npc_manager=npc_manager,
+        pathfinding=(10, 10),
+        target=(5, 5),  # Same tile as NPC
+    )
+
+    assert len(commands) == 1
+    assert isinstance(commands[0], ContinueCommand)
+    # Direction may be NONE depending on implementation, but command must exist
+
+
+def test_ghost_policy_no_pathfinding_phases_through(npc, npc_manager):
+    npc_manager.get_entity_pos.return_value = None
+
+    policy = GhostReroutePolicy()
+    commands = policy.on_obstruction(
+        owner=npc,
+        npc_manager=npc_manager,
+        pathfinding=None,
+        target=(6, 5),
+    )
+
+    assert len(commands) == 1
+    cmd = commands[0]
+    assert isinstance(cmd, ContinueCommand)
+    assert cmd.direction == Direction.RIGHT
+
+
+def test_ghost_policy_ignores_any_target_obstruction_if_destination_clear(
+    npc, npc_manager
+):
+    # Target tile blocked by something (NPC or treated as obstruction), destination clear
+    def get_entity_at_pos(pos):
+        if pos == (6, 5):  # target tile
+            return MagicMock()  # obstruction at target
+        return None  # destination (10,10) is clear
+
+    npc_manager.get_entity_pos.side_effect = get_entity_at_pos
+
+    policy = GhostReroutePolicy()
+    commands = policy.on_obstruction(
+        owner=npc,
+        npc_manager=npc_manager,
+        pathfinding=(10, 10),
+        target=(6, 5),
+    )
+
+    assert len(commands) == 1
+    assert isinstance(commands[0], ContinueCommand)

--- a/tuxemon/entity/path/policies/reroute.py
+++ b/tuxemon/entity/path/policies/reroute.py
@@ -33,13 +33,14 @@ class ReroutePolicy:
         pathfinding: tuple[int, int] | None,
         target: tuple[int, int],
     ) -> list[MovementCommand]:
+
         commands: list[MovementCommand] = []
 
         if pathfinding:
-            npc = npc_manager.get_entity_pos(pathfinding)
+            obstacle = npc_manager.get_entity_pos(target)
 
-            if npc:
-                # Short cooldown, immediate repath
+            if obstacle:
+                # Immediate repath around dynamic obstruction (e.g., player)
                 commands.append(
                     RepathCommand(
                         destination=pathfinding,
@@ -49,7 +50,7 @@ class ReroutePolicy:
                 )
                 return commands
 
-            # Longer cooldown, stop moving; path is left as-is
+            # Static obstruction → delayed repath + stop
             commands.append(
                 RepathCommand(
                     destination=pathfinding,
@@ -67,7 +68,8 @@ class ReroutePolicy:
 
 class GhostReroutePolicy(ReroutePolicy):
     """
-    Ghosts ignore walls. They only wait if the *destination* is occupied.
+    Ghosts ignore walls and NPCs blocking the next tile.
+    They only wait if the *final destination* is occupied.
     """
 
     def on_obstruction(
@@ -80,8 +82,8 @@ class GhostReroutePolicy(ReroutePolicy):
 
         commands: list[MovementCommand] = []
 
-        # If the destination is occupied by an NPC → wait
         if pathfinding:
+            # Ghosts only care about the FINAL destination
             npc = npc_manager.get_entity_pos(pathfinding)
             if npc:
                 commands.append(
@@ -94,7 +96,7 @@ class GhostReroutePolicy(ReroutePolicy):
                 commands.append(StopMovementCommand())
                 return commands
 
-        # Otherwise: ghosts phase through walls → force movement
+        # Otherwise ghosts phase through anything
         direction = get_direction(owner.tile_pos, target)
         commands.append(ContinueCommand(direction))
         return commands


### PR DESCRIPTION
Even if I was not able to reproduce the issues reported in #3525, I identified a logic flaw in the obstruction handling code. This PR corrects that flaw and expands the test suite to prevent regressions.

**ReroutePolicy** now checks the next movement tile instead of the final destination. This allows it to detect dynamic blocking and trigger an immediate repath when another NPC occupies the target tile. **GhostReroutePolicy** now checks only the final destination and ignores intermediate obstructions, matching its intended behavior.

The updated test suite covers dynamic blocking, static blocking, ghost phasing, destination blocking, zero‑distance movement, and cases without active pathfinding. All tests pass. Fix #3525.