### PR TITLE
Remember last save/load location

### DIFF
--- a/tuxemon/event/actions/load_game.py
+++ b/tuxemon/event/actions/load_game.py
@@ -89,6 +89,7 @@ class LoadGameAction(EventAction):
         client.push_state("WorldState", session=session, map_name=map_path)
 
         session.load_state(save_data)
+        session.current_slot = slot
 
         if npc_state.tile_pos is None:
             logger.error("Save data missing tile position.")

--- a/tuxemon/session.py
+++ b/tuxemon/session.py
@@ -156,6 +156,10 @@ class Session(AbstractSession["BaseClient"]):
         """The slot index most recently saved or loaded."""
         return self._current_slot
 
+    @current_slot.setter
+    def current_slot(self, value: int | None) -> None:
+        self._current_slot = value
+
     def load_state(self, save_data: SaveData) -> None:
         """
         Loads the player, world, and other session-level states from a saved game model.

--- a/tuxemon/world/manager.py
+++ b/tuxemon/world/manager.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from tuxemon.item.filter import ItemFilter
 from tuxemon.locale.locale import T
+from tuxemon.save_system.save_slots import save_index_to_ui
+from tuxemon.session import local_session
 from tuxemon.world.menu_flags import MenuFlags
 
 if TYPE_CHECKING:
@@ -238,10 +240,18 @@ class WorldMenuManager:
             )
 
         if self.menu_flags.is_enabled("menu_save"):
-            current_menu.append(self._menu_item("menu_save", "SaveMenuState"))
+            slot = local_session.current_slot
+            idx = save_index_to_ui(slot) if slot else 0
+            current_menu.append(
+                self._menu_item("menu_save", "SaveMenuState", selected_index=idx)
+            )
 
         if self.menu_flags.is_enabled("menu_load"):
-            current_menu.append(self._menu_item("menu_load", "LoadMenuState"))
+            slot = local_session.current_slot
+            idx = save_index_to_ui(slot) if slot else 0
+            current_menu.append(
+                self._menu_item("menu_load", "LoadMenuState", selected_index=idx)
+            )
 
         current_menu.append(self._menu_item("menu_options", "ControlState"))
 


### PR DESCRIPTION
Whichever save slot was last saved or loaded is remembered, so the cursor starts there the next time the save or load menus are opened. 