### PR TITLE
Correcting Wild condition odds

### DIFF
--- a/tuxemon/core/effects/wild.py
+++ b/tuxemon/core/effects/wild.py
@@ -26,7 +26,7 @@ class WildEffect(CoreEffect):
 
     **Parameters**
 
-    - ``chance``: The probability of avoiding the penalty (float between 0 and 1).
+    - ``chance``: The probability of getting the penalty (float between 0 and 1).
     - ``divisor``: The divisor used to calculate self-inflicted damage
       (e.g. 8 for one-eighth of max HP).
 
@@ -49,7 +49,7 @@ class WildEffect(CoreEffect):
         tech: list[Technique] = []
         if (
             status.has_phase(EffectPhase.PRE_CHECKING)
-            and random.random() > self.chance
+            and random.random() < self.chance
         ):
             user = status.host
             empty = status.on_tech_use


### PR DESCRIPTION
As per the wiki, the Wild condition should have a 1/4 chance of triggering each round. It had a 3/4 chance -- this fixes that. 