### PR TITLE
Monsters increase current HP on level up

### DIFF
--- a/tuxemon/monster/monster.py
+++ b/tuxemon/monster/monster.py
@@ -606,11 +606,13 @@ class Monster:
             self._levelup_start_level = old_level
 
         self.experience_handler.set_level(new_level)
+        old_max_hp = self.hp
         self.set_stats()
 
         if new_level > old_level:
             self._levelup_end_stats = self.base_stats.copy()
             self._levelup_end_level = new_level
+            self.current_hp += self.hp - old_max_hp
 
         level_delta = new_level - old_level
 


### PR DESCRIPTION
Previously, when monsters gained a new level, their max HP increased but current HP did not. This made it look like monsters had taken damage just for levelling up. Now, current HP keeps up. 