### PR TITLE
Remember item menu position

### DIFF
--- a/tuxemon/entity/npc.py
+++ b/tuxemon/entity/npc.py
@@ -118,6 +118,10 @@ class NPC(Entity):
         self.bag = BagHandler(item_boxes=self.item_boxes, owner=self)
         self.evolution_registry = EvolutionRegistry()
         self.steps: float = 0.0
+        # Slug of last item used outside battle; persists across battles.
+        self.last_used_item_slug: str | None = None
+        # Slug of last item used inside battle; cleared when battle ends.
+        self.battle_last_used_item_slug: str | None = None
         self.dialogue: DialogueProfile | None = None
         self.sprite_controller = SpriteController(self)
         self.daycare = Daycare(owner=self)

--- a/tuxemon/item/controller.py
+++ b/tuxemon/item/controller.py
@@ -75,6 +75,7 @@ class ItemController:
                     self.session.client.push_state(monster_menu)
                 else:
                     result = self.item.use(self.session, self.char, None)
+                    self.char.last_used_item_slug = self.item.slug
                     self.session.client.remove_state_by_name("ItemMenuState")
                     self.session.client.remove_state_by_name("WorldMenuState")
                     self._show_item_result(result)
@@ -111,6 +112,7 @@ class ItemController:
 
             monster = menu_item.game_object
             result = self.item.use(self.session, self.char, monster)
+            self.char.last_used_item_slug = self.item.slug
             self.session.client.remove_state_by_name("MonsterMenuState")
             self.session.client.remove_state_by_name("ItemMenuState")
             self.session.client.remove_state_by_name("WorldMenuState")

--- a/tuxemon/states/combat_menus.py
+++ b/tuxemon/states/combat_menus.py
@@ -339,6 +339,7 @@ class MainCombatMenuState(PopUpMenu[MenuGameObj]):
 
             # enqueue the item
             self.combat_session.enqueue_action(self.character, item, target)
+            self.character.battle_last_used_item_slug = item.slug
 
             # close all the open menus
             self.client.remove_state_by_name("MainCombatMenuState")

--- a/tuxemon/states/combat_state.py
+++ b/tuxemon/states/combat_state.py
@@ -1006,6 +1006,8 @@ class CombatState(CombatAnimations):
     def end_combat(self) -> None:
         """End the combat."""
         self.event_bus.publish("clean_combat")
+        for player in self.combat_session.players:
+            player.battle_last_used_item_slug = None
         new_entry = self.combat_session.get_variable("new_tuxepedia")
         self.combat_session.reset()
         self.unregister_event_handlers()

--- a/tuxemon/states/item_menu.py
+++ b/tuxemon/states/item_menu.py
@@ -71,6 +71,7 @@ class ItemMenuState(Menu[Item]):
         self.current_page = 0
         self.total_pages = 0
         self.inventory = self.filter_controller.get_filtered_inventory()
+        self._cursor_positioned = False
 
         # this is the area where the item description is displayed
         rect = self.client.context.rect.copy()
@@ -261,6 +262,19 @@ class ItemMenuState(Menu[Item]):
         else:
             self.total_pages = 1
 
+        # On the first open, seek the page that holds the last-used item.
+        seek_slug: str | None = None
+        if not self._cursor_positioned:
+            if self.source == "MainCombatMenuState":
+                seek_slug = self.char.battle_last_used_item_slug
+            else:
+                seek_slug = self.char.last_used_item_slug
+            if seek_slug and self.page_size:
+                inv_slugs = [item.slug for item in self.inventory]
+                if seek_slug in inv_slugs:
+                    item_global_index = inv_slugs.index(seek_slug)
+                    self.current_page = item_global_index // self.page_size
+
         # Clamp current page
         self.current_page = max(
             0, min(self.current_page, self.total_pages - 1)
@@ -276,20 +290,39 @@ class ItemMenuState(Menu[Item]):
             self.total_pages = 1
             self.current_page = 0
             self.update_page_number_display(0)
+            self._cursor_positioned = True
             return
 
-        for obj in self.sorter.sort(page_items):
+        sorted_items = self.sorter.sort(page_items)
+
+        for obj in sorted_items:
             enable = self.is_valid_entry(obj)
             menu_item = self.create_menu_item(obj, is_enabled=enable)
             self.add(menu_item)
 
         if self.menu_items:
-            self.selected_index = min(
-                self.selected_index, len(self.menu_items) - 1
-            )
+            if seek_slug:
+                target_index = next(
+                    (
+                        i
+                        for i, obj in enumerate(sorted_items)
+                        if obj.slug == seek_slug
+                    ),
+                    None,
+                )
+                self.selected_index = (
+                    target_index
+                    if target_index is not None
+                    else min(self.selected_index, len(self.menu_items) - 1)
+                )
+            else:
+                self.selected_index = min(
+                    self.selected_index, len(self.menu_items) - 1
+                )
         else:
             self.selected_index = -1
 
+        self._cursor_positioned = True
         self.update_page_number_display(len(self.inventory))
         self.on_menu_selection_change()
 


### PR DESCRIPTION
When the player uses an item, the next time they open the menu the cursor starts at that item. Separate tracking for a battle vs out of battle item use. 