### PR TITLE
Remove unused import readline

### DIFF
--- a/scripts/TestClient.py
+++ b/scripts/TestClient.py
@@ -3,7 +3,6 @@ dont_extract = True  # Switching to false will make the download function
 #                    # extract the downloaded package to the mods folder
 
 import os
-import readline
 
 from tuxemon.mod_manager import Manager
 


### PR DESCRIPTION
## 问题背景
在文件 `scripts/TestClient.py` 中，`readline` 模块被导入但未使用。这违反了Python的导入最佳实践，可能导致lint工具（如flake8）报告警告，影响代码质量和维护性。

## 修改内容
- 移除了 `import readline` 这一行代码，因为它没有在代码中被引用。

## 验证方式
1. 运行Python lint检查（例如 `flake8 scripts/TestClient.py`）确认不再有未使用的导入警告。
2. 手动测试脚本功能，确保移除导入后程序行为保持不变，特别是输入功能正常工作。