### PR TITLE
Update the Spyder economy

### DIFF
--- a/mods/tuxemon/db/economy/spyder_scoops.yaml
+++ b/mods/tuxemon/db/economy/spyder_scoops.yaml
@@ -19,29 +19,35 @@
 
 - background: gfx/ui/item/item_menu_bg.png
   items:
-  - cost: 5
+  - cost: 50
     slug: potion
-    price: 20
-  - cost: 20
-    slug: revive
     price: 100
-  - cost: 10
+  - cost: 50
     slug: tuxeball
-    price: 50
+    price: 100
+  - cost: 200
+    slug: restoration
+    price: 400
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_paper_scoop
 - background: gfx/ui/item/item_menu_bg.png
   items:
-  - cost: 5
-    slug: potion
-    price: 20
-  - cost: 20
-    slug: revive
+  - cost: 50
+    slug: repellent
     price: 100
-  - cost: 10
+  - cost: 50
+    slug: potion
+    price: 100
+  - cost: 50
     slug: tuxeball
-    price: 50
+    price: 100
+  - cost: 200
+    slug: restoration
+    price: 400
+  - cost: 300
+    slug: escape_key
+    price: 600
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_cotton_scoop
@@ -64,49 +70,75 @@
     inventory: 1
     slug: tm_blossom
     price: 1000
+  monsters:
+  - cost: 2000
+    slug: memnomnom
+    price: 4000
+    level: 10
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_cotton_tech
 - background: gfx/ui/item/item_menu_bg.png
   items:
-  - cost: 10
-    slug: super_potion
-    price: 50
-  - cost: 20
-    slug: revive
-    price: 100
   - cost: 50
-    slug: cureall
-    price: 250
-  - cost: 30
-    slug: tuxeball_noble
-    price: 150
-  - cost: 40
+    slug: repellent
+    price: 100
+  - cost: 500
+    slug: revive
+    price: 1000
+  - cost: 150
+    slug: super_potion
+    price: 300
+  - cost: 150
     slug: tuxeball_lavish
-    price: 200
+    price: 300
+  - cost: 200
+    slug: restoration
+    price: 400
+  - cost: 300
+    slug: escape_key
+    price: 600
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_leather_scoop
 - background: gfx/ui/item/item_menu_bg.png
   items:
-  - cost: 10
-    slug: super_potion
-    price: 50
   - cost: 50
-    slug: mega_potion
-    price: 200
-  - cost: 20
-    slug: revive
+    slug: repellent
     price: 100
-  - cost: 50
-    slug: cureall
-    price: 250
-  - cost: 40
+  - cost: 500
+    slug: revive
+    price: 1000
+  - cost: 150
+    slug: super_potion
+    price: 300
+  - cost: 150
     slug: tuxeball_lavish
-    price: 200
-  - cost: 50
-    slug: tuxeball_grand
-    price: 250
+    price: 300
+  - cost: 300
+    slug: tuxeball_majestic
+    price: 600
+  - cost: 200
+    slug: restoration
+    price: 400
+  - cost: 750
+    slug: cureall
+    price: 1500
+  - cost: 300
+    slug: escape_key
+    price: 600
+  - cost: 150
+    slug: tuxeball_diurnal
+    price: 300
+    variables:
+      - key: daytime
+        value: "true"
+  - cost: 150
+    slug: tuxeball_nocturnal
+    price: 300
+    variables:
+      - key: daytime
+        value: "false"
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_flower_scoop
@@ -137,36 +169,63 @@
   slug: spyder_flower_petshop
 - background: gfx/ui/item/item_menu_bg.png
   items:
-  - cost: 10
-    slug: super_potion
-    price: 50
   - cost: 50
-    slug: mega_potion
-    price: 200
-  - cost: 20
-    slug: revive
+    slug: repellent
     price: 100
-  - cost: 50
-    slug: cureall
-    price: 250
-  - cost: 50
-    slug: tuxeball_grand
-    price: 250
-  - cost: 80
+  - cost: 500
+    slug: revive
+    price: 1000
+  - cost: 150
+    slug: super_potion
+    price: 300
+  - cost: 150
+    slug: tuxeball_lavish
+    price: 300
+  - cost: 300
     slug: tuxeball_majestic
+    price: 600
+  - cost: 200
+    slug: restoration
     price: 400
-  - cost: 60
-    slug: tuxeball_diurnal
-    price: 300
-    variables:
-      - key: daytime
-        value: "true"
-  - cost: 60
-    slug: tuxeball_nocturnal
-    price: 300
-    variables:
-      - key: daytime
-        value: "false"
+  - cost: 750
+    slug: cureall
+    price: 1500
+  - cost: 300
+    slug: escape_key
+    price: 600
+  - cost: 275
+    slug: boost_armour
+    price: 550
+  - cost: 275
+    slug: boost_dodge
+    price: 550
+  - cost: 275
+    slug: boost_melee
+    price: 550
+  - cost: 275
+    slug: boost_ranged
+    price: 550
+  - cost: 275
+    slug: boost_speed
+    price: 550
+  - cost: 5000
+    slug: raise_hp
+    price: 10000
+  - cost: 5000
+    slug: raise_armour
+    price: 10000
+  - cost: 5000
+    slug: raise_dodge
+    price: 10000
+  - cost: 5000
+    slug: raise_melee
+    price: 10000
+  - cost: 5000
+    slug: raise_ranged
+    price: 10000
+  - cost: 5000
+    slug: raise_speed
+    price: 10000
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_timber_scoop

--- a/mods/tuxemon/db/economy/spyder_scoops.yaml
+++ b/mods/tuxemon/db/economy/spyder_scoops.yaml
@@ -103,6 +103,21 @@
   slug: spyder_leather_scoop
 - background: gfx/ui/item/item_menu_bg.png
   items:
+  - cost: 1000
+    slug: stovepipe
+    price: 2000
+  - cost: 1000
+    slug: tectonic_drill
+    price: 2000
+  monsters: 
+  - cost: 2000
+    slug: ignibus
+    price: 4000
+    level: 10
+  resale_multiplier: 0.5
+  slug: spyder_leather_tech
+- background: gfx/ui/item/item_menu_bg.png
+  items:
   - cost: 50
     slug: repellent
     price: 100
@@ -142,6 +157,21 @@
   monsters: []
   resale_multiplier: 0.5
   slug: spyder_flower_scoop
+- background: gfx/ui/item/item_menu_bg.png
+  items:
+  - cost: 1000
+    slug: flintstone
+    price: 2000
+  - cost: 1000
+    slug: thunderstone
+    price: 2000
+  monsters: 
+  - cost: 2000
+    slug: grintot
+    price: 4000
+    level: 10
+  resale_multiplier: 0.5
+  slug: spyder_flower_tech
 - background: gfx/ui/item/item_menu_bg.png
   items: []
   monsters:
@@ -231,6 +261,21 @@
   slug: spyder_timber_scoop
 - background: gfx/ui/item/item_menu_bg.png
   items:
+  - cost: 1000
+    slug: sweet_sand
+    price: 2000
+  - cost: 1000
+    slug: sea_girdle
+    price: 2000
+  monsters: 
+  - cost: 2000
+    slug: dollfin
+    price: 4000
+    level: 10
+  resale_multiplier: 0.5
+  slug: spyder_timber_tech
+- background: gfx/ui/item/item_menu_bg.png
+  items:
   - cost: 50
     slug: mega_potion
     price: 200
@@ -263,10 +308,10 @@
   slug: spyder_candy_scoop
 - background: gfx/ui/item/item_menu_bg.png
   items:
-  - cost: 400
+  - cost: 1000
     slug: peace_lily
     price: 2000
-  - cost: 400
+  - cost: 1000
     slug: lucky_bamboo
     price: 2000
   - cost: 400
@@ -285,6 +330,10 @@
     inventory: 1
     slug: tm_acid
     price: 2000
-  monsters: []
+  monsters: 
+  - cost: 2000
+    slug: budaye
+    price: 4000
+    level: 10
   resale_multiplier: 0.5
   slug: spyder_candy_tech

--- a/mods/tuxemon/db/economy/spyder_scoops.yaml
+++ b/mods/tuxemon/db/economy/spyder_scoops.yaml
@@ -75,7 +75,6 @@
     slug: memnomnom
     price: 4000
     level: 10
-  monsters: []
   resale_multiplier: 0.5
   slug: spyder_cotton_tech
 - background: gfx/ui/item/item_menu_bg.png

--- a/mods/tuxemon/db/item/mega_potion.yaml
+++ b/mods/tuxemon/db/item/mega_potion.yaml
@@ -18,7 +18,7 @@ slug: mega_potion
 sort: potion
 sprite: gfx/items/mega_potion.png
 category: potion
-cost: 400
+cost: 500
 usable_in:
 - MainCombatMenuState
 - WorldState

--- a/mods/tuxemon/db/item/potion.yaml
+++ b/mods/tuxemon/db/item/potion.yaml
@@ -18,7 +18,7 @@ slug: potion
 sort: potion
 sprite: gfx/items/potion.png
 category: potion
-cost: 50
+cost: 100
 usable_in:
 - MainCombatMenuState
 - WorldState

--- a/mods/tuxemon/db/item/repellent.yaml
+++ b/mods/tuxemon/db/item/repellent.yaml
@@ -1,0 +1,25 @@
+conditions: []
+effects:
+- type: repellent
+  parameters:
+  - '100'
+slug: repellent
+sort: utility
+sprite: gfx/items/box.png
+category: none
+cost: 100
+usable_in:
+- WorldState
+modifiers: []
+behaviors:
+  requires_monster_menu: false
+use_failure: generic_failure
+use_item: combat_used_x
+use_success: generic_success
+visuals:
+  animation: null
+  flip_axes: ''
+  loop: 0
+sound:
+  sfx: null
+  volume: 0.0

--- a/mods/tuxemon/db/item/restoration.yaml
+++ b/mods/tuxemon/db/item/restoration.yaml
@@ -17,7 +17,7 @@ slug: restoration
 sort: potion
 sprite: gfx/items/apple.png
 category: potion
-cost: 700
+cost: 400
 usable_in:
 - MainCombatMenuState
 - WorldState

--- a/mods/tuxemon/db/item/revive.yaml
+++ b/mods/tuxemon/db/item/revive.yaml
@@ -18,7 +18,7 @@ slug: revive
 sort: potion
 sprite: gfx/items/revive.png
 category: potion
-cost: 1500
+cost: 1000
 usable_in:
 - MainCombatMenuState
 - WorldState

--- a/mods/tuxemon/db/item/super_potion.yaml
+++ b/mods/tuxemon/db/item/super_potion.yaml
@@ -18,7 +18,7 @@ slug: super_potion
 sort: potion
 sprite: gfx/items/super_potion.png
 category: potion
-cost: 100
+cost: 300
 usable_in:
 - MainCombatMenuState
 - WorldState

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -415,6 +415,12 @@ msgstr ""
 "Thick, mucosal secretion harvested from the scent glands of apex predators "
 "at the peak of their territorial cycle."
 
+msgid "repellent"
+msgstr "Repellent"
+
+msgid "repellent_description"
+msgstr "Deter wild encounters with this stinky spray."
+
 msgid "fishing_rod"
 msgstr "Fishing Rod"
 

--- a/mods/tuxemon/maps/spyder_candy_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_candy_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.2" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="38">
+<map version="1.8" tiledversion="1.8.2" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -94,9 +94,25 @@
    <properties>
     <property name="act1" value="char_face spyder_wayfarer1_norm,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act3" value="translated_dialog_choice menu_item:menu_monster,techchoice"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed INTERACT"/>
+    <property name="cond3" value="not variable_set techchoice:menu_item"/>
+    <property name="cond4" value="not variable_set techchoice:menu_monster"/>
+   </properties>
+  </object>
+  <object id="38" name="Tech Buy Items" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_item"/>
+   </properties>
+  </object>
+  <object id="39" name="Tech Buy Monsters" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,buy_monster"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_monster"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_cotton_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_cotton_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.2" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="38">
+<map version="1.8" tiledversion="1.8.2" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="40">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -152,9 +152,25 @@
    <properties>
     <property name="act1" value="char_face spyder_wayfarer1_norm,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act3" value="translated_dialog_choice menu_item:menu_monster,techchoice"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed INTERACT"/>
+    <property name="cond3" value="not variable_set techchoice:menu_item"/>
+    <property name="cond4" value="not variable_set techchoice:menu_monster"/>
+   </properties>
+  </object>
+  <object id="38" name="Tech Buy Items" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_item"/>
+   </properties>
+  </object>
+  <object id="39" name="Tech Buy Monsters" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,buy_monster"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_monster"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_flower_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_flower_scoop.yaml
@@ -7,6 +7,14 @@ events:
     conditions:
     - not char_exists spyder_shopassistant
     type: event
+  Create Tech Shop:
+    actions:
+    - create_npc spyder_wayfarer1_norm,1,4
+    - char_face spyder_wayfarer1_norm,right
+    - set_economy spyder_wayfarer1_norm,spyder_flower_tech
+    conditions:
+    - not char_exists spyder_wayfarer1_norm
+    type: event
   Flashback:
     actions:
     - lock_controls
@@ -80,6 +88,17 @@ events:
     type: event
     x: 1
     y: 7
+  Open Tech:
+    actions:
+    - char_face spyder_wayfarer1_norm,right
+    - translated_dialog spyder_scoop_welcome
+    - open_shop spyder_wayfarer1_norm,both_item
+    conditions:
+    - is char_facing_tile player
+    - is button_pressed INTERACT
+    type: event
+    x: 2
+    y: 4
   Route Music:
     actions:
     - play_music music_cathedral_theme

--- a/mods/tuxemon/maps/spyder_flower_scoop.yaml
+++ b/mods/tuxemon/maps/spyder_flower_scoop.yaml
@@ -92,13 +92,29 @@ events:
     actions:
     - char_face spyder_wayfarer1_norm,right
     - translated_dialog spyder_scoop_welcome
-    - open_shop spyder_wayfarer1_norm,both_item
+    - translated_dialog_choice menu_item:menu_monster,techchoice
     conditions:
     - is char_facing_tile player
     - is button_pressed INTERACT
+    - not variable_set techchoice:menu_item
+    - not variable_set techchoice:menu_monster
     type: event
     x: 2
     y: 4
+  Tech Buy Items:
+    actions:
+    - open_shop spyder_wayfarer1_norm,both_item
+    - clear_variable techchoice
+    conditions:
+    - is variable_set techchoice:menu_item
+    type: event
+  Tech Buy Monsters:
+    actions:
+    - open_shop spyder_wayfarer1_norm,buy_monster
+    - clear_variable techchoice
+    conditions:
+    - is variable_set techchoice:menu_monster
+    type: event
   Route Music:
     actions:
     - play_music music_cathedral_theme

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="28">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -82,6 +82,23 @@
     <property name="act2" value="char_face spyder_shopassistant,right"/>
     <property name="act3" value="set_economy spyder_shopassistant,spyder_leather_scoop"/>
     <property name="cond1" value="not char_exists spyder_shopassistant"/>
+   </properties>
+  </object>
+  <object id="28" name="Create Tech Shop" type="event" x="16" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_wayfarer1_norm,1,4"/>
+    <property name="act2" value="char_face spyder_wayfarer1_norm,right"/>
+    <property name="act3" value="set_economy spyder_wayfarer1_norm,spyder_leather_tech"/>
+    <property name="cond1" value="not char_exists spyder_wayfarer1_norm"/>
+   </properties>
+  </object>
+  <object id="29" name="Open Tech" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="char_face spyder_wayfarer1_norm,right"/>
+    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
+    <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_leather_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_leather_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="30">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" compressionlevel="0" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="32">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -96,9 +96,25 @@
    <properties>
     <property name="act1" value="char_face spyder_wayfarer1_norm,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act3" value="translated_dialog_choice menu_item:menu_monster,techchoice"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed INTERACT"/>
+    <property name="cond3" value="not variable_set techchoice:menu_item"/>
+    <property name="cond4" value="not variable_set techchoice:menu_monster"/>
+   </properties>
+  </object>
+  <object id="30" name="Tech Buy Items" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_item"/>
+   </properties>
+  </object>
+  <object id="31" name="Tech Buy Monsters" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,buy_monster"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_monster"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -94,9 +94,25 @@
    <properties>
     <property name="act1" value="char_face spyder_wayfarer1_norm,right"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
-    <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act3" value="translated_dialog_choice menu_item:menu_monster,techchoice"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed INTERACT"/>
+    <property name="cond3" value="not variable_set techchoice:menu_item"/>
+    <property name="cond4" value="not variable_set techchoice:menu_monster"/>
+   </properties>
+  </object>
+  <object id="39" name="Tech Buy Items" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,both_item"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_item"/>
+   </properties>
+  </object>
+  <object id="40" name="Tech Buy Monsters" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="open_shop spyder_wayfarer1_norm,buy_monster"/>
+    <property name="act2" value="clear_variable techchoice"/>
+    <property name="cond1" value="is variable_set techchoice:menu_monster"/>
    </properties>
   </object>
  </objectgroup>

--- a/mods/tuxemon/maps/spyder_timber_scoop.tmx
+++ b/mods/tuxemon/maps/spyder_timber_scoop.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="37">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="13" height="11" tilewidth="16" tileheight="16" infinite="0" nextlayerid="7" nextobjectid="39">
  <properties>
   <property name="edges" value="clamped"/>
   <property name="inside" type="bool" value="true"/>
@@ -78,6 +78,23 @@
     <property name="act1" value="char_face spyder_shopassistant,down"/>
     <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
     <property name="act3" value="open_shop spyder_shopassistant,both_item"/>
+    <property name="cond1" value="is char_facing_tile player"/>
+    <property name="cond2" value="is button_pressed INTERACT"/>
+   </properties>
+  </object>
+  <object id="37" name="Create Tech Shop" type="event" x="16" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="create_npc spyder_wayfarer1_norm,1,4"/>
+    <property name="act2" value="char_face spyder_wayfarer1_norm,right"/>
+    <property name="act3" value="set_economy spyder_wayfarer1_norm,spyder_timber_tech"/>
+    <property name="cond1" value="not char_exists spyder_wayfarer1_norm"/>
+   </properties>
+  </object>
+  <object id="38" name="Open Tech" type="event" x="32" y="64" width="16" height="16">
+   <properties>
+    <property name="act1" value="char_face spyder_wayfarer1_norm,right"/>
+    <property name="act2" value="translated_dialog spyder_scoop_welcome"/>
+    <property name="act3" value="open_shop spyder_wayfarer1_norm,both_item"/>
     <property name="cond1" value="is char_facing_tile player"/>
     <property name="cond2" value="is button_pressed INTERACT"/>
    </properties>


### PR DESCRIPTION
This updates the Spyder campaign economy so all "Gold Pass" starters can now be purchased, along with evolution items, and stores sell items for their value instead of earlier, mostly cheaper, prices.