### PR TITLE
A technique's healing can be targeted separately to its damage

### DIFF
--- a/mods/tuxemon/db/technique/battery_discharge.yaml
+++ b/mods/tuxemon/db/technique/battery_discharge.yaml
@@ -3,6 +3,8 @@ accuracy: 0.8
 effects:
 - type: damage
 - type: healing
+  parameters:
+  - own_monster
 healing_power: 3.0
 speed: normal
 potency: 0.0

--- a/mods/tuxemon/db/technique/blossom.yaml
+++ b/mods/tuxemon/db/technique/blossom.yaml
@@ -3,6 +3,8 @@ accuracy: 0.85
 effects:
 - type: damage
 - type: healing
+  parameters:
+  - own_monster
 healing_power: 2.0
 speed: normal
 potency: 1

--- a/mods/tuxemon/db/technique/potluck.yaml
+++ b/mods/tuxemon/db/technique/potluck.yaml
@@ -10,6 +10,11 @@ effects:
   - noddingoff
   - enemy_monster
 - type: healing
+  parameters:
+  - own_monster
+- type: healing
+  parameters:
+  - enemy_monster
 healing_power: 1.0
 speed: normal
 potency: 0.8

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -1706,7 +1706,10 @@ msgid "spyderbite_miss"
 msgstr "And the technique was lost."
 
 msgid "combat_full_health"
-msgstr "But it's already at full health."
+msgstr "But {name} is already at full health."
+
+msgid "combat_state_healed"
+msgstr "{name}'s health was restored."
 
 msgid "combat_forfeit"
 msgstr ""

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -575,6 +575,7 @@ class CombatSession:
     def apply_technique(
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> tuple[TechEffectResult, StatusEffectResult | None]:
+        pre_status = user.status.current_status
         result = tech.use(session, user, target)
         logger.debug(
             f"{user.name} used {tech.slug} on {target.name} > success={result.success}"
@@ -582,7 +583,11 @@ class CombatSession:
 
         status_result = None
         status = user.status.current_status
-        if status:
+        # Only run the PERFORM_TECH phase on a status the user already had
+        # before this technique executed. Otherwise a technique that grants a
+        # status to its own user (e.g. Life Surge granting "chargedup") would
+        # have that status consumed by this same action's PERFORM_TECH hook.
+        if status and status is pre_status:
             status_result = status.use(session, EffectPhase.PERFORM_TECH)
             if status_result.statuses:
                 chosen = random.choice(status_result.statuses)

--- a/tuxemon/combat/session.py
+++ b/tuxemon/combat/session.py
@@ -341,6 +341,15 @@ class CombatSession:
         self._prize = 0
 
     # Random tech hit
+    #
+    # Accuracy is rolled once per monster per round: initialize_hit_chances()
+    # stores a single random value per monster, and get_tech_hit() only reads
+    # that cached value (it does not re-roll). This means every effect of a
+    # technique that compares `tech.accuracy >= get_tech_hit(user)` shares the
+    # same hit/miss result, so the accuracy check is effectively performed once
+    # per technique even when it has both damage and healing effects. The only
+    # deliberate exception is multiattack, which calls set_tech_hit() to re-roll
+    # for each of its repeated hits.
     def set_tech_hit(
         self, monster: Monster, value: float | None = None
     ) -> None:

--- a/tuxemon/core/effects/healing.py
+++ b/tuxemon/core/effects/healing.py
@@ -2,17 +2,21 @@
 # Copyright (c) 2014-2026 William Edwards <shadowapex@gmail.com>, Benjamin Bean <superman2k5@gmail.com>
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.db import TargetType
+from tuxemon.locale.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.monster.monster import Monster
     from tuxemon.session import Session
     from tuxemon.technique.technique import Technique
 
+logger = logging.getLogger(__name__)
 
 @dataclass
 class HealingEffect(CoreEffect):
@@ -24,16 +28,38 @@ class HealingEffect(CoreEffect):
     the same formula as the damage that would be dealt by a reliable
     technique of equal power.
 
+    **Parameters**
+      - ``objective``: Which targets to heal. When omitted, the technique's
+        own target block is used (the same targets the other effects hit).
+        Otherwise it may be any single target type, letting the heal target
+        differently from the rest of the technique:
+          - ``own_monster``: the monster using the technique
+          - ``own_team``: the user's active team
+          - ``own_trainer``: the user's whole party
+          - ``enemy_monster``: the targeted monster
+          - ``enemy_team``: the target's active team
+          - ``enemy_trainer``: the target's whole party
+
     **Example**
+
+    Heal whatever the technique targets:
 
     .. code-block:: json
 
         "effects": [
             "healing"
         ]
+
+    Heal the user regardless of the technique's target block (e.g. a move
+    that damages an enemy but heals the caster):
+    .. code-block:: json
+        "effects": [
+            "healing own_monster"
+        ]
     """
 
     name = "healing"
+    objective: str = ""
 
     def apply_tech_target(
         self, session: Session, tech: Technique, user: Monster, target: Monster
@@ -46,17 +72,31 @@ class HealingEffect(CoreEffect):
         tech.hit = tech.accuracy >= hit
 
         if tech.hit:
-            targets = session.client.combat_session.get_targets(
-                tech, user, target
-            )
+            targets = self._resolve_targets(session, tech, user, target)
 
         if targets:
             for monster in targets:
                 heal = formula.simple_heal(tech, monster)
+                params = {"name": monster.name}
                 if monster.hp_ratio < 1.0:
                     heal_amount = min(heal, monster.missing_hp)
                     monster.current_hp += heal_amount
                     done = True
+                    extra.append(T.format("combat_state_healed", params))
                 elif monster.hp_ratio == 1.0:
-                    extra = ["combat_full_health"]
+                    extra.append(T.format("combat_full_health", params))
         return TechEffectResult(name=tech.name, success=done, extras=extra)
+
+
+    def _resolve_targets(
+        self, session: Session, tech: Technique, user: Monster, target: Monster
+    ) -> list[Monster]:
+        combat = session.client.combat_session
+        if not self.objective:
+            return combat.get_targets(tech, user, target)
+        if self.objective not in {t.value for t in TargetType}:
+            logger.error(
+                f"{tech.name}: invalid healing objective '{self.objective}'"
+            )
+            return []
+        return combat.get_targets_from_map(self.objective, user, target)

--- a/tuxemon/core/effects/healing.py
+++ b/tuxemon/core/effects/healing.py
@@ -29,16 +29,18 @@ class HealingEffect(CoreEffect):
     technique of equal power.
 
     **Parameters**
-      - ``objective``: Which targets to heal. When omitted, the technique's
-        own target block is used (the same targets the other effects hit).
-        Otherwise it may be any single target type, letting the heal target
-        differently from the rest of the technique:
-          - ``own_monster``: the monster using the technique
-          - ``own_team``: the user's active team
-          - ``own_trainer``: the user's whole party
-          - ``enemy_monster``: the targeted monster
-          - ``enemy_team``: the target's active team
-          - ``enemy_trainer``: the target's whole party
+
+    - ``objective``: Which targets to heal. When omitted, the technique's
+      own target block is used (the same targets the other effects hit).
+      Otherwise it may be any single target type, letting the heal target
+      differently from the rest of the technique:
+
+      - ``own_monster``: the monster using the technique
+      - ``own_team``: the user's active team
+      - ``own_trainer``: the user's whole party
+      - ``enemy_monster``: the targeted monster
+      - ``enemy_team``: the target's active team
+      - ``enemy_trainer``: the target's whole party
 
     **Example**
 
@@ -52,7 +54,9 @@ class HealingEffect(CoreEffect):
 
     Heal the user regardless of the technique's target block (e.g. a move
     that damages an enemy but heals the caster):
+
     .. code-block:: json
+
         "effects": [
             "healing own_monster"
         ]

--- a/tuxemon/core/effects/photogenesis.py
+++ b/tuxemon/core/effects/photogenesis.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon import formula
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.locale.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.monster.monster import Monster
@@ -60,7 +61,7 @@ class PhotogenesisEffect(CoreEffect):
             return TechEffectResult(name=tech.name)
 
         if user.hp_ratio >= 1.0:
-            extra = ["combat_full_health"]
+            extra = [T.format("combat_full_health", {"name": user.name})]
             return TechEffectResult(name=tech.name, success=True, extras=extra)
 
         hour = session.time.get_time_variables().hour
@@ -83,4 +84,5 @@ class PhotogenesisEffect(CoreEffect):
 
         heal_amount = min(heal, user.missing_hp)
         user.current_hp += heal_amount
-        return TechEffectResult(name=tech.name, success=True)
+        extra = [T.format("combat_state_healed", {"name": user.name})]
+        return TechEffectResult(name=tech.name, success=True, extras=extra)

--- a/tuxemon/core/effects/step_healing.py
+++ b/tuxemon/core/effects/step_healing.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
 from tuxemon.formula import simple_heal
+from tuxemon.locale.locale import T
 
 if TYPE_CHECKING:
     from tuxemon.monster.monster import Monster
@@ -75,10 +76,13 @@ class StepHealingEffect(CoreEffect):
                 )
                 tech.healing_power = new_power
                 heal = simple_heal(tech, monster)
+                params = {"name": monster.name}
                 if monster.hp_ratio < 1.0:
                     heal_amount = min(heal, monster.missing_hp)
                     monster.current_hp += heal_amount
                     done = True
+                    extra.append(T.format("combat_state_healed", params))
                 elif monster.hp_ratio == 1.0:
                     extra = ["combat_full_health"]
+                    extra.append(T.format("combat_full_health", params))
         return TechEffectResult(name=tech.name, success=done, extras=extra)


### PR DESCRIPTION
At the moment, techniques like Blossom (damage enemy + healing self) weren't working because they both took the same target. With this change, the healing effect within a target can have a different target to its overall target. 

EDIT: Have made a related change, based on a bug I noticed while testing Life Surge:

If a monster gains Charged Up by using a technique, Charged Up immediately turns into Exhausted -- because Charged Up becomes Exhausted on technique use. But it should only convert when it was already possessed before the technique is used. Otherwise it's useless as it immediately changes to Exhausted. 