### PR TITLE
Minor technique-related bug fixes

### DIFF
--- a/tuxemon/combat/machine.py
+++ b/tuxemon/combat/machine.py
@@ -64,9 +64,11 @@ class CombatMachine:
                     "Only one player remaining — transitioning to RAN_AWAY."
                 )
                 return CombatPhase.RAN_AWAY
-            elif len(self.session.action_queue.queue) == len(
-                self.session.active_monsters
-            ):
+            active_set = set(self.session.active_monsters)
+            queued_users = {
+                a.user for a in self.session.action_queue.queue
+            } & active_set
+            if active_set and queued_users >= active_set:
                 logger.debug(
                     "All monsters have actions — transitioning to PRE_ACTION."
                 )

--- a/tuxemon/core/effects/locked.py
+++ b/tuxemon/core/effects/locked.py
@@ -67,8 +67,8 @@ class LockedMoveEffect(CoreEffect):
             user.locked_move = None
 
             if random.random() < self.confuse_chance:
-                status = Status.create("confused", target, target.steps)
-                result = target.status.apply_status(session, status)
+                status = Status.create("confused", user, user.steps)
+                result = user.status.apply_status(session, status)
                 if result.applied:
                     event_bus = session.client.event_bus
                     event_bus.publish("status_applied")

--- a/tuxemon/core/effects/ramp.py
+++ b/tuxemon/core/effects/ramp.py
@@ -43,7 +43,8 @@ class RampEffect(CoreEffect):
         self, session: Session, tech: Technique, user: Monster, target: Monster
     ) -> TechEffectResult:
         user.ramp_counter += 1
+        base_power = tech.base_stats.power + tech.custom_boosts.power
         tech.power = int(
-            tech.power * (self.multiplier ** (user.ramp_counter - 1))
+            base_power * (self.multiplier ** (user.ramp_counter - 1))
         )
         return TechEffectResult(name=tech.name, success=True)

--- a/tuxemon/core/effects/transfer.py
+++ b/tuxemon/core/effects/transfer.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from tuxemon.core.core_effect import CoreEffect, TechEffectResult
+from tuxemon.status.status import Status
 
 if TYPE_CHECKING:
     from tuxemon.monster.monster import Monster
@@ -61,7 +62,8 @@ class TransferEffect(CoreEffect):
                 else (target, user)
             )
             if source.status.has_status(self.condition):
-                dest.status = source.status
                 source.status.clear_status(session)
+                new_status = Status.create(self.condition, dest, dest.steps)
+                dest.status.add_status(new_status)
                 done = True
         return TechEffectResult(name=tech.name, success=done)

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -218,7 +218,7 @@ def calculate_time_based_multiplier(
         hour += 24
     if peak_hour < start:
         peak_hour += 24
-    if (end or hour or peak_hour) > 47:
+    if end > 47 or hour > 47 or peak_hour > 47:
         return 0.0
 
     if start <= hour < end:


### PR DESCRIPTION
Here are five technique-related bugs, each fixed in their own commit. Bugs spotted by Claude -- in one case through playtesting, in other cases through scanning the code. 

* The ramping effect doubles damage each time (x1, x2, x4), whereas the earlier version was quadrupling 
* The transfer effect moves a condition from one monster to another, whereas the earlier version moved the condition and then removed it from both original monster and target monster
* The foresight effect caused a crash in a double battle because the system expected four actions, but in the round a foresight effect comes true, it's additional to the action chosen by the user that turn. Now system looks for as many or more actions as monsters, not just as many.
* The locked effect can cause confusion after it ends, but the original version put the confusion on the other monster.
* There's a formula checking that photosynthesis "hour ranges" have been set correctly, and the original allowed some wrong numbers to be set. 