### PR TITLE
Small bug fixes

### DIFF
--- a/tuxemon/core/conditions/has_status.py
+++ b/tuxemon/core/conditions/has_status.py
@@ -33,4 +33,4 @@ class HasStatusCondition(CoreCondition):
     name = "has_status"
 
     def test_with_monster(self, session: Session, target: Monster) -> bool:
-        return bool(target.status)
+        return target.status.status_exists()

--- a/tuxemon/core/effects/repellent.py
+++ b/tuxemon/core/effects/repellent.py
@@ -56,4 +56,4 @@ class RepellentEffect(CoreEffect):
         logger.info(
             f"Applied repellent from '{item.name}' to '{player.name}' for {self.steps} steps."
         )
-        return ItemEffectResult(success=True)
+        return ItemEffectResult(name=item.name, success=True)

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -455,7 +455,7 @@ def calculate_status_modifier(item: Item, target: Monster) -> float:
             )
             status_modifier *= specific_modifier
 
-        if status.category:
+        elif status.category:
             category_modifier = (
                 negative_modifier
                 if status.category == "negative"

--- a/tuxemon/formula.py
+++ b/tuxemon/formula.py
@@ -503,16 +503,19 @@ def calculate_capdev_modifier(
         logger.debug(
             f"Checking specific element modifiers for item '{item.slug}' and target types"
         )
+        element_matched = False
         for slug, modifier in specific_element_modifiers.items():
             if target.has_type(slug):
                 logger.debug(
                     f"Target matches element '{slug}'. Applying modifier: {modifier}"
                 )
                 capdev_modifier *= modifier
-        logger.debug(
-            "No matching element found. Applying fallback_element_malus"
-        )
-        capdev_modifier *= config.fallback_element_malus
+                element_matched = True
+        if not element_matched:
+            logger.debug(
+                "No matching element found. Applying fallback_element_malus"
+            )
+            capdev_modifier *= config.fallback_element_malus
 
     specific_gender_modifiers = config.specific_gender_modifiers
 
@@ -520,12 +523,15 @@ def calculate_capdev_modifier(
         logger.debug(
             f"Checking specific gender modifiers for item '{item.slug}' and target gender '{target.gender}'"
         )
+        gender_matched = False
         for slug, modifier in specific_gender_modifiers.items():
             if target.gender == slug:
-                logger.debug(
-                    f"Target matches gender '{slug}'. Applying modifier: {modifier}"
-                )
-                capdev_modifier *= modifier
+                gender_matched = True
+        if not gender_matched:
+            logger.debug(
+                "No matching gender found. Applying fallback_gender_malus"
+            )
+            capdev_modifier *= config.fallback_gender_malus
         logger.debug(
             "No matching gender found. Applying fallback_gender_malus"
         )
@@ -537,6 +543,7 @@ def calculate_capdev_modifier(
         logger.debug(
             f"Checking specific variable modifiers for item '{item.slug}' and target game variables"
         )
+        variable_matched = False
         for variables in specific_variables_modifiers:
             if (
                 not isinstance(variables, dict)
@@ -554,11 +561,13 @@ def calculate_capdev_modifier(
                     f"Applying fallback_variables_bonus"
                 )
                 capdev_modifier *= config.fallback_variables_bonus
+                variable_matched = True
 
-        logger.debug(
-            "No matching variable found. Applying fallback_variables_malus"
-        )
-        capdev_modifier *= config.fallback_variables_malus
+        if not variable_matched:
+            logger.debug(
+                "No matching variable found. Applying fallback_variables_malus"
+            )
+            capdev_modifier *= config.fallback_variables_malus
 
     random_bounds = config.random_bounds
 


### PR DESCRIPTION
Four fixes in four separate commits:
* A catch device that meets a particular condition only applies the bonus associated with that condition, not also the general penalty for having no condition met
* The repellent effect returns the item's name
* If a more specific status (condition) applies to a catch rate, that takes precedent over the general catch penalty for having any status (condition). 
* "has_status" only returns true if the target has a status, not if it has an empty slot for a status. 