### PR TITLE
Saves/Loads on second page crash

### DIFF
--- a/tuxemon/sprite.py
+++ b/tuxemon/sprite.py
@@ -924,6 +924,14 @@ class VisualSpriteList(RelativeGroup[_MenuElement]):
         if not (event.pressed and event.button in self._allowed_input()):
             return index
 
+        # The incoming index may point outside the visible page (e.g. it was
+        # restored from a save slot that lives on another page). Advancing from
+        # an off-page index would make _advance_input() raise ValueError via
+        # visible.index(), which is not caught below, so snap onto the page
+        # first.
+        if index not in self._visible_indices():
+            return self.snap_selection(index)
+
         sprites = self.sprites()
         last_enabled = index
 

--- a/tuxemon/states/save_and_load.py
+++ b/tuxemon/states/save_and_load.py
@@ -46,6 +46,28 @@ class PaginatedMenuState(PopUpMenu[None]):
     def __init__(self, client: BaseClient, **kwargs: Any):
         super().__init__(client=client, **kwargs)
 
+    def reload_items(self) -> None:
+        super().reload_items()
+        self._align_page_to_selection()
+
+    def _align_page_to_selection(self) -> None:
+        """
+        Open on the page that contains the requested selection.
+        The menu can be opened with a ``selected_index`` taken from the
+        current save slot, which may live on a later page. Without aligning
+        the page, the selection would point off the visible page, leaving the
+        cursor on nothing and crashing on the first cursor move. Setting the
+        page and snapping guarantees a valid, visible selection.
+        """
+        page_size = self.menu_items.page_size
+        if not page_size:
+            return
+
+        self.menu_items.set_page(self.selected_index // page_size)
+        self.selected_index = self.menu_items.snap_selection(
+            self.selected_index
+        )
+
     def _snap_selection_to_page(self) -> None:
         """Delegate snapping to VisualSpriteList."""
         self.selected_index = self.menu_items.snap_selection(


### PR DESCRIPTION
When I added #3553 I introduced a bug, sorry!

Load a game that's on the second page of saves (saves 4 through 6). 

Go into the save or load menu. It should start on save 4, 5 or 6 depending on what you have open. But instead it'll start you on save 1, and when you move up or down it crashes. 

These changes should fix that. 